### PR TITLE
fix: preserve Gemini thought_signature in tool calls and add ddgs dependency 

### DIFF
--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -28,6 +28,7 @@ requests>=2.31.0
 yfinance>=0.2.30
 akshare>=1.12.0
 ccxt>=4.0.0
+ddgs>=6.0.0
 
 # REST API & SSE
 fastapi>=0.104.0

--- a/agent/src/agent/context.py
+++ b/agent/src/agent/context.py
@@ -70,8 +70,9 @@ class ContextBuilder:
         skills_loader: Skills loader.
     """
 
-    def __init__(self, registry: ToolRegistry, memory: WorkspaceMemory,
-                 skills_loader: Optional[SkillsLoader] = None) -> None:
+    def __init__(
+        self, registry: ToolRegistry, memory: WorkspaceMemory, skills_loader: Optional[SkillsLoader] = None
+    ) -> None:
         """Initialize ContextBuilder.
 
         Args:
@@ -148,6 +149,9 @@ class ContextBuilder:
     def format_assistant_tool_calls(tool_calls: list, content: Optional[str] = None) -> Dict[str, Any]:
         """Format an assistant tool_calls message, preserving thinking text.
 
+        Includes Gemini ``thought_signature`` in ``extra_content.google.thought_signature``
+        when present, so subsequent API calls to Gemini preserve the signature.
+
         Args:
             tool_calls: List of tool call objects.
             content: Model reasoning/thinking text.
@@ -155,18 +159,25 @@ class ContextBuilder:
         Returns:
             OpenAI-format assistant message.
         """
+        formatted_calls = []
+        for tc in tool_calls:
+            call_dict = {
+                "id": tc.id,
+                "type": "function",
+                "function": {
+                    "name": tc.name,
+                    "arguments": json.dumps(tc.arguments, ensure_ascii=False),
+                },
+            }
+            if getattr(tc, "thought_signature", None):
+                call_dict["extra_content"] = {
+                    "google": {
+                        "thought_signature": tc.thought_signature,
+                    },
+                }
+            formatted_calls.append(call_dict)
         return {
             "role": "assistant",
             "content": content,
-            "tool_calls": [
-                {
-                    "id": tc.id,
-                    "type": "function",
-                    "function": {
-                        "name": tc.name,
-                        "arguments": json.dumps(tc.arguments, ensure_ascii=False),
-                    },
-                }
-                for tc in tool_calls
-            ],
+            "tool_calls": formatted_calls,
         }

--- a/agent/src/providers/chat.py
+++ b/agent/src/providers/chat.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
-from src.providers.llm import build_llm
+from src.providers.llm import GeminiChatOpenAI, build_llm
 
 
 @dataclass
@@ -19,11 +19,13 @@ class ToolCallRequest:
         id: Tool call ID (used to match tool_result messages).
         name: Tool name.
         arguments: Tool argument dict.
+        thought_signature: Gemini thought_signature for this tool call (if any).
     """
 
     id: str
     name: str
     arguments: Dict[str, Any]
+    thought_signature: Optional[str] = None
 
 
 @dataclass
@@ -64,7 +66,12 @@ class ChatLLM:
         self.model_name = model_name
         self._llm = build_llm(model_name=model_name)
 
-    def chat(self, messages: List[Dict[str, Any]], tools: Optional[List[Dict[str, Any]]] = None, timeout: Optional[int] = None) -> LLMResponse:
+    def chat(
+        self,
+        messages: List[Dict[str, Any]],
+        tools: Optional[List[Dict[str, Any]]] = None,
+        timeout: Optional[int] = None,
+    ) -> LLMResponse:
         """Call the LLM synchronously.
 
         Args:
@@ -92,6 +99,10 @@ class ChatLLM:
         Iterates AIMessageChunk; each text delta invokes ``on_text_chunk``.
         Aggregates chunks into one response; on failure falls back to ``chat()``.
 
+        For Gemini (GeminiChatOpenAI), streaming is bypassed in favor of
+        ``chat()`` because the streaming path does not preserve
+        ``extra_content.google.thought_signature`` from the raw response.
+
         Args:
             messages: Messages in OpenAI format.
             tools: Tool definitions for function calling.
@@ -101,6 +112,9 @@ class ChatLLM:
         Returns:
             Parsed ``LLMResponse``.
         """
+        if isinstance(self._llm, GeminiChatOpenAI):
+            return self.chat(messages, tools=tools, timeout=timeout)
+
         try:
             llm = self._llm.bind_tools(tools) if tools else self._llm
             config = {"timeout": timeout} if timeout else {}
@@ -115,7 +129,12 @@ class ChatLLM:
         except Exception:
             return self.chat(messages, tools=tools, timeout=timeout)
 
-    async def achat(self, messages: List[Dict[str, Any]], tools: Optional[List[Dict[str, Any]]] = None, timeout: Optional[int] = None) -> LLMResponse:
+    async def achat(
+        self,
+        messages: List[Dict[str, Any]],
+        tools: Optional[List[Dict[str, Any]]] = None,
+        timeout: Optional[int] = None,
+    ) -> LLMResponse:
         """Async LLM invocation.
 
         Args:
@@ -143,12 +162,25 @@ class ChatLLM:
         """
         content = ai_message.content if hasattr(ai_message, "content") else None
         raw_calls = getattr(ai_message, "tool_calls", None) or []
+        tool_call_extras: Dict[str, Any] = {}
+        if hasattr(ai_message, "additional_kwargs"):
+            tool_call_extras = ai_message.additional_kwargs.get("tool_call_extras", {})
         tool_calls = []
         for tc in raw_calls:
-            tool_calls.append(ToolCallRequest(
-                id=tc.get("id", ""),
-                name=tc.get("name", ""),
-                arguments=tc.get("args", {}),
-            ))
+            tc_id = tc.get("id", "")
+            thought_signature = None
+            if tc_id and tc_id in tool_call_extras:
+                extra = tool_call_extras[tc_id]
+                if isinstance(extra, dict):
+                    google_extra = extra.get("google", {})
+                    thought_signature = google_extra.get("thought_signature")
+            tool_calls.append(
+                ToolCallRequest(
+                    id=tc_id,
+                    name=tc.get("name", ""),
+                    arguments=tc.get("args", {}),
+                    thought_signature=thought_signature,
+                )
+            )
         finish = getattr(ai_message, "response_metadata", {}).get("finish_reason", "stop")
         return LLMResponse(content=content, tool_calls=tool_calls, finish_reason=finish)

--- a/agent/src/providers/llm.py
+++ b/agent/src/providers/llm.py
@@ -17,6 +17,12 @@ try:
 except ImportError:
     ChatOpenAI = None  # type: ignore
 
+
+def _get_current_provider() -> str:
+    _ensure_dotenv()
+    return os.getenv("LANGCHAIN_PROVIDER", "openai").lower()
+
+
 AGENT_DIR = Path(__file__).resolve().parents[2]
 
 # .env search order: ~/.vibe-trading/.env → agent/.env → $CWD/.env
@@ -68,18 +74,18 @@ def _sync_provider_env() -> None:
 
     # (api_key_env, base_url_env)
     _PROVIDER_MAP: dict[str, tuple[str | None, str]] = {
-        "openai":     ("OPENAI_API_KEY",     "OPENAI_BASE_URL"),
-        "openrouter": ("OPENROUTER_API_KEY",  "OPENROUTER_BASE_URL"),
-        "deepseek":   ("DEEPSEEK_API_KEY",    "DEEPSEEK_BASE_URL"),
-        "gemini":     ("GEMINI_API_KEY",      "GEMINI_BASE_URL"),
-        "groq":       ("GROQ_API_KEY",        "GROQ_BASE_URL"),
-        "dashscope":  ("DASHSCOPE_API_KEY",   "DASHSCOPE_BASE_URL"),
-        "qwen":       ("DASHSCOPE_API_KEY",   "DASHSCOPE_BASE_URL"),
-        "zhipu":      ("ZHIPU_API_KEY",       "ZHIPU_BASE_URL"),
-        "moonshot":   ("MOONSHOT_API_KEY",    "MOONSHOT_BASE_URL"),
-        "minimax":    ("MINIMAX_API_KEY",     "MINIMAX_BASE_URL"),
-        "mimo":       ("MIMO_API_KEY",        "MIMO_BASE_URL"),
-        "ollama":     (None,                  "OLLAMA_BASE_URL"),
+        "openai": ("OPENAI_API_KEY", "OPENAI_BASE_URL"),
+        "openrouter": ("OPENROUTER_API_KEY", "OPENROUTER_BASE_URL"),
+        "deepseek": ("DEEPSEEK_API_KEY", "DEEPSEEK_BASE_URL"),
+        "gemini": ("GEMINI_API_KEY", "GEMINI_BASE_URL"),
+        "groq": ("GROQ_API_KEY", "GROQ_BASE_URL"),
+        "dashscope": ("DASHSCOPE_API_KEY", "DASHSCOPE_BASE_URL"),
+        "qwen": ("DASHSCOPE_API_KEY", "DASHSCOPE_BASE_URL"),
+        "zhipu": ("ZHIPU_API_KEY", "ZHIPU_BASE_URL"),
+        "moonshot": ("MOONSHOT_API_KEY", "MOONSHOT_BASE_URL"),
+        "minimax": ("MINIMAX_API_KEY", "MINIMAX_BASE_URL"),
+        "mimo": ("MIMO_API_KEY", "MIMO_BASE_URL"),
+        "ollama": (None, "OLLAMA_BASE_URL"),
     }
 
     spec = _PROVIDER_MAP.get(provider, _PROVIDER_MAP["openai"])
@@ -101,6 +107,45 @@ def _sync_provider_env() -> None:
         os.environ.setdefault("OPENAI_BASE_URL", base_url)
 
 
+if ChatOpenAI is not None:
+
+    class GeminiChatOpenAI(ChatOpenAI):
+        """ChatOpenAI subclass that preserves Gemini thought_signature on tool calls.
+
+        Gemini's OpenAI-compatible endpoint returns ``extra_content.google.thought_signature``
+        on each tool call. The base ``ChatOpenAI`` strips this during parsing. This subclass
+        captures the signature from the raw response and stores it in
+        ``AIMessage.additional_kwargs["tool_call_extras"]`` so downstream code can
+        include it in subsequent turns.
+        """
+
+        def _create_chat_result(self, response: Any, generation_info: Any = None) -> Any:
+            result = super()._create_chat_result(response, generation_info)
+            try:
+                msg = result.generations[0].message
+                extras: dict[str, Any] = {}
+                raw_choices = getattr(response, "choices", None) or []
+                for choice in raw_choices:
+                    raw_tcs = getattr(getattr(choice, "message", None), "tool_calls", None) or []
+                    for raw_tc in raw_tcs:
+                        tc_extra = getattr(raw_tc, "extra_content", None)
+                        if not tc_extra:
+                            pydantic_extra = getattr(raw_tc, "__pydantic_extra__", None)
+                            if pydantic_extra and isinstance(pydantic_extra, dict):
+                                tc_extra = pydantic_extra.get("extra_content")
+                        if tc_extra:
+                            tc_id = getattr(raw_tc, "id", "") or ""
+                            extras[tc_id] = tc_extra
+                if extras:
+                    msg.additional_kwargs["tool_call_extras"] = extras
+            except Exception:
+                pass
+            return result
+
+else:
+    GeminiChatOpenAI = None  # type: ignore
+
+
 def build_llm(*, model_name: Optional[str] = None, callbacks: Any = None) -> Any:
     """Construct a ChatOpenAI instance.
 
@@ -109,7 +154,7 @@ def build_llm(*, model_name: Optional[str] = None, callbacks: Any = None) -> Any
         callbacks: Optional LangChain callbacks.
 
     Returns:
-        ChatOpenAI instance.
+        ChatOpenAI instance (GeminiChatOpenAI when provider is gemini).
 
     Raises:
         RuntimeError: If langchain-openai is missing or LANGCHAIN_MODEL_NAME is unset.
@@ -123,7 +168,9 @@ def build_llm(*, model_name: Optional[str] = None, callbacks: Any = None) -> Any
     temperature = float(os.getenv("LANGCHAIN_TEMPERATURE", "0.0"))
     timeout = int(os.getenv("TIMEOUT_SECONDS", "120"))
     max_retries = int(os.getenv("MAX_RETRIES", "2"))
-    return ChatOpenAI(
+    provider = _get_current_provider()
+    cls = GeminiChatOpenAI if provider == "gemini" else ChatOpenAI
+    return cls(
         model=name,
         temperature=temperature,
         timeout=timeout,

--- a/agent/tests/test_gemini_thought_signature.py
+++ b/agent/tests/test_gemini_thought_signature.py
@@ -1,0 +1,474 @@
+"""Tests for Gemini thought_signature preservation across the full data flow.
+
+Covers:
+  1. GeminiChatOpenAI._create_chat_result() extracting extra_content from raw responses
+  2. ChatLLM._parse_response() extracting thought_signature from additional_kwargs
+  3. ContextBuilder.format_assistant_tool_calls() including thought_signature in output
+  4. Full end-to-end flow: raw response -> parsed -> formatted message
+  5. stream_chat() bypass for GeminiChatOpenAI
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from openai.types.chat import ChatCompletion, ChatCompletionMessage, ChatCompletionMessageToolCall
+from openai.types.chat.chat_completion_message_tool_call import Function
+from openai.types.chat.chat_completion import Choice
+from openai.types.completion_usage import CompletionUsage
+
+from src.providers.llm import GeminiChatOpenAI, _get_current_provider, build_llm
+from src.providers.chat import ChatLLM, ToolCallRequest, LLMResponse
+from src.agent.context import ContextBuilder
+
+
+# ---------------------------------------------------------------------------
+# Helpers: build fake Gemini API responses using real OpenAI SDK models
+# ---------------------------------------------------------------------------
+
+
+def _make_raw_tool_call(
+    tc_id: str = "call_abc123",
+    name: str = "web_search",
+    args: str = '{"query": "gold price"}',
+    thought_signature: str | None = "sig_deadbeef",
+) -> dict:
+    """Build a dict matching OpenAI tool_call format with optional extra_content.
+
+    Returns a plain dict (not a Pydantic model) because the OpenAI SDK
+    ChatCompletionMessageToolCall uses extra='allow' and will preserve
+    extra_content if we construct via model_validate.
+    """
+    tc_dict = {
+        "id": tc_id,
+        "type": "function",
+        "function": {"name": name, "arguments": args},
+    }
+    if thought_signature:
+        tc_dict["extra_content"] = {"google": {"thought_signature": thought_signature}}
+    return tc_dict
+
+
+def _make_raw_response(
+    tool_calls: list[dict] | None = None,
+    content: str | None = None,
+) -> ChatCompletion:
+    """Build a ChatCompletion with optional tool_calls including extra_content."""
+    if tool_calls is not None:
+        raw_tcs = [ChatCompletionMessageToolCall.model_validate(tc) for tc in tool_calls]
+        message = ChatCompletionMessage(
+            role="assistant",
+            content=content,
+            tool_calls=raw_tcs,
+        )
+    else:
+        message = ChatCompletionMessage(
+            role="assistant",
+            content=content or "Hello",
+        )
+
+    return ChatCompletion(
+        id="chatcmpl-test",
+        choices=[
+            Choice(
+                finish_reason="tool_calls" if tool_calls else "stop",
+                index=0,
+                message=message,
+            )
+        ],
+        created=0,
+        model="gemini-2.5-flash",
+        object="chat.completion",
+        usage=CompletionUsage(prompt_tokens=10, completion_tokens=20, total_tokens=30),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. GeminiChatOpenAI._create_chat_result
+# ---------------------------------------------------------------------------
+
+
+class TestGeminiChatOpenAICreateChatResult:
+    """Test that _create_chat_result preserves extra_content from raw responses."""
+
+    def test_extracts_thought_signature_from_single_tool_call(self) -> None:
+        raw_response = _make_raw_response(tool_calls=[_make_raw_tool_call(thought_signature="sig_abc123")])
+
+        llm = GeminiChatOpenAI(model="gemini-2.5-flash", api_key="fake")
+        result = llm._create_chat_result(raw_response)
+
+        msg = result.generations[0].message
+        extras = msg.additional_kwargs.get("tool_call_extras", {})
+        assert "call_abc123" in extras
+        assert extras["call_abc123"] == {"google": {"thought_signature": "sig_abc123"}}
+
+    def test_extracts_thought_signature_from_multiple_tool_calls(self) -> None:
+        raw_response = _make_raw_response(
+            tool_calls=[
+                _make_raw_tool_call(tc_id="call_1", name="web_search", thought_signature="sig_1"),
+                _make_raw_tool_call(tc_id="call_2", name="read_url", thought_signature="sig_2"),
+            ]
+        )
+
+        llm = GeminiChatOpenAI(model="gemini-2.5-flash", api_key="fake")
+        result = llm._create_chat_result(raw_response)
+
+        msg = result.generations[0].message
+        extras = msg.additional_kwargs.get("tool_call_extras", {})
+        assert extras["call_1"]["google"]["thought_signature"] == "sig_1"
+        assert extras["call_2"]["google"]["thought_signature"] == "sig_2"
+
+    def test_no_extra_content_when_no_thought_signature(self) -> None:
+        raw_response = _make_raw_response(tool_calls=[_make_raw_tool_call(thought_signature=None)])
+
+        llm = GeminiChatOpenAI(model="gemini-2.5-flash", api_key="fake")
+        result = llm._create_chat_result(raw_response)
+
+        msg = result.generations[0].message
+        extras = msg.additional_kwargs.get("tool_call_extras", {})
+        assert "call_abc123" not in extras
+
+    def test_no_tool_calls_means_no_extras(self) -> None:
+        raw_response = _make_raw_response(tool_calls=None, content="Hello!")
+
+        llm = GeminiChatOpenAI(model="gemini-2.5-flash", api_key="fake")
+        result = llm._create_chat_result(raw_response)
+
+        msg = result.generations[0].message
+        assert "tool_call_extras" not in msg.additional_kwargs
+
+    def test_only_first_tool_call_carries_signature_parallel(self) -> None:
+        raw_response = _make_raw_response(
+            tool_calls=[
+                _make_raw_tool_call(tc_id="call_1", name="web_search", thought_signature="sig_first"),
+                _make_raw_tool_call(tc_id="call_2", name="read_url", thought_signature=None),
+            ]
+        )
+
+        llm = GeminiChatOpenAI(model="gemini-2.5-flash", api_key="fake")
+        result = llm._create_chat_result(raw_response)
+
+        msg = result.generations[0].message
+        extras = msg.additional_kwargs.get("tool_call_extras", {})
+        assert extras["call_1"]["google"]["thought_signature"] == "sig_first"
+        assert "call_2" not in extras
+
+
+# ---------------------------------------------------------------------------
+# 2. ChatLLM._parse_response
+# ---------------------------------------------------------------------------
+
+
+class TestParseResponseWithThoughtSignature:
+    """Test that _parse_response extracts thought_signature from additional_kwargs."""
+
+    def test_extracts_thought_signature(self) -> None:
+        from langchain_core.messages import AIMessage
+
+        ai_msg = AIMessage(
+            content="",
+            tool_calls=[
+                {"id": "call_1", "name": "web_search", "args": {"query": "gold"}, "type": "tool_call"},
+            ],
+            additional_kwargs={
+                "tool_call_extras": {
+                    "call_1": {"google": {"thought_signature": "sig_xyz"}},
+                },
+            },
+        )
+
+        response = ChatLLM._parse_response(ai_msg)
+        assert len(response.tool_calls) == 1
+        assert response.tool_calls[0].thought_signature == "sig_xyz"
+
+    def test_no_thought_signature_when_missing(self) -> None:
+        from langchain_core.messages import AIMessage
+
+        ai_msg = AIMessage(
+            content="",
+            tool_calls=[
+                {"id": "call_1", "name": "web_search", "args": {"query": "gold"}, "type": "tool_call"},
+            ],
+        )
+
+        response = ChatLLM._parse_response(ai_msg)
+        assert len(response.tool_calls) == 1
+        assert response.tool_calls[0].thought_signature is None
+
+    def test_mixed_tool_calls_with_and_without_signature(self) -> None:
+        from langchain_core.messages import AIMessage
+
+        ai_msg = AIMessage(
+            content="",
+            tool_calls=[
+                {"id": "call_1", "name": "web_search", "args": {"query": "gold"}, "type": "tool_call"},
+                {"id": "call_2", "name": "read_url", "args": {"url": "http://x"}, "type": "tool_call"},
+            ],
+            additional_kwargs={
+                "tool_call_extras": {
+                    "call_1": {"google": {"thought_signature": "sig_1"}},
+                },
+            },
+        )
+
+        response = ChatLLM._parse_response(ai_msg)
+        assert len(response.tool_calls) == 2
+        assert response.tool_calls[0].thought_signature == "sig_1"
+        assert response.tool_calls[1].thought_signature is None
+
+
+# ---------------------------------------------------------------------------
+# 3. ContextBuilder.format_assistant_tool_calls
+# ---------------------------------------------------------------------------
+
+
+class TestFormatAssistantToolCalls:
+    """Test that format_assistant_tool_calls includes thought_signature."""
+
+    def test_includes_extra_content_with_signature(self) -> None:
+        tc = ToolCallRequest(
+            id="call_1",
+            name="web_search",
+            arguments={"query": "gold"},
+            thought_signature="sig_abc",
+        )
+        msg = ContextBuilder.format_assistant_tool_calls([tc])
+
+        assert msg["role"] == "assistant"
+        assert len(msg["tool_calls"]) == 1
+        tc_dict = msg["tool_calls"][0]
+        assert "extra_content" in tc_dict
+        assert tc_dict["extra_content"]["google"]["thought_signature"] == "sig_abc"
+
+    def test_no_extra_content_without_signature(self) -> None:
+        tc = ToolCallRequest(
+            id="call_1",
+            name="web_search",
+            arguments={"query": "gold"},
+        )
+        msg = ContextBuilder.format_assistant_tool_calls([tc])
+
+        assert msg["role"] == "assistant"
+        assert len(msg["tool_calls"]) == 1
+        assert "extra_content" not in msg["tool_calls"][0]
+
+    def test_mixed_tool_calls(self) -> None:
+        tc1 = ToolCallRequest(
+            id="call_1",
+            name="web_search",
+            arguments={"query": "gold"},
+            thought_signature="sig_1",
+        )
+        tc2 = ToolCallRequest(
+            id="call_2",
+            name="read_url",
+            arguments={"url": "http://x"},
+        )
+        msg = ContextBuilder.format_assistant_tool_calls([tc1, tc2])
+
+        assert len(msg["tool_calls"]) == 2
+        assert "extra_content" in msg["tool_calls"][0]
+        assert "extra_content" not in msg["tool_calls"][1]
+
+    def test_output_is_valid_for_gemini_api(self) -> None:
+        tc = ToolCallRequest(
+            id="call_1",
+            name="web_search",
+            arguments={"query": "gold"},
+            thought_signature="sig_test",
+        )
+        msg = ContextBuilder.format_assistant_tool_calls([tc])
+
+        tc_dict = msg["tool_calls"][0]
+        assert tc_dict["id"] == "call_1"
+        assert tc_dict["type"] == "function"
+        assert tc_dict["function"]["name"] == "web_search"
+        assert json.loads(tc_dict["function"]["arguments"]) == {"query": "gold"}
+        assert tc_dict["extra_content"]["google"]["thought_signature"] == "sig_test"
+
+
+# ---------------------------------------------------------------------------
+# 4. End-to-end flow: raw response -> parsed -> formatted
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEndThoughtSignatureFlow:
+    """Test the complete data flow from raw Gemini response to formatted message."""
+
+    def test_full_flow_single_tool_call(self) -> None:
+        raw_response = _make_raw_response(tool_calls=[_make_raw_tool_call(thought_signature="sig_e2e")])
+
+        llm = GeminiChatOpenAI(model="gemini-2.5-flash", api_key="fake")
+        result = llm._create_chat_result(raw_response)
+        ai_message = result.generations[0].message
+
+        parsed = ChatLLM._parse_response(ai_message)
+        assert parsed.tool_calls[0].thought_signature == "sig_e2e"
+
+        formatted = ContextBuilder.format_assistant_tool_calls(parsed.tool_calls)
+        tc_dict = formatted["tool_calls"][0]
+        assert tc_dict["extra_content"]["google"]["thought_signature"] == "sig_e2e"
+
+    def test_full_flow_multiple_iterations(self) -> None:
+        for sig_value in ["sig_iter1", "sig_iter2"]:
+            raw_response = _make_raw_response(tool_calls=[_make_raw_tool_call(thought_signature=sig_value)])
+
+            llm = GeminiChatOpenAI(model="gemini-2.5-flash", api_key="fake")
+            result = llm._create_chat_result(raw_response)
+            ai_message = result.generations[0].message
+
+            parsed = ChatLLM._parse_response(ai_message)
+            assert parsed.tool_calls[0].thought_signature == sig_value
+
+            formatted = ContextBuilder.format_assistant_tool_calls(parsed.tool_calls)
+            tc_dict = formatted["tool_calls"][0]
+            assert tc_dict["extra_content"]["google"]["thought_signature"] == sig_value
+
+    def test_full_flow_roundtrip_preserves_signature_in_json(self) -> None:
+        """Verify the formatted message can be serialized and the signature survives."""
+        raw_response = _make_raw_response(tool_calls=[_make_raw_tool_call(thought_signature="sig_json_test")])
+
+        llm = GeminiChatOpenAI(model="gemini-2.5-flash", api_key="fake")
+        result = llm._create_chat_result(raw_response)
+        ai_message = result.generations[0].message
+
+        parsed = ChatLLM._parse_response(ai_message)
+        formatted = ContextBuilder.format_assistant_tool_calls(parsed.tool_calls)
+
+        serialized = json.dumps(formatted, ensure_ascii=False)
+        deserialized = json.loads(serialized)
+
+        assert deserialized["tool_calls"][0]["extra_content"]["google"]["thought_signature"] == "sig_json_test"
+
+
+# ---------------------------------------------------------------------------
+# 5. stream_chat() bypass for GeminiChatOpenAI
+# ---------------------------------------------------------------------------
+
+
+class TestStreamChatBypass:
+    """Test that stream_chat() falls back to chat() for GeminiChatOpenAI."""
+
+    def test_stream_chat_uses_chat_for_gemini(self) -> None:
+        llm = ChatLLM.__new__(ChatLLM)
+        llm._llm = GeminiChatOpenAI(model="gemini-2.5-flash", api_key="fake")
+        llm.model_name = "gemini-2.5-flash"
+
+        with patch.object(llm, "chat", return_value=LLMResponse(content="test")) as mock_chat:
+            result = llm.stream_chat(
+                [{"role": "user", "content": "hello"}],
+                tools=None,
+            )
+            mock_chat.assert_called_once()
+            assert result.content == "test"
+
+    def test_stream_chat_streams_for_regular_chat_openai(self) -> None:
+        """Verify non-Gemini ChatOpenAI uses streaming path (not the bypass)."""
+        from langchain_openai import ChatOpenAI
+
+        llm = ChatLLM.__new__(ChatLLM)
+        llm._llm = ChatOpenAI(model="gpt-4o", api_key="fake")
+        llm.model_name = "gpt-4o"
+
+        assert not isinstance(llm._llm, GeminiChatOpenAI)
+
+    def test_stream_chat_gemini_bypass_does_not_call_stream(self) -> None:
+        """Verify that for Gemini, the chat method is used instead of streaming."""
+        llm = ChatLLM.__new__(ChatLLM)
+        llm._llm = GeminiChatOpenAI(model="gemini-2.5-flash", api_key="fake")
+        llm.model_name = "gemini-2.5-flash"
+
+        with patch.object(llm, "chat", return_value=LLMResponse(content="test")) as mock_chat:
+            llm.stream_chat([{"role": "user", "content": "hello"}], tools=None)
+            mock_chat.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# 6. build_llm() returns correct class for gemini provider
+# ---------------------------------------------------------------------------
+
+
+class TestBuildLlmProviderSelection:
+    """Test that build_llm() returns GeminiChatOpenAI for gemini provider."""
+
+    def test_gemini_provider_returns_gemini_chat(self) -> None:
+        import src.providers.llm as llm_mod
+
+        llm_mod._dotenv_loaded = True
+
+        env = {
+            "LANGCHAIN_PROVIDER": "gemini",
+            "GEMINI_API_KEY": "test-key",
+            "GEMINI_BASE_URL": "https://generativelanguage.googleapis.com/v1beta/openai/",
+            "LANGCHAIN_MODEL_NAME": "gemini-2.5-flash",
+        }
+        clean = {k: v for k, v in os.environ.items() if not k.startswith(("OPENAI_", "LANGCHAIN_", "GEMINI_"))}
+        clean.update(env)
+        with patch.dict(os.environ, clean, clear=True):
+            result = build_llm()
+            assert isinstance(result, GeminiChatOpenAI)
+
+    def test_openai_provider_returns_base_chat(self) -> None:
+        from langchain_openai import ChatOpenAI
+        import src.providers.llm as llm_mod
+
+        llm_mod._dotenv_loaded = True
+
+        env = {
+            "LANGCHAIN_PROVIDER": "openai",
+            "OPENAI_API_KEY": "sk-test",
+            "OPENAI_BASE_URL": "https://api.openai.com/v1",
+            "LANGCHAIN_MODEL_NAME": "gpt-4o",
+        }
+        clean = {k: v for k, v in os.environ.items() if not k.startswith(("OPENAI_", "LANGCHAIN_"))}
+        clean.update(env)
+        with patch.dict(os.environ, clean, clear=True):
+            result = build_llm()
+            assert type(result) is ChatOpenAI
+            assert not isinstance(result, GeminiChatOpenAI)
+
+
+# ---------------------------------------------------------------------------
+# 7. _get_current_provider helper
+# ---------------------------------------------------------------------------
+
+
+class TestGetCurrentProvider:
+    def test_returns_gemini(self) -> None:
+        import src.providers.llm as llm_mod
+
+        llm_mod._dotenv_loaded = True
+        with patch.dict(os.environ, {"LANGCHAIN_PROVIDER": "gemini"}, clear=False):
+            assert _get_current_provider() == "gemini"
+
+    def test_defaults_to_openai(self) -> None:
+        import src.providers.llm as llm_mod
+
+        llm_mod._dotenv_loaded = True
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("LANGCHAIN_PROVIDER", None)
+            assert _get_current_provider() == "openai"
+
+
+# ---------------------------------------------------------------------------
+# 8. Regression: WebSearchTool gracefully handles missing ddgs
+# ---------------------------------------------------------------------------
+
+
+class TestWebSearchToolGracfulFailure:
+    """Ensure WebSearchTool returns a valid JSON error when ddgs is missing."""
+
+    def test_returns_error_json_when_ddgs_missing(self) -> None:
+        from src.tools.web_search_tool import WebSearchTool
+
+        tool = WebSearchTool()
+        result = tool.execute(query="test")
+        data = json.loads(result)
+        if data.get("status") == "error" and "not installed" in data.get("error", ""):
+            pytest.skip("ddgs not installed (expected in CI without full deps)")
+        else:
+            assert data["status"] == "ok"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "yfinance>=0.2.30",
     "akshare>=1.12.0",
     "ccxt>=4.0.0",
+    "ddgs>=6.0.0",
     "fastapi>=0.104.0",
     "uvicorn[standard]>=0.24.0",
     "pydantic>=2.0.0",


### PR DESCRIPTION
## Summary
Fixes #25 — two bugs that cause Gemini provider to fail when using tool calls.

### Bug 1: Missing `ddgs` dependency
`WebSearchTool` imports `ddgs`/`duckduckgo_search` at runtime, but the package was not listed in `pyproject.toml` or `agent/requirements.txt`. This caused `web_search` to always return a JSON error, which then triggered Bug 2.


### Bug 2: Gemini `thought_signature` not preserved across turns
Gemini's API returns `extra_content.google.thought_signature` on tool call responses. This signature **must** be echoed back in subsequent conversation turns. However, `ChatOpenAI` from `langchain-openai` strips `extra_content` during parsing. When the conversation history was sent back to Gemini without the signature, it returned a `400 INVALID_ARGUMENT` error:
> Function call is missing a thought_signature in functionCall parts.


## Changes
- **`pyproject.toml` / `agent/requirements.txt`** — Added `ddgs>=6.0.0` dependency
- **`agent/src/providers/llm.py`** — Added `GeminiChatOpenAI` subclass of `ChatOpenAI` that overrides `_create_chat_result()` to capture `extra_content` from raw API responses and store it in `AIMessage.additional_kwargs["tool_call_extras"]`. Updated `build_llm()` to use this class when `LANGCHAIN_PROVIDER=gemini`.
- **`agent/src/providers/chat.py`** — Added `thought_signature` field to `ToolCallRequest`. Updated `_parse_response()` to extract signatures from `tool_call_extras`. Updated `stream_chat()` to bypass streaming for Gemini (since stream chunks don't preserve `extra_content`) and use `chat()` directly.
- **`agent/src/agent/context.py`** — Updated `format_assistant_tool_calls()` to include `extra_content.google.thought_signature` in formatted assistant messages when present.
- **`agent/tests/test_gemini_thought_signature.py`** — Added 23 tests covering the full thought_signature preservation flow, including end-to-end tests with real OpenAI SDK Pydantic models.



## Testing
| Platform | Tests | Result |
|----------|-------|--------|
| Linux (native) | 23 new + 35 existing | 🗹 All pass |
| Wine (Windows compat) | 23 new + 35 existing | 🗹 All pass |
| Wine (live) | `WebSearchTool` with `ddgs` | 🗹 Returns results |