### PR TITLE
feat(skill): add ashare-pre-st-filter — A股 ST/*ST 风险预测框架

### DIFF
--- a/agent/src/skills/ashare-pre-st-filter/SKILL.md
+++ b/agent/src/skills/ashare-pre-st-filter/SKILL.md
@@ -48,7 +48,7 @@ category: risk-analysis
 | 审计意见 | `fina_audit` | `ts_code` + 最近 2 个年报 period | **akshare 无对应接口** | 缺失时在输出中标注"审计意见数据缺失"，**不得跳过**——必须提示用户去官网查 |
 | 分红 | `dividend` | `ts_code` + 近 5 年 `div_proc='实施'` | `stock_history_dividend_detail(symbol='600000', indicator='分红')` | 字段中文，需把"派息"金额×总股本得到现金分红总额 |
 | 日线行情（1 元退市预警） | `daily` | `ts_code` + 最近 30 个交易日 | `stock_zh_a_hist(symbol='600000', period='daily', adjust='')` | 必须用**不复权**价格判断 1 元退市线 |
-| 每日指标（市值） | `daily_basic` | `ts_code` + 最近一个交易日 | `stock_zh_a_spot_em()` 全市场快照筛 `代码=600000` | 字段名为"总市值"（单位元），需 /1e8 换算成亿元 |
+| 每日指标（市值） | `daily_basic` | `ts_code` + 最近一个交易日 | `stock_zh_a_spot_em()` 全市场快照筛 `代码=600000` | 字段名为"总市值"（**单位：元**，东方财富 push2 原始口径，akshare 不做缩放），换算成亿元需 `/1e8`。⚠️ 不要与 tushare `daily_basic.total_mv`（万元）混淆——本列是 akshare 兜底口径 |
 | 财报披露日期 | `disclosure_date` | `ts_code` + 当前年度 | **akshare 无对应接口** | 缺失时按经验估算（4/30 年报、8/31 中报、10/31 三季报） |
 | 监管处罚 | — | — | **走本 skill 自带 sina 脚本** | 见 E2 章节 |
 
@@ -411,7 +411,7 @@ python agent/src/skills/ashare-pre-st-filter/scripts/fetch_sina_penalties.py \
   --ts-code 000729.SZ --start-date 2025-01-01 --end-date 2025-12-31
 ```
 
-输出 JSON 到 stdout；失败返回 `{"source": "unavailable", "error": "..."}` 而非抛异常，便于 LLM 兜底处理。
+正常情况下输出 JSON 到 stdout；网络/解析失败或参数非法时返回 `{"source": "unavailable", "error": "..."}` 到 stdout 并以非零退出码结束（不抛 traceback），便于 LLM 兜底处理。
 
 ## 端到端调用伪代码
 

--- a/agent/src/skills/ashare-pre-st-filter/SKILL.md
+++ b/agent/src/skills/ashare-pre-st-filter/SKILL.md
@@ -1,0 +1,511 @@
+---
+name: ashare-pre-st-filter
+description: A 股 ST/*ST 风险预测框架 — 基于最新中报/三季报或业绩预告/快报，预测下一财年是否会因营收、利润、净资产、分红不达标而被风险警示，并将新浪监管处罚记录作为独立证据面纳入风险等级。仅适用于 A 股，不预测财务造假。
+category: risk-analysis
+---
+
+> **依赖**：本 skill 必须配合 [tushare skill](../tushare/SKILL.md) 使用，缺数据时回退到 [akshare skill](../akshare/SKILL.md)。
+
+# A 股 ST/*ST 风险预测
+
+## 适用范围
+
+- 仅 A 股**主板 / 创业板 / 科创板**。港股、美股、加密、商品、**北交所**（`8xxxxx.BJ` 监管规则与本 skill 阈值不一致）均不适用，本 skill 直接拒绝。
+- 仅做"下一财年是否会被 ST/*ST"的前瞻预测，不做财务造假预测。
+- 输出双轴结果：**触线风险等级** + **预测可信度**。
+
+## 触发条件
+
+用户提问形如：
+- "分析 000729.SZ 的 ST 风险"
+- "600xxx 下个年报会不会被 ST"
+- "帮我看一下 300xxx 是否有退市风险"
+
+收到此类请求时，按下面"分析流程"执行；其他场景不要主动启用本 skill。
+
+## 数据获取规范（tushare 优先 → akshare 兜底）
+
+**铁律**：
+
+1. **所有财务/基本面/分红/审计/ST 状态数据，必须先调用 [tushare skill](../tushare/SKILL.md)**，按下表指定的接口名、`ts_code`、`period` 拉取。
+2. 当 tushare 接口因积分不足、token 缺失或返回空时，**回退到 [akshare skill](../akshare/SKILL.md)** 对应函数。
+3. **akshare 兜底数据必须在最终输出"备注"中显式标注**：`数据源：akshare（非官方聚合，不保证完整性，建议核对原始公告）`。**不允许只用 akshare 给出"高可信度"预测**——akshare 兜底的红线项可信度强制降一档（高→中高，中高→中，中→低）。
+4. 监管处罚（E2）走本 skill 自带的 [scripts/fetch_sina_penalties.py](scripts/fetch_sina_penalties.py)，不经过 tushare/akshare。
+
+### 数据需求映射表
+
+| 数据需求 | tushare 接口（首选） | 抓取参数 / 时间窗口 | akshare 兜底 | akshare 注意事项 |
+|---------|---------------------|-------------------|-------------|----------------|
+| 当前 ST 状态 | `stock_st` | 最近一个交易日 | `stock_zh_a_st_em()` | 仅返回当前 ST/退市整理板列表，历史不可查 |
+| 历史改名 | `namechange` | `ts_code` 全历史 | `stock_zh_a_new_em()`（仅新股，无改名） | akshare 无完整改名接口，必要时跳过 |
+| 股票基础信息（板块判断） | `stock_basic` | `list_status='L'` | `stock_individual_info_em(symbol)` | 字段名不同，需自行映射 |
+| 业绩预告 | `forecast` | `ts_code` + 最近 2 个 period（`{Y}0630`/`{Y}0930`/`{Y}1231`） | `stock_yjyg_em(date='YYYYMMDD')` | 按报告期日期反查，需先按 period 拉全市场再筛 ts_code |
+| 业绩快报 | `express` | 同上，最近 2 个 period | `stock_yjbb_em(date='YYYYMMDD')` | 同上，全市场快照需筛 |
+| 利润表 | `income` | `ts_code` + 最近 5 个 period（过去 4 年年报 `{Y}1231` + 最新中报/三季报） | `stock_financial_report_sina(stock='sh600000', symbol='利润表')` | 单位不一致（万元 vs 元），需做归一；季报缺失常见 |
+| 资产负债表 | `balancesheet` | 同上 | `stock_financial_report_sina(stock='sh600000', symbol='资产负债表')` | 同上 |
+| 现金流量表 | `cashflow` | 同上 | `stock_financial_report_sina(stock='sh600000', symbol='现金流量表')` | 同上 |
+| 财务指标（扣非净利润等） | `fina_indicator` | `ts_code` + 最近 5 个 period | `stock_financial_analysis_indicator(symbol='600000')` | 字段中文，扣非字段名为"扣除非经常性损益后的净利润" |
+| 审计意见 | `fina_audit` | `ts_code` + 最近 2 个年报 period | **akshare 无对应接口** | 缺失时在输出中标注"审计意见数据缺失"，**不得跳过**——必须提示用户去官网查 |
+| 分红 | `dividend` | `ts_code` + 近 5 年 `div_proc='实施'` | `stock_history_dividend_detail(symbol='600000', indicator='分红')` | 字段中文，需把"派息"金额×总股本得到现金分红总额 |
+| 日线行情（1 元退市预警） | `daily` | `ts_code` + 最近 30 个交易日 | `stock_zh_a_hist(symbol='600000', period='daily', adjust='')` | 必须用**不复权**价格判断 1 元退市线 |
+| 每日指标（市值） | `daily_basic` | `ts_code` + 最近一个交易日 | `stock_zh_a_spot_em()` 全市场快照筛 `代码=600000` | 字段名为"总市值"（单位元），需 /1e8 换算成亿元 |
+| 财报披露日期 | `disclosure_date` | `ts_code` + 当前年度 | **akshare 无对应接口** | 缺失时按经验估算（4/30 年报、8/31 中报、10/31 三季报） |
+| 监管处罚 | — | — | **走本 skill 自带 sina 脚本** | 见 E2 章节 |
+
+### 时间窗口口径统一
+
+按数据类型分别处理，**禁止用单一 60 天经验值统一对齐**：
+
+- **财务报表（income / balancesheet / cashflow / fina_indicator）**：以 `disclosure_date` 实际公告日为准；该接口不可用时按法定截止日（年报 4/30、中报 8/31、三季报 10/31、一季报 4/30）做兜底。在公告日 +1 天起方可视该 period 为"最新可得"。
+- **"过去 N 年年报"**：一律 `period = {Y}1231`，不要用日历年起止。
+- **业绩预告 forecast / 业绩快报 express**：只取 `ann_date ≥ 当前年度 1 月 1 日` 的记录；按 `ann_date` 倒序取最新一条，老 period 的预告对预测无效。
+- **dividend**：按 `(end_date, ann_date, cash_div_tax)` 三元组**强制去重**——tushare 同一笔分红会出现 3-4 行（预案/股东大会通过/实施），直接累加会三倍误算。
+
+## 第一步：当前状态核查（M0）
+
+**判断公司当前是否已被风险警示，并据此调整分析方向（不一刀切结束）**：
+
+调用顺序：
+1. 优先调用 `stock_st`（tushare skill，3000 积分），按当前最近交易日查询；记录 `type` / `type_name`。
+2. 如积分不足，回退到 `namechange`（免费）：拉取 `ts_code` 全部历史改名记录，取按 `start_date` 排序的最新一条；判断 `name` 前缀。
+3. 兜底用 `stock_basic.name` 做名称确认。
+
+**分支处理**：
+
+| 当前状态 | 分析方向 | 是否继续 |
+|---------|---------|---------|
+| 正常股票 | 预测下一财年是否会被 ST/*ST | **是**（默认流程） |
+| 已 ST（普通） | 改为预测：是否会进一步转 *ST 或退市；R1-R4 阈值需更严格（亏损链门槛降一年） | **是** |
+| 已 *ST | 改为预测：是否会被强制退市；重点看 R1 营收 + R2 净资产 + E1 审计意见 | **是** |
+| 已退市整理期 / 已摘牌 | 直接结束 | **否** |
+
+## 第二步：板块阈值表（决定红线）
+
+**先用 `ts_code` 前缀判断板块，再套用对应阈值。不要混用。**
+
+| 板块 | 代码识别 | 营收红线 | 市值退市线 | 三年累计分红阈值 |
+|------|---------|---------|-----------|----------------|
+| 主板 | `60xxxx.SH` / `00xxxx.SZ`（除 30 / 688 开头外） | 净利润为负 且 营收 < 3 亿 | 市值 < 5 亿 | 累计 < 5000 万 且 < 年均净利润 30% |
+| 创业板 | `30xxxx.SZ` | 净利润为负 且 营收 < 1 亿 | 市值 < 3 亿 | 累计 < 3000 万 且 < 年均净利润 30%（研发豁免：研发投入占营收 ≥ 5% 或近三年累计 ≥ 6000 万） |
+| 科创板 | `688xxx.SH` | 净利润为负 且 营收 < 1 亿 | 市值 < 3 亿 | 累计 < 3000 万 且 < 年均净利润 30%（研发豁免：研发投入占营收 ≥ 5% 或近三年累计 ≥ 6000 万） |
+
+## 第三步：预测时点选择
+
+按"最新可得证据"原则确定基准时点，从下到上择优：
+
+| 基准时点 | 数据接口 | 可信度基线 | 适用季节 |
+|---------|---------|-----------|---------|
+| **业绩预告 forecast** | `forecast` | **高** | 1 月底 / 7 月中旬 / 10 月底高发期 |
+| **业绩快报 express** | `express` | **高** | 1-4 月年报前夕 |
+| **三季报** | `income/balancesheet/cashflow` (`period=YYYYMMDD`，9 月末) | **中高** | 10 月底披露后到次年年报前 |
+| **中报** | 同上，6 月末 period | **中** | 8 月底披露后到三季报前 |
+| **去年年报** | 同上，12 月末 period | **低** | 仅作为基准对照 |
+
+**证据优先级**（同一指标多个来源时，高的覆盖低的）：
+
+```
+forecast / express > 三季报 > 中报 > 去年年报 > 经验外推
+```
+
+输出时**必须在每个预测项明示采用了哪一级证据**。如果存在 forecast 给出的全年净利润区间，**禁止再用三季报机械年化覆盖**。
+
+## 第四步：四项可预测红线
+
+### R1 营收 + 净利润红线
+
+**目标**：预测全年营收、归母净利润和**扣非净利润**，按监管口径"扣非前后孰低者"判定。
+
+**口径关键**：监管原文是 `min(n_income, profit_dedt) < 0` 且 `revenue < 板块阈值` —— **必须同时预测扣非净利润**，不能只用归母。仅看归母会漏掉"归母为正但扣非为负"的造壳公司。
+
+**预测方法（按基准时点选用，至少一种）**：
+
+- **forecast 直采法**：若 `forecast` 给出 `net_profit_min` / `net_profit_max`，直接取区间作为全年归母预测；扣非用过去两年扣非率（`profit_dedt / n_income` 中位数）折算；可信度=高。营收红线仍需结合最新报表外推。
+- **express 直采法**：若 `express` 已披露，`revenue` / `n_income` 即为全年快报值；扣非同样按过去两年率折算（express 一般无扣非字段）；可信度=高。
+- **Q4 单季回补法**（三季报基准）：
+  - `Q1Q3_revenue` = 三季报营业收入
+  - `Q4_revenue_est` = 过去两年 Q4 营收占全年比例的中位数 × 当前年化预估值
+  - `revenue_full_year_est = Q1Q3_revenue + Q4_revenue_est`
+  - `n_income` / `profit_dedt` 同法处理
+  - 可信度=中高
+- **下半年情景外推法**（中报基准，强季节性公司必须用）：
+  - 取过去两年 H2 营收占全年比例均值，给出悲观/基准/乐观三情景
+  - `revenue_full_year_est = H1_revenue / H1_share_avg`
+  - 可信度=中
+- **同比延续法**（中报基准，弱季节性公司可用）：
+  - `revenue_full_year_est = H1_revenue × (last_year_full_revenue / last_year_H1_revenue)`
+  - 可信度=中
+
+**禁止**：H1 直接乘 2、Q1-Q3 直接乘 4/3。任何机械年化**强制降到"低"可信度**并在输出中注明。
+
+**触线判定**（口径：`worst_profit = min(n_income_est, profit_dedt_est)`）：
+- 高风险：`worst_profit < 0` 且 `revenue_est < 板块阈值`
+- 中风险：`worst_profit < 0` 但营收达标；或营收逼近阈值（< 阈值 × 1.2）
+- 低风险：上述均不满足
+
+> **系数说明**：R1 中风险的 1.2 是预测项预警 buffer（预测本身有误差，需窄 buffer）；R4 高风险的 1.5 是双年联动判定 buffer（两年都亏且营收接近阈值才是真退市信号，需宽 buffer）。两个系数不同是有意为之，**不要错误地统一**。
+
+### R2 年末净资产红线
+
+**目标**：判断年末归母股东权益是否可能转负。
+
+**方法**：
+1. 取最新一期 `balancesheet.total_hldr_eqy_exc_min_int`（最新中报或三季报），记为 `current_eq`。
+2. 计算 `eq_year_end_est = current_eq + 剩余季度净利润预测 − 当前年度已实施现金分红总额`。
+   - 剩余季度净利润：中报基准用 R1 的 H2 预测，三季报基准用 R1 的 Q4 预测。
+   - 已实施分红总额：见 R3 的去重 + 量纲公式 `cash_div_tax / 10 × total_share`。
+
+**触线判定**（统一相对阈值，单位：元）：
+- 高风险：`current_eq < 0` 或 `eq_year_end_est < 0`
+- 中风险：`0 ≤ eq_year_end_est < 1e8`（1 亿元）
+- 低风险：`eq_year_end_est ≥ 1e8`
+
+**注意**：商誉减值、长期股权投资减值在 Q3/Q4 集中确认，应在备注提示"若计提大额减值，净资产可能进一步下行"，但**不得在没有公告依据时擅自减值**。
+
+### R3 分红达标前瞻
+
+**目标**：判断"近三年累计现金分红 < 年均净利润 30% 且 < 板块累计阈值"是否会在下一次年度考核时同时满足（监管原文：两条件**同时**触发才警示）。
+
+**单笔分红量纲公式**（**必须用此公式，不要用 `cash_div_tax × base_share`**）：
+
+```
+cash_dividend_total = cash_div_tax / 10 × total_share
+```
+
+其中 `cash_div_tax` 来自 `dividend`（每 10 股派现金额，含税），`total_share` 来自 `daily_basic.total_share`（最新总股本，单位万股 → 需 ×1e4 换成股）或 `stock_basic`。tushare `dividend.base_share` 字段对很多公司为 None，**禁止直接使用**。
+
+**方法**：
+1. 用 `dividend` 拉取该 `ts_code` 近五年记录，按 `(end_date, ann_date, cash_div_tax)` 三元组**强制去重**——同一笔分红 tushare 会返回"预案/股东大会通过/实施"3-4 行。
+2. 折算系数（按 `div_proc` 状态）：`实施=1.0` / `股东大会通过=0.7` / `预案=0.5`；同一 `end_date` 取系数最高那条。
+3. 用 `income` 拉取近三年完整年度归母净利润（period=YYYY1231）。
+4. 计算考核窗口 = `[当前年-2, 当前年]`，即"过去两年已落地分红 + 本年度预计分红"。
+5. 本年度预计分红：
+   - 若 `dividend` 已查到本年度记录：按上面折算系数计入。
+   - 否则用"过去两年平均分红率"× R1 预测全年净利润（基准情景）做估算，可信度降一档。
+6. 与年均净利润比较：
+   - 条件 A：`cumulative_div_3y < 30% × avg_n_income_3y`
+   - 条件 B：`cumulative_div_3y < 板块累计阈值`
+7. 创业板 / 科创板若研发投入占比满足豁免条件，备注提示"研发达标可能豁免"。
+
+**触线判定**：
+- 高风险：A 和 B 同时满足 **且** 过去三年至少一年净利润为正（即"盈利年份未达标"——监管以盈利年为基准）。
+- 中风险：仅一个条件满足；或本年度分红尚未公告。
+- 低风险：累计分红已稳定达标；或过去三年累计净利润 ≤ 0（无分红基础，按 R1 联动）。
+
+**禁止**：本年度尚未公告分红时，不得断言"必然不达标"，只能给出概率。
+
+### R4 连续亏损 / 扣非亏损链
+
+**目标**：判断是否会触发"连续两年扣非前后净利润孰低者为负" → *ST。
+
+**口径关键**：监管原文是**连续两年**（不是三年），且 *ST 财务类强制退市的法定条件是 **"亏损 + 营收<板块阈值" 必须同时满足**——只看亏损链会系统性高估风险（实证：闻泰科技 2024 年亏损但营收超千亿，不会被 *ST）。
+
+**方法**：
+1. 取过去一年完整年报的 `n_income`、`fina_indicator.profit_dedt`，记 `worst_last = min(n_income, profit_dedt)`、`revenue_last`。
+2. 用 R1 已经预测好的 `worst_profit_est` 和 `revenue_full_year_est`（基准情景），对应当前年度。
+3. 检查两年的 `worst < 0` 组合，**并叠加营收联动条件**。
+
+**触线判定**（双条件，亏损链 + 营收联动）：
+- 高风险：`worst_last < 0` 且 `worst_profit_est < 0`，**且**（R1 当前年命中高风险 **或** `revenue_full_year_est < 板块阈值 × 1.5`）——即两年均亏 + 营收处于退市风险区间。
+- 中风险：(a) 连续两年均亏但营收远超阈值（≥ 阈值 × 1.5）——亏损链成立但不会触发财务类 *ST，仍可能因经营恶化转 ST；(b) 仅 `worst_profit_est < 0`（当前年预测亏损，去年盈利，未形成连续）；(c) 仅 `worst_last < 0` 但当前年预测为正且接近 0（< 板块阈值 × 0.5）。
+- 低风险：`worst_last ≥ 0` 且 `worst_profit_est ≥ 0`。
+
+**为什么要叠加营收**：A 股 *ST 财务类强制退市的法定条件是"扣非前后净利润孰低 < 0 **且** 营收 < 板块阈值"，二者必须同时满足。仅亏损不达营收阈值的公司（如大型周期股短期亏损）会被市场和监管视作"周期性亏损"而非"持续经营存疑"。
+
+## 第五步：三项事实/临界证据面（不参与预测可信度）
+
+### E1 审计意见（事实）
+
+调用 `fina_audit`，取最近 2 个完整年报：
+- 高风险：最新年报 `audit_result` 含"无法表示意见"或"否定意见"；**或单次出现"保留意见"**（实证支持：上交所近年规范类 *ST 案例多为单次保留即触发）。
+- 中风险：连续两年同一负面结论但本期已修正；或带强调事项段的无保留意见涉及持续经营。
+- 低风险：标准无保留意见。
+
+**禁止预测下一份审计意见**——审计是事后行为。
+
+**akshare 兜底缺失时的人工核查路径**（`fina_audit` 无 akshare 替代接口，必须给出可点击 URL）：
+
+| 来源 | URL 模板 | 查询方式 |
+|------|---------|---------|
+| 巨潮资讯网（公告原文，权威） | `http://www.cninfo.com.cn/new/disclosure/stock?orgId=&stockCode={code6}` | 进入页面后筛选"定期报告 → 年度报告"，下载 PDF 在第十节"财务报告 → 审计报告"查 `审计意见类型` |
+| 巨潮高级搜索（按关键词） | `http://www.cninfo.com.cn/new/fulltextSearch/full?searchkey={code6}+审计报告&sdate=&edate=&isfulltext=false&sortName=time&sortType=desc` | 直接命中含"审计报告"标题的公告 |
+| 上交所信息披露 | `http://www.sse.com.cn/disclosure/listedinfo/regular/?stockCode={code6}` | 仅限 60xxxx / 688xxx |
+| 深交所信息披露 | `http://www.szse.cn/disclosure/listed/notice/index.html?stock={code6}` | 仅限 00xxxx / 30xxxx |
+
+其中 `{code6}` 为 6 位股票代码（去掉 `.SH` / `.SZ` 后缀）。**强制要求**：当 `fina_audit` 返回空时，输出报告的"备注"必须列出上面巨潮的两条 URL 之一，便于用户人工核查；不得只写一句"审计意见数据缺失"了事。
+
+### E2 监管处罚（事实，双窗口：上一财年 + 过去 12 个月）
+
+**这是本 skill 的关键证据面。**
+
+**窗口规则（双窗口策略，单次抓取在内存中切片）**：
+
+- 窗口 A — `[当前年-1 的 1 月 1 日, 当前年-1 的 12 月 31 日]`（上一个完整财年）：用于 reason_normalized 单条评级。
+- 窗口 B — `[分析日 - 365 天, 分析日]`（过去 12 个月滚动）：用于**频次增强规则**。
+- 若分析时点已经在 5 月之后且最新年报已披露完毕，窗口 A 可改为 `[最新年报 end_date - 365 天, 最新年报 end_date]`。
+
+**调用方式（推荐：单次拉全量 + 内存切片）**：
+
+```bash
+python agent/src/skills/ashare-pre-st-filter/scripts/fetch_sina_penalties.py \
+  --ts-code 000729.SZ --no-filter
+```
+
+返回页面全量记录后，由 LLM 在内存中按窗口 A、窗口 B 切两份。也可以用 `--start-date / --end-date` 单独抓取，但同一次分析**避免发起两次 HTTP**。
+
+输出 JSON 列表，字段：`ann_date / event_type / title / reason / reason_normalized / content / issuer / issuer_normalized / subject_normalized / source_url`。
+
+**`subject_normalized` 字段**（用于频次权重折算）：
+- `company` — 处罚主体是公司本身（默认；不含个人身份关键词时归此类）
+- `shareholder` — 控股股东 / 实控人 / 5% 以上大股东
+- `officer` — 董事 / 监事 / 高管（董事长、总经理、董秘、财务总监等）
+
+**风险等级判定**：
+
+| 命中 `reason_normalized` | 等级贡献 |
+|---|---|
+| 财务造假 / 虚假陈述 / 信息披露违规 | 高（强烈预警） |
+| 违规担保 / 占用资金 | 高（直接触及 ST 红线） |
+| 内幕交易 / 市场操纵 / 违规减持 | 中 |
+| 其他/unknown | 低（仅作背景） |
+
+**频次增强规则（治理质量预警，窗口 B）**：
+
+监管函本身反映公司治理与内控质量，密集出现是"规范类 ST"（保留意见、内控非标、信披重大缺陷）的强领先指标。但**处罚主体不同，治理含义不同**：股东减持违规、董监高短线交易反映的是个人合规问题，不应等同于"公司治理失序"。
+
+**主体加权计数**（按 `subject_normalized` 折算后再查表）：
+
+```
+加权条数 = Σ 单条权重
+  其中：subject_normalized == "company"     → 权重 1.0
+        subject_normalized == "officer"     → 权重 0.5
+        subject_normalized == "shareholder" → 权重 0.5
+```
+
+| 过去 12 个月监管函/问询/警示函**加权条数** | 频次等级 |
+|---|---|
+| ≥ 5.0 | **极高** |
+| 3.0 - 4.5 | 高 |
+| 2.0 - 2.5 | 中 |
+| < 2.0 | 低 |
+
+**判定来源**：脚本输出的 `event_type ∈ {警示, 问讯, 监管关注, 监管函}` 或 `issuer_normalized ∈ {上交所, 深交所, 北交所, 证监会, 地方证监局}` 计入条数；条数按 `subject_normalized` 折算后再查表。
+
+**输出要求**：必须同时给出"原始条数"和"加权条数"两个数字，便于用户审阅折算逻辑。例如：`窗口 B 命中 6 条（公司 2 条 + 股东 3 条 + 高管 1 条 → 加权 4.0 条），频次等级：高`。
+
+**E2 综合等级合成规则**（解决单条评级与频次叠加的问题）：
+
+```
+E2_单条等级 = 窗口 A 内所有 reason_normalized 单条等级的最大值
+E2_频次等级 = 窗口 B 频次表查得
+E2_综合等级 = max(E2_单条等级, E2_频次等级)
+```
+
+**叠加加成**：若同时满足 `E2_频次等级 ≥ 高` 且 `E2_单条等级 ≥ 高`（含财务造假/虚假陈述/违规担保/占用资金）→ **直升极高**。
+
+**为什么要这条规则**：纯量化红线只能捕捉"财务类 ST"，无法预警"规范类 ST"。频次规则把"治理失序"作为前瞻信号纳入。
+
+**注意**：处罚证据**只抬升风险等级，不影响预测可信度**——这是事实证据，不是预测项。
+
+### E3 交易类临界预警（事实）
+
+调用 `daily`（近 30 个交易日，**必须 `adjust=''` 不复权**）和 `daily_basic`（最新一日，单位：万元）：
+
+**1 元退市预警**（用 `daily.close`，**不复权**）：
+- 高风险：近 20 个交易日中收盘价 < 1 元的天数 ≥ 10
+- 中风险：≥ 1 但 < 10
+- 低风险：0 天
+
+**市值退市预警**（用 `daily_basic.total_mv`，单位万元 → ×1e4 换算成元 → /1e8 换算成亿元）：
+
+| 板块 | 高风险阈值 | 中风险阈值 |
+|---|---|---|
+| 主板 | < 5 亿 | < 5 × 1.5 = 7.5 亿 |
+| 创业板 / 科创板 | < 3 亿 | < 3 × 1.5 = 4.5 亿 |
+
+## 第六步：双轴输出模板
+
+每次分析必须按下面模板输出。**风险等级 + 可信度两个维度都要给**。
+
+```markdown
+## ST 风险预测：{name}（{ts_code}）
+
+### 当前状态
+- 是否已 ST/*ST：{是 / 否}
+- 板块：{主板 / 创业板 / 科创板}
+- 基准预测时点：{forecast / express / 三季报（period） / 中报（period）}
+
+### 量化红线预测（双轴）
+
+| 红线 | 基准情景结论 | 风险等级 | 可信度 | 主要证据 |
+|------|-------------|---------|-------|---------|
+| R1 营收+净利润 | 全年营收预测 X 亿，净利润 Y 亿 | 高/中/低 | 高/中高/中/低 | forecast/三季报/... |
+| R2 年末净资产 | 当前 X 亿，年末预计 Y 亿 | 高/中/低 | 高/中高/中/低 | balancesheet + R1 |
+| R3 分红达标 | 三年累计预计 X，对应阈值 Y | 高/中/低 | 中/低 | dividend + income |
+| R4 连续亏损链 | 过去两年 + 当前年是否均亏 | 高/中/低 | 同 R1 | income + fina_indicator |
+
+### 事实证据面（不参与预测可信度）
+
+| 证据 | 结论 | 影响 |
+|------|------|------|
+| E1 审计意见 | 最新结论 | 抬升/无影响 |
+| E2 监管处罚（窗口 A 上一财年 / 窗口 B 过去 12 个月） | A 命中 Na 条（最高单条等级：…），B 原始 Nb_raw 条 / 加权 Nb_w 条（公司 a + 股东 b + 高管 c → a×1.0+b×0.5+c×0.5），频次等级：…，E2_综合等级：… | 抬升/无影响 |
+| E3 交易类临界 | 收盘价/市值情况 | 抬升/无影响 |
+
+### 综合结论
+- **下一财年被 ST/*ST 风险等级**：{极高 / 高 / 中 / 低}
+- **预测综合可信度**：{高 / 中高 / 中 / 低}
+- **关键风险点**（最多 3 条）：...
+- **缓解信号**（如有）：...
+
+### 备注
+- 数据时点：{所用最新报告期}
+- 已忽略的不可预测项：财务造假、未来审计意见
+- 季节性提醒（如适用）：...
+```
+
+## 禁止事项
+
+1. 不预测财务造假（事前不可知）。
+2. 不预测下一份审计意见（事后才出）。
+3. 不在没有公告依据时擅自计提减值。
+4. 不混用板块阈值（主板 vs 创业板/科创板的营收/市值/分红阈值不同）。
+5. 不把机械年化（H1×2、Q1Q3×4/3）伪装成"高可信度"。
+6. 不在港股 / 美股 / 加密 / **北交所**（`8xxxxx.BJ`，监管规则与本 skill 阈值不一致）上启用本 skill。
+7. 不把"违规处罚记录"计入预测可信度（仅抬升风险等级）。
+8. 不在 R3 分红计算中使用 `cash_div_tax × base_share`（base_share 经常为 None，会得 0）；必须用 `cash_div_tax / 10 × total_share`，且按 `(end_date, ann_date, cash_div_tax)` 三元组去重。
+9. 不在 R1 触线判定中只用 `n_income`；必须用 `min(n_income, profit_dedt)`，否则会漏掉造壳公司。
+10. 不把 R4 写成"连续三年"；监管原文是"连续两年"。**且 R4 高风险必须叠加营收联动条件**——仅"连续两年亏损"不构成 *ST 财务类强制退市，必须同时满足"营收 < 板块阈值 × 1.5"或 R1 已命中高风险，否则只能给中风险。
+11. 不把 E2 监管处罚"按主体一刀切"计数——必须用 `subject_normalized` 加权（公司 ×1.0 / 股东 ×0.5 / 董监高 ×0.5），否则股东动荡的公司会被系统性高估。
+
+## 依赖的 tushare 接口清单
+
+| 用途 | 接口 | 备注 |
+|------|------|------|
+| 当前 ST 状态 | `stock_st` | 3000 积分；不可用时回退 `namechange` |
+| 历史改名 | `namechange` | 免费 |
+| 板块判断 | `stock_basic` | 免费 |
+| 利润表 | `income` | 2000 积分，多 period 拉取 |
+| 资产负债表 | `balancesheet` | 2000 积分 |
+| 财务指标（扣非等） | `fina_indicator` | 2000 积分 |
+| 业绩预告 | `forecast` | 2000 积分 |
+| 业绩快报 | `express` | 2000 积分 |
+| 审计意见 | `fina_audit` | 500 积分 |
+| 分红 | `dividend` | 2000 积分 |
+| 日线 | `daily` | 免费 |
+| 每日指标（市值） | `daily_basic` | 免费 |
+| 财报披露日期 | `disclosure_date` | 500 积分 |
+
+## 自带脚本
+
+- [scripts/fetch_sina_penalties.py](scripts/fetch_sina_penalties.py) — 抓取新浪财经 vGP_GetOutOfLine 处罚页，stdlib 实现，无外部依赖；reason / issuer 标准化。
+
+调用方式：
+
+```bash
+# 单次拉全量（推荐：本 skill 双窗口策略由 LLM 在内存中切片）
+python agent/src/skills/ashare-pre-st-filter/scripts/fetch_sina_penalties.py \
+  --ts-code 000729.SZ --no-filter
+
+# 或指定单一窗口
+python agent/src/skills/ashare-pre-st-filter/scripts/fetch_sina_penalties.py \
+  --ts-code 000729.SZ --start-date 2025-01-01 --end-date 2025-12-31
+```
+
+输出 JSON 到 stdout；失败返回 `{"source": "unavailable", "error": "..."}` 而非抛异常，便于 LLM 兜底处理。
+
+## 端到端调用伪代码
+
+用于减少 LLM 调用顺序漂移，按下列骨架组织：
+
+```python
+import os, json, subprocess
+import tushare as ts
+
+ts_code = '000729.SZ'
+pro = ts.pro_api(os.environ['TUSHARE_TOKEN'])
+
+# === Step 0: M0 当前状态 ===
+basic = pro.stock_basic(ts_code=ts_code, fields='ts_code,name,market').to_dict('records')[0]
+st_hit = pro.stock_st()  # 失败则回退 namechange
+name_chg = pro.namechange(ts_code=ts_code).sort_values('start_date', ascending=False)
+
+# === Step 1: 板块判断 ===
+board = '科创板' if ts_code.startswith('688') else '创业板' if ts_code.startswith('30') else '主板'
+threshold_revenue = 1e8 if board != '主板' else 3e8
+threshold_mv = 3e8 if board != '主板' else 5e8
+
+# === Step 2: 拉财务（最新 5 期 + 过去 4 年年报） ===
+income = pro.income(ts_code=ts_code).sort_values('end_date', ascending=False).drop_duplicates('end_date')
+balance = pro.balancesheet(ts_code=ts_code).sort_values('end_date', ascending=False).drop_duplicates('end_date')
+fina_ind = pro.fina_indicator(ts_code=ts_code).sort_values('end_date', ascending=False).drop_duplicates('end_date')
+forecast = pro.forecast(ts_code=ts_code).sort_values('ann_date', ascending=False)
+express = pro.express(ts_code=ts_code).sort_values('ann_date', ascending=False)
+
+# === Step 3: R1-R4 计算（按各章节口径，注意 min(n_income, profit_dedt)） ===
+# ... 略
+
+# === Step 4: E1 审计 ===
+audit = pro.fina_audit(ts_code=ts_code).sort_values('end_date', ascending=False).head(2)
+
+# === Step 5: E2 监管处罚（双窗口 + 主体加权）===
+from datetime import date, timedelta
+result = subprocess.run([
+    'python', 'agent/src/skills/ashare-pre-st-filter/scripts/fetch_sina_penalties.py',
+    '--ts-code', ts_code, '--no-filter',
+], capture_output=True, text=True)
+penalties = json.loads(result.stdout).get('records', [])
+
+# 在内存中切双窗口（避免两次 HTTP）
+this_year = date.today().year
+win_a_start, win_a_end = f'{this_year-1}-01-01', f'{this_year-1}-12-31'
+win_b_start = (date.today() - timedelta(days=365)).isoformat()
+win_b_end   = date.today().isoformat()
+
+def _in(rec, s, e):
+    d = rec.get('ann_date') or ''
+    return bool(d) and s <= d <= e
+
+win_a = [r for r in penalties if _in(r, win_a_start, win_a_end)]
+win_b = [r for r in penalties if _in(r, win_b_start, win_b_end)]
+
+# 窗口 A：单条等级取最高
+REASON_LEVEL = {
+    '财务造假': 3, '虚假陈述': 3, '信息披露违规': 3,
+    '违规担保': 3, '占用资金': 3,
+    '内幕交易': 2, '市场操纵': 2, '违规减持': 2,
+}
+levels_a = [REASON_LEVEL.get(r['reason_normalized'], 1) for r in win_a]
+e2_single = max(levels_a) if levels_a else 0
+
+# 窗口 B：原始条数 + 主体加权条数
+FREQ_EVENT_TYPES = {'警示', '问讯', '监管关注', '监管函', '警示函'}
+FREQ_ISSUERS = {'上交所', '深交所', '北交所', '证监会', '地方证监局'}
+SUBJECT_WEIGHT = {'company': 1.0, 'shareholder': 0.5, 'officer': 0.5}
+
+freq_pool = [r for r in win_b
+             if r['event_type'] in FREQ_EVENT_TYPES
+             or r['issuer_normalized'] in FREQ_ISSUERS]
+nb_raw = len(freq_pool)
+nb_weighted = round(sum(SUBJECT_WEIGHT.get(r['subject_normalized'], 1.0)
+                        for r in freq_pool), 1)
+
+# 频次等级（基于加权条数）
+if nb_weighted >= 5.0:    e2_freq = 4   # 极高
+elif nb_weighted >= 3.0:  e2_freq = 3   # 高
+elif nb_weighted >= 2.0:  e2_freq = 2   # 中
+else:                     e2_freq = 1   # 低
+
+e2_overall = max(e2_single, e2_freq)
+# 叠加加成：频次高 + 单条高同时命中 → 直升极高
+if e2_freq >= 3 and e2_single >= 3:
+    e2_overall = 4
+
+# === Step 6: E3 交易临界 ===
+daily = pro.daily(ts_code=ts_code).sort_values('trade_date', ascending=False).head(30)
+daily_basic = pro.daily_basic(ts_code=ts_code).sort_values('trade_date', ascending=False).head(1).iloc[0]
+total_mv_yi = daily_basic['total_mv'] * 1e4 / 1e8  # 万元 → 亿元
+
+# === Step 7: 双轴合成输出 ===
+# 风险等级 = max(R1, R2, R3, R4, E1, E2_综合, E3)
+# 可信度 = 加权平均(R1, R2, R3, R4 各项可信度)，akshare 兜底项降一档
+```

--- a/agent/src/skills/ashare-pre-st-filter/scripts/fetch_sina_penalties.py
+++ b/agent/src/skills/ashare-pre-st-filter/scripts/fetch_sina_penalties.py
@@ -23,7 +23,6 @@ import re
 import sys
 import time
 import unicodedata
-from html import unescape
 from html.parser import HTMLParser
 from typing import Any
 from urllib.error import HTTPError, URLError
@@ -230,12 +229,6 @@ class _TableExtractor(HTMLParser):
     def handle_charref(self, name: str) -> None:
         if self._capture:
             self._buf.append(f"&#{name};")
-
-
-def _strip_html(html: str) -> str:
-    text = re.sub(r"<[^>]+>", "", html)
-    text = unescape(text)
-    return re.sub(r"\s+", " ", text).strip()
 
 
 # event_type 黑名单：head 文本首个中文片段如果落在这些"结构性字面量"上，
@@ -504,12 +497,24 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps({"source": "unavailable", "error": str(exc)}, ensure_ascii=False))
         return 2
 
-    result = fetch_penalty_list(
-        args.ts_code,
-        start_date=start_date,
-        end_date=end_date,
-        timeout=args.timeout,
-    )
+    try:
+        result = fetch_penalty_list(
+            args.ts_code,
+            start_date=start_date,
+            end_date=end_date,
+            timeout=args.timeout,
+        )
+    except ValueError as exc:
+        # _validate_stockid 等参数校验异常：保持脚本契约
+        # （永远输出 JSON，不抛 traceback），返回非零退出码。
+        json.dump(
+            {"source": "unavailable", "ts_code": args.ts_code, "error": f"invalid_input: {exc}", "records": []},
+            sys.stdout,
+            ensure_ascii=False,
+            indent=args.indent,
+        )
+        sys.stdout.write("\n")
+        return 2
     json.dump(result, sys.stdout, ensure_ascii=False, indent=args.indent)
     sys.stdout.write("\n")
     return 0 if result.get("source") == "sina" else 1

--- a/agent/src/skills/ashare-pre-st-filter/scripts/fetch_sina_penalties.py
+++ b/agent/src/skills/ashare-pre-st-filter/scripts/fetch_sina_penalties.py
@@ -1,0 +1,519 @@
+#!/usr/bin/env python3
+"""新浪财经 A 股监管处罚记录抓取脚本（独立 stdlib 实现）。
+
+用途：为 ashare-pre-st-filter skill 的 E2 证据面提供输入。
+
+数据源：vip.stock.finance.sina.com.cn/corp/go.php/vGP_GetOutOfLine/stockid/<6位>.phtml
+解析目标：HTML 表格 <table id="collectFund_1">，每条记录由 <thead>(类型/公告日期) + 4 行 (标题/批复原因/批复内容/处理人) 构成。
+
+安全约束：
+- SSRF 防护：仅允许 host == vip.stock.finance.sina.com.cn
+- GBK 解码（新浪页面）
+- 节流 + 指数退避重试
+
+输出：JSON 到 stdout；失败时返回 {"source": "unavailable", "error": "..."}。
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import re
+import sys
+import time
+import unicodedata
+from html import unescape
+from html.parser import HTMLParser
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+ALLOWED_HOST = "vip.stock.finance.sina.com.cn"
+URL_TEMPLATE = (
+    "https://vip.stock.finance.sina.com.cn/corp/go.php/vGP_GetOutOfLine/stockid/{code6}.phtml"
+)
+USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0 Safari/537.36"
+)
+DEFAULT_TIMEOUT = 15
+MAX_RETRIES = 3
+THROTTLE_SECONDS = 0.4
+
+REASON_KEYWORDS = [
+    ("信息披露违规", ["信息披露", "未及时披露", "未披露", "披露不", "披露违规"]),
+    ("内幕交易", ["内幕交易", "内幕信息"]),
+    ("市场操纵", ["操纵市场", "操纵股价", "操纵证券"]),
+    ("财务造假", ["财务造假", "虚增收入", "虚增利润", "财务舞弊"]),
+    ("虚假陈述", ["虚假记载", "虚假陈述", "误导性陈述"]),
+    ("违规减持", ["违规减持", "短线交易", "违规增减持"]),
+    ("占用资金", ["占用资金", "资金占用", "非经营性占用"]),
+    ("违规担保", ["违规担保", "对外担保"]),
+]
+
+ISSUER_KEYWORDS = [
+    ("上交所", ["上海证券交易所", "上交所"]),
+    ("深交所", ["深圳证券交易所", "深交所"]),
+    ("北交所", ["北京证券交易所", "北交所"]),
+    # 地方证监局必须优先于证监会，否则"中国证监会北京监管局"会被误归为证监会。
+    ("地方证监局", ["证监局"]),
+    ("证监会", ["中国证券监督管理委员会", "证监会"]),
+]
+
+# 处罚主体识别。匹配优先级：shareholder > officer > company（默认）。
+# 用于 E2 频次规则的权重折算——非公司主体（股东/董监高）权重 ×0.5，
+# 因为这类处罚反映个人行为，不等同于"公司治理失序"。
+#
+# 优先级决策依据（CR P1-2）：身份叠加（如"董事长 X 兼控股股东"）时，
+# 监管语境取最重责任主体——shareholder 责任高于 officer，故先扫 shareholder。
+SUBJECT_KEYWORDS = [
+    ("shareholder", [
+        "控股股东", "实际控制人", "实控人", "原实际控制人", "原实控人",
+        "持股5%以上", "持股 5%以上", "5%以上股东", "5%以上的股东",
+        "第一大股东", "二股东", "大股东", "股东减持",
+        "原股东", "前股东", "一致行动人",
+    ]),
+    ("officer", [
+        "董事长", "副董事长", "总经理", "副总经理", "总裁",
+        "财务总监", "董事会秘书", "董秘", "证券事务代表",
+        "监事会主席", "独立董事",
+        "时任董事", "时任监事", "时任高管", "时任董秘",
+        "高级管理人员", "高管人员", "聘任的高级管理人员",
+    ]),
+]
+
+DATE_RE = re.compile(r"公告日期[:：]\s*(\d{4}-\d{1,2}-\d{1,2})")
+
+
+def _norm_text(text: str) -> str:
+    """文本归一化：NFKC 折叠全角/半角 + 去除内部空白。
+
+    应用场景（CR P2）：新浪页面会出现“５％以上股东”、“控股 股东”等变体，
+    原吝始“kw in text”会漏命中。归一化后“５％”→“5%”，中文间空格被吃掉。
+    """
+    if not text:
+        return ""
+    s = unicodedata.normalize("NFKC", text)
+    return re.sub(r"\s+", "", s)
+
+
+def _validate_stockid(ts_code: str) -> str:
+    """从 600000.SH / 000001.SZ / 600000 中抽取 6 位股票代码。"""
+    if not ts_code:
+        raise ValueError("ts_code is required")
+    s = ts_code.strip().upper()
+    s = re.sub(r"\.(SH|SZ|BJ)$", "", s)
+    if not re.fullmatch(r"\d{6}", s):
+        raise ValueError(f"invalid ts_code: {ts_code!r} (expect 6-digit code)")
+    return s
+
+
+def _normalize_reason(text: str) -> str:
+    if not text:
+        return "unknown"
+    norm = _norm_text(text)
+    for label, kws in REASON_KEYWORDS:
+        for kw in kws:
+            if _norm_text(kw) in norm:
+                return label
+    return "unknown"
+
+
+def _normalize_issuer(text: str) -> str:
+    if not text:
+        return "unknown"
+    norm = _norm_text(text)
+    for label, kws in ISSUER_KEYWORDS:
+        for kw in kws:
+            if _norm_text(kw) in norm:
+                return label
+    return "unknown"
+
+
+def _normalize_subject(text: str) -> str:
+    """从标题/原因/内容文本推断处罚主体。
+
+    返回值：
+    - "shareholder"  控股股东 / 实控人 / 5% 以上大股东
+    - "officer"      董事 / 监事 / 高管（董秘、财务总监等）
+    - "company"      默认；当文本无任何上述关键词时归为公司本身
+
+    供 E2 频次规则做主体权重折算（非公司主体 ×0.5）。
+    """
+    if not text:
+        return "company"
+    norm = _norm_text(text)
+    for label, kws in SUBJECT_KEYWORDS:
+        for kw in kws:
+            if _norm_text(kw) in norm:
+                return label
+    return "company"
+
+
+def _http_get_gbk(url: str, *, timeout: int = DEFAULT_TIMEOUT) -> str:
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError(f"disallowed scheme: {parsed.scheme}")
+    if parsed.hostname != ALLOWED_HOST:
+        raise ValueError(f"disallowed host: {parsed.hostname}")
+
+    last_err: Exception | None = None
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            req = Request(
+                url,
+                headers={
+                    "User-Agent": USER_AGENT,
+                    "Accept": "text/html,application/xhtml+xml",
+                    "Accept-Encoding": "gzip",
+                    "Accept-Language": "zh-CN,zh;q=0.9",
+                },
+            )
+            with urlopen(req, timeout=timeout) as resp:  # noqa: S310 — host is whitelisted
+                raw = resp.read()
+                if resp.headers.get("Content-Encoding", "").lower() == "gzip":
+                    raw = gzip.decompress(raw)
+            try:
+                return raw.decode("gbk", errors="replace")
+            except LookupError:
+                return raw.decode("utf-8", errors="replace")
+        except (HTTPError, URLError, TimeoutError) as exc:
+            last_err = exc
+            time.sleep(THROTTLE_SECONDS * (2 ** (attempt - 1)))
+    raise RuntimeError(f"http get failed after {MAX_RETRIES} retries: {last_err}")
+
+
+class _TableExtractor(HTMLParser):
+    """提取 <table id="collectFund_1"> 的内部 HTML 文本（包含子标签）。"""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=False)
+        self._depth = 0
+        self._capture = False
+        self._buf: list[str] = []
+        self.found: str | None = None
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag == "table":
+            attrs_d = dict(attrs)
+            if not self._capture and attrs_d.get("id") == "collectFund_1":
+                self._capture = True
+                self._depth = 1
+                return
+            if self._capture:
+                self._depth += 1
+        if self._capture:
+            attr_str = "".join(f' {k}="{v}"' if v is not None else f" {k}" for k, v in attrs)
+            self._buf.append(f"<{tag}{attr_str}>")
+
+    def handle_endtag(self, tag: str) -> None:
+        if not self._capture:
+            return
+        if tag == "table":
+            self._depth -= 1
+            if self._depth <= 0:
+                self.found = "".join(self._buf)
+                self._capture = False
+                return
+        self._buf.append(f"</{tag}>")
+
+    def handle_data(self, data: str) -> None:
+        if self._capture:
+            self._buf.append(data)
+
+    def handle_entityref(self, name: str) -> None:
+        if self._capture:
+            self._buf.append(f"&{name};")
+
+    def handle_charref(self, name: str) -> None:
+        if self._capture:
+            self._buf.append(f"&#{name};")
+
+
+def _strip_html(html: str) -> str:
+    text = re.sub(r"<[^>]+>", "", html)
+    text = unescape(text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+# event_type 黑名单：head 文本首个中文片段如果落在这些"结构性字面量"上，
+# 说明该 thead 没有显式标注事件类型，应回退到"未分类"。
+# （CR P0-3：避免把"公告日期"误识别为 event_type，导致 E2 频次规则漏命中。）
+_EVENT_TYPE_BLOCKLIST = {
+    "公告日期", "日期", "批复", "批复内容", "批复原因",
+    "处罚日期", "处罚原因", "处罚内容", "处罚机关",
+    "标题", "处理人", "类型",
+}
+
+
+def _extract_event_type(head_text: str) -> str:
+    """从 thead 文本中提取事件类型，跳过结构性字面量。"""
+    for m in re.finditer(r"[\u4e00-\u9fa5]+", head_text):
+        token = m.group(0)
+        if token in _EVENT_TYPE_BLOCKLIST:
+            continue
+        return token
+    return "未分类"
+
+
+class _RecordParser(HTMLParser):
+    """以 HTMLParser 切分 collectFund_1 表格中的单条记录。
+
+    替代原 `_DATA_ROW_RE` + `_RECORD_HEAD_RE` 正则方案——后者
+    在 `re.DOTALL + (?:(?!</tr>).)*?` 下属于灾难性回溯模式，
+    遇到未闭合 `<tr>` 的脏 HTML 会指数级回溯（CR P0-1）。
+
+    解析模型：
+    - 状态机以 `<thead>` 为记录起点；遇到下一个 `<thead>` 落盘上一条。
+    - 记录内的 `<tr>` 抓取 `<strong>KEY</strong>` 与同行第一个 `<td>VALUE</td>`。
+    """
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.records: list[dict[str, str]] = []
+        self._cur: dict[str, Any] | None = None
+        self._mode: str | None = None  # 'thead' | 'tr_key' | 'tr_val' | None
+        self._buf: list[str] = []
+        self._cur_key: str = ""
+        self._val_captured: bool = False  # 同一 tr 内只取第一个 value td
+
+    def _flush(self) -> None:
+        if self._cur is not None:
+            self.records.append(self._cur)
+        self._cur = {"_head": "", "_fields": {}}
+
+    def _capture(self, data: str) -> None:
+        if self._mode in ("thead", "tr_key", "tr_val"):
+            self._buf.append(data)
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:  # noqa: ARG002
+        if tag == "thead":
+            self._flush()
+            self._mode = "thead"
+            self._buf = []
+        elif tag == "tr":
+            self._cur_key = ""
+            self._val_captured = False
+        elif tag == "strong" and self._mode not in ("thead", "tr_val"):
+            # 仅在 row 起始（尚未进入 value td）时把 strong 视为 key；
+            # 否则可能是 value 内的 <strong> 嵌套，应保留为 value 文本。
+            self._mode = "tr_key"
+            self._buf = []
+        elif tag == "td":
+            # 进入 td：仅当已读到 key 且本行尚未捕获 value 时切到 tr_val
+            if self._mode != "thead" and self._cur_key and not self._val_captured:
+                self._mode = "tr_val"
+                self._buf = []
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "thead" and self._mode == "thead":
+            head_text = re.sub(r"\s+", " ", "".join(self._buf)).strip()
+            if self._cur is None:
+                self._cur = {"_head": "", "_fields": {}}
+            self._cur["_head"] = head_text
+            self._mode = None
+            self._buf = []
+        elif tag == "strong" and self._mode == "tr_key":
+            self._cur_key = "".join(self._buf).strip().rstrip(":：")
+            self._mode = None
+            self._buf = []
+        elif tag == "td" and self._mode == "tr_val":
+            val = re.sub(r"\s+", " ", "".join(self._buf)).strip()
+            if self._cur is not None and self._cur_key:
+                self._cur["_fields"][self._cur_key] = val
+            self._val_captured = True
+            self._cur_key = ""
+            self._mode = None
+            self._buf = []
+        elif tag == "tr":
+            self._cur_key = ""
+            self._val_captured = False
+
+    def handle_data(self, data: str) -> None:
+        self._capture(data)
+
+    def close(self) -> None:  # type: ignore[override]
+        super().close()
+        # 落盘最后一条
+        if self._cur is not None and (self._cur.get("_head") or self._cur.get("_fields")):
+            self.records.append(self._cur)
+            self._cur = None
+
+
+def _build_record(raw: dict[str, Any]) -> dict[str, Any] | None:
+    head = raw.get("_head") or ""
+    fields: dict[str, str] = raw.get("_fields") or {}
+
+    date_m = DATE_RE.search(head)
+    ann_date = ""
+    if date_m:
+        try:
+            y, mo, d = date_m.group(1).split("-")
+            ann_date = f"{int(y):04d}-{int(mo):02d}-{int(d):02d}"
+        except Exception:
+            ann_date = date_m.group(1)
+
+    # event_type：先剥掉"公告日期: YYYY-MM-DD"再扫剩余首个中文片段；
+    # 双重防御——剥不干净时再用黑名单兜底（CR P0-3）。
+    head_wo_date = DATE_RE.sub("", head)
+    head_wo_date = re.sub(r"公告日期[:：]?", "", head_wo_date)
+    event_type = _extract_event_type(head_wo_date) or _extract_event_type(head)
+
+    title = fields.get("标题", "")
+    reason = fields.get("批复原因", "") or fields.get("处罚原因", "")
+    content = fields.get("批复内容", "") or fields.get("处罚内容", "")
+    issuer = fields.get("处理人", "") or fields.get("处罚机关", "")
+
+    if not (title or reason or content):
+        return None
+
+    combined_for_reason = " ".join([title, reason, content])
+    return {
+        "ann_date": ann_date,
+        "event_type": event_type,
+        "title": title,
+        "reason": reason,
+        "reason_normalized": _normalize_reason(combined_for_reason),
+        "content": content,
+        "issuer": issuer,
+        "issuer_normalized": _normalize_issuer(issuer),
+        "subject_normalized": _normalize_subject(combined_for_reason),
+    }
+
+
+def _parse_penalty_list(html: str) -> list[dict[str, Any]]:
+    extractor = _TableExtractor()
+    extractor.feed(html)
+    if not extractor.found:
+        return []
+    parser = _RecordParser()
+    parser.feed(extractor.found)
+    parser.close()
+    out: list[dict[str, Any]] = []
+    for raw in parser.records:
+        rec = _build_record(raw)
+        if rec is not None:
+            out.append(rec)
+    return out
+
+
+def _apply_date_filter(
+    records: list[dict[str, Any]],
+    start_date: str | None,
+    end_date: str | None,
+) -> list[dict[str, Any]]:
+    if not start_date and not end_date:
+        return records
+    out: list[dict[str, Any]] = []
+    for rec in records:
+        d = rec.get("ann_date") or ""
+        if not d:
+            # 公告日缺失时保留记录，但添加标记供 LLM 识别。
+            rec.setdefault("_warning", "missing_ann_date")
+            out.append(rec)
+            continue
+        if start_date and d < start_date:
+            continue
+        if end_date and d > end_date:
+            continue
+        out.append(rec)
+    return out
+
+
+def fetch_penalty_list(
+    ts_code: str,
+    *,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> dict[str, Any]:
+    code6 = _validate_stockid(ts_code)
+    url = URL_TEMPLATE.format(code6=code6)
+    try:
+        html = _http_get_gbk(url, timeout=timeout)
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "source": "unavailable",
+            "ts_code": ts_code,
+            "url": url,
+            "error": f"http_failed: {exc}",
+            "records": [],
+        }
+    try:
+        records = _parse_penalty_list(html)
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "source": "unavailable",
+            "ts_code": ts_code,
+            "url": url,
+            "error": f"parse_failed: {exc}",
+            "records": [],
+        }
+    filtered = _apply_date_filter(records, start_date, end_date)
+    for rec in filtered:
+        rec["source_url"] = url
+    return {
+        "source": "sina",
+        "ts_code": ts_code,
+        "url": url,
+        "start_date": start_date,
+        "end_date": end_date,
+        "total_in_page": len(records),
+        "matched": len(filtered),
+        "records": filtered,
+    }
+
+
+def _normalize_date_arg(s: str | None) -> str | None:
+    if not s:
+        return None
+    s = s.strip()
+    if not s:
+        return None
+    m = re.fullmatch(r"(\d{4})[-/]?(\d{1,2})[-/]?(\d{1,2})", s)
+    if not m:
+        raise ValueError(f"invalid date: {s!r}")
+    y, mo, d = m.groups()
+    return f"{int(y):04d}-{int(mo):02d}-{int(d):02d}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ts-code", required=True, help="例如 600000.SH / 000001.SZ / 688001")
+    parser.add_argument("--start-date", default=None, help="YYYY-MM-DD，含端点")
+    parser.add_argument("--end-date", default=None, help="YYYY-MM-DD，含端点")
+    parser.add_argument(
+        "--no-filter",
+        action="store_true",
+        help="返回页面全量记录、忽略 --start-date / --end-date（推荐：由调用方在内存中切双窗口，避免两次 HTTP）",
+    )
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT)
+    parser.add_argument("--indent", type=int, default=2)
+    args = parser.parse_args(argv)
+
+    try:
+        if args.no_filter:
+            start_date = None
+            end_date = None
+        else:
+            start_date = _normalize_date_arg(args.start_date)
+            end_date = _normalize_date_arg(args.end_date)
+    except ValueError as exc:
+        print(json.dumps({"source": "unavailable", "error": str(exc)}, ensure_ascii=False))
+        return 2
+
+    result = fetch_penalty_list(
+        args.ts_code,
+        start_date=start_date,
+        end_date=end_date,
+        timeout=args.timeout,
+    )
+    json.dump(result, sys.stdout, ensure_ascii=False, indent=args.indent)
+    sys.stdout.write("\n")
+    return 0 if result.get("source") == "sina" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent/tests/test_fetch_sina_penalties.py
+++ b/agent/tests/test_fetch_sina_penalties.py
@@ -260,6 +260,23 @@ class TestFetchPenaltyListFallback:
         assert result["source"] == "unavailable"
         assert "parse_failed" in result["error"]
 
+    def test_http_get_gbk_rejects_disallowed_host(self, fsp):
+        # SSRF 防护：非白名单 host 必须在 _http_get_gbk 立即抛 ValueError
+        with pytest.raises(ValueError, match="disallowed host"):
+            fsp._http_get_gbk("https://example.com/foo")
+
+    def test_http_get_gbk_rejects_disallowed_scheme(self, fsp):
+        with pytest.raises(ValueError, match="disallowed scheme"):
+            fsp._http_get_gbk("file:///etc/passwd")
+
+    def test_disallowed_host_url_returns_fallback(self, fsp, monkeypatch):
+        # 若 URL_TEMPLATE 被改坏指向非白名单 host，fetch_penalty_list 应走 http_failed fallback
+        monkeypatch.setattr(fsp, "URL_TEMPLATE", "https://evil.example.com/{code6}.phtml")
+        result = fsp.fetch_penalty_list("600000.SH")
+        assert result["source"] == "unavailable"
+        assert "http_failed" in result["error"]
+        assert "disallowed host" in result["error"]
+
 
 # ---------------------------------------------------------------------------
 # 抗灾难性回溯：脏 HTML 不应卡死

--- a/agent/tests/test_fetch_sina_penalties.py
+++ b/agent/tests/test_fetch_sina_penalties.py
@@ -1,0 +1,374 @@
+"""ashare-pre-st-filter / fetch_sina_penalties.py 单元测试。
+
+覆盖 CR P0/P1 修复点：
+- HTMLParser 解析正确性（替代灾难性回溯正则）
+- event_type 结构化提取（不会把"公告日期"误识别）
+- subject_normalized 主体识别 + 优先级
+- 日期过滤边界
+- HTTP 失败时 fetch_penalty_list 返回 fallback JSON
+- _validate_stockid 输入校验
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "skills"
+    / "ashare-pre-st-filter"
+    / "scripts"
+    / "fetch_sina_penalties.py"
+)
+
+
+@pytest.fixture(scope="module")
+def fsp():
+    spec = importlib.util.spec_from_file_location("fsp", _MODULE_PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# _validate_stockid
+# ---------------------------------------------------------------------------
+
+class TestValidateStockid:
+    def test_with_sh_suffix(self, fsp):
+        assert fsp._validate_stockid("600000.SH") == "600000"
+
+    def test_with_sz_suffix(self, fsp):
+        assert fsp._validate_stockid("000001.SZ") == "000001"
+
+    def test_bare_six_digits(self, fsp):
+        assert fsp._validate_stockid("688001") == "688001"
+
+    def test_lowercase_suffix(self, fsp):
+        assert fsp._validate_stockid("300750.sz") == "300750"
+
+    def test_empty_raises(self, fsp):
+        with pytest.raises(ValueError):
+            fsp._validate_stockid("")
+
+    def test_invalid_length_raises(self, fsp):
+        with pytest.raises(ValueError):
+            fsp._validate_stockid("60000")
+
+
+# ---------------------------------------------------------------------------
+# _normalize_subject —— 主体识别 + 优先级
+# ---------------------------------------------------------------------------
+
+class TestNormalizeSubject:
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ("某公司未及时披露关联交易", "company"),
+            ("控股股东张三违规减持", "shareholder"),
+            ("XX 公司原董事长李四短线交易", "officer"),
+            ("实际控制人内幕交易", "shareholder"),
+            ("财务总监未履行勤勉尽责义务", "officer"),
+            ("证券事务代表信息披露违规", "officer"),
+            ("一致行动人未及时披露权益变动", "shareholder"),
+            ("5%以上股东减持未预披露", "shareholder"),
+            ("聘任的高级管理人员违规交易", "officer"),
+            ("", "company"),
+        ],
+    )
+    def test_keyword_match(self, fsp, text, expected):
+        assert fsp._normalize_subject(text) == expected
+
+    def test_priority_shareholder_over_officer(self, fsp):
+        # 身份叠加：董事长 + 控股股东 → 取更重责任主体 shareholder
+        text = "董事长 X 作为控股股东违规减持"
+        assert fsp._normalize_subject(text) == "shareholder"
+
+
+# ---------------------------------------------------------------------------
+# _extract_event_type / _build_record —— event_type 不会误识别"公告日期"
+# ---------------------------------------------------------------------------
+
+class TestExtractEventType:
+    def test_normal_warning(self, fsp):
+        assert fsp._extract_event_type("警示函 公告日期 2024-05-12") == "警示函"
+
+    def test_skip_date_literal(self, fsp):
+        # 黑名单兜底：head 文本里只剩"公告日期"时不应当作 event_type
+        assert fsp._extract_event_type("公告日期") == "未分类"
+
+    def test_skip_label_then_pick_real_type(self, fsp):
+        # 假设新浪改版把"类型"当字面量放在前面
+        assert fsp._extract_event_type("类型 监管关注") == "监管关注"
+
+    def test_no_chinese_returns_default(self, fsp):
+        assert fsp._extract_event_type("2024-05-12") == "未分类"
+
+
+# ---------------------------------------------------------------------------
+# _parse_penalty_list —— HTMLParser 端到端解析
+# ---------------------------------------------------------------------------
+
+_FIXTURE_HTML = """
+<html><body>
+<table id="collectFund_1">
+  <thead><tr><th>警示函 公告日期: 2024-05-12</th></tr></thead>
+  <tr><td><strong>标题:</strong></td><td>关于对某公司的警示函</td></tr>
+  <tr><td><strong>批复原因:</strong></td><td>未及时披露关联交易</td></tr>
+  <tr><td><strong>批复内容:</strong></td><td>责令改正</td></tr>
+  <tr><td><strong>处理人:</strong></td><td>上海证券交易所</td></tr>
+
+  <thead><tr><th>监管关注 公告日期: 2024-08-20</th></tr></thead>
+  <tr><td><strong>标题:</strong></td><td>关于对控股股东张三的监管关注函</td></tr>
+  <tr><td><strong>批复原因:</strong></td><td>违规减持</td></tr>
+  <tr><td><strong>批复内容:</strong></td><td>提请关注</td></tr>
+  <tr><td><strong>处理人:</strong></td><td>深圳证券交易所</td></tr>
+
+  <thead><tr><th>处罚 公告日期: 2025-02-01</th></tr></thead>
+  <tr><td><strong>标题:</strong></td><td>对 XX 公司原董事长李四的行政处罚</td></tr>
+  <tr><td><strong>处罚原因:</strong></td><td>短线交易</td></tr>
+  <tr><td><strong>处罚内容:</strong></td><td>罚款 50 万元</td></tr>
+  <tr><td><strong>处罚机关:</strong></td><[email protected]>北京证监局</td></tr>
+</table>
+</body></html>
+""".replace("[email protected]", "td")
+
+
+class TestParsePenaltyList:
+    def test_parses_three_records(self, fsp):
+        recs = fsp._parse_penalty_list(_FIXTURE_HTML)
+        assert len(recs) == 3
+
+    def test_record_schema(self, fsp):
+        rec = fsp._parse_penalty_list(_FIXTURE_HTML)[0]
+        expected_keys = {
+            "ann_date", "event_type", "title", "reason",
+            "reason_normalized", "content", "issuer",
+            "issuer_normalized", "subject_normalized",
+        }
+        assert expected_keys.issubset(rec.keys())
+
+    def test_event_type_extracted(self, fsp):
+        recs = fsp._parse_penalty_list(_FIXTURE_HTML)
+        assert recs[0]["event_type"] == "警示函"
+        assert recs[1]["event_type"] == "监管关注"
+        # 不会出现"公告日期"被当作 event_type
+        for r in recs:
+            assert r["event_type"] != "公告日期"
+
+    def test_ann_date_normalized(self, fsp):
+        recs = fsp._parse_penalty_list(_FIXTURE_HTML)
+        assert recs[0]["ann_date"] == "2024-05-12"
+        assert recs[2]["ann_date"] == "2025-02-01"
+
+    def test_subject_classification(self, fsp):
+        recs = fsp._parse_penalty_list(_FIXTURE_HTML)
+        # 第 1 条：公司本身
+        assert recs[0]["subject_normalized"] == "company"
+        # 第 2 条：含"控股股东" → shareholder
+        assert recs[1]["subject_normalized"] == "shareholder"
+        # 第 3 条：含"原董事长" → officer
+        assert recs[2]["subject_normalized"] == "officer"
+
+    def test_issuer_normalized(self, fsp):
+        recs = fsp._parse_penalty_list(_FIXTURE_HTML)
+        assert recs[0]["issuer_normalized"] == "上交所"
+        assert recs[1]["issuer_normalized"] == "深交所"
+        # 地方证监局优先于证监会
+        assert recs[2]["issuer_normalized"] == "地方证监局"
+
+    def test_empty_html(self, fsp):
+        assert fsp._parse_penalty_list("<html></html>") == []
+
+    def test_no_target_table(self, fsp):
+        html = '<table id="other"><tr><td>noise</td></tr></table>'
+        assert fsp._parse_penalty_list(html) == []
+
+
+# ---------------------------------------------------------------------------
+# _apply_date_filter —— 日期过滤边界
+# ---------------------------------------------------------------------------
+
+class TestApplyDateFilter:
+    def _records(self):
+        return [
+            {"ann_date": "2024-01-01", "title": "a"},
+            {"ann_date": "2024-06-15", "title": "b"},
+            {"ann_date": "2024-12-31", "title": "c"},
+            {"ann_date": "", "title": "no-date"},
+        ]
+
+    def test_no_filter_returns_all(self, fsp):
+        out = fsp._apply_date_filter(self._records(), None, None)
+        assert len(out) == 4
+
+    def test_inclusive_endpoints(self, fsp):
+        out = fsp._apply_date_filter(self._records(), "2024-01-01", "2024-12-31")
+        # 端点应该被包含；缺失日期记录也保留并打 _warning
+        titles = {r["title"] for r in out}
+        assert {"a", "b", "c", "no-date"} == titles
+
+    def test_start_only(self, fsp):
+        out = fsp._apply_date_filter(self._records(), "2024-06-01", None)
+        assert {r["title"] for r in out if r["title"] != "no-date"} == {"b", "c"}
+
+    def test_end_only(self, fsp):
+        out = fsp._apply_date_filter(self._records(), None, "2024-06-15")
+        assert {r["title"] for r in out if r["title"] != "no-date"} == {"a", "b"}
+
+    def test_missing_date_marked(self, fsp):
+        out = fsp._apply_date_filter(self._records(), "2024-01-01", "2024-12-31")
+        no_date = [r for r in out if r["title"] == "no-date"][0]
+        assert no_date.get("_warning") == "missing_ann_date"
+
+
+# ---------------------------------------------------------------------------
+# fetch_penalty_list —— HTTP 失败 / host 校验失败时的 fallback
+# ---------------------------------------------------------------------------
+
+class TestFetchPenaltyListFallback:
+    def test_invalid_ts_code_raises(self, fsp):
+        # _validate_stockid 在 fetch_penalty_list 顶部调用，无效输入直接抛
+        with pytest.raises(ValueError):
+            fsp.fetch_penalty_list("INVALID")
+
+    def test_http_failure_returns_fallback(self, fsp, monkeypatch):
+        def _boom(url, *, timeout=15):
+            raise RuntimeError("http get failed: simulated")
+
+        monkeypatch.setattr(fsp, "_http_get_gbk", _boom)
+        result = fsp.fetch_penalty_list("600000.SH")
+        assert result["source"] == "unavailable"
+        assert "http_failed" in result["error"]
+        assert result["records"] == []
+        # 仍包含 ts_code / url 上下文
+        assert result["ts_code"] == "600000.SH"
+
+    def test_parse_failure_returns_fallback(self, fsp, monkeypatch):
+        monkeypatch.setattr(fsp, "_http_get_gbk", lambda *a, **kw: "<html></html>")
+
+        def _boom(html):
+            raise RuntimeError("parse exploded")
+
+        monkeypatch.setattr(fsp, "_parse_penalty_list", _boom)
+        result = fsp.fetch_penalty_list("600000.SH")
+        assert result["source"] == "unavailable"
+        assert "parse_failed" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# 抗灾难性回溯：脏 HTML 不应卡死
+# ---------------------------------------------------------------------------
+
+class TestNoCatastrophicBacktracking:
+    def test_unclosed_tr_does_not_hang(self, fsp):
+        """未闭合 <tr> 的脏 HTML，旧灾难性正则在此会指数级回溯。
+
+        新 HTMLParser 实现应在毫秒级完成。
+        """
+        import time
+
+        dirty = (
+            '<table id="collectFund_1">'
+            + '<thead><tr><th>警示函 公告日期: 2024-05-12</th></tr></thead>'
+            + ('<tr><td><strong>标题</strong></td><td>x</td>' * 200)  # 故意不闭合 </tr>
+            + "</table>"
+        )
+        t0 = time.perf_counter()
+        recs = fsp._parse_penalty_list(dirty)
+        elapsed = time.perf_counter() - t0
+        # 即便解析结果数为 0 也无所谓，关键是不能卡死
+        assert elapsed < 1.0, f"parsing dirty html took {elapsed:.3f}s — possible regex backtracking"
+        assert isinstance(recs, list)
+
+
+# ---------------------------------------------------------------------------
+# P2: 全半角 / 大小写归一
+# ---------------------------------------------------------------------------
+
+class TestNormalizeFullwidth:
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ("５％以上股东减持未预披露", "shareholder"),  # 全角数字+全角百分号
+            ("控股 股东 张三", "shareholder"),            # 含全角空格
+            ("董\u3000秘违规交易", "officer"),            # 全角空格在词中
+            ("ＤＤ公司未及时披露", "company"),            # 全角字母不影响
+        ],
+    )
+    def test_subject_with_fullwidth(self, fsp, text, expected):
+        assert fsp._normalize_subject(text) == expected
+
+    def test_reason_with_fullwidth(self, fsp):
+        assert fsp._normalize_reason("信　息　披　露 违规") == "信息披露违规"
+
+    def test_issuer_with_fullwidth(self, fsp):
+        assert fsp._normalize_issuer("上 海 证 券 交 易 所") == "上交所"
+
+
+# ---------------------------------------------------------------------------
+# P2: _RecordParser 边界 / thead 嵌套 / 多空白
+# ---------------------------------------------------------------------------
+
+class TestRecordParserEdgeCases:
+    def test_nested_strong_in_value(self, fsp):
+        """value td 内包含 <strong> 嵌套时，不应被误当作下一行 key。"""
+        html = (
+            '<table id="collectFund_1">'
+            '<thead><tr><th>警示函 公告日期: 2024-01-01</th></tr></thead>'
+            '<tr><td><strong>标题:</strong></td><td>关于 <strong>重要</strong> 事项的警示函</td></tr>'
+            '<tr><td><strong>批复原因:</strong></td><td>违规减持</td></tr>'
+            '</table>'
+        )
+        recs = fsp._parse_penalty_list(html)
+        assert len(recs) == 1
+        assert "重要" in recs[0]["title"]
+        assert recs[0]["reason"] == "违规减持"
+
+    def test_extra_whitespace_in_thead(self, fsp):
+        html = (
+            '<table id="collectFund_1">'
+            '<thead><tr><th>  \n\t 监管关注\n  公告日期:  2024-08-20  </th></tr></thead>'
+            '<tr><td><strong>标题:</strong></td><td>x</td></tr>'
+            '<tr><td><strong>批复原因:</strong></td><td>y</td></tr>'
+            '</table>'
+        )
+        recs = fsp._parse_penalty_list(html)
+        assert len(recs) == 1
+        assert recs[0]["event_type"] == "监管关注"
+        assert recs[0]["ann_date"] == "2024-08-20"
+
+    def test_record_without_strong_dropped(self, fsp):
+        """完全没有 strong key 的 thead 段（无任何字段），_build_record 返回 None。"""
+        html = (
+            '<table id="collectFund_1">'
+            '<thead><tr><th>警示函 公告日期: 2024-05-12</th></tr></thead>'
+            '<tr><td>noise</td><td>noise</td></tr>'
+            '</table>'
+        )
+        assert fsp._parse_penalty_list(html) == []
+
+    def test_multiple_td_after_key_only_first_taken(self, fsp):
+        """key 后出现多个 td 时，只取第一个作为 value。"""
+        html = (
+            '<table id="collectFund_1">'
+            '<thead><tr><th>警示函 公告日期: 2024-05-12</th></tr></thead>'
+            '<tr><td><strong>标题:</strong></td><td>真实标题</td><td>多余的td</td></tr>'
+            '<tr><td><strong>批复原因:</strong></td><td>r</td></tr>'
+            '</table>'
+        )
+        recs = fsp._parse_penalty_list(html)
+        assert recs[0]["title"] == "真实标题"
+
+    def test_no_thead_returns_empty(self, fsp):
+        html = (
+            '<table id="collectFund_1">'
+            '<tr><td><strong>标题:</strong></td><td>x</td></tr>'
+            '</table>'
+        )
+        assert fsp._parse_penalty_list(html) == []


### PR DESCRIPTION
## 以下内容为人类手打
### 什么时候用？什么情况用？
- 这是一个基础的SKILL，它告诉Agent如何预测一只股票在下个年报季是否会被ST。
- 对于指数型满仓策略，由于该策略头寸固定，需全年优先执行此策略进行风险防控。
- 对于短期操作策略（如缠论和聪明钱策略），使用者需在每年4月1日至4月28日期间执行该策略以规避风险。
- 对于大部分超短线用户, 每年春节后至年报发布完成后一周内，利用该策略调整头寸进行做:
    - 示例1: 策略可与双针探底等蜡烛图形态学策略配合使用：当预判股票可能被ST后，提前减仓，待其被ST后出现二次圆弧底形态时再介入
    - 示例2: 反向使用本策略, 预测一只ST多大可能被摘帽
 
### 策略的量化部分

检查项 | 问的是什么 | 高风险触发条件 | 中风险触发条件
-- | -- | -- | --
R1 亏损+营收 | 明年会同时亏损且营收不够吗？ | min(归母, 扣非) < 0 且营收 < 板块阈值（主板3亿/其他1亿） | 净利润为负但营收达标；或营收 < 阈值×1.2
R2 净资产 | 年末净资产会变负吗？ | 当前净资产 < 0，或年末预测（当前 + 剩余利润 − 已分红）< 0 | 0 ~ 1亿之间
R3 分红 | 三年累计分红交卷了吗？ | 累计 < 年均利润×30% 且 < 板块阈值（主板5000万/其他3000万），两条同时触发 | 仅一条触发；或本年分红未公告
R4 亏损链 | 已连续两年亏损了吗？ | 去年亏 + 今年预测亏，且营收 < 阈值×1.5（光亏损不够，必须叠加营收条件） | 仅今年预测亏；或连续亏但营收远超阈值
E1 审计 | 审计师认可这家公司吗？ | 保留/否定/无法表示意见 | 带持续经营强调段的无保留意见
E2 监管处罚 | 过去一年被罚了多少次？ | 加权条数≥5（极高）或≥3（高）；或单条含财务造假/违规担保 | 加权条数 2~2.5
E3 交易临界 | 股价和市值还在线吗？ | 近20日收盘<1元天数≥10；或市值<退市线（主板5亿/其他3亿） | 天数1~9；或市值<退市线×1.5


--------

Claude:
## Summary

新增 skill `ashare-pre-st-filter`：A 股 ST/*ST 风险预测框架。

基于最新中报/三季报或业绩预告/快报，预测**下一财年**是否会因
营收 / 利润 / 净资产 / 分红不达标而被风险警示，并将新浪监管处罚
记录作为独立证据面纳入风险等级。仅适用于 A 股，**不预测财务造假**
（造假属事后归因，无法事前预测）。

## Motivation

A 股 *ST 的核心法定双条件——净利润 < 0 **且** 营收 < 板块阈值
（主板 3 亿 / 创业板·科创板 1 亿）——在投资侧具有强可预测性。
当前缺乏一个把"硬触线"+"双年联动"+"监管处罚证据"统一进双轴
（风险等级 × 可信度）输出的 skill。

## Design Highlights

| 维度 | 决策 |
|---|---|
| **输出** | 双轴：`risk_level ∈ {低,中,高,极高}` × `confidence ∈ {低,中,高}`，避免单维度误导 |
| **R1 触线** | `worst_profit = min(n_income_est, profit_dedt_est)` < 0 且营收触线 → 高；营收 < 阈值 ×1.2 → 中（预测 buffer） |
| **R4 双年联动** | 当年触线 + 下年营收 < 阈值 ×1.5 → 高（更宽 buffer，因双年联动判定要求更严证据） |
| **E2 监管处罚** | 双窗口：A = 上一完整财年（单条等级）/ B = 过去 12 个月（频次） |
| **主体加权** | `subject_normalized` 三态：company×1.0 / shareholder×0.5 / officer×0.5（个人行为不等同于公司治理失序） |
| **频次阈值** | 加权条数 ≥5.0 极高 / 3.0 高 / 2.0 中 / <2.0 低；E2_freq 与 E2_single 同高 → 升极高 |

## Implementation

### `agent/src/skills/ashare-pre-st-filter/scripts/fetch_sina_penalties.py`
- **零外部依赖**：纯 stdlib（`HTMLParser` + `urllib` + `gzip` + `unicodedata`）
- **SSRF 防护**：白名单 `vip.stock.finance.sina.com.cn`
- **抗 ReDoS**：`_RecordParser` 状态机替代多重否定先行正则
- **NFKC 归一**：`_norm_text` 兼容全/半角变体（如 `５％以上股东`）
- **健壮性**：HTTP / parse 失败均回落 `{"source":"unavailable",...}`，3 次指数退避
- **优先级**：`SUBJECT_KEYWORDS` 中 shareholder 先于 officer，处理身份叠加

### `agent/src/skills/ashare-pre-st-filter/SKILL.md`
- E 证据面（E1 巨潮 / E2 处罚 / E3 财报 / E4 …），每面给出 issuer/链接/抓取脚本
- 端到端伪代码（含 Step 5 双窗口 Python，可直接执行）
- R1 ×1.2 / R4 ×1.5 系数差异显式注释，禁止统一

## Tests

`agent/tests/test_fetch_sina_penalties.py` — **49 case 全 pass**：

| 类 | case 数 | 覆盖 |
|---|---:|---|
| `TestValidateStockid` | 6 | `.SH/.SZ/.BJ` 后缀、6 位裸码、空/格式错误 |
| `TestNormalizeSubject` | 11 | 主体识别 + shareholder > officer 优先级 |
| `TestExtractEventType` | 4 | 黑名单防"公告日期"误识别 |
| `TestParsePenaltyList` | 9 | HTMLParser 端到端 |
| `TestApplyDateFilter` | 5 | 日期过滤端点 + 缺失日期标记 |
| `TestFetchPenaltyListFallback` | 3 | host 校验失败 / HTTP 失败 / parse 失败 |
| `TestNoCatastrophicBacktracking` | 1 | 200 行未闭合 `<tr>` < 1s |
| `TestNormalizeFullwidth` | 6 | NFKC 归一全/半角变体 |
| `TestRecordParserEdgeCases` | 5 | 嵌套 `<strong>` / 多 `<td>` / 缺 `<thead>` |

### 真实页面冒烟
```bash
$ python agent/src/skills/ashare-pre-st-filter/scripts/fetch_sina_penalties.py \
    --ts-code 600745.SH --no-filter
source=sina  matched=40
{
  "ann_date":"2025-07-10",
  "event_type":"问讯",
  "title":"闻泰科技:关于2024年年度报告的信息披露监管问询函的回复公告",
  "reason_normalized":"信息披露违规",
  "issuer_normalized":"上交所",
  "subject_normalized":"company",
  ...
}
```

## CR / 修复轨迹

本 PR 已经历 P0/P1/P2 三轮自查：
- **P0-1** 灾难性回溯正则 → HTMLParser 状态机
- **P0-2** SKILL.md 双窗口伪代码完整化
- **P0-3** event_type 黑名单防"公告日期"误识别
- **P1-1** subject 关键词扩充（一致行动人 / 5%以上股东 / …）
- **P1-3** R1/R4 系数差异注释
- **P1-4** pytest 覆盖 ≥5 核心 case（实际 49）
- **P1-5** 输出模板加权条数
- **P2** NFKC 归一 + `_RecordParser` 边界（修复期间真实抓到 1 个嵌套 strong bug）

## Files

- `agent/src/skills/ashare-pre-st-filter/SKILL.md` (+511)
- `agent/src/skills/ashare-pre-st-filter/scripts/fetch_sina_penalties.py` (+519)
- `agent/tests/test_fetch_sina_penalties.py` (+374)

总计 1404 行，0 删除。

## Risks & Limitations

1. 数据源依赖新浪页面结构；若改版需更新 `_RecordParser`（已抗 ReDoS / 容错降级）
5. 不预测财务造假（设计取舍，已在 SKILL 文档显式说明）
6. `SUBJECT_KEYWORDS` 基于现有公开监管文书归纳，新身份语境可能漏召（fallback 到 `company`，影响仅是少 0.5 权重折扣）

## Checklist

- [x] 49/49 单元测试通过
- [x] 真实页面端到端冒烟通过
- [x] 仅 stdlib，无新增依赖
- [x] SSRF 防护 + 输入校验 + 抗 ReDoS
- [x] CR P0/P1/P2 全部闭环
