### PR TITLE
docs: add Chinese, Japanese and Korean README translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 <p align="center">
+  <b>English</b> | <a href="README_zh.md">中文</a> | <a href="README_ja.md">日本語</a> | <a href="README_ko.md">한국어</a>
+</p>
+
+<p align="center">
   <img src="assets/icon.png" width="120" alt="Vibe-Trading Logo"/>
 </p>
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,0 +1,619 @@
+<p align="center">
+  <a href="README.md">English</a> | <a href="README_zh.md">中文</a> | <b>日本語</b> | <a href="README_ko.md">한국어</a>
+</p>
+
+<p align="center">
+  <img src="assets/icon.png" width="120" alt="Vibe-Trading Logo"/>
+</p>
+
+<h1 align="center">Vibe-Trading: あなたのパーソナルトレーディングエージェント</h1>
+
+<p align="center">
+  <b>たった1コマンドで、包括的なトレーディング機能を備えたエージェントを起動</b>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Python-3.11%2B-3776AB?style=flat&logo=python&logoColor=white" alt="Python">
+  <img src="https://img.shields.io/badge/Backend-FastAPI-009688?style=flat" alt="FastAPI">
+  <img src="https://img.shields.io/badge/Frontend-React%2019-61DAFB?style=flat&logo=react&logoColor=white" alt="React">
+  <a href="https://pypi.org/project/vibe-trading-ai/"><img src="https://img.shields.io/pypi/v/vibe-trading-ai?style=flat&logo=pypi&logoColor=white" alt="PyPI"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow?style=flat" alt="License"></a>
+  <br>
+  <img src="https://img.shields.io/badge/Skills-68-orange" alt="Skills">
+  <img src="https://img.shields.io/badge/Swarm_Presets-29-7C3AED" alt="Swarm">
+  <img src="https://img.shields.io/badge/Tools-21-0F766E" alt="Tools">
+  <img src="https://img.shields.io/badge/Data_Sources-5-2563EB" alt="Data Sources">
+  <br>
+  <a href="https://github.com/HKUDS/.github/blob/main/profile/README.md"><img src="https://img.shields.io/badge/Feishu-Group-E9DBFC?style=flat-square&logo=feishu&logoColor=white" alt="Feishu"></a>
+  <a href="https://github.com/HKUDS/.github/blob/main/profile/README.md"><img src="https://img.shields.io/badge/WeChat-Group-C5EAB4?style=flat-square&logo=wechat&logoColor=white" alt="WeChat"></a>
+  <a href="https://discord.gg/2vDYc2w5"><img src="https://img.shields.io/badge/Discord-Join-7289DA?style=flat-square&logo=discord&logoColor=white" alt="Discord"></a>
+</p>
+
+<p align="center">
+  <a href="#-主な機能">機能</a> &nbsp;&middot;&nbsp;
+  <a href="#-デモ">デモ</a> &nbsp;&middot;&nbsp;
+  <a href="#-vibe-tradingとは">概要</a> &nbsp;&middot;&nbsp;
+  <a href="#-クイックスタート">始め方</a> &nbsp;&middot;&nbsp;
+  <a href="#-cli-リファレンス">CLI</a> &nbsp;&middot;&nbsp;
+  <a href="#-api-サーバー">API</a> &nbsp;&middot;&nbsp;
+  <a href="#-mcp-プラグイン">MCP</a> &nbsp;&middot;&nbsp;
+  <a href="#-プロジェクト構成">構成</a> &nbsp;&middot;&nbsp;
+  <a href="#-ロードマップ">ロードマップ</a> &nbsp;&middot;&nbsp;
+  <a href="#貢献">貢献</a>
+</p>
+
+<p align="center">
+  <a href="#-クイックスタート"><img src="assets/pip-install.svg" height="45" alt="pip install vibe-trading-ai"></a>
+</p>
+
+---
+
+## 📰 ニュース
+
+- **2026-04-10** 📦 **v0.1.4**: Dockerビルドを修正（[#8](https://github.com/HKUDS/Vibe-Trading/issues/8)）、`web_search` MCPツールを追加（合計17）、依存関係とMCPに`akshare`/`ccxt`を追加。11のLLMプロバイダー（DeepSeek, Groq, Gemini, Ollama など）、すべての調整パラメータを`.env`で設定可能。`ml-strategy`スキルを強化。PyPIとClawHubに公開。
+- **2026-04-09** 📊 **Backtest Wave 2 — マルチアセットエンジン**: ChinaFutures（CFFEX/SHFE/DCE/ZCE、50+銘柄）、GlobalFutures（CME/ICE/Eurex、30+銘柄）、Forex（24通貨ペア、スプレッド＋スワップ）、Options v2（アメリカン行使、IVスマイル）を追加。統計的検証: モンテカルロ置換検定、ブートストラップSharpe信頼区間、ウォークフォワード分析。
+- **2026-04-08** 🔧 **マルチマーケットバックテスト**（市場別ルール対応）と**TradingView向けPine Script v6エクスポート**。**データソース拡張**: 自動フォールバック付き5ソース、`web_search`ツール、スキル分類（7カテゴリ）。
+- **2026-04-01** 🚀 **v0.1.0** — 初期リリース: ReActエージェント、64スキル、29スウォームプリセット、クロスマーケットバックテスト、CLI + Web UI + MCPサーバー。
+
+---
+
+## 💡 Vibe-Tradingとは？
+
+Vibe-Tradingは、自然言語リクエストをグローバル市場向けの実行可能なトレーディング戦略、リサーチ洞察、ポートフォリオ分析へと変換する、AI駆動のマルチエージェント金融ワークスペースです。
+
+### 主な能力:
+• **Strategy Generation** — アイデアから自動でトレーディングコードを生成<br>
+• **Smart Data Access** — 自動フォールバック付き5つのデータソース、全市場ゼロ設定<br>
+• **Performance Testing** — 歴史的市場データで戦略を検証<br>
+• **TradingView Export** — ワンクリックでTradingView用Pine Script v6に変換<br>
+• **Expert Teams** — 複雑なリサーチタスクに特化したAIエージェントチームを展開<br>
+• **Live Updates** — 分析プロセス全体をリアルタイムで観察
+
+---
+
+## ✨ 主な機能
+
+<table width="100%">
+  <tr>
+    <td align="center" width="25%" valign="top">
+      <img src="assets/scene-research.png" height="150" alt="Research"/><br>
+      <h3>🔍 トレーディング向けDeepResearch</h3>
+      <img src="https://img.shields.io/badge/68_Skills-FF6B6B?style=for-the-badge&logo=bookstack&logoColor=white" alt="Skills" /><br><br>
+      <div align="left" style="font-size: 4px;">
+        • 市場横断のマルチドメイン分析<br>
+        • 自動ストラテジー／シグナル生成<br>
+        • マクロ経済リサーチとインサイト<br>
+        • チャットによる自然言語タスクルーティング
+      </div>
+    </td>
+    <td align="center" width="25%" valign="top">
+      <img src="assets/scene-swarm.png" height="150" alt="Swarm"/><br>
+      <h3>🐝 スウォームインテリジェンス</h3>
+      <img src="https://img.shields.io/badge/29_Trading_Teams-4ECDC4?style=for-the-badge&logo=hive&logoColor=white" alt="Swarm" /><br><br>
+      <div align="left">
+        • 即戦力の29種トレーディングチームプリセット<br>
+        • DAGベースのマルチエージェントオーケストレーション<br>
+        • リアルタイム意思決定ストリーミングダッシュボード<br>
+        • YAMLによるカスタムチーム構築
+      </div>
+    </td>
+    <td align="center" width="25%" valign="top">
+      <img src="assets/scene-backtest.png" height="150" alt="Backtest"/><br>
+      <h3>📊 クロスマーケットバックテスト</h3>
+      <img src="https://img.shields.io/badge/5_Data_Sources-FFD93D?style=for-the-badge&logo=bitcoin&logoColor=black" alt="Backtest" /><br><br>
+      <div align="left">
+        • A株、HK/US株式、暗号資産、先物、FXに対応<br>
+        • 7つの市場エンジン: A株、US/HK株、暗号資産、中国先物、グローバル先物、FX<br>
+        • 統計的検証: モンテカルロ、ブートストラップCI、ウォークフォワード<br>
+        • 15以上のパフォーマンス指標と4種類のオプティマイザー
+      </div>
+    </td>
+    <td align="center" width="25%" valign="top">
+      <img src="assets/scene-quant.png" height="150" alt="Quant"/><br>
+      <h3>🧮 クオンツ分析ツールキット</h3>
+      <img src="https://img.shields.io/badge/Quant_Tools-C77DFF?style=for-the-badge&logo=wolfram&logoColor=white" alt="Quant" /><br><br>
+      <div align="left">
+        • ファクターIC/IR分析と分位バックテスト<br>
+        • ブラック–ショールズ価格と完全なギリシャ計算<br>
+        • テクニカルパターンの認識と検出<br>
+        • MVO/リスクパリティ/BLによるポートフォリオ最適化
+      </div>
+    </td>
+  </tr>
+</table>
+
+## 7カテゴリにわたる68スキル
+
+- 📊 68の金融特化スキルを7カテゴリに整理
+- 🌐 伝統的市場から暗号・DeFiまで完全カバー
+- 🔬 データ取得からクオンツリサーチまでの包括的能力
+
+| Category | Skills | Examples |
+|----------|--------|----------|
+| Data Source | 6 | `data-routing`, `tushare`, `yfinance`, `okx-market`, `akshare`, `ccxt` |
+| Strategy | 16 | `strategy-generate`, `technical-basic`, `candlestick`, `ichimoku`, `elliott-wave`, `smc`, `multi-factor`, `ml-strategy` |
+| Analysis | 15 | `factor-research`, `macro-analysis`, `global-macro`, `valuation-model`, `earnings-forecast`, `credit-analysis` |
+| Asset Class | 9 | `options-strategy`, `options-advanced`, `convertible-bond`, `etf-analysis`, `asset-allocation`, `sector-rotation` |
+| Crypto | 7 | `perp-funding-basis`, `liquidation-heatmap`, `stablecoin-flow`, `defi-yield`, `onchain-analysis` |
+| Flow | 7 | `hk-connect-flow`, `us-etf-flow`, `edgar-sec-filings`, `financial-statement`, `adr-hshare` |
+| Tool | 8 | `backtest-diagnose`, `report-generate`, `pine-script`, `doc-reader`, `web-reader` |
+
+## 29種のエージェントスウォームチームプリセット
+
+- 🏢 即利用できる29種のエージェントチーム
+- ⚡ 事前構成された金融ワークフロー
+- 🎯 投資・トレーディング・リスク管理のプリセット
+
+| Preset | Workflow |
+|--------|----------|
+| `investment_committee` | 強気/弱気ディベート → リスクレビュー → PM最終判断 |
+| `global_equities_desk` | A株 + HK/US + 暗号研究者 → グローバルストラテジスト |
+| `crypto_trading_desk` | ファンディング/ベーシス + 清算 + フロー → リスクマネージャー |
+| `earnings_research_desk` | ファンダメンタル + リビジョン + オプション → 決算ストラテジスト |
+| `macro_rates_fx_desk` | 金利 + FX + コモディティ → マクロPM |
+| `quant_strategy_desk` | スクリーニング + ファクターリサーチ → バックテスト → リスク監査 |
+| `technical_analysis_panel` | クラシックTA + 一目均衡表 + ハーモニック + エリオット + SMC → コンセンサス |
+| `risk_committee` | ドローダウン + テイルリスク + レジームレビュー → サインオフ |
+| `global_allocation_committee` | A株 + 暗号 + HK/US → クロスマーケット配分 |
+
+<sub>さらに20以上の専門プリセット — `vibe-trading --swarm-presets`で全プリセットを確認できます。</sub>
+
+### 🎬 デモ
+
+<div align="center">
+<table>
+<tr>
+<td width="50%">
+
+https://github.com/user-attachments/assets/4e4dcb80-7358-4b9a-92f0-1e29612e6e86
+
+</td>
+<td width="50%">
+
+https://github.com/user-attachments/assets/3754a414-c3ee-464f-b1e8-78e1a74fbd30
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="center"><sub>☝️ 自然言語バックテスト＆マルチエージェントスウォームディベート — Web UI + CLI</sub></td>
+</tr>
+</table>
+</div>
+
+---
+
+## 🚀 クイックスタート
+
+### ワンラインインストール（PyPI）
+
+```bash
+pip install vibe-trading-ai
+```
+
+> **パッケージ名とコマンド:** PyPIパッケージは`vibe-trading-ai`。インストール後に3つのコマンドが使えます:
+>
+> | Command | Purpose |
+> |---------|---------|
+> | `vibe-trading` | 対話型CLI / TUI |
+> | `vibe-trading serve` | FastAPIウェブサーバー起動 |
+> | `vibe-trading-mcp` | MCPサーバー起動（Claude Desktop, OpenClaw, Cursorなど） |
+
+```bash
+vibe-trading init              # 対話的な.envセットアップ
+vibe-trading                   # CLI起動
+vibe-trading serve --port 8899 # Web UI起動
+vibe-trading-mcp               # MCPサーバー（stdio）起動
+```
+
+### 使い方を選ぶ
+
+| Path | Best for | Time |
+|------|----------|------|
+| **A. Docker** | 今すぐ試す、ローカル設定ゼロ | 2分 |
+| **B. Local install** | 開発、フルCLIアクセス | 5分 |
+| **C. MCP plugin** | 既存エージェントへ組み込み | 3分 |
+| **D. ClawHub** | クローン不要のワンコマンド | 1分 |
+
+### 前提条件
+
+- サポートされる任意のプロバイダーの**LLM APIキー** — もしくは**Ollama**でローカル実行（キー不要）
+- Path Bでは**Python 3.11+**
+- Path Aでは**Docker**
+
+> **サポートされるLLMプロバイダー:** OpenRouter, OpenAI, DeepSeek, Gemini, Groq, DashScope/Qwen, Zhipu, Moonshot/Kimi, MiniMax, Xiaomi MIMO, Ollama（ローカル）。設定は`.env.example`を参照。
+
+> **Tip:** すべての市場でAPIキーなしでも動作（自動フォールバック）。yfinance（HK/US）、OKX（暗号）、AKShare（A株・US・HK・先物・FX）は無料。Tushareトークンは任意 — A株はAKShareで無料フォールバック。
+
+### Path A: Docker（セットアップ不要）
+
+```bash
+git clone https://github.com/HKUDS/Vibe-Trading.git
+cd Vibe-Trading
+cp agent/.env.example agent/.env
+# agent/.envを編集 — 利用するLLMプロバイダーのキーを設定
+docker compose up --build
+```
+
+`http://localhost:8899`を開きます。バックエンドとフロントエンドを1コンテナで提供。
+
+### Path B: ローカルインストール
+
+```bash
+git clone https://github.com/HKUDS/Vibe-Trading.git
+cd Vibe-Trading
+python -m venv .venv
+
+# Activate
+source .venv/bin/activate          # Linux / macOS
+# .venv\Scripts\Activate.ps1       # Windows PowerShell
+
+pip install -e .
+cp agent/.env.example agent/.env   # 編集 — LLMプロバイダーのAPIキーを設定
+vibe-trading                       # 対話型TUIを起動
+```
+
+<details>
+<summary><b>Web UIを起動（任意）</b></summary>
+
+```bash
+# Terminal 1: APIサーバー
+vibe-trading serve --port 8899
+
+# Terminal 2: フロントエンド開発サーバー
+cd frontend && npm install && npm run dev
+```
+
+`http://localhost:5899`を開きます。フロントエンドは`localhost:8899`へAPIプロキシします。
+
+**本番モード（単一サーバー）:**
+
+```bash
+cd frontend && npm run build && cd ..
+vibe-trading serve --port 8899     # FastAPIがdist/を静的配信
+```
+
+</details>
+
+### Path C: MCP プラグイン
+
+下記の[MCP プラグイン](#-mcp-プラグイン)セクションを参照。
+
+### Path D: ClawHub（ワンコマンド）
+
+```bash
+npx clawhub@latest install vibe-trading --force
+```
+
+スキル＋MCP設定がエージェントのskillsディレクトリにダウンロードされます。詳細は[MCP プラグイン](#-mcp-プラグイン)を参照。
+
+---
+
+## 🧠 環境変数
+
+`agent/.env.example`を`agent/.env`へコピーし、使いたいプロバイダーのブロックをアンコメント。各プロバイダーは3〜4変数を使用:
+
+| Variable | Required | Description |
+|----------|:--------:|-------------|
+| `LANGCHAIN_PROVIDER` | Yes | プロバイダー名（`openrouter`, `deepseek`, `groq`, `ollama` など） |
+| `<PROVIDER>_API_KEY` | Yes* | APIキー（`OPENROUTER_API_KEY`, `DEEPSEEK_API_KEY` など） |
+| `<PROVIDER>_BASE_URL` | Yes | APIエンドポイントURL |
+| `LANGCHAIN_MODEL_NAME` | Yes | モデル名（例: `deepseek/deepseek-v3.2`） |
+| `TUSHARE_TOKEN` | No | A株データ用Tushare Proトークン（AKShareにフォールバック） |
+| `TIMEOUT_SECONDS` | No | LLM呼び出しタイムアウト（既定120s） |
+
+<sub>* OllamaはAPIキー不要。</sub>
+
+**無料データ（キー不要）:** AKShare経由のA株、yfinance経由のHK/US株式、OKX経由の暗号、CCXT経由の100+暗号取引所。市場ごとに最適なソースを自動選択。
+
+---
+
+## 🖥 CLI リファレンス
+
+```bash
+vibe-trading               # 対話型TUI
+vibe-trading run -p "..."  # シングル実行
+vibe-trading serve         # APIサーバー
+```
+
+<details>
+<summary><b>TUI内スラッシュコマンド</b></summary>
+
+| Command | Description |
+|---------|-------------|
+| `/help` | すべてのコマンドを表示 |
+| `/skills` | 68の金融スキルを一覧表示 |
+| `/swarm` | 29のスウォームチームプリセットを一覧表示 |
+| `/swarm run <preset> [vars_json]` | スウォームチームをライブストリーミングで実行 |
+| `/swarm list` | スウォーム実行履歴 |
+| `/swarm show <run_id>` | スウォーム実行の詳細 |
+| `/swarm cancel <run_id>` | 実行中スウォームをキャンセル |
+| `/list` | 直近の実行 |
+| `/show <run_id>` | 実行詳細と指標 |
+| `/code <run_id>` | 生成された戦略コード |
+| `/pine <run_id>` | TradingView用Pine Script |
+| `/trace <run_id>` | 実行リプレイ |
+| `/continue <run_id> <prompt>` | 実行を新指示で継続 |
+| `/sessions` | チャットセッション一覧 |
+| `/settings` | 実行時設定を表示 |
+| `/clear` | 画面クリア |
+| `/quit` | 終了 |
+</details>
+
+<details>
+<summary><b>単発実行とフラグ</b></summary>
+
+```bash
+vibe-trading run -p "Backtest BTC-USDT MACD strategy, last 30 days"
+vibe-trading run -p "Analyze AAPL momentum" --json
+vibe-trading run -f strategy.txt
+echo "Backtest 000001.SZ RSI" | vibe-trading run
+```
+
+```bash
+vibe-trading -p "your prompt"
+vibe-trading --skills
+vibe-trading --swarm-presets
+vibe-trading --swarm-run investment_committee '{"topic":"BTC outlook"}'
+vibe-trading --list
+vibe-trading --show <run_id>
+vibe-trading --code <run_id>
+vibe-trading --pine <run_id>           # TradingView用Pine Script
+vibe-trading --trace <run_id>
+vibe-trading --continue <run_id> "refine the strategy"
+vibe-trading --upload report.pdf
+```
+
+</details>
+
+---
+
+## 🌐 API サーバー
+
+```bash
+vibe-trading serve --port 8899
+```
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/runs` | 実行一覧 |
+| `GET` | `/runs/{run_id}` | 実行詳細 |
+| `GET` | `/runs/{run_id}/pine` | Pine Scriptエクスポート |
+| `POST` | `/sessions` | セッション作成 |
+| `POST` | `/sessions/{id}/messages` | メッセージ送信 |
+| `GET` | `/sessions/{id}/events` | SSEイベントストリーム |
+| `POST` | `/upload` | PDF/ファイルのアップロード |
+| `GET` | `/swarm/presets` | スウォームプリセット一覧 |
+| `POST` | `/swarm/runs` | スウォーム実行開始 |
+| `GET` | `/swarm/runs/{id}/events` | スウォームSSEストリーム |
+
+インタラクティブドキュメント: `http://localhost:8899/docs`
+
+---
+
+## 🔌 MCP プラグイン
+
+Vibe-Tradingは、あらゆるMCP互換クライアント向けに17のMCPツールを提供します。stdioサブプロセスとして実行 — サーバーセットアップ不要。**17中16ツールはAPIキー不要**（HK/US/暗号）。`run_swarm`のみLLMキーが必要。
+
+<details>
+<summary><b>Claude Desktop</b></summary>
+
+`claude_desktop_config.json`に追加:
+
+```json
+{
+  "mcpServers": {
+    "vibe-trading": {
+      "command": "vibe-trading-mcp"
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary><b>OpenClaw</b></summary>
+
+`~/.openclaw/config.yaml`に追加:
+
+```yaml
+skills:
+  - name: vibe-trading
+    command: vibe-trading-mcp
+```
+
+</details>
+
+<details>
+<summary><b>Cursor / Windsurf / 他MCPクライアント</b></summary>
+
+```bash
+vibe-trading-mcp                  # stdio（デフォルト）
+vibe-trading-mcp --transport sse  # Webクライアント向けSSE
+```
+
+</details>
+
+**公開MCPツール（17）:** `list_skills`, `load_skill`, `backtest`, `factor_analysis`, `analyze_options`, `pattern_recognition`, `get_market_data`, `web_search`, `read_url`, `read_document`, `read_file`, `write_file`, `list_swarm_presets`, `run_swarm`, `get_swarm_status`, `get_run_result`, `list_runs`。
+
+<details>
+<summary><b>ClawHubからインストール（ワンコマンド）</b></summary>
+
+```bash
+npx clawhub@latest install vibe-trading --force
+```
+
+> 外部APIを参照するためVirusTotalの自動スキャンが走るので`--force`が必要。コードは完全オープンソースで検証可能。
+
+スキル＋MCP設定がエージェントのskillsディレクトリにダウンロードされます。クローン不要。
+
+ClawHubで閲覧: [clawhub.ai/skills/vibe-trading](https://clawhub.ai/skills/vibe-trading)
+
+</details>
+
+<details>
+<summary><b>OpenSpace — 自己進化スキル</b></summary>
+
+全68金融スキルは[open-space.cloud](https://open-space.cloud)に公開され、OpenSpaceの自己進化エンジンで自律的に進化します。
+
+OpenSpaceで使うには、両方のMCPサーバーをエージェント設定に追加:
+
+```json
+{
+  "mcpServers": {
+    "openspace": {
+      "command": "openspace-mcp",
+      "toolTimeout": 600,
+      "env": {
+        "OPENSPACE_HOST_SKILL_DIRS": "/path/to/vibe-trading/agent/src/skills",
+        "OPENSPACE_WORKSPACE": "/path/to/OpenSpace"
+      }
+    },
+    "vibe-trading": {
+      "command": "vibe-trading-mcp"
+    }
+  }
+}
+```
+
+OpenSpaceが全68スキルを自動検出し、auto-fix/auto-improve/コミュニティ共有を有効化。`search_skills("finance backtest")`でVibe-Tradingスキルを検索可能。
+
+</details>
+
+---
+
+## 📁 プロジェクト構成
+
+<details>
+<summary><b>クリックして展開</b></summary>
+
+```
+Vibe-Trading/
+├── agent/                          # バックエンド (Python)
+│   ├── cli.py                      # CLIエントリーポイント — 対話型TUI + サブコマンド
+│   ├── api_server.py               # FastAPIサーバー — runs, sessions, upload, swarm, SSE
+│   ├── mcp_server.py               # MCPサーバー — OpenClaw / Claude Desktop向け17ツール
+│   │
+│   ├── src/
+│   │   ├── agent/                  # ReActエージェントコア
+│   │   │   ├── loop.py             #   メイン推論ループ
+│   │   │   ├── skills.py           #   スキルローダー（68 SKILL.md, 7カテゴリ）
+│   │   │   ├── tools.py            #   ツールオーケストレーション
+│   │   │   ├── context.py          #   システムプロンプトビルダー
+│   │   │   ├── memory.py           #   実行メモリ / アーティファクトストア
+│   │   │   └── trace.py            #   実行トレースライター
+│   │   │
+│   │   ├── tools/                  # 21のエージェントツール
+│   │   │   ├── backtest_tool.py    #   バックテスト実行
+│   │   │   ├── factor_analysis_tool.py
+│   │   │   ├── options_pricing_tool.py
+│   │   │   ├── pattern_tool.py     #   チャートパターン検出
+│   │   │   ├── doc_reader_tool.py  #   PDFリーダー（OCRフォールバック）
+│   │   │   ├── web_reader_tool.py  #   webページリーダー（Jina）
+│   │   │   ├── web_search_tool.py  #   DuckDuckGoウェブ検索
+│   │   │   ├── swarm_tool.py       #   スウォームチーム起動
+│   │   │   └── ...                 #   ファイルI/O, bash, tasks など
+│   │   │
+│   │   ├── skills/                 # 7カテゴリに渡る68金融スキル (各SKILL.md)
+│   │   ├── swarm/                  # スウォームDAG実行エンジン
+│   │   ├── session/                # マルチターンチャットセッション管理
+│   │   └── providers/              # LLMプロバイダー抽象化
+│   │
+│   ├── backtest/                   # バックテストエンジン
+│   │   ├── engines/                #   7エンジン: china_a, global_equity, crypto, china_futures, global_futures, forex + options_portfolio
+│   │   ├── loaders/                #   5ソース: tushare, okx, yfinance, akshare, ccxt
+│   │   │   ├── base.py             #   DataLoader Protocol
+│   │   │   └── registry.py         #   レジストリ + 自動フォールバックチェーン
+│   │   └── optimizers/             #   MVO, equal vol, max div, risk parity
+│   │
+│   └── config/swarm/               # 29のスウォームプリセットYAML定義
+│
+├── frontend/                       # Web UI (React 19 + Vite + TypeScript)
+│   └── src/
+│       ├── pages/                  #   Home, Agent, RunDetail, Compare
+│       ├── components/             #   chat, charts, layout
+│       └── stores/                 #   Zustandステート管理
+│
+├── Dockerfile                      # マルチステージビルド
+├── docker-compose.yml              # ワンコマンドデプロイ
+├── pyproject.toml                  # パッケージ設定 + CLIエントリーポイント
+└── LICENSE                         # MIT
+```
+
+</details>
+
+---
+
+## 🏛 エコシステム
+
+Vibe-Tradingは**[HKUDS](https://github.com/HKUDS)**エージェントエコシステムの一部です:
+
+<table>
+  <tr>
+    <td align="center" width="25%">
+      <a href="https://github.com/HKUDS/ClawTeam"><b>ClawTeam</b></a><br>
+      <sub>エージェントスウォームインテリジェンス</sub>
+    </td>
+    <td align="center" width="25%">
+      <a href="https://github.com/HKUDS/nanobot"><b>NanoBot</b></a><br>
+      <sub>超軽量パーソナルAIアシスタント</sub>
+    </td>
+    <td align="center" width="25%">
+      <a href="https://github.com/HKUDS/CLI-Anything"><b>CLI-Anything</b></a><br>
+      <sub>すべてのソフトウェアをエージェントネイティブに</sub>
+    </td>
+    <td align="center" width="25%">
+      <a href="https://github.com/HKUDS/OpenSpace"><b>OpenSpace</b></a><br>
+      <sub>自己進化型AIエージェントスキル</sub>
+    </td>
+  </tr>
+</table>
+
+---
+
+## 🗺 ロードマップ
+
+> 段階的にリリースします。作業開始時に[Issues](https://github.com/HKUDS/Vibe-Trading/issues)へ移動します。
+
+| Phase | Feature | Status |
+|-------|---------|--------|
+| **Analysis & Viz** | オプションボラティリティサーフェスとギリシャ値3D可視化 | Planned |
+| | ローリングウィンドウ＋クラスタリングによるクロスアセット相関ヒートマップ | Planned |
+| | CLIバックテスト出力でのベンチマーク比較 | Planned |
+| | バックテスト指標へのCalmar Ratio & Omega Ratio追加 | Planned |
+| **Skills & Presets** | 配当分析スキル | Planned |
+| | ESG/サステナブル投資スウォームプリセット | Planned |
+| | 新興市場リサーチデスクスウォームプリセット | Planned |
+| **Portfolio & Optimization** | レバレッジ・セクター上限・回転率制約付き高度ポートフォリオオプティマイザー | Planned |
+| **Future** | 初心者チュートリアル: 「5分で自然言語バックテスト」 | Planned |
+| | WebSocket経由のライブデータストリーミング | Exploring |
+| | ストラテジーマーケットプレイス（共有・発見） | Exploring |
+
+---
+
+## 貢献
+
+貢献を歓迎します！ガイドラインは[CONTRIBUTING.md](CONTRIBUTING.md)を参照してください。
+
+**Good first issues**は[`good first issue`](https://github.com/HKUDS/Vibe-Trading/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)タグ付き — どれか選んで始めてください。
+
+より大きな貢献を検討中ですか？上記[ロードマップ](#-ロードマップ)を確認し、着手前にIssueで相談してください。
+
+---
+
+## 免責事項
+
+Vibe-Tradingはリサーチ・シミュレーション・バックテスト用途のみです。投資助言ではなく、リアルトレードを実行しません。過去の実績は将来の結果を保証しません。
+
+## ライセンス
+
+MIT License — [LICENSE](LICENSE)を参照
+
+---
+
+<p align="center">
+  <b>Vibe-Trading</b>への訪問に感謝 ✨
+</p>
+<p align="center">
+  <img src="https://visitor-badge.laobi.icu/badge?page_id=HKUDS.Vibe-Trading&style=flat" alt="visitors"/>
+</p>

--- a/README_ko.md
+++ b/README_ko.md
@@ -1,0 +1,620 @@
+<p align="center">
+  <a href="README.md">English</a> | <a href="README_zh.md">中文</a> | <a href="README_ja.md">日本語</a> | <b>한국어</b>
+</p>
+
+<p align="center">
+  <img src="assets/icon.png" width="120" alt="Vibe-Trading 로고"/>
+</p>
+
+<h1 align="center">Vibe-Trading: 당신의 개인 트레이딩 에이전트</h1>
+
+<p align="center">
+  <b>한 번의 명령으로 에이전트를 종합 트레이딩 기능으로 강화</b>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Python-3.11%2B-3776AB?style=flat&logo=python&logoColor=white" alt="Python">
+  <img src="https://img.shields.io/badge/Backend-FastAPI-009688?style=flat" alt="FastAPI">
+  <img src="https://img.shields.io/badge/Frontend-React%2019-61DAFB?style=flat&logo=react&logoColor=white" alt="React">
+  <a href="https://pypi.org/project/vibe-trading-ai/"><img src="https://img.shields.io/pypi/v/vibe-trading-ai?style=flat&logo=pypi&logoColor=white" alt="PyPI"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow?style=flat" alt="License"></a>
+  <br>
+  <img src="https://img.shields.io/badge/Skills-68-orange" alt="Skills">
+  <img src="https://img.shields.io/badge/Swarm_Presets-29-7C3AED" alt="Swarm">
+  <img src="https://img.shields.io/badge/Tools-21-0F766E" alt="Tools">
+  <img src="https://img.shields.io/badge/Data_Sources-5-2563EB" alt="Data Sources">
+  <br>
+  <a href="https://github.com/HKUDS/.github/blob/main/profile/README.md"><img src="https://img.shields.io/badge/Feishu-Group-E9DBFC?style=flat-square&logo=feishu&logoColor=white" alt="Feishu"></a>
+  <a href="https://github.com/HKUDS/.github/blob/main/profile/README.md"><img src="https://img.shields.io/badge/WeChat-Group-C5EAB4?style=flat-square&logo=wechat&logoColor=white" alt="WeChat"></a>
+  <a href="https://discord.gg/2vDYc2w5"><img src="https://img.shields.io/badge/Discord-Join-7289DA?style=flat-square&logo=discord&logoColor=white" alt="Discord"></a>
+</p>
+
+<p align="center">
+  <a href="#-주요-기능">기능</a> &nbsp;&middot;&nbsp;
+  <a href="#-데모">데모</a> &nbsp;&middot;&nbsp;
+  <a href="#-vibe-trading이란">개요</a> &nbsp;&middot;&nbsp;
+  <a href="#-빠른-시작">시작하기</a> &nbsp;&middot;&nbsp;
+  <a href="#-cli-참조">CLI</a> &nbsp;&middot;&nbsp;
+  <a href="#-api-서버">API</a> &nbsp;&middot;&nbsp;
+  <a href="#-mcp-플러그인">MCP</a> &nbsp;&middot;&nbsp;
+  <a href="#-프로젝트-구조">구조</a> &nbsp;&middot;&nbsp;
+  <a href="#-로드맵">로드맵</a> &nbsp;&middot;&nbsp;
+  <a href="#기여하기">기여</a>
+</p>
+
+<p align="center">
+  <a href="#-빠른-시작"><img src="assets/pip-install.svg" height="45" alt="pip install vibe-trading-ai"></a>
+</p>
+
+---
+
+## 📰 뉴스
+
+- **2026-04-10** 📦 **v0.1.4**: Docker 빌드 수정([#8](https://github.com/HKUDS/Vibe-Trading/issues/8)), `web_search` MCP 도구 추가(총 17개), 의존성 및 MCP에 `akshare`/`ccxt` 추가. 11개 LLM 제공자(DeepSeek, Groq, Gemini, Ollama 등), 모든 튜닝 파라미터를 `.env`로 설정. `ml-strategy` 스킬 하드닝. PyPI와 ClawHub에 게시.
+- **2026-04-09** 📊 **Backtest Wave 2 — 멀티자산 엔진**: ChinaFutures(CFFEX/SHFE/DCE/ZCE, 50+ 종목), GlobalFutures(CME/ICE/Eurex, 30+ 종목), Forex(24 페어, 스프레드 + 스왑), Options v2(미국형 행사, IV 스마일) 추가. 통계 검증: 몬테카를로 순열 테스트, Bootstrap 샤프 CI, 워크포워드 분석.
+- **2026-04-08** 🔧 **다중 시장 백테스트**: 시장별 규칙, TradingView용 **Pine Script v6 내보내기**. **데이터 소스 확장**: 자동 폴백 포함 5개 소스, `web_search` 도구, 스킬 7개 카테고리화.
+- **2026-04-01** 🚀 **v0.1.0** — 초기 릴리스: ReAct 에이전트, 64 스킬, 29 스웜 프리셋, 크로스마켓 백테스트, CLI + Web UI + MCP 서버.
+
+---
+
+## 💡 Vibe-Trading이란?
+
+Vibe-Trading은 AI 기반 멀티 에이전트 금융 워크스페이스로, 자연어 요청을 전 세계 시장의 실행 가능한 트레이딩 전략, 리서치 인사이트, 포트폴리오 분석으로 전환합니다.
+
+### 핵심 역량:
+• **전략 생성** — 아이디어를 자동으로 트레이딩 코드로 작성<br>
+• **스마트 데이터 접근** — 자동 폴백이 있는 5개 데이터 소스; 모든 시장 무설정<br>
+• **성능 테스트** — 전략을 과거 시장 데이터로 검증<br>
+• **TradingView 내보내기** — 클릭 한 번으로 전략을 Pine Script v6로 변환<br>
+• **전문 팀** — 복잡한 리서치 작업에 특화 에이전트 팀 배치<br>
+• **실시간 업데이트** — 전체 분석 과정을 실시간 스트리밍
+
+---
+
+## ✨ 주요 기능
+
+<table width="100%">
+  <tr>
+    <td align="center" width="25%" valign="top">
+      <img src="assets/scene-research.png" height="150" alt="Research"/><br>
+      <h3>🔍 트레이딩용 DeepResearch</h3>
+      <img src="https://img.shields.io/badge/68_Skills-FF6B6B?style=for-the-badge&logo=bookstack&logoColor=white" alt="Skills" /><br><br>
+      <div align="left" style="font-size: 4px;">
+        • 시장 전반을 아우르는 다중 도메인 분석<br>
+        • 자동 전략 및 시그널 생성<br>
+        • 거시경제 리서치와 인사이트<br>
+        • 대화형 자연어 태스크 라우팅
+      </div>
+    </td>
+    <td align="center" width="25%" valign="top">
+      <img src="assets/scene-swarm.png" height="150" alt="Swarm"/><br>
+      <h3>🐝 스웜 인텔리전스</h3>
+      <img src="https://img.shields.io/badge/29_Trading_Teams-4ECDC4?style=for-the-badge&logo=hive&logoColor=white" alt="Swarm" /><br><br>
+      <div align="left">
+        • 29개 즉시 사용 가능한 트레이딩 팀 프리셋<br>
+        • DAG 기반 멀티 에이전트 오케스트레이션<br>
+        • 실시간 의사결정 스트리밍 대시보드<br>
+        • YAML을 통한 커스텀 팀 구성
+      </div>
+    </td>
+    <td align="center" width="25%" valign="top">
+      <img src="assets/scene-backtest.png" height="150" alt="Backtest"/><br>
+      <h3>📊 크로스마켓 백테스트</h3>
+      <img src="https://img.shields.io/badge/5_Data_Sources-FFD93D?style=for-the-badge&logo=bitcoin&logoColor=black" alt="Backtest" /><br><br>
+      <div align="left">
+        • A주, 홍콩/미국 주식, 크립토, 선물 및 FX<br>
+        • 7개 시장 엔진: A주, 미/홍콩 주식, 크립토, 중국 선물, 글로벌 선물, FX<br>
+        • 통계 검증: 몬테카를로, Bootstrap CI, 워크포워드<br>
+        • 15+ 성과 지표 및 4개 옵티마이저
+      </div>
+    </td>
+    <td align="center" width="25%" valign="top">
+      <img src="assets/scene-quant.png" height="150" alt="Quant"/><br>
+      <h3>🧮 퀀트 분석 툴킷</h3>
+      <img src="https://img.shields.io/badge/Quant_Tools-C77DFF?style=for-the-badge&logo=wolfram&logoColor=white" alt="Quant" /><br><br>
+      <div align="left">
+        • 팩터 IC/IR 분석 및 분위 백테스트<br>
+        • 블랙-숄즈 가격 산출 및 풀 그릭스 계산<br>
+        • 기술적 패턴 인식 및 감지<br>
+        • MVO/리스크 패리티/BL 기반 포트폴리오 최적화
+      </div>
+    </td>
+  </tr>
+</table>
+
+## 7개 카테고리에 걸친 68개 스킬
+
+- 📊 7개 카테고리에 조직된 68개 금융 스킬
+- 🌐 전통 시장부터 크립토·DeFi까지 완전 커버리지
+- 🔬 데이터 소싱부터 정량 리서치까지 포괄적 기능
+
+| 카테고리 | 스킬 | 예시 |
+|----------|------|------|
+| Data Source | 6 | `data-routing`, `tushare`, `yfinance`, `okx-market`, `akshare`, `ccxt` |
+| Strategy | 16 | `strategy-generate`, `technical-basic`, `candlestick`, `ichimoku`, `elliott-wave`, `smc`, `multi-factor`, `ml-strategy` |
+| Analysis | 15 | `factor-research`, `macro-analysis`, `global-macro`, `valuation-model`, `earnings-forecast`, `credit-analysis` |
+| Asset Class | 9 | `options-strategy`, `options-advanced`, `convertible-bond`, `etf-analysis`, `asset-allocation`, `sector-rotation` |
+| Crypto | 7 | `perp-funding-basis`, `liquidation-heatmap`, `stablecoin-flow`, `defi-yield`, `onchain-analysis` |
+| Flow | 7 | `hk-connect-flow`, `us-etf-flow`, `edgar-sec-filings`, `financial-statement`, `adr-hshare` |
+| Tool | 8 | `backtest-diagnose`, `report-generate`, `pine-script`, `doc-reader`, `web-reader` |
+
+## 29개 에이전트 스웜 팀 프리셋
+
+- 🏢 29개 즉시 사용 가능한 에이전트 팀
+- ⚡ 사전 구성된 금융 워크플로우
+- 🎯 투자, 트레이딩 및 리스크 관리 프리셋
+
+| 프리셋 | 워크플로우 |
+|--------|------------|
+| `investment_committee` | 불/베어 토론 → 리스크 리뷰 → PM 최종 결정 |
+| `global_equities_desk` | A주 + HK/US + 크립토 리서처 → 글로벌 전략가 |
+| `crypto_trading_desk` | 펀딩/베이시스 + 청산 + 플로우 → 리스크 매니저 |
+| `earnings_research_desk` | 펀더멘털 + 리비전 + 옵션 → 실적 전략가 |
+| `macro_rates_fx_desk` | 금리 + FX + 원자재 → 매크로 PM |
+| `quant_strategy_desk` | 스크리닝 + 팩터 리서치 → 백테스트 → 리스크 감사 |
+| `technical_analysis_panel` | 클래식 TA + 일목균형표 + 하모닉 + 엘리엇 + SMC → 컨센서스 |
+| `risk_committee` | 드로다운 + 테일 리스크 + 레짐 리뷰 → 승인 |
+| `global_allocation_committee` | A주 + 크립토 + HK/US → 크로스마켓 배분 |
+
+<sub>추가로 20+ 특화 프리셋 — 모든 항목은 vibe-trading --swarm-presets로 확인.</sub>
+
+### 🎬 데모
+
+<div align="center">
+<table>
+<tr>
+<td width="50%">
+
+https://github.com/user-attachments/assets/4e4dcb80-7358-4b9a-92f0-1e29612e6e86
+
+</td>
+<td width="50%">
+
+https://github.com/user-attachments/assets/3754a414-c3ee-464f-b1e8-78e1a74fbd30
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="center"><sub>☝️ 자연어 백테스트 & 멀티 에이전트 스웜 토론 — Web UI + CLI</sub></td>
+</tr>
+</table>
+</div>
+
+---
+
+## 🚀 빠른 시작
+
+### 한 줄 설치 (PyPI)
+
+```bash
+pip install vibe-trading-ai
+```
+
+> **패키지 이름 vs 명령:** PyPI 패키지는 `vibe-trading-ai`입니다. 설치하면 세 가지 명령을 얻습니다:
+>
+> | Command | Purpose |
+> |---------|---------|
+> | `vibe-trading` | 인터랙티브 CLI / TUI |
+> | `vibe-trading serve` | FastAPI 웹 서버 실행 |
+> | `vibe-trading-mcp` | MCP 서버 시작(Claude Desktop, OpenClaw, Cursor 등) |
+
+```bash
+vibe-trading init              # 인터랙티브 .env 설정
+vibe-trading                   # CLI 실행
+vibe-trading serve --port 8899 # 웹 UI 실행
+vibe-trading-mcp               # MCP 서버 시작(stdio)
+```
+
+### 또는 경로 선택
+
+| Path | 최적 용도 | 소요 시간 |
+|------|-----------|-----------|
+| **A. Docker** | 즉시 체험, 로컬 설정 없음 | 2분 |
+| **B. Local install** | 개발, 전체 CLI 접근 | 5분 |
+| **C. MCP plugin** | 기존 에이전트에 플러그인 | 3분 |
+| **D. ClawHub** | 한 줄 설치, 클론 불필요 | 1분 |
+
+### 사전 요구사항
+
+- 지원 제공자의 **LLM API 키** — 또는 **Ollama** 로컬 실행(키 불필요)
+- 경로 B용 **Python 3.11+**
+- 경로 A용 **Docker**
+
+> **지원 LLM 제공자:** OpenRouter, OpenAI, DeepSeek, Gemini, Groq, DashScope/Qwen, Zhipu, Moonshot/Kimi, MiniMax, Xiaomi MIMO, Ollama(로컬). 설정은 `.env.example` 참고.
+
+> **팁:** 모든 시장은 자동 폴백 덕분에 API 키 없이도 작동합니다. yfinance(HK/US), OKX(크립토), AKShare(A주, 미국, HK, 선물, FX)는 모두 무료입니다. Tushare 토큰은 선택 사항 — AKShare가 A주 무료 폴백을 제공합니다.
+
+### 경로 A: Docker (설정 불필요)
+
+```bash
+git clone https://github.com/HKUDS/Vibe-Trading.git
+cd Vibe-Trading
+cp agent/.env.example agent/.env
+# agent/.env 수정 — 사용할 LLM 제공자를 주석 해제하고 API 키 설정
+docker compose up --build
+```
+
+`http://localhost:8899`를 엽니다. 백엔드 + 프런트엔드가 하나의 컨테이너에 있습니다.
+
+### 경로 B: 로컬 설치
+
+```bash
+git clone https://github.com/HKUDS/Vibe-Trading.git
+cd Vibe-Trading
+python -m venv .venv
+
+# 활성화
+source .venv/bin/activate          # Linux / macOS
+# .venv\Scripts\Activate.ps1       # Windows PowerShell
+
+pip install -e .
+cp agent/.env.example agent/.env   # 편집 — LLM 제공자 API 키 설정
+vibe-trading                       # 인터랙티브 TUI 실행
+```
+
+<details>
+<summary><b>웹 UI 시작(선택 사항)</b></summary>
+
+```bash
+# 터미널 1: API 서버
+vibe-trading serve --port 8899
+
+# 터미널 2: 프런트엔드 개발 서버
+cd frontend && npm install && npm run dev
+```
+
+`http://localhost:5899`를 엽니다. 프런트엔드는 `localhost:8899`로 API를 프록시합니다.
+
+**프로덕션 모드(단일 서버):**
+
+```bash
+cd frontend && npm run build && cd ..
+vibe-trading serve --port 8899     # FastAPI가 dist/를 정적 파일로 서빙
+```
+
+</details>
+
+### 경로 C: MCP 플러그인
+
+아래 [MCP 플러그인](#-mcp-플러그인) 섹션을 참조하세요.
+
+### 경로 D: ClawHub (한 줄)
+
+```bash
+npx clawhub@latest install vibe-trading --force
+```
+
+스킬과 MCP 설정이 에이전트의 스킬 디렉터리에 다운로드됩니다. 자세한 내용은 [ClawHub 설치](#-mcp-플러그인)를 참고하세요.
+
+---
+
+## 🧠 환경 변수
+
+`agent/.env.example`을 `agent/.env`로 복사하고 원하는 제공자 블록의 주석을 해제하세요. 각 제공자에 3~4개의 변수가 필요합니다:
+
+| Variable | Required | Description |
+|----------|:--------:|-------------|
+| `LANGCHAIN_PROVIDER` | Yes | 제공자 이름(`openrouter`, `deepseek`, `groq`, `ollama` 등) |
+| `<PROVIDER>_API_KEY` | Yes* | API 키(`OPENROUTER_API_KEY`, `DEEPSEEK_API_KEY` 등) |
+| `<PROVIDER>_BASE_URL` | Yes | API 엔드포인트 URL |
+| `LANGCHAIN_MODEL_NAME` | Yes | 모델 이름(예: `deepseek/deepseek-v3.2`) |
+| `TUSHARE_TOKEN` | No | A주 데이터용 Tushare Pro 토큰(AKShare 폴백) |
+| `TIMEOUT_SECONDS` | No | LLM 호출 타임아웃, 기본 120초 |
+
+<sub>* Ollama는 API 키가 필요 없습니다.</sub>
+
+**무료 데이터(키 불필요):** AKShare의 A주, yfinance의 HK/US 주식, OKX의 크립토, CCXT의 100+ 크립토 거래소. 시스템이 시장별로 최적 소스를 자동 선택합니다.
+
+---
+
+## 🖥 CLI 참조
+
+```bash
+vibe-trading               # 인터랙티브 TUI
+vibe-trading run -p "..."  # 단일 실행
+vibe-trading serve         # API 서버
+```
+
+<details>
+<summary><b>TUI 내 슬래시 명령</b></summary>
+
+| Command | Description |
+|---------|-------------|
+| `/help` | 모든 명령 표시 |
+| `/skills` | 68개 금융 스킬 목록 |
+| `/swarm` | 29개 스웜 팀 프리셋 목록 |
+| `/swarm run <preset> [vars_json]` | 라이브 스트리밍으로 스웜 팀 실행 |
+| `/swarm list` | 스웜 실행 이력 |
+| `/swarm show <run_id>` | 스웜 실행 상세 |
+| `/swarm cancel <run_id>` | 실행 중인 스웜 취소 |
+| `/list` | 최근 실행 |
+| `/show <run_id>` | 실행 상세 + 지표 |
+| `/code <run_id>` | 생성된 전략 코드 |
+| `/pine <run_id>` | TradingView용 Pine Script |
+| `/trace <run_id>` | 전체 실행 리플레이 |
+| `/continue <run_id> <prompt>` | 새 지시로 실행 계속 |
+| `/sessions` | 채팅 세션 목록 |
+| `/settings` | 런타임 설정 표시 |
+| `/clear` | 화면 지우기 |
+| `/quit` | 종료 |
+
+</details>
+
+<details>
+<summary><b>단일 실행 & 플래그</b></summary>
+
+```bash
+vibe-trading run -p "Backtest BTC-USDT MACD strategy, last 30 days"
+vibe-trading run -p "Analyze AAPL momentum" --json
+vibe-trading run -f strategy.txt
+echo "Backtest 000001.SZ RSI" | vibe-trading run
+```
+
+```bash
+vibe-trading -p "your prompt"
+vibe-trading --skills
+vibe-trading --swarm-presets
+vibe-trading --swarm-run investment_committee '{"topic":"BTC outlook"}'
+vibe-trading --list
+vibe-trading --show <run_id>
+vibe-trading --code <run_id>
+vibe-trading --pine <run_id>           # Pine Script for TradingView
+vibe-trading --trace <run_id>
+vibe-trading --continue <run_id> "refine the strategy"
+vibe-trading --upload report.pdf
+```
+
+</details>
+
+---
+
+## 🌐 API 서버
+
+```bash
+vibe-trading serve --port 8899
+```
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/runs` | 실행 목록 |
+| `GET` | `/runs/{run_id}` | 실행 상세 |
+| `GET` | `/runs/{run_id}/pine` | Pine Script 내보내기 |
+| `POST` | `/sessions` | 세션 생성 |
+| `POST` | `/sessions/{id}/messages` | 메시지 전송 |
+| `GET` | `/sessions/{id}/events` | SSE 이벤트 스트림 |
+| `POST` | `/upload` | PDF/파일 업로드 |
+| `GET` | `/swarm/presets` | 스웜 프리셋 목록 |
+| `POST` | `/swarm/runs` | 스웜 실행 시작 |
+| `GET` | `/swarm/runs/{id}/events` | 스웜 SSE 스트림 |
+
+인터랙티브 문서: `http://localhost:8899/docs`
+
+---
+
+## 🔌 MCP 플러그인
+
+Vibe-Trading은 MCP 호환 클라이언트용 17개 MCP 도구를 제공합니다. stdio 서브프로세스로 실행 — 서버 설정 불필요. **17개 중 16개 도구는 API 키 없이 작동**(HK/US/크립토). `run_swarm`만 LLM 키가 필요합니다.
+
+<details>
+<summary><b>Claude Desktop</b></summary>
+
+`claude_desktop_config.json`에 추가:
+
+```json
+{
+  "mcpServers": {
+    "vibe-trading": {
+      "command": "vibe-trading-mcp"
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary><b>OpenClaw</b></summary>
+
+`~/.openclaw/config.yaml`에 추가:
+
+```yaml
+skills:
+  - name: vibe-trading
+    command: vibe-trading-mcp
+```
+
+</details>
+
+<details>
+<summary><b>Cursor / Windsurf / 기타 MCP 클라이언트</b></summary>
+
+```bash
+vibe-trading-mcp                  # stdio (default)
+vibe-trading-mcp --transport sse  # 웹 클라이언트용 SSE
+```
+
+</details>
+
+**제공 MCP 도구(17):** `list_skills`, `load_skill`, `backtest`, `factor_analysis`, `analyze_options`, `pattern_recognition`, `get_market_data`, `web_search`, `read_url`, `read_document`, `read_file`, `write_file`, `list_swarm_presets`, `run_swarm`, `get_swarm_status`, `get_run_result`, `list_runs`.
+
+<details>
+<summary><b>ClawHub에서 설치(한 줄)</b></summary>
+
+```bash
+npx clawhub@latest install vibe-trading --force
+```
+
+> 외부 API를 참조하는 스킬이 있어 VirusTotal 자동 스캔이 트리거되므로 `--force`가 필요합니다. 코드는 완전 오픈소스이며 검토 가능합니다.
+
+이 명령은 스킬과 MCP 설정을 에이전트의 스킬 디렉터리에 다운로드합니다. 클론이 필요 없습니다.
+
+ClawHub에서 보기: [clawhub.ai/skills/vibe-trading](https://clawhub.ai/skills/vibe-trading)
+
+</details>
+
+<details>
+<summary><b>OpenSpace — 자가 진화 스킬</b></summary>
+
+모든 68개 금융 스킬은 [open-space.cloud](https://open-space.cloud)에 게시되어 OpenSpace의 자가 진화 엔진을 통해 스스로 발전합니다.
+
+OpenSpace와 함께 사용하려면 두 MCP 서버를 에이전트 설정에 추가하세요:
+
+```json
+{
+  "mcpServers": {
+    "openspace": {
+      "command": "openspace-mcp",
+      "toolTimeout": 600,
+      "env": {
+        "OPENSPACE_HOST_SKILL_DIRS": "/path/to/vibe-trading/agent/src/skills",
+        "OPENSPACE_WORKSPACE": "/path/to/OpenSpace"
+      }
+    },
+    "vibe-trading": {
+      "command": "vibe-trading-mcp"
+    }
+  }
+}
+```
+
+OpenSpace는 모든 68개 스킬을 자동으로 탐지하여 자동 수정, 자동 개선, 커뮤니티 공유를 활성화합니다. OpenSpace 연결 에이전트에서 `search_skills("finance backtest")`로 Vibe-Trading 스킬을 검색하세요.
+
+</details>
+
+---
+
+## 📁 프로젝트 구조
+
+<details>
+<summary><b>클릭하여 펼치기</b></summary>
+
+```
+Vibe-Trading/
+├── agent/                          # Backend (Python)
+│   ├── cli.py                      # CLI 엔트리포인트 — 인터랙티브 TUI + 서브커맨드
+│   ├── api_server.py               # FastAPI 서버 — 실행, 세션, 업로드, 스웜, SSE
+│   ├── mcp_server.py               # MCP 서버 — OpenClaw / Claude Desktop용 17개 도구
+│   │
+│   ├── src/
+│   │   ├── agent/                  # ReAct 에이전트 코어
+│   │   │   ├── loop.py             #   메인 추론 루프
+│   │   │   ├── skills.py           #   스킬 로더(68 SKILL.md, 7 카테고리)
+│   │   │   ├── tools.py            #   도구 오케스트레이션
+│   │   │   ├── context.py          #   시스템 프롬프트 빌더
+│   │   │   ├── memory.py           #   실행 메모리 / 아티팩트 저장소
+│   │   │   └── trace.py            #   실행 트레이스 기록기
+│   │   │
+│   │   ├── tools/                  # 21개 에이전트 도구
+│   │   │   ├── backtest_tool.py    #   백테스트 실행
+│   │   │   ├── factor_analysis_tool.py
+│   │   │   ├── options_pricing_tool.py
+│   │   │   ├── pattern_tool.py     #   차트 패턴 감지
+│   │   │   ├── doc_reader_tool.py  #   PDF 리더(OCR 폴백)
+│   │   │   ├── web_reader_tool.py  #   웹 페이지 리더(Jina)
+│   │   │   ├── web_search_tool.py  #   DuckDuckGo 웹 검색
+│   │   │   ├── swarm_tool.py       #   스웜 팀 실행
+│   │   │   └── ...                 #   파일 I/O, bash, 태스크 등
+│   │   │
+│   │   ├── skills/                 # 7개 카테고리의 68개 금융 스킬(SKILL.md 각각)
+│   │   ├── swarm/                  # 스웜 DAG 실행 엔진
+│   │   ├── session/                # 멀티턴 채팅 세션 관리
+│   │   └── providers/              # LLM 제공자 추상화
+│   │
+│   ├── backtest/                   # 백테스트 엔진
+│   │   ├── engines/                #   7개 엔진: china_a, global_equity, crypto, china_futures, global_futures, forex + options_portfolio
+│   │   ├── loaders/                #   5개 소스: tushare, okx, yfinance, akshare, ccxt
+│   │   │   ├── base.py             #   DataLoader Protocol
+│   │   │   └── registry.py         #   레지스트리 + 자동 폴백 체인
+│   │   └── optimizers/             #   MVO, equal vol, max div, risk parity
+│   │
+│   └── config/swarm/               # 29개 스웜 프리셋 YAML 정의
+│
+├── frontend/                       # Web UI (React 19 + Vite + TypeScript)
+│   └── src/
+│       ├── pages/                  #   Home, Agent, RunDetail, Compare
+│       ├── components/             #   chat, charts, layout
+│       └── stores/                 #   Zustand 상태 관리
+│
+├── Dockerfile                      # 멀티 스테이지 빌드
+├── docker-compose.yml              # 원커맨드 배포
+├── pyproject.toml                  # 패키지 설정 + CLI 엔트리포인트
+└── LICENSE                         # MIT
+```
+
+</details>
+
+---
+
+## 🏛 생태계
+
+Vibe-Trading은 **[HKUDS](https://github.com/HKUDS)** 에이전트 생태계의 일부입니다:
+
+<table>
+  <tr>
+    <td align="center" width="25%">
+      <a href="https://github.com/HKUDS/ClawTeam"><b>ClawTeam</b></a><br>
+      <sub>에이전트 스웜 인텔리전스</sub>
+    </td>
+    <td align="center" width="25%">
+      <a href="https://github.com/HKUDS/nanobot"><b>NanoBot</b></a><br>
+      <sub>초경량 개인 AI 어시스턴트</sub>
+    </td>
+    <td align="center" width="25%">
+      <a href="https://github.com/HKUDS/CLI-Anything"><b>CLI-Anything</b></a><br>
+      <sub>모든 소프트웨어를 에이전트 네이티브로</sub>
+    </td>
+    <td align="center" width="25%">
+      <a href="https://github.com/HKUDS/OpenSpace"><b>OpenSpace</b></a><br>
+      <sub>자가 진화 AI 에이전트 스킬</sub>
+    </td>
+  </tr>
+</table>
+
+---
+
+## 🗺 로드맵
+
+> 단계적으로 배포합니다. 작업이 시작되면 항목이 [Issues](https://github.com/HKUDS/Vibe-Trading/issues)로 이동합니다.
+
+| Phase | Feature | Status |
+|-------|---------|--------|
+| **Analysis & Viz** | 옵션 변동성 서피스 및 그릭스 3D 시각화 | Planned |
+| | 롤링 윈도우 + 클러스터링 기반 크로스자산 상관 히트맵 | Planned |
+| | CLI 백테스트 출력에 벤치마크 비교 | Planned |
+| | 백테스트 지표에 Calmar Ratio & Omega Ratio | Planned |
+| **Skills & Presets** | 배당 분석 스킬 | Planned |
+| | ESG / 지속가능 투자 스웜 프리셋 | Planned |
+| | 이머징 마켓 리서치 데스크 스웜 프리셋 | Planned |
+| **Portfolio & Optimization** | 레버리지, 섹터 캡, 턴오버 제약을 포함한 고급 포트폴리오 옵티마이저 | Planned |
+| **Future** | 초보자 튜토리얼: "5분 자연어 백테스트" | Planned |
+| | WebSocket 기반 실시간 데이터 스트리밍 | Exploring |
+| | 전략 마켓플레이스(공유 & 발견) | Exploring |
+
+---
+
+## 기여하기
+
+기여를 환영합니다! 가이드는 [CONTRIBUTING.md](CONTRIBUTING.md)를 참고하세요.
+
+**Good first issues**는 [`good first issue`](https://github.com/HKUDS/Vibe-Trading/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) 라벨로 표시되어 있습니다 — 선택해 바로 시작해 보세요.
+
+더 큰 기여를 원하나요? 위 [로드맵](#-로드맵)을 확인하고 시작 전에 이슈를 열어 논의해주세요.
+
+---
+
+## 면책조항
+
+Vibe-Trading은 리서치, 시뮬레이션, 백테스트 용도입니다. 투자 조언이 아니며 실거래를 실행하지 않습니다. 과거 성과는 미래 수익을 보장하지 않습니다.
+
+## 라이선스
+
+MIT License — [LICENSE](LICENSE) 참조
+
+---
+
+<p align="center">
+  방문해 주셔서 감사합니다 <b>Vibe-Trading</b> ✨
+</p>
+<p align="center">
+  <img src="https://visitor-badge.laobi.icu/badge?page_id=HKUDS.Vibe-Trading&style=flat" alt="visitors"/>
+</p>

--- a/README_zh.md
+++ b/README_zh.md
@@ -77,7 +77,7 @@ Vibe-Trading 是一个由 AI 驱动的多代理金融工作台，将自然语言
   <tr>
     <td align="center" width="25%" valign="top">
       <img src="assets/scene-research.png" height="150" alt="Research"/><br>
-      <h3>🔍 DeepResearch for Trading</h3>
+      <h3>🔍 面向交易的深度研究</h3>
       <img src="https://img.shields.io/badge/68_Skills-FF6B6B?style=for-the-badge&logo=bookstack&logoColor=white" alt="Skills" /><br><br>
       <div align="left" style="font-size: 4px;">
         • 覆盖多市场的多领域分析<br>
@@ -88,7 +88,7 @@ Vibe-Trading 是一个由 AI 驱动的多代理金融工作台，将自然语言
     </td>
     <td align="center" width="25%" valign="top">
       <img src="assets/scene-swarm.png" height="150" alt="Swarm"/><br>
-      <h3>🐝 Swarm Intelligence</h3>
+      <h3>🐝 群体智能</h3>
       <img src="https://img.shields.io/badge/29_Trading_Teams-4ECDC4?style=for-the-badge&logo=hive&logoColor=white" alt="Swarm" /><br><br>
       <div align="left">
         • 29 个开箱即用的交易团队预设<br>
@@ -99,7 +99,7 @@ Vibe-Trading 是一个由 AI 驱动的多代理金融工作台，将自然语言
     </td>
     <td align="center" width="25%" valign="top">
       <img src="assets/scene-backtest.png" height="150" alt="Backtest"/><br>
-      <h3>📊 Cross-Market Backtest</h3>
+      <h3>📊 跨市场回测</h3>
       <img src="https://img.shields.io/badge/5_Data_Sources-FFD93D?style=for-the-badge&logo=bitcoin&logoColor=black" alt="Backtest" /><br><br>
       <div align="left">
         • A 股、港美股、加密、期货与外汇<br>
@@ -110,7 +110,7 @@ Vibe-Trading 是一个由 AI 驱动的多代理金融工作台，将自然语言
     </td>
     <td align="center" width="25%" valign="top">
       <img src="assets/scene-quant.png" height="150" alt="Quant"/><br>
-      <h3>🧮 Quant Analysis Toolkit</h3>
+      <h3>🧮 量化分析工具箱</h3>
       <img src="https://img.shields.io/badge/Quant_Tools-C77DFF?style=for-the-badge&logo=wolfram&logoColor=white" alt="Quant" /><br><br>
       <div align="left">
         • 因子 IC/IR 分析与分位回测<br>

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,0 +1,619 @@
+<p align="center">
+  <a href="README.md">English</a> | <b>中文</b> | <a href="README_ja.md">日本語</a> | <a href="README_ko.md">한국어</a>
+</p>
+
+<p align="center">
+  <img src="assets/icon.png" width="120" alt="Vibe-Trading Logo"/>
+</p>
+
+<h1 align="center">Vibe-Trading：你的个人交易代理</h1>
+
+<p align="center">
+  <b>一条命令，为你的代理赋予全栈交易能力</b>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Python-3.11%2B-3776AB?style=flat&logo=python&logoColor=white" alt="Python">
+  <img src="https://img.shields.io/badge/Backend-FastAPI-009688?style=flat" alt="FastAPI">
+  <img src="https://img.shields.io/badge/Frontend-React%2019-61DAFB?style=flat&logo=react&logoColor=white" alt="React">
+  <a href="https://pypi.org/project/vibe-trading-ai/"><img src="https://img.shields.io/pypi/v/vibe-trading-ai?style=flat&logo=pypi&logoColor=white" alt="PyPI"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow?style=flat" alt="License"></a>
+  <br>
+  <img src="https://img.shields.io/badge/Skills-68-orange" alt="Skills">
+  <img src="https://img.shields.io/badge/Swarm_Presets-29-7C3AED" alt="Swarm">
+  <img src="https://img.shields.io/badge/Tools-21-0F766E" alt="Tools">
+  <img src="https://img.shields.io/badge/Data_Sources-5-2563EB" alt="Data Sources">
+  <br>
+  <a href="https://github.com/HKUDS/.github/blob/main/profile/README.md"><img src="https://img.shields.io/badge/Feishu-Group-E9DBFC?style=flat-square&logo=feishu&logoColor=white" alt="Feishu"></a>
+  <a href="https://github.com/HKUDS/.github/blob/main/profile/README.md"><img src="https://img.shields.io/badge/WeChat-Group-C5EAB4?style=flat-square&logo=wechat&logoColor=white" alt="WeChat"></a>
+  <a href="https://discord.gg/2vDYc2w5"><img src="https://img.shields.io/badge/Discord-Join-7289DA?style=flat-square&logo=discord&logoColor=white" alt="Discord"></a>
+</p>
+
+<p align="center">
+  <a href="#-核心功能">核心功能</a> &nbsp;&middot;&nbsp;
+  <a href="#-演示">演示</a> &nbsp;&middot;&nbsp;
+  <a href="#-vibe-trading-是什么">产品介绍</a> &nbsp;&middot;&nbsp;
+  <a href="#-快速开始">快速开始</a> &nbsp;&middot;&nbsp;
+  <a href="#-cli-参考">CLI</a> &nbsp;&middot;&nbsp;
+  <a href="#-api-服务">API</a> &nbsp;&middot;&nbsp;
+  <a href="#-mcp-插件">MCP</a> &nbsp;&middot;&nbsp;
+  <a href="#-项目结构">项目结构</a> &nbsp;&middot;&nbsp;
+  <a href="#-路线图">路线图</a> &nbsp;&middot;&nbsp;
+  <a href="#贡献指南">贡献</a>
+</p>
+
+<p align="center">
+  <a href="#-快速开始"><img src="assets/pip-install.svg" height="45" alt="pip install vibe-trading-ai"></a>
+</p>
+
+---
+
+## 📰 新闻
+
+- **2026-04-10** 📦 **v0.1.4**：修复 Docker 构建（[#8](https://github.com/HKUDS/Vibe-Trading/issues/8)），新增 `web_search` MCP 工具（共 17 个），在依赖与 MCP 中加入 `akshare`/`ccxt`。支持 11 家 LLM 提供商（DeepSeek、Groq、Gemini、Ollama 等），全部调优参数可通过 `.env` 配置。加固 `ml-strategy` 技能。已发布至 PyPI 和 ClawHub。
+- **2026-04-09** 📊 **回测 Wave 2 —— 多资产引擎**：新增 ChinaFutures（CFFEX/SHFE/DCE/ZCE，50+ 合约）、GlobalFutures（CME/ICE/Eurex，30+ 合约）、Forex（24 货币对，点差 + 掉期）、Options v2（美式行权、IV 微笑）。统计验证：蒙特卡洛置换检验、Bootstrap 夏普区间、Walk-Forward 分析。
+- **2026-04-08** 🔧 **多市场回测** 支持分市场规则；**TradingView Pine Script v6 导出**。**数据源扩展**：5 源自动回退，`web_search` 工具，技能分 7 类。
+- **2026-04-01** 🚀 **v0.1.0** —— 初始发布：ReAct 代理，64 技能，29 个 swarm 预设，跨市场回测，CLI + Web UI + MCP 服务器。
+
+---
+
+## 💡 Vibe-Trading 是什么？
+
+Vibe-Trading 是一个由 AI 驱动的多代理金融工作台，将自然语言请求转化为可执行的交易策略、研究洞见和跨全球市场的投资组合分析。
+
+### 核心能力：
+• **Strategy Generation** —— 从你的想法自动生成交易代码<br>
+• **Smart Data Access** —— 5 大数据源自动回退；所有市场零配置<br>
+• **Performance Testing** —— 使用历史行情测试你的策略<br>
+• **TradingView Export** —— 一键转换为 TradingView 的 Pine Script v6<br>
+• **Expert Teams** —— 部署专职 AI 代理处理复杂研究任务<br>
+• **Live Updates** —— 全程实时查看分析过程
+
+---
+
+## ✨ 核心功能
+
+<table width="100%">
+  <tr>
+    <td align="center" width="25%" valign="top">
+      <img src="assets/scene-research.png" height="150" alt="Research"/><br>
+      <h3>🔍 DeepResearch for Trading</h3>
+      <img src="https://img.shields.io/badge/68_Skills-FF6B6B?style=for-the-badge&logo=bookstack&logoColor=white" alt="Skills" /><br><br>
+      <div align="left" style="font-size: 4px;">
+        • 覆盖多市场的多领域分析<br>
+        • 自动生成策略与信号<br>
+        • 宏观经济研究与洞察<br>
+        • 基于聊天的自然语言任务路由
+      </div>
+    </td>
+    <td align="center" width="25%" valign="top">
+      <img src="assets/scene-swarm.png" height="150" alt="Swarm"/><br>
+      <h3>🐝 Swarm Intelligence</h3>
+      <img src="https://img.shields.io/badge/29_Trading_Teams-4ECDC4?style=for-the-badge&logo=hive&logoColor=white" alt="Swarm" /><br><br>
+      <div align="left">
+        • 29 个开箱即用的交易团队预设<br>
+        • 基于 DAG 的多代理编排<br>
+        • 实时决策流式仪表盘<br>
+        • 通过 YAML 自定义团队
+      </div>
+    </td>
+    <td align="center" width="25%" valign="top">
+      <img src="assets/scene-backtest.png" height="150" alt="Backtest"/><br>
+      <h3>📊 Cross-Market Backtest</h3>
+      <img src="https://img.shields.io/badge/5_Data_Sources-FFD93D?style=for-the-badge&logo=bitcoin&logoColor=black" alt="Backtest" /><br><br>
+      <div align="left">
+        • A 股、港美股、加密、期货与外汇<br>
+        • 7 个市场引擎：A 股、美港股、加密、中国期货、全球期货、外汇<br>
+        • 统计验证：蒙特卡洛、Bootstrap 置信区间、Walk-Forward<br>
+        • 15+ 绩效指标与 4 种优化器
+      </div>
+    </td>
+    <td align="center" width="25%" valign="top">
+      <img src="assets/scene-quant.png" height="150" alt="Quant"/><br>
+      <h3>🧮 Quant Analysis Toolkit</h3>
+      <img src="https://img.shields.io/badge/Quant_Tools-C77DFF?style=for-the-badge&logo=wolfram&logoColor=white" alt="Quant" /><br><br>
+      <div align="left">
+        • 因子 IC/IR 分析与分位回测<br>
+        • Black-Scholes 定价与全套 Greeks 计算<br>
+        • 技术形态识别与检测<br>
+        • 投资组合优化：MVO/风险平价/BL
+      </div>
+    </td>
+  </tr>
+</table>
+
+## 7 大类别中的 68 个技能
+
+- 📊 68 个金融专长技能，划分 7 大类
+- 🌐 覆盖传统市场到加密与 DeFi
+- 🔬 覆盖数据获取到量化研究的全链路能力
+
+| Category | Skills | Examples |
+|----------|--------|----------|
+| Data Source | 6 | `data-routing`, `tushare`, `yfinance`, `okx-market`, `akshare`, `ccxt` |
+| Strategy | 16 | `strategy-generate`, `technical-basic`, `candlestick`, `ichimoku`, `elliott-wave`, `smc`, `multi-factor`, `ml-strategy` |
+| Analysis | 15 | `factor-research`, `macro-analysis`, `global-macro`, `valuation-model`, `earnings-forecast`, `credit-analysis` |
+| Asset Class | 9 | `options-strategy`, `options-advanced`, `convertible-bond`, `etf-analysis`, `asset-allocation`, `sector-rotation` |
+| Crypto | 7 | `perp-funding-basis`, `liquidation-heatmap`, `stablecoin-flow`, `defi-yield`, `onchain-analysis` |
+| Flow | 7 | `hk-connect-flow`, `us-etf-flow`, `edgar-sec-filings`, `financial-statement`, `adr-hshare` |
+| Tool | 8 | `backtest-diagnose`, `report-generate`, `pine-script`, `doc-reader`, `web-reader` |
+
+## 29 个 Agent Swarm 团队预设
+
+- 🏢 29 组可即用的代理团队
+- ⚡ 预配置的金融工作流
+- 🎯 投资、交易与风险管理场景预设
+
+| Preset | Workflow |
+|--------|----------|
+| `investment_committee` | 多空辩论 → 风险复核 → PM 最终决策 |
+| `global_equities_desk` | A 股 + 港美股 + 加密研究员 → 全球策略师 |
+| `crypto_trading_desk` | 资金费/基差 + 清算 + 资金流 → 风险经理 |
+| `earnings_research_desk` | 基本面 + 修正 + 期权 → 财报策略师 |
+| `macro_rates_fx_desk` | 利率 + 外汇 + 商品 → 宏观 PM |
+| `quant_strategy_desk` | 筛选 + 因子研究 → 回测 → 风险审计 |
+| `technical_analysis_panel` | 经典 TA + 一目均衡 + 谐波 + 艾略特 + SMC → 共识 |
+| `risk_committee` | 回撤 + 尾部风险 + Regime 评审 → 签核 |
+| `global_allocation_committee` | A 股 + 加密 + 港美股 → 跨市场配置 |
+
+<sub>另有 20+ 专项预设 —— 运行 vibe-trading --swarm-presets 查看全部。</sub>
+
+### 🎬 演示
+
+<div align="center">
+<table>
+<tr>
+<td width="50%">
+
+https://github.com/user-attachments/assets/4e4dcb80-7358-4b9a-92f0-1e29612e6e86
+
+</td>
+<td width="50%">
+
+https://github.com/user-attachments/assets/3754a414-c3ee-464f-b1e8-78e1a74fbd30
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="center"><sub>☝️ 自然语言回测与多代理 swarm 辩论 —— Web UI + CLI</sub></td>
+</tr>
+</table>
+</div>
+
+---
+
+## 🚀 快速开始
+
+### 一行安装（PyPI）
+
+```bash
+pip install vibe-trading-ai
+```
+
+> **包名与命令：** PyPI 包名是 `vibe-trading-ai`。安装后会获得三个命令：
+>
+> | Command | Purpose |
+> |---------|---------|
+> | `vibe-trading` | 交互式 CLI / TUI |
+> | `vibe-trading serve` | 启动 FastAPI Web 服务器 |
+> | `vibe-trading-mcp` | 启动 MCP 服务器（Claude Desktop、OpenClaw、Cursor 等） |
+
+```bash
+vibe-trading init              # 交互式 .env 配置
+vibe-trading                   # 启动 CLI
+vibe-trading serve --port 8899 # 启动 Web UI
+vibe-trading-mcp               # 启动 MCP 服务器（stdio）
+```
+
+### 或选择一条路径
+
+| Path | Best for | Time |
+|------|----------|------|
+| **A. Docker** | 立即体验，零本地配置 | 2 min |
+| **B. Local install** | 开发、完整 CLI 访问 | 5 min |
+| **C. MCP plugin** | 接入你现有的代理 | 3 min |
+| **D. ClawHub** | 一条命令，无需克隆 | 1 min |
+
+### 前置条件
+
+- 任一支持提供商的 **LLM API key**——或使用 **Ollama** 本地运行（无需 key）
+- Path B 需 **Python 3.11+**
+- Path A 需 **Docker**
+
+> **支持的 LLM 提供商：** OpenRouter、OpenAI、DeepSeek、Gemini、Groq、DashScope/Qwen、智谱、Moonshot/Kimi、MiniMax、小米 MIMO、Ollama（本地）。参见 `.env.example` 配置。
+
+> **提示：** 所有市场都可在无 API key 情况下运行，因自动回退。yfinance（港美股）、OKX（加密）、AKShare（A 股、美股、港股、期货、外汇）均免费。Tushare token 可选——A 股可回退到 AKShare 免费获取。
+
+### Path A: Docker（零配置）
+
+```bash
+git clone https://github.com/HKUDS/Vibe-Trading.git
+cd Vibe-Trading
+cp agent/.env.example agent/.env
+# 编辑 agent/.env —— 取消注释你的 LLM 提供商并填写 API key
+docker compose up --build
+```
+
+打开 `http://localhost:8899`。后端与前端同一容器。
+
+### Path B: 本地安装
+
+```bash
+git clone https://github.com/HKUDS/Vibe-Trading.git
+cd Vibe-Trading
+python -m venv .venv
+
+# 激活
+source .venv/bin/activate          # Linux / macOS
+# .venv\Scripts\Activate.ps1       # Windows PowerShell
+
+pip install -e .
+cp agent/.env.example agent/.env   # 编辑 —— 设置你的 LLM 提供商 API key
+vibe-trading                       # 启动交互式 TUI
+```
+
+<details>
+<summary><b>启动 Web UI（可选）</b></summary>
+
+```bash
+# 终端 1：API 服务器
+vibe-trading serve --port 8899
+
+# 终端 2：前端开发服务器
+cd frontend && npm install && npm run dev
+```
+
+打开 `http://localhost:5899`。前端会代理到 `localhost:8899`。
+
+**生产模式（单服务器）：**
+
+```bash
+cd frontend && npm run build && cd ..
+vibe-trading serve --port 8899     # FastAPI 同时提供 dist/ 静态文件
+```
+
+</details>
+
+### Path C: MCP 插件
+
+见下方 [MCP 插件](#-mcp-插件) 章节。
+
+### Path D: ClawHub（一条命令）
+
+```bash
+npx clawhub@latest install vibe-trading --force
+```
+
+技能与 MCP 配置会下载到你代理的技能目录。详情见 [ClawHub 安装](#-mcp-插件)。
+
+---
+
+## 🧠 环境变量
+
+复制 `agent/.env.example` 到 `agent/.env`，取消注释你需要的提供商块。每个提供商需 3-4 个变量：
+
+| Variable | Required | Description |
+|----------|:--------:|-------------|
+| `LANGCHAIN_PROVIDER` | Yes | 提供商名称（`openrouter`、`deepseek`、`groq`、`ollama` 等） |
+| `<PROVIDER>_API_KEY` | Yes* | API key（`OPENROUTER_API_KEY`、`DEEPSEEK_API_KEY` 等） |
+| `<PROVIDER>_BASE_URL` | Yes | API 端点 URL |
+| `LANGCHAIN_MODEL_NAME` | Yes | 模型名（如 `deepseek/deepseek-v3.2`） |
+| `TUSHARE_TOKEN` | No | A 股数据的 Tushare Pro token（可回退 AKShare） |
+| `TIMEOUT_SECONDS` | No | LLM 调用超时，默认 120s |
+
+<sub>* Ollama 不需要 API key。</sub>
+
+**免费数据（无需 key）：** A 股经 AKShare，港美股经 yfinance，加密经 OKX，100+ 加密交易所经 CCXT。系统会为每个市场自动选择最佳可用数据源。
+
+---
+
+## 🖥 CLI 参考
+
+```bash
+vibe-trading               # 交互式 TUI
+vibe-trading run -p "..."  # 单次运行
+vibe-trading serve         # API 服务器
+```
+
+<details>
+<summary><b>TUI 内斜杠命令</b></summary>
+
+| Command | Description |
+|---------|-------------|
+| `/help` | 显示全部命令 |
+| `/skills` | 列出 68 个金融技能 |
+| `/swarm` | 列出 29 个 swarm 团队预设 |
+| `/swarm run <preset> [vars_json]` | 以流式输出运行一个 swarm 团队 |
+| `/swarm list` | Swarm 运行历史 |
+| `/swarm show <run_id>` | Swarm 运行详情 |
+| `/swarm cancel <run_id>` | 取消运行中的 swarm |
+| `/list` | 最近的运行 |
+| `/show <run_id>` | 运行详情与指标 |
+| `/code <run_id>` | 生成的策略代码 |
+| `/pine <run_id>` | TradingView 的 Pine Script |
+| `/trace <run_id>` | 完整执行回放 |
+| `/continue <run_id> <prompt>` | 带新指令继续运行 |
+| `/sessions` | 列出聊天会话 |
+| `/settings` | 显示运行时配置 |
+| `/clear` | 清屏 |
+| `/quit` | 退出 |
+</details>
+
+<details>
+<summary><b>单次运行与参数</b></summary>
+
+```bash
+vibe-trading run -p "Backtest BTC-USDT MACD strategy, last 30 days"
+vibe-trading run -p "Analyze AAPL momentum" --json
+vibe-trading run -f strategy.txt
+echo "Backtest 000001.SZ RSI" | vibe-trading run
+```
+
+```bash
+vibe-trading -p "your prompt"
+vibe-trading --skills
+vibe-trading --swarm-presets
+vibe-trading --swarm-run investment_committee '{"topic":"BTC outlook"}'
+vibe-trading --list
+vibe-trading --show <run_id>
+vibe-trading --code <run_id>
+vibe-trading --pine <run_id>           # TradingView 的 Pine Script
+vibe-trading --trace <run_id>
+vibe-trading --continue <run_id> "refine the strategy"
+vibe-trading --upload report.pdf
+```
+
+</details>
+
+---
+
+## 🌐 API 服务
+
+```bash
+vibe-trading serve --port 8899
+```
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/runs` | 列出运行 |
+| `GET` | `/runs/{run_id}` | 运行详情 |
+| `GET` | `/runs/{run_id}/pine` | Pine Script 导出 |
+| `POST` | `/sessions` | 创建会话 |
+| `POST` | `/sessions/{id}/messages` | 发送消息 |
+| `GET` | `/sessions/{id}/events` | SSE 事件流 |
+| `POST` | `/upload` | 上传 PDF/文件 |
+| `GET` | `/swarm/presets` | 列出 swarm 预设 |
+| `POST` | `/swarm/runs` | 启动 swarm 运行 |
+| `GET` | `/swarm/runs/{id}/events` | Swarm SSE 流 |
+
+交互式文档：`http://localhost:8899/docs`
+
+---
+
+## 🔌 MCP 插件
+
+Vibe-Trading 为任意 MCP 兼容客户端提供 17 个 MCP 工具。以 stdio 子进程运行——无需服务器部署。**17 个工具中有 16 个无需任何 API key**（港美股/加密）。仅 `run_swarm` 需要 LLM key。
+
+<details>
+<summary><b>Claude Desktop</b></summary>
+
+添加到 `claude_desktop_config.json`：
+
+```json
+{
+  "mcpServers": {
+    "vibe-trading": {
+      "command": "vibe-trading-mcp"
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary><b>OpenClaw</b></summary>
+
+添加到 `~/.openclaw/config.yaml`：
+
+```yaml
+skills:
+  - name: vibe-trading
+    command: vibe-trading-mcp
+```
+
+</details>
+
+<details>
+<summary><b>Cursor / Windsurf / 其他 MCP 客户端</b></summary>
+
+```bash
+vibe-trading-mcp                  # stdio（默认）
+vibe-trading-mcp --transport sse  # 供 Web 客户端的 SSE
+```
+
+</details>
+
+**已暴露的 MCP 工具（17）：** `list_skills`, `load_skill`, `backtest`, `factor_analysis`, `analyze_options`, `pattern_recognition`, `get_market_data`, `web_search`, `read_url`, `read_document`, `read_file`, `write_file`, `list_swarm_presets`, `run_swarm`, `get_swarm_status`, `get_run_result`, `list_runs`。
+
+<details>
+<summary><b>ClawHub 一键安装</b></summary>
+
+```bash
+npx clawhub@latest install vibe-trading --force
+```
+
+> 需要 `--force`，因为该技能引用外部 API，会触发 VirusTotal 自动扫描。代码完全开源，可自行审阅。
+
+这会将技能与 MCP 配置下载到你的代理技能目录。无需克隆。
+
+浏览 ClawHub： [clawhub.ai/skills/vibe-trading](https://clawhub.ai/skills/vibe-trading)
+
+</details>
+
+<details>
+<summary><b>OpenSpace — 自进化技能</b></summary>
+
+全部 68 个金融技能已发布在 [open-space.cloud](https://open-space.cloud)，并通过 OpenSpace 的自进化引擎自动演进。
+
+要在 OpenSpace 中使用，在代理配置中添加两个 MCP 服务器：
+
+```json
+{
+  "mcpServers": {
+    "openspace": {
+      "command": "openspace-mcp",
+      "toolTimeout": 600,
+      "env": {
+        "OPENSPACE_HOST_SKILL_DIRS": "/path/to/vibe-trading/agent/src/skills",
+        "OPENSPACE_WORKSPACE": "/path/to/OpenSpace"
+      }
+    },
+    "vibe-trading": {
+      "command": "vibe-trading-mcp"
+    }
+  }
+}
+```
+
+OpenSpace 会自动发现全部 68 个技能，支持自动修复、自动改进与社区共享。在任意连接 OpenSpace 的代理中通过 `search_skills("finance backtest")` 搜索 Vibe-Trading 技能。
+
+</details>
+
+---
+
+## 📁 项目结构
+
+<details>
+<summary><b>展开查看</b></summary>
+
+```
+Vibe-Trading/
+├── agent/                          # 后端（Python）
+│   ├── cli.py                      # CLI 入口——交互式 TUI + 子命令
+│   ├── api_server.py               # FastAPI 服务器——运行、会话、上传、swarm、SSE
+│   ├── mcp_server.py               # MCP 服务器——为 OpenClaw / Claude Desktop 提供 17 个工具
+│   │
+│   ├── src/
+│   │   ├── agent/                  # ReAct 代理核心
+│   │   │   ├── loop.py             #   主推理循环
+│   │   │   ├── skills.py           #   技能加载器（68 个 SKILL.md，7 类）
+│   │   │   ├── tools.py            #   工具编排
+│   │   │   ├── context.py          #   系统提示构建器
+│   │   │   ├── memory.py           #   运行记忆 / artifact 存储
+│   │   │   └── trace.py            #   执行轨迹写入
+│   │   │
+│   │   ├── tools/                  # 21 个代理工具
+│   │   │   ├── backtest_tool.py    #   运行回测
+│   │   │   ├── factor_analysis_tool.py
+│   │   │   ├── options_pricing_tool.py
+│   │   │   ├── pattern_tool.py     #   图表形态检测
+│   │   │   ├── doc_reader_tool.py  #   PDF 阅读（OCR 回退）
+│   │   │   ├── web_reader_tool.py  #   网页读取（Jina）
+│   │   │   ├── web_search_tool.py  #   DuckDuckGo 搜索
+│   │   │   ├── swarm_tool.py       #   启动 swarm 团队
+│   │   │   └── ...                 #   文件 I/O、bash、任务等
+│   │   │
+│   │   ├── skills/                 # 68 个金融技能（7 类，每个 SKILL.md）
+│   │   ├── swarm/                  # Swarm DAG 执行引擎
+│   │   ├── session/                # 多轮对话管理
+│   │   └── providers/              # LLM 提供商抽象
+│   │
+│   ├── backtest/                   # 回测引擎
+│   │   ├── engines/                #   7 个引擎：china_a、global_equity、crypto、china_futures、global_futures、forex + options_portfolio
+│   │   ├── loaders/                #   5 个数据源：tushare、okx、yfinance、akshare、ccxt
+│   │   │   ├── base.py             #   DataLoader Protocol
+│   │   │   └── registry.py         #   注册表 + 自动回退链
+│   │   └── optimizers/             #   MVO、等波动、最大分散、风险平价
+│   │
+│   └── config/swarm/               # 29 个 swarm 预设 YAML 定义
+│
+├── frontend/                       # Web UI（React 19 + Vite + TypeScript）
+│   └── src/
+│       ├── pages/                  #   Home、Agent、RunDetail、Compare
+│       ├── components/             #   chat、charts、layout
+│       └── stores/                 #   Zustand 状态管理
+│
+├── Dockerfile                      # 多阶段构建
+├── docker-compose.yml              # 一键部署
+├── pyproject.toml                  # 包配置 + CLI 入口
+└── LICENSE                         # MIT
+```
+
+</details>
+
+---
+
+## 🏛 生态
+
+Vibe-Trading 属于 **[HKUDS](https://github.com/HKUDS)** 代理生态的一部分：
+
+<table>
+  <tr>
+    <td align="center" width="25%">
+      <a href="https://github.com/HKUDS/ClawTeam"><b>ClawTeam</b></a><br>
+      <sub>代理 swarm 智能</sub>
+    </td>
+    <td align="center" width="25%">
+      <a href="https://github.com/HKUDS/nanobot"><b>NanoBot</b></a><br>
+      <sub>超轻量个人 AI 助手</sub>
+    </td>
+    <td align="center" width="25%">
+      <a href="https://github.com/HKUDS/CLI-Anything"><b>CLI-Anything</b></a><br>
+      <sub>让所有软件都可被代理驱动</sub>
+    </td>
+    <td align="center" width="25%">
+      <a href="https://github.com/HKUDS/OpenSpace"><b>OpenSpace</b></a><br>
+      <sub>自进化 AI 代理技能</sub>
+    </td>
+  </tr>
+</table>
+
+---
+
+## 🗺 路线图
+
+> 我们分阶段发布。工作开始后会移至 [Issues](https://github.com/HKUDS/Vibe-Trading/issues)。
+
+| Phase | Feature | Status |
+|-------|---------|--------|
+| **Analysis & Viz** | 期权波动率曲面与 Greeks 三维可视化 | Planned |
+| | 跨资产相关性热力图（滚动窗口 + 聚类） | Planned |
+| | CLI 回测输出中的基准对比 | Planned |
+| | 回测指标新增 Calmar Ratio 与 Omega Ratio | Planned |
+| **Skills & Presets** | 分红分析技能 | Planned |
+| | ESG / 可持续投资 swarm 预设 | Planned |
+| | 新兴市场研究台 swarm 预设 | Planned |
+| **Portfolio & Optimization** | 高级组合优化器：杠杆、行业上限、换手约束 | Planned |
+| **Future** | 新手教程：“5 分钟自然语言回测” | Planned |
+| | 通过 WebSocket 的实时数据流 | Exploring |
+| | 策略市场（分享与发现） | Exploring |
+
+---
+
+## 贡献指南
+
+欢迎贡献！请参见 [CONTRIBUTING.md](CONTRIBUTING.md) 获取指南。
+
+**Good first issues** 带有 [`good first issue`](https://github.com/HKUDS/Vibe-Trading/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) 标签——挑一个开始吧。
+
+想做更大的贡献？查看上方 [路线图](#-路线图)，开始前先开个 issue 讨论。
+
+---
+
+## 免责声明
+
+Vibe-Trading 仅用于研究、模拟与回测。它不是投资建议，也不会执行实盘交易。历史表现不代表未来结果。
+
+## 许可证
+
+MIT 许可证——参见 [LICENSE](LICENSE)
+
+---
+
+<p align="center">
+  感谢关注 <b>Vibe-Trading</b> ✨
+</p>
+<p align="center">
+  <img src="https://visitor-badge.laobi.icu/badge?page_id=HKUDS.Vibe-Trading&style=flat" alt="visitors"/>
+</p>


### PR DESCRIPTION
### Summary of changes
- -Added translated README files:
  - `README_zh.md` (简体中文)
  - `README_ja.md` (日本語)
  - `README_ko.md` (한국어)
- Added a language switcher navigation link at the top of all README files.
- Ensured all technical terms (tool names, CLI commands, config keys) remained untranslated as per the guidelines.
- Localized the intra-document anchor links (e.g., in the language switcher and headings) within each translated file to ensure internal navigation works flawlessly for native readers.

### Related issue number
Closes #11 

### Test plan
- Visually verified the Markdown rendering locally.
- Checked that the language switcher successfully links to the correct files.
- Tested the intra-document anchor links (`href="#..."`) in each localized README to ensure they correctly jump to the translated headings.
