### PR TITLE
feat: add optional market sentiment tool

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main, master]
   pull_request:
-    branches: [master]
+    branches: [main, master]
 
 jobs:
   build:
@@ -20,7 +20,12 @@ jobs:
           cache: pip
 
       - name: Install dependencies
-        run: pip install -e .
+        run: |
+          pip install -e .
+          pip install pytest
+
+      - name: Unit tests
+        run: python -m pytest tests/ -q
 
       - name: Syntax check
         run: |

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <br>
   <img src="https://img.shields.io/badge/Skills-68-orange" alt="Skills">
   <img src="https://img.shields.io/badge/Swarm_Presets-29-7C3AED" alt="Swarm">
-  <img src="https://img.shields.io/badge/Tools-21-0F766E" alt="Tools">
+  <img src="https://img.shields.io/badge/Tools-22-0F766E" alt="Tools">
   <img src="https://img.shields.io/badge/Data_Sources-5-2563EB" alt="Data Sources">
   <br>
   <a href="https://github.com/HKUDS/.github/blob/main/profile/README.md"><img src="https://img.shields.io/badge/Feishu-Group-E9DBFC?style=flat-square&logo=feishu&logoColor=white" alt="Feishu"></a>
@@ -44,7 +44,7 @@
 
 ## 📰 News
 
-- **2026-04-09** 🔧 **Data source expansion**: 5 data sources with auto-fallback (tushare, yfinance, OKX, AKShare, CCXT) — zero-config backtesting across A-shares, US/HK equities, crypto, futures, and forex. Added `web_search` tool (DuckDuckGo), skill categorization (7 categories), and `data-routing` meta-skill for intelligent source selection.
+- **2026-04-09** 🔧 **Data source expansion**: 5 data sources with auto-fallback (tushare, yfinance, OKX, AKShare, CCXT) — zero-config backtesting across A-shares, US/HK equities, crypto, futures, and forex. Added `web_search` tool (DuckDuckGo), optional `market_sentiment` structured alt-data tool, skill categorization (7 categories), and `data-routing` meta-skill for intelligent source selection.
 - **2026-04-08** 🔧 Multi-market backtest engines with per-market rules; **Pine Script v6 export** — convert strategies to TradingView in one command (`/pine`, API, frontend viewer).
 - **2026-04-01** 🚀 Released **v0.1.0** — Initial release: ReAct agent, 64 skills, 29 swarm presets, cross-market backtest, CLI + Web UI + MCP server.
 
@@ -292,6 +292,7 @@ Edit `agent/.env`:
 | `LANGCHAIN_PROVIDER` | Yes | LLM provider selector (e.g. `openrouter`) |
 | `LANGCHAIN_MODEL_NAME` | Yes | Model name (e.g. `deepseek/deepseek-v3.2`) |
 | `TUSHARE_TOKEN` | No | Tushare Pro token for A-share data (falls back to AKShare if missing) |
+| `ADANOS_API_KEY` | No | Optional Adanos key for structured US-stock market sentiment snapshots and trending tickers |
 | `CCXT_EXCHANGE` | No | CCXT exchange name, default `binance` |
 | `TIMEOUT_SECONDS` | No | Agent timeout, default 2400s |
 
@@ -385,7 +386,7 @@ Interactive docs: `http://localhost:8899/docs`
 
 ## 🔌 MCP Plugin
 
-Vibe-Trading exposes 16 MCP tools for any MCP-compatible client. Runs as a stdio subprocess — no server setup needed. **15 of 16 tools work with zero API keys** (HK/US/crypto). Only `run_swarm` needs an LLM key.
+Vibe-Trading exposes 17 MCP tools for any MCP-compatible client. Runs as a stdio subprocess — no server setup needed. **15 of 17 tools work with zero API keys** for default markets. `run_swarm` needs an LLM key, and `market_sentiment` is optional and only active when `ADANOS_API_KEY` is set.
 
 <details>
 <summary><b>Claude Desktop</b></summary>
@@ -427,7 +428,7 @@ vibe-trading-mcp --transport sse  # SSE for web clients
 
 </details>
 
-**MCP tools exposed (16):** `list_skills`, `load_skill`, `backtest`, `factor_analysis`, `analyze_options`, `pattern_recognition`, `get_market_data`, `read_url`, `read_document`, `read_file`, `write_file`, `list_swarm_presets`, `run_swarm`, `get_swarm_status`, `get_run_result`, `list_runs`.
+**MCP tools exposed (17):** `list_skills`, `load_skill`, `backtest`, `factor_analysis`, `analyze_options`, `pattern_recognition`, `get_market_data`, `market_sentiment`, `read_url`, `read_document`, `read_file`, `write_file`, `list_swarm_presets`, `run_swarm`, `get_swarm_status`, `get_run_result`, `list_runs`.
 
 <details>
 <summary><b>Install from ClawHub (one command)</b></summary>
@@ -485,7 +486,7 @@ Vibe-Trading/
 ├── agent/                          # Backend (Python)
 │   ├── cli.py                      # CLI entrypoint — interactive TUI + subcommands
 │   ├── api_server.py               # FastAPI server — runs, sessions, upload, swarm, SSE
-│   ├── mcp_server.py               # MCP server — 16 tools for OpenClaw / Claude Desktop
+│   ├── mcp_server.py               # MCP server — 17 tools for OpenClaw / Claude Desktop
 │   │
 │   ├── src/
 │   │   ├── agent/                  # ReAct agent core
@@ -496,7 +497,7 @@ Vibe-Trading/
 │   │   │   ├── memory.py           #   run memory / artifact store
 │   │   │   └── trace.py            #   execution trace writer
 │   │   │
-│   │   ├── tools/                  # 21 agent tools
+│   │   ├── tools/                  # 22 agent tools
 │   │   │   ├── backtest_tool.py    #   run backtests
 │   │   │   ├── factor_analysis_tool.py
 │   │   │   ├── options_pricing_tool.py
@@ -504,6 +505,7 @@ Vibe-Trading/
 │   │   │   ├── doc_reader_tool.py  #   PDF reader (OCR fallback)
 │   │   │   ├── web_reader_tool.py  #   web page reader (Jina)
 │   │   │   ├── web_search_tool.py  #   DuckDuckGo web search
+│   │   │   ├── market_sentiment_tool.py # optional Adanos sentiment snapshots
 │   │   │   ├── swarm_tool.py       #   launch swarm teams
 │   │   │   └── ...                 #   file I/O, bash, tasks, etc.
 │   │   │

--- a/agent/.env.example
+++ b/agent/.env.example
@@ -12,6 +12,8 @@ LANGCHAIN_TEMPERATURE=0.0
 # ============================================================================
 # A-shares: Tushare Pro (requires token, https://tushare.pro)
 TUSHARE_TOKEN=your-tushare-token
+# Optional structured US-stock sentiment snapshots/trending (https://api.adanos.org)
+ADANOS_API_KEY=
 # HK/US equities: yfinance (free, no key needed)
 # Crypto: OKX public API (free, no key needed)
 

--- a/agent/cli.py
+++ b/agent/cli.py
@@ -497,6 +497,7 @@ def _show_settings() -> None:
         "Temperature": os.getenv("LANGCHAIN_TEMPERATURE", "0.0"),
         "Timeout": os.getenv("TIMEOUT_SECONDS", "2400") + "s",
         "Tushare Token": "***" if os.getenv("TUSHARE_TOKEN") else "(not set)",
+        "Adanos API Key": "***" if os.getenv("ADANOS_API_KEY") else "(not set)",
     }
     for k, v in settings.items():
         table.add_row(k, v)
@@ -1439,6 +1440,7 @@ def cmd_init() -> int:
     model = input(f"Model name [{default_model.get(provider, '')}]: ").strip() or default_model.get(provider, "")
 
     tushare = input("Tushare token (A-shares, optional) []: ").strip()
+    adanos = input("Adanos API key (structured sentiment, optional) []: ").strip()
 
     env_content = (
         f"LANGCHAIN_PROVIDER={provider}\n"
@@ -1451,6 +1453,8 @@ def cmd_init() -> int:
     )
     if tushare:
         env_content += f"TUSHARE_TOKEN={tushare}\n"
+    if adanos:
+        env_content += f"ADANOS_API_KEY={adanos}\n"
 
     _INIT_ENV_DIR.mkdir(parents=True, exist_ok=True)
     _INIT_ENV_PATH.write_text(env_content, encoding="utf-8")

--- a/agent/config/swarm/sentiment_intelligence_team.yaml
+++ b/agent/config/swarm/sentiment_intelligence_team.yaml
@@ -26,8 +26,9 @@ agents:
       5. **Sentiment trend vs prior** — vs yesterday (daily) or prior week (weekly): direction, magnitude, speed
       6. **Tail-risk news** — items that could crater sentiment (geo / financial-system / black-swan watch)
 
+      If `market_sentiment` is configured, use it first for structured finance-news sentiment and hot-name context, then deepen with read_url for article detail.
       Use load_skill("web-reader"), load_skill("sentiment-analysis"), read_url.
-    tools: [bash, read_file, write_file, load_skill, read_url]
+    tools: [bash, read_file, write_file, load_skill, read_url, market_sentiment]
     skills: [web-reader, sentiment-analysis, social-media-intelligence]
     max_iterations: 50
     timeout_seconds: 600
@@ -56,8 +57,9 @@ agents:
       5. **Bias map** — dominant biases and expected price impact (momentum vs reversal after overreaction)
       6. **Retail flow inflection** — forecast when retail flows may turn within {timeframe}
 
+      If `market_sentiment` is configured, use it first for structured retail heat and sentiment extremes on the target market before broader web sampling.
       Use load_skill("behavioral-finance"), load_skill("sentiment-analysis"), read_url.
-    tools: [bash, read_file, write_file, load_skill, read_url]
+    tools: [bash, read_file, write_file, load_skill, read_url, market_sentiment]
     skills: [behavioral-finance, sentiment-analysis, social-media-intelligence]
     max_iterations: 50
     timeout_seconds: 600
@@ -118,8 +120,9 @@ agents:
       5. **Time window** — expected days until sentiment mean-reverts if reversal signal on
       6. **Limitations** — when sentiment fails in trends; blend with fundamentals; key uncertainties
 
+      If `market_sentiment` is configured, use it to ground the composite score with structured multi-source sentiment before blending news/social/flow outputs.
       Use load_skill("behavioral-finance"), load_skill("risk-analysis").
-    tools: [bash, read_file, write_file, load_skill]
+    tools: [bash, read_file, write_file, load_skill, market_sentiment]
     skills: [behavioral-finance, risk-analysis]
     max_iterations: 50
     timeout_seconds: 600

--- a/agent/config/swarm/social_alpha_team.yaml
+++ b/agent/config/swarm/social_alpha_team.yaml
@@ -51,9 +51,10 @@ agents:
       4. **Narratives** — 3–5 dominant market narratives; novelty; stage (emerging / peak / late)
       5. **Tradable signals** — 1–3 observable, historically tested social signals (KOL consensus extreme / retail extreme / narrative stage) with rough historical hit rates
 
+      If `market_sentiment` is configured, use it first for structured X/Reddit/news/Polymarket sentiment snapshots on "{target}", then deepen with web reading as needed.
       Use load_skill("social-media-intelligence"), load_skill("sentiment-analysis").
-      Use read_url for X/FinTwit sources.
-    tools: [bash, read_file, write_file, load_skill, read_url]
+      Use read_url for X/FinTwit sources when the optional sentiment tool is unavailable or insufficient.
+    tools: [bash, read_file, write_file, load_skill, read_url, market_sentiment]
     skills: [social-media-intelligence, sentiment-analysis]
     max_iterations: 50
     timeout_seconds: 600
@@ -173,9 +174,10 @@ agents:
       4. **Attention lead** — Historical lead/lag; names with rising attention but flat price
       5. **Contrarian flag** — At greed/fear extremes, explicit fade signal with historical stats
 
+      If `market_sentiment` is configured, use it first for structured Reddit-centered snapshots or trending names on "{target}", then deepen with manual Reddit reading as needed.
       Use load_skill("social-media-intelligence"), load_skill("behavioral-finance"), load_skill("sentiment-analysis").
-      Use read_url for Reddit pages/API data.
-    tools: [bash, read_file, write_file, load_skill, read_url]
+      Use read_url for Reddit pages/API data when the optional sentiment tool is unavailable or insufficient.
+    tools: [bash, read_file, write_file, load_skill, read_url, market_sentiment]
     skills: [social-media-intelligence, behavioral-finance, sentiment-analysis]
     max_iterations: 50
     timeout_seconds: 600
@@ -236,9 +238,10 @@ agents:
       4. **Combined alpha verdict** — Buy / neutral / sell / contrarian for "{target}"; strength 1–5 stars; suggested holding horizon
       5. **Monitoring plan** — Refresh cadence, key thresholds, decay updates; blend with fundamental factors
 
+      If `market_sentiment` is configured, use it to anchor the three-channel scorecard with structured cross-source snapshots before doing historical validation.
       Use load_skill("social-media-intelligence"), load_skill("factor-research"), load_skill("quant-statistics").
       Use factor_analysis for factor stats.
-    tools: [bash, read_file, write_file, load_skill, factor_analysis]
+    tools: [bash, read_file, write_file, load_skill, factor_analysis, market_sentiment]
     skills: [social-media-intelligence, factor-research, quant-statistics]
     max_iterations: 50
     timeout_seconds: 600

--- a/agent/mcp_server.py
+++ b/agent/mcp_server.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Vibe-Trading MCP Server — expose 16 finance research tools to any MCP client.
+"""Vibe-Trading MCP Server — expose 17 finance research tools to any MCP client.
 
 Works with OpenClaw, Claude Desktop, Cursor, and any MCP-compatible client.
 Zero API key required for HK/US/crypto markets (yfinance + OKX are free).
@@ -422,6 +422,38 @@ def get_market_data(
             results[symbol] = records
 
     return json.dumps(results, ensure_ascii=False, indent=2)
+
+
+@mcp.tool
+def market_sentiment(
+    mode: str = "snapshot",
+    tickers: list[str] | None = None,
+    source: str = "all",
+    days: int = 7,
+    limit: int = 10,
+) -> str:
+    """Fetch optional structured market sentiment for US equities and ETFs.
+
+    The Adanos sentiment integration is optional and only becomes active when
+    ADANOS_API_KEY is configured. Without it, the tool returns
+    {"status":"not_configured"} so agents can fall back to web research.
+
+    Args:
+        mode: "snapshot" for ticker comparison or "trending" for hot names.
+        tickers: List of tickers for snapshot mode (e.g. ["AAPL", "NVDA", "TSLA"]).
+        source: all, reddit, x, news, or polymarket.
+        days: Lookback window in days.
+        limit: Max trending rows per source.
+    """
+    from src.tools.market_sentiment_tool import run_market_sentiment
+
+    return run_market_sentiment(
+        mode=mode,
+        tickers=tickers,
+        source=source,
+        days=days,
+        limit=limit,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/agent/src/agent/context.py
+++ b/agent/src/agent/context.py
@@ -9,8 +9,8 @@ from src.agent.memory import WorkspaceMemory
 from src.agent.skills import SkillsLoader
 from src.agent.tools import ToolRegistry
 
-_SYSTEM_PROMPT = """You are a finance research agent with 68 specialist skills, 21 tools, 5 data sources (with auto-fallback), and 29 multi-agent swarm teams.
-You handle backtesting, factor analysis, options pricing, risk audits, research reports, document/web reading, web search, and team-based workflows.
+_SYSTEM_PROMPT = """You are a finance research agent with 68 specialist skills, 22 tools, 5 core market-data sources (with auto-fallback), and 29 multi-agent swarm teams.
+You handle backtesting, factor analysis, options pricing, risk audits, research reports, document/web reading, web search, structured market sentiment, and team-based workflows.
 
 ## Tools
 
@@ -40,8 +40,8 @@ Decide which workflow to use based on the request:
 - Examples: risk audit, investment committee, equity research, technical panel, cross-market allocation.
 - Do NOT attempt multi-dimensional analysis solo. Use swarm.
 
-**Analysis / research** — user wants factor analysis, options pricing, market data, or general research:
-- Load the relevant skill first, then use the matching tool (factor_analysis, options_pricing, bash for custom scripts).
+**Analysis / research** — user wants factor analysis, options pricing, market data, market sentiment, or general research:
+- Load the relevant skill first, then use the matching tool (factor_analysis, options_pricing, market_sentiment, bash for custom scripts).
 
 **Document / web** — user provides a PDF or URL:
 - `read_document(path=...)` for PDFs, `read_url(url=...)` for web pages.

--- a/agent/src/tools/__init__.py
+++ b/agent/src/tools/__init__.py
@@ -22,6 +22,7 @@ def build_registry() -> ToolRegistry:
     from src.tools.background_tools import BackgroundRunTool, CheckBackgroundTool
     from src.tools.web_reader_tool import WebReaderTool
     from src.tools.web_search_tool import WebSearchTool
+    from src.tools.market_sentiment_tool import MarketSentimentTool
     from src.tools.doc_reader_tool import DocReaderTool
     from src.tools.factor_analysis_tool import FactorAnalysisTool
     from src.tools.options_pricing_tool import OptionsPricingTool
@@ -32,7 +33,7 @@ def build_registry() -> ToolRegistry:
                  PatternTool(), CompactTool(), SubagentTool(),
                  TaskCreateTool(), TaskUpdateTool(), TaskListTool(), TaskGetTool(),
                  BackgroundRunTool(), CheckBackgroundTool(),
-                 WebReaderTool(), WebSearchTool(), DocReaderTool(),
+                 WebReaderTool(), WebSearchTool(), MarketSentimentTool(), DocReaderTool(),
                  FactorAnalysisTool(), OptionsPricingTool(), SwarmTool()]:
         registry.register(tool)
     return registry

--- a/agent/src/tools/market_sentiment_tool.py
+++ b/agent/src/tools/market_sentiment_tool.py
@@ -1,0 +1,387 @@
+"""Optional Adanos market sentiment tool for structured US-stock sentiment snapshots."""
+
+from __future__ import annotations
+
+import json
+import os
+from statistics import mean
+from typing import Any
+
+import requests
+
+from src.agent.tools import BaseTool
+
+_API_BASE = "https://api.adanos.org"
+_TIMEOUT_SECONDS = 20
+_MAX_TICKERS = 10
+_SUPPORTED_SOURCES = ("reddit", "x", "news", "polymarket")
+_COMPARE_PATHS = {
+    "reddit": "/reddit/stocks/v1/compare",
+    "x": "/x/stocks/v1/compare",
+    "news": "/news/stocks/v1/compare",
+    "polymarket": "/polymarket/stocks/v1/compare",
+}
+_TRENDING_PATHS = {
+    "reddit": "/reddit/stocks/v1/trending",
+    "x": "/x/stocks/v1/trending",
+    "news": "/news/stocks/v1/trending",
+    "polymarket": "/polymarket/stocks/v1/trending",
+}
+
+
+def _get_api_key() -> str:
+    return os.getenv("ADANOS_API_KEY", "").strip()
+
+
+def _normalize_source(source: Any) -> str:
+    normalized = str(source or "all").strip().lower()
+    if normalized in {"", "all"}:
+        return "all"
+    if normalized not in _SUPPORTED_SOURCES:
+        raise ValueError(
+            f"Unsupported source '{normalized}'. Use one of: all, {', '.join(_SUPPORTED_SOURCES)}"
+        )
+    return normalized
+
+
+def _normalize_tickers(tickers: Any) -> list[str]:
+    if tickers is None:
+        return []
+
+    if isinstance(tickers, str):
+        raw_values = tickers.split(",")
+    elif isinstance(tickers, (list, tuple, set)):
+        raw_values = list(tickers)
+    else:
+        raise ValueError("tickers must be a comma-separated string or a list of ticker symbols")
+
+    seen: set[str] = set()
+    normalized: list[str] = []
+    for value in raw_values:
+        ticker = str(value).strip().upper().replace("$", "")
+        if ticker and ticker not in seen:
+            seen.add(ticker)
+            normalized.append(ticker)
+
+    if len(normalized) > _MAX_TICKERS:
+        raise ValueError(f"Maximum {_MAX_TICKERS} tickers allowed")
+    return normalized
+
+
+def _extract_rows(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        return [row for row in payload if isinstance(row, dict)]
+    if isinstance(payload, dict):
+        for key in ("stocks", "results"):
+            rows = payload.get(key)
+            if isinstance(rows, list):
+                return [row for row in rows if isinstance(row, dict)]
+    return []
+
+
+def _request_json(path: str, params: dict[str, Any], api_key: str, *, allow_404: bool = False) -> Any:
+    response = requests.get(
+        f"{_API_BASE}{path}",
+        params=params,
+        headers={"X-API-Key": api_key},
+        timeout=_TIMEOUT_SECONDS,
+    )
+    if allow_404 and response.status_code == 404:
+        return []
+    if response.status_code != 200:
+        raise RuntimeError(f"{path} returned {response.status_code}: {response.text[:300]}")
+    return response.json()
+
+
+def _extract_activity(row: dict[str, Any]) -> tuple[str | None, int | float | None]:
+    for key in ("mentions", "unique_tweets", "trade_count", "unique_posts", "source_count", "unique_traders"):
+        value = row.get(key)
+        if value is not None:
+            return key, value
+    return None, None
+
+
+def _normalize_compare_row(source: str, row: dict[str, Any]) -> dict[str, Any]:
+    activity_key, activity_value = _extract_activity(row)
+    return {
+        "ticker": row.get("ticker"),
+        "company_name": row.get("company_name"),
+        "buzz_score": row.get("buzz_score"),
+        "sentiment_score": row.get("sentiment_score"),
+        "bullish_pct": row.get("bullish_pct"),
+        "bearish_pct": row.get("bearish_pct"),
+        "trend": row.get("trend"),
+        "activity_label": activity_key,
+        "activity": activity_value,
+        "source": source,
+    }
+
+
+def _normalize_trending_row(source: str, row: dict[str, Any]) -> dict[str, Any]:
+    normalized = _normalize_compare_row(source, row)
+    normalized["rank"] = row.get("rank")
+    return normalized
+
+
+def _has_signal(row: dict[str, Any]) -> bool:
+    for key in ("buzz_score", "sentiment_score", "bullish_pct", "activity"):
+        value = row.get(key)
+        if value is None:
+            continue
+        try:
+            if float(value) > 0:
+                return True
+        except (TypeError, ValueError):
+            continue
+    return False
+
+
+def _classify_alignment(bullish_values: list[float]) -> str:
+    if not bullish_values:
+        return "no_signal"
+    if len(bullish_values) == 1:
+        return "single_source"
+
+    bullish_sources = sum(value >= 55 for value in bullish_values)
+    bearish_sources = sum(value <= 45 for value in bullish_values)
+
+    if bullish_sources == len(bullish_values) or bearish_sources == len(bullish_values):
+        return "aligned"
+    if bullish_sources and bearish_sources:
+        return "divergent"
+    return "mixed"
+
+
+def _aggregate_snapshot(tickers: list[str], per_source_rows: dict[str, dict[str, dict[str, Any]]]) -> list[dict[str, Any]]:
+    aggregated: list[dict[str, Any]] = []
+    for ticker in tickers:
+        source_rows = {
+            source: rows[ticker]
+            for source, rows in per_source_rows.items()
+            if ticker in rows
+        }
+        signal_rows = [row for row in source_rows.values() if _has_signal(row)]
+        buzz_values = [
+            float(row["buzz_score"])
+            for row in signal_rows
+            if row.get("buzz_score") is not None
+        ]
+        bullish_values = [
+            float(row["bullish_pct"])
+            for row in signal_rows
+            if row.get("bullish_pct") is not None
+        ]
+        sentiment_values = [
+            float(row["sentiment_score"])
+            for row in signal_rows
+            if row.get("sentiment_score") is not None
+        ]
+
+        company_name = next(
+            (row.get("company_name") for row in source_rows.values() if row.get("company_name")),
+            None,
+        )
+        aggregated.append(
+            {
+                "ticker": ticker,
+                "company_name": company_name,
+                "average_buzz": round(mean(buzz_values), 2) if buzz_values else 0.0,
+                "average_bullish_pct": round(mean(bullish_values), 1) if bullish_values else None,
+                "average_sentiment_score": round(mean(sentiment_values), 3) if sentiment_values else None,
+                "coverage": len(signal_rows),
+                "source_alignment": _classify_alignment(bullish_values),
+                "sources": source_rows,
+            }
+        )
+
+    aggregated.sort(key=lambda item: item["average_buzz"], reverse=True)
+    return aggregated
+
+
+def run_market_sentiment(
+    *,
+    mode: str = "snapshot",
+    tickers: Any = None,
+    source: str = "all",
+    days: int = 7,
+    limit: int = 10,
+) -> str:
+    """Run optional Adanos market sentiment lookup.
+
+    Args:
+        mode: snapshot or trending.
+        tickers: Comma-separated string or list of tickers for snapshot mode.
+        source: all, reddit, x, news, or polymarket.
+        days: Lookback window in days.
+        limit: Max trending rows per source.
+
+    Returns:
+        JSON-formatted result.
+    """
+    api_key = _get_api_key()
+    if not api_key:
+        return json.dumps(
+            {
+                "status": "not_configured",
+                "message": "Set ADANOS_API_KEY to enable structured market sentiment snapshots and trending tickers.",
+            },
+            ensure_ascii=False,
+        )
+
+    mode_normalized = str(mode or "snapshot").strip().lower()
+    if mode_normalized not in {"snapshot", "trending"}:
+        return json.dumps(
+            {"status": "error", "error": "mode must be 'snapshot' or 'trending'"},
+            ensure_ascii=False,
+        )
+
+    try:
+        days_value = int(days)
+        limit_value = int(limit)
+        if days_value < 1 or days_value > 90:
+            raise ValueError("days must be between 1 and 90")
+        if limit_value < 1 or limit_value > 25:
+            raise ValueError("limit must be between 1 and 25")
+        source_value = _normalize_source(source)
+    except ValueError as exc:
+        return json.dumps({"status": "error", "error": str(exc)}, ensure_ascii=False)
+
+    selected_sources = list(_SUPPORTED_SOURCES) if source_value == "all" else [source_value]
+
+    if mode_normalized == "snapshot":
+        try:
+            ticker_list = _normalize_tickers(tickers)
+        except ValueError as exc:
+            return json.dumps({"status": "error", "error": str(exc)}, ensure_ascii=False)
+        if not ticker_list:
+            return json.dumps(
+                {"status": "error", "error": "tickers is required for snapshot mode"},
+                ensure_ascii=False,
+            )
+
+        per_source_rows: dict[str, dict[str, dict[str, Any]]] = {}
+        errors: dict[str, str] = {}
+        for source_name in selected_sources:
+            try:
+                payload = _request_json(
+                    _COMPARE_PATHS[source_name],
+                    {"tickers": ",".join(ticker_list), "days": days_value},
+                    api_key,
+                )
+                rows = {
+                    str(row.get("ticker", "")).upper(): _normalize_compare_row(source_name, row)
+                    for row in _extract_rows(payload)
+                    if row.get("ticker")
+                }
+                per_source_rows[source_name] = rows
+            except Exception as exc:  # pragma: no cover - covered via error contract tests
+                errors[source_name] = str(exc)
+
+        if not per_source_rows:
+            return json.dumps(
+                {"status": "error", "error": "All Adanos sentiment requests failed", "errors": errors},
+                ensure_ascii=False,
+            )
+
+        status = "ok" if not errors else "partial"
+        return json.dumps(
+            {
+                "status": status,
+                "mode": "snapshot",
+                "period_days": days_value,
+                "sources_requested": selected_sources,
+                "tickers": _aggregate_snapshot(ticker_list, per_source_rows),
+                "errors": errors,
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+
+    trending_results: dict[str, list[dict[str, Any]]] = {}
+    errors: dict[str, str] = {}
+    for source_name in selected_sources:
+        try:
+            payload = _request_json(
+                _TRENDING_PATHS[source_name],
+                {"days": days_value, "limit": limit_value},
+                api_key,
+                allow_404=True,
+            )
+            rows = [
+                _normalize_trending_row(source_name, row)
+                for row in _extract_rows(payload if isinstance(payload, dict) else payload)
+            ]
+            trending_results[source_name] = rows[:limit_value]
+        except Exception as exc:  # pragma: no cover - covered via error contract tests
+            errors[source_name] = str(exc)
+
+    if not trending_results:
+        return json.dumps(
+            {"status": "error", "error": "All Adanos sentiment requests failed", "errors": errors},
+            ensure_ascii=False,
+        )
+
+    payload: dict[str, Any] = {
+        "status": "ok" if not errors else "partial",
+        "mode": "trending",
+        "period_days": days_value,
+        "sources_requested": selected_sources,
+        "errors": errors,
+    }
+    if source_value == "all":
+        payload["results"] = trending_results
+    else:
+        payload["results"] = trending_results[selected_sources[0]]
+    return json.dumps(payload, ensure_ascii=False, indent=2)
+
+
+class MarketSentimentTool(BaseTool):
+    """Optional structured market sentiment tool powered by Adanos."""
+
+    name = "market_sentiment"
+    description = (
+        "Fetch structured stock market sentiment from an optional Adanos API integration. "
+        "Use snapshot mode for ticker comparisons or trending mode for source-ranked hot names. "
+        "Returns status=not_configured when ADANOS_API_KEY is missing."
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "mode": {
+                "type": "string",
+                "description": "Mode: snapshot or trending",
+                "default": "snapshot",
+            },
+            "tickers": {
+                "type": ["string", "array"],
+                "description": "Comma-separated tickers or a ticker list for snapshot mode (max 10)",
+            },
+            "source": {
+                "type": "string",
+                "description": "Sentiment source: all, reddit, x, news, or polymarket",
+                "default": "all",
+            },
+            "days": {
+                "type": "integer",
+                "description": "Lookback window in days (1-90, depending on account)",
+                "default": 7,
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Trending result limit per source (1-25)",
+                "default": 10,
+            },
+        },
+        "required": ["mode"],
+    }
+    repeatable = True
+
+    def execute(self, **kwargs: Any) -> str:
+        """Execute market sentiment lookup."""
+        return run_market_sentiment(
+            mode=kwargs.get("mode", "snapshot"),
+            tickers=kwargs.get("tickers"),
+            source=kwargs.get("source", "all"),
+            days=kwargs.get("days", 7),
+            limit=kwargs.get("limit", 10),
+        )

--- a/agent/src/tools/market_sentiment_tool.py
+++ b/agent/src/tools/market_sentiment_tool.py
@@ -353,8 +353,8 @@ class MarketSentimentTool(BaseTool):
                 "default": "snapshot",
             },
             "tickers": {
-                "type": ["string", "array"],
-                "description": "Comma-separated tickers or a ticker list for snapshot mode (max 10)",
+                "type": "string",
+                "description": "Comma-separated tickers for snapshot mode (max 10), e.g. AAPL,NVDA,TSLA",
             },
             "source": {
                 "type": "string",

--- a/tests/test_market_sentiment_tool.py
+++ b/tests/test_market_sentiment_tool.py
@@ -157,6 +157,18 @@ def test_market_sentiment_trending_allows_partial_source_failures(monkeypatch):
     assert "polymarket" in payload["errors"]
 
 
+def test_market_sentiment_validates_mode_and_source(monkeypatch):
+    monkeypatch.setenv("ADANOS_API_KEY", "demo-key")
+
+    invalid_mode = json.loads(run_market_sentiment(mode="heatmap", tickers="AAPL"))
+    invalid_source = json.loads(run_market_sentiment(mode="trending", source="telegram"))
+
+    assert invalid_mode["status"] == "error"
+    assert "snapshot" in invalid_mode["error"]
+    assert invalid_source["status"] == "error"
+    assert "Unsupported source" in invalid_source["error"]
+
+
 def test_registry_includes_market_sentiment_tool():
     registry = build_registry()
     tool = registry.get("market_sentiment")

--- a/tests/test_market_sentiment_tool.py
+++ b/tests/test_market_sentiment_tool.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+AGENT_DIR = REPO_ROOT / "agent"
+if str(AGENT_DIR) not in sys.path:
+    sys.path.insert(0, str(AGENT_DIR))
+
+from src.tools import build_registry
+from src.tools.market_sentiment_tool import run_market_sentiment
+
+
+class DummyResponse:
+    def __init__(self, status_code: int, payload):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = json.dumps(payload)
+
+    def json(self):
+        return self._payload
+
+
+def test_market_sentiment_returns_not_configured_without_api_key(monkeypatch):
+    monkeypatch.delenv("ADANOS_API_KEY", raising=False)
+
+    payload = json.loads(run_market_sentiment(mode="snapshot", tickers="AAPL,NVDA"))
+
+    assert payload["status"] == "not_configured"
+    assert "ADANOS_API_KEY" in payload["message"]
+
+
+def test_market_sentiment_snapshot_aggregates_sources(monkeypatch):
+    monkeypatch.setenv("ADANOS_API_KEY", "demo-key")
+
+    calls: list[str] = []
+
+    def fake_get(url, *, params, headers, timeout):
+        calls.append(url)
+        assert headers["X-API-Key"] == "demo-key"
+        assert timeout == 20
+        assert params["tickers"] == "AAPL,NVDA"
+        if url.endswith("/reddit/stocks/v1/compare"):
+            return DummyResponse(
+                200,
+                {
+                    "period_days": 7,
+                    "stocks": [
+                        {"ticker": "AAPL", "company_name": "Apple Inc.", "buzz_score": 60.0, "bullish_pct": 65, "sentiment_score": 0.42, "mentions": 120, "trend": "rising"},
+                        {"ticker": "NVDA", "company_name": "NVIDIA", "buzz_score": 75.0, "bullish_pct": 70, "sentiment_score": 0.55, "mentions": 180, "trend": "rising"},
+                    ],
+                },
+            )
+        if url.endswith("/x/stocks/v1/compare"):
+            return DummyResponse(
+                200,
+                {
+                    "period_days": 7,
+                    "stocks": [
+                        {"ticker": "AAPL", "company_name": "Apple Inc.", "buzz_score": 40.0, "bullish_pct": 35, "sentiment_score": -0.12, "unique_tweets": 88, "trend": "stable"},
+                        {"ticker": "NVDA", "company_name": "NVIDIA", "buzz_score": 55.0, "bullish_pct": 67, "sentiment_score": 0.31, "unique_tweets": 96, "trend": "stable"},
+                    ],
+                },
+            )
+        if url.endswith("/news/stocks/v1/compare"):
+            return DummyResponse(
+                200,
+                {
+                    "period_days": 7,
+                    "stocks": [
+                        {"ticker": "AAPL", "company_name": "Apple Inc.", "buzz_score": 30.0, "bullish_pct": 58, "sentiment_score": 0.19, "mentions": 12, "trend": "stable"},
+                    ],
+                },
+            )
+        if url.endswith("/polymarket/stocks/v1/compare"):
+            return DummyResponse(
+                200,
+                {
+                    "period_days": 7,
+                    "stocks": [
+                        {"ticker": "AAPL", "company_name": "Apple Inc.", "buzz_score": 50.0, "bullish_pct": 62, "sentiment_score": 0.27, "trade_count": 250, "trend": "stable"},
+                    ],
+                },
+            )
+        raise AssertionError(f"Unexpected URL: {url}")
+
+    monkeypatch.setattr("src.tools.market_sentiment_tool.requests.get", fake_get)
+
+    payload = json.loads(run_market_sentiment(mode="snapshot", tickers=["AAPL", "NVDA"], days=7))
+
+    assert payload["status"] == "ok"
+    assert payload["mode"] == "snapshot"
+    assert len(calls) == 4
+    assert payload["tickers"][0]["ticker"] == "NVDA"
+    assert payload["tickers"][0]["coverage"] == 2
+    assert payload["tickers"][0]["source_alignment"] == "aligned"
+
+    aapl = next(item for item in payload["tickers"] if item["ticker"] == "AAPL")
+    assert aapl["coverage"] == 4
+    assert aapl["average_buzz"] == 45.0
+    assert aapl["average_bullish_pct"] == 55.0
+    assert aapl["source_alignment"] == "divergent"
+    assert aapl["sources"]["polymarket"]["activity"] == 250
+    assert aapl["sources"]["x"]["activity_label"] == "unique_tweets"
+
+
+def test_market_sentiment_snapshot_excludes_zero_placeholders_from_coverage(monkeypatch):
+    monkeypatch.setenv("ADANOS_API_KEY", "demo-key")
+
+    def fake_get(url, *, params, headers, timeout):
+        return DummyResponse(
+            200,
+            {
+                "period_days": 7,
+                "stocks": [
+                    {"ticker": "PLTR", "company_name": "Palantir", "buzz_score": 0.0, "bullish_pct": None, "sentiment_score": None, "mentions": 0, "trend": None},
+                ],
+            },
+        )
+
+    monkeypatch.setattr("src.tools.market_sentiment_tool.requests.get", fake_get)
+
+    payload = json.loads(run_market_sentiment(mode="snapshot", tickers="PLTR", source="all", days=7))
+
+    assert payload["status"] == "ok"
+    assert payload["tickers"][0]["ticker"] == "PLTR"
+    assert payload["tickers"][0]["coverage"] == 0
+    assert payload["tickers"][0]["average_buzz"] == 0.0
+    assert payload["tickers"][0]["source_alignment"] == "no_signal"
+
+
+def test_market_sentiment_trending_allows_partial_source_failures(monkeypatch):
+    monkeypatch.setenv("ADANOS_API_KEY", "demo-key")
+
+    def fake_get(url, *, params, headers, timeout):
+        if url.endswith("/reddit/stocks/v1/trending"):
+            return DummyResponse(200, [{"ticker": "TSLA", "buzz_score": 81.0, "bullish_pct": 63, "mentions": 210, "trend": "rising"}])
+        if url.endswith("/x/stocks/v1/trending"):
+            return DummyResponse(404, {"detail": "No trending stocks found"})
+        if url.endswith("/news/stocks/v1/trending"):
+            return DummyResponse(200, [{"ticker": "NVDA", "buzz_score": 54.0, "bullish_pct": 59, "mentions": 24, "trend": "stable"}])
+        if url.endswith("/polymarket/stocks/v1/trending"):
+            return DummyResponse(500, {"detail": "upstream error"})
+        raise AssertionError(f"Unexpected URL: {url}")
+
+    monkeypatch.setattr("src.tools.market_sentiment_tool.requests.get", fake_get)
+
+    payload = json.loads(run_market_sentiment(mode="trending", source="all", days=3, limit=5))
+
+    assert payload["status"] == "partial"
+    assert set(payload["results"]) == {"reddit", "x", "news"}
+    assert payload["results"]["x"] == []
+    assert "polymarket" in payload["errors"]
+
+
+def test_registry_includes_market_sentiment_tool():
+    registry = build_registry()
+    tool = registry.get("market_sentiment")
+    assert tool is not None
+    assert tool.name == "market_sentiment"


### PR DESCRIPTION
## Summary
- add an optional `market_sentiment` tool for structured US-stock sentiment snapshots and trending names
- expose the same capability through the MCP server
- wire the tool into the existing sentiment-focused swarm presets as an optional fast path

## Why
Vibe-Trading already has strong social/sentiment swarm presets, but today they rely on broad web reading and manual synthesis. This patch adds a structured market-sentiment input that is useful when available, while remaining fully optional.

## Design
- no change to the default data-provider or backtest paths
- no requests are made unless `ADANOS_API_KEY` is configured
- when the key is missing, the tool returns `status=not_configured` so agents can fall back to existing web research flows
- the new tool supports `snapshot` and `trending` modes across Reddit, X, finance news, and Polymarket

## Validation
- `python3 -m pytest tests/ -q`
- `cd agent && python3 -m py_compile cli.py api_server.py mcp_server.py src/agent/loop.py src/tools/__init__.py src/tools/market_sentiment_tool.py`
- `git diff --check`