### PR TITLE
fix(kimi): preserve reasoning_content in thinking tool-call context

### DIFF
--- a/agent/src/agent/context.py
+++ b/agent/src/agent/context.py
@@ -209,7 +209,11 @@ class ContextBuilder:
         }
 
     @staticmethod
-    def format_assistant_tool_calls(tool_calls: list, content: Optional[str] = None) -> Dict[str, Any]:
+    def format_assistant_tool_calls(
+        tool_calls: list,
+        content: Optional[str] = None,
+        reasoning_content: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """Format an assistant tool_calls message, preserving thinking text.
 
         Args:
@@ -219,7 +223,7 @@ class ContextBuilder:
         Returns:
             OpenAI-format assistant message.
         """
-        return {
+        message = {
             "role": "assistant",
             "content": content,
             "tool_calls": [
@@ -234,3 +238,6 @@ class ContextBuilder:
                 for tc in tool_calls
             ],
         }
+        if reasoning_content is not None:
+            message["reasoning_content"] = reasoning_content
+        return message

--- a/agent/src/agent/loop.py
+++ b/agent/src/agent/loop.py
@@ -378,7 +378,13 @@ class AgentLoop:
                     react_trace.append({"type": "answer", "content": final_content[:500]})
                     break
 
-                messages.append(context.format_assistant_tool_calls(response.tool_calls, content=response.content))
+                messages.append(
+                    context.format_assistant_tool_calls(
+                        response.tool_calls,
+                        content=response.content,
+                        reasoning_content=response.reasoning_content or thinking_text or None,
+                    )
+                )
 
                 # Execute tools with read/write batching
                 compact_requested, focus_topic = self._process_tool_calls(

--- a/agent/src/providers/chat.py
+++ b/agent/src/providers/chat.py
@@ -38,6 +38,7 @@ class LLMResponse:
 
     content: Optional[str] = None
     tool_calls: List[ToolCallRequest] = field(default_factory=list)
+    reasoning_content: Optional[str] = None
     finish_reason: str = "stop"
 
     @property
@@ -142,6 +143,11 @@ class ChatLLM:
             ``LLMResponse``.
         """
         content = ai_message.content if hasattr(ai_message, "content") else None
+        reasoning_content = (
+            getattr(ai_message, "reasoning_content", None)
+            or getattr(ai_message, "additional_kwargs", {}).get("reasoning_content")
+            or getattr(ai_message, "response_metadata", {}).get("reasoning_content")
+        )
         raw_calls = getattr(ai_message, "tool_calls", None) or []
         tool_calls = []
         for tc in raw_calls:
@@ -151,4 +157,9 @@ class ChatLLM:
                 arguments=tc.get("args", {}),
             ))
         finish = getattr(ai_message, "response_metadata", {}).get("finish_reason", "stop")
-        return LLMResponse(content=content, tool_calls=tool_calls, finish_reason=finish)
+        return LLMResponse(
+            content=content,
+            tool_calls=tool_calls,
+            reasoning_content=reasoning_content,
+            finish_reason=finish,
+        )

--- a/agent/src/swarm/worker.py
+++ b/agent/src/swarm/worker.py
@@ -371,7 +371,9 @@ def run_worker(
         # Append assistant message with tool calls
         messages.append(
             ContextBuilder.format_assistant_tool_calls(
-                response.tool_calls, content=response.content
+                response.tool_calls,
+                content=response.content,
+                reasoning_content=response.reasoning_content,
             )
         )
 

--- a/agent/tests/test_kimi_reasoning_content.py
+++ b/agent/tests/test_kimi_reasoning_content.py
@@ -1,0 +1,75 @@
+"""Regression tests for Kimi thinking/tool-call compatibility."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from src.agent.context import ContextBuilder
+from src.providers.chat import ChatLLM, ToolCallRequest
+
+
+class TestKimiReasoningContent:
+    def test_parse_response_keeps_reasoning_content(self) -> None:
+        ai_message = SimpleNamespace(
+            content="",
+            reasoning_content="step-by-step reasoning",
+            tool_calls=[
+                {
+                    "id": "tc_1",
+                    "name": "bash",
+                    "args": {"command": "pwd"},
+                }
+            ],
+            additional_kwargs={},
+            response_metadata={"finish_reason": "tool_calls"},
+        )
+
+        response = ChatLLM._parse_response(ai_message)
+
+        assert response.reasoning_content == "step-by-step reasoning"
+        assert response.finish_reason == "tool_calls"
+        assert len(response.tool_calls) == 1
+        assert response.tool_calls[0].arguments == {"command": "pwd"}
+
+    def test_parse_response_falls_back_to_additional_kwargs(self) -> None:
+        ai_message = SimpleNamespace(
+            content="",
+            tool_calls=[],
+            additional_kwargs={"reasoning_content": "fallback reasoning"},
+            response_metadata={"finish_reason": "stop"},
+        )
+
+        response = ChatLLM._parse_response(ai_message)
+
+        assert response.reasoning_content == "fallback reasoning"
+
+    def test_format_assistant_tool_calls_preserves_reasoning_content(self) -> None:
+        message = ContextBuilder.format_assistant_tool_calls(
+            [
+                ToolCallRequest(
+                    id="tc_1",
+                    name="bash",
+                    arguments={"command": "pwd"},
+                )
+            ],
+            content="",
+            reasoning_content="step-by-step reasoning",
+        )
+
+        assert message["role"] == "assistant"
+        assert message["reasoning_content"] == "step-by-step reasoning"
+        assert message["tool_calls"][0]["id"] == "tc_1"
+
+    def test_format_assistant_tool_calls_omits_reasoning_when_absent(self) -> None:
+        message = ContextBuilder.format_assistant_tool_calls(
+            [
+                ToolCallRequest(
+                    id="tc_1",
+                    name="bash",
+                    arguments={"command": "pwd"},
+                )
+            ],
+            content="",
+        )
+
+        assert "reasoning_content" not in message


### PR DESCRIPTION
## Summary

- Fixes Kimi K2.5 thinking/tool-call compatibility by preserving `reasoning_content` in replayed assistant tool-call messages.

- Extracts `reasoning_content` from provider responses and carries it through the shared `LLMResponse` object.

- Adds regression tests to prevent this compatibility break from recurring.

## Why

Closes (#39 )the Kimi `400 invalid_request_error` where follow-up tool-call requests fail with `thinking is enabled but reasoning_content is missing in assistant tool call message...`. 

## Changes

- Core response parsing: Updated `agent/src/providers/chat.py` to add `reasoning_content` to `LLMResponse` and extract it from direct attributes plus LangChain fallbacks.

- Assistant tool-call formatting: Updated `agent/src/agent/context.py` so assistant messages with `tool_calls` include `reasoning_content` when present.

- Main agent loop: Updated `agent/src/agent/loop.py` to pass `reasoning_content` back into replayed tool-call messages, with `thinking_text` as a fallback.

- Swarm execution path: Updated `agent/src/swarm/worker.py` so swarm runs preserve the same field.

- Regression tests: Added `agent/tests/test_kimi_reasoning_content.py` covering extraction, fallback extraction, preservation, and omission behavior.

## Test Plan

- [x] New regression tests pass (`python -m pytest agent/tests/test_kimi_reasoning_content.py -q`)

- [ ] Integration verified with a valid official Moonshot/Kimi API key against `kimi-k2.5` thinking + tool-calls

- [x] Tested manually: verified local protocol-layer behavior preserves `reasoning_content` in parsed responses and formatted assistant tool-call messages

## Checklist

- [x] No changes to protected areas without prior discussion

- [x] No hardcoded values (API keys, file paths, magic numbers)

- [x] Code follows `CONTRIBUTING.md` guidelines

- [x] Documentation updated (if user-facing change)
