### PR TITLE
feat(loop): add _normalize_tool_run_dir function and corresponding tests

### DIFF
--- a/agent/src/agent/loop.py
+++ b/agent/src/agent/loop.py
@@ -237,6 +237,31 @@ def _is_tool_success(result: str) -> bool:
     return True
 
 
+def _normalize_tool_run_dir(args: dict[str, Any], memory_run_dir: str | None) -> dict[str, Any]:
+    """Normalize ``run_dir`` in tool args to an absolute path when possible.
+
+    If the model supplies a relative ``run_dir`` (for example ``"."`` or
+    ``"risk_parity_run"``), resolve it against the active run directory.
+    """
+    normalized = dict(args)
+    if not memory_run_dir:
+        return normalized
+
+    if "run_dir" not in normalized:
+        normalized["run_dir"] = memory_run_dir
+        return normalized
+
+    run_dir_value = str(normalized["run_dir"]).strip()
+    if not run_dir_value:
+        normalized["run_dir"] = memory_run_dir
+        return normalized
+
+    candidate = Path(run_dir_value)
+    if not candidate.is_absolute():
+        normalized["run_dir"] = str((Path(memory_run_dir) / candidate).resolve())
+    return normalized
+
+
 class AgentLoop:
     """ReAct Agent core loop.
 
@@ -559,9 +584,7 @@ class AgentLoop:
         # Prepare args + emit events
         runnable: list[tuple] = []
         for tc in tool_calls:
-            args = dict(tc.arguments)
-            if "run_dir" not in args and self.memory.run_dir:
-                args["run_dir"] = self.memory.run_dir
+            args = _normalize_tool_run_dir(tc.arguments, self.memory.run_dir)
             self._emit("tool_call", {"tool": tc.name, "arguments": {k: str(v)[:200] for k, v in args.items()}, "iter": iteration})
             trace.write({"type": "tool_call", "iter": iteration, "tool": tc.name, "args": {k: str(v)[:200] for k, v in args.items()}})
             runnable.append((tc, args))
@@ -607,9 +630,7 @@ class AgentLoop:
             react_trace: React trace list.
             iteration: Current iteration.
         """
-        args = dict(tc.arguments)
-        if "run_dir" not in args and self.memory.run_dir:
-            args["run_dir"] = self.memory.run_dir
+        args = _normalize_tool_run_dir(tc.arguments, self.memory.run_dir)
 
         self._emit("tool_call", {"tool": tc.name, "arguments": {k: str(v)[:200] for k, v in args.items()}, "iter": iteration})
         trace.write({"type": "tool_call", "iter": iteration, "tool": tc.name, "args": {k: str(v)[:200] for k, v in args.items()}})

--- a/agent/tests/test_loop_helpers.py
+++ b/agent/tests/test_loop_helpers.py
@@ -15,6 +15,7 @@ from src.agent.loop import (
     _context_collapse,
     _fix_tool_pairs,
     _is_tool_success,
+    _normalize_tool_run_dir,
 )
 
 
@@ -248,3 +249,30 @@ class TestIsToolSuccess:
 
     def test_success_invalid_json(self) -> None:
         assert _is_tool_success("{not json}") is True
+
+
+# ---------------------------------------------------------------------------
+# _normalize_tool_run_dir
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeToolRunDir:
+    def test_injects_memory_run_dir_when_missing(self) -> None:
+        args = {"path": "config.json"}
+        out = _normalize_tool_run_dir(args, "/tmp/run_123")
+        assert out["run_dir"] == "/tmp/run_123"
+
+    def test_resolves_relative_dot_to_memory_run_dir(self) -> None:
+        args = {"run_dir": "."}
+        out = _normalize_tool_run_dir(args, "/tmp/run_123")
+        assert out["run_dir"] == "/tmp/run_123"
+
+    def test_resolves_relative_child_to_memory_run_dir(self) -> None:
+        args = {"run_dir": "risk_parity_run"}
+        out = _normalize_tool_run_dir(args, "/tmp/run_123")
+        assert out["run_dir"] == "/tmp/run_123/risk_parity_run"
+
+    def test_preserves_absolute_run_dir(self) -> None:
+        args = {"run_dir": "/var/tmp/custom_run"}
+        out = _normalize_tool_run_dir(args, "/tmp/run_123")
+        assert out["run_dir"] == "/var/tmp/custom_run"


### PR DESCRIPTION
This pull request introduces a utility function to consistently normalize the `run_dir` argument for tool calls, ensuring it is always an absolute path and defaults to the agent's memory run directory when not specified. The new function is integrated into both parallel and single tool execution paths, and comprehensive tests are added to verify its behavior.

**Tool argument normalization:**

* Added the `_normalize_tool_run_dir` function in `agent/src/agent/loop.py` to ensure the `run_dir` argument in tool calls is always an absolute path, resolving relative paths against the agent's memory run directory and defaulting to it when missing.

* Updated `_execute_parallel` and `_execute_single` methods in `agent/src/agent/loop.py` to use `_normalize_tool_run_dir` for preparing tool arguments, replacing previous ad-hoc handling. [[1]](diffhunk://#diff-05538ff129a20f24656f68c49520ee708e50573df02ec9dc1dfb68bd5b058345L562-R587) [[2]](diffhunk://#diff-05538ff129a20f24656f68c49520ee708e50573df02ec9dc1dfb68bd5b058345L610-R633)

**Testing:**

* Imported `_normalize_tool_run_dir` in `agent/tests/test_loop_helpers.py` and added a new `TestNormalizeToolRunDir` class with tests covering missing, relative, and absolute `run_dir` values. [[1]](diffhunk://#diff-cff2f0e07683c3bb5b9858324d54961c8a7d6ac869ed51f88323fe8f3f11e65dR18) [[2]](diffhunk://#diff-cff2f0e07683c3bb5b9858324d54961c8a7d6ac869ed51f88323fe8f3f11e65dR252-R278)

<img width="3199" height="1924" alt="image" src="https://github.com/user-attachments/assets/ee420096-274a-4c7d-9e14-19b877e62573" />
