### PR TITLE
WIP: feat: add ashare financial enrichment and skill packs

### DIFF
--- a/agent/backtest/financials/__init__.py
+++ b/agent/backtest/financials/__init__.py
@@ -1,0 +1,6 @@
+"""Market-scoped financial data helpers for backtest runtimes.
+
+Current implementations live under market-specific subpackages such as
+``backtest.financials.ashare`` so additional regions can be added without
+overloading generic module names.
+"""

--- a/agent/backtest/financials/ashare/__init__.py
+++ b/agent/backtest/financials/ashare/__init__.py
@@ -1,0 +1,35 @@
+"""A-share financial data helpers for backtest runtimes."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from backtest.financials.contracts import MarketFinancialRuntime
+from backtest.financials.ashare.field_inference import (
+	infer_financial_fields,
+	infer_financial_fields_from_file,
+	infer_financial_fields_from_prompt,
+	infer_financial_fields_from_source,
+)
+from backtest.financials.ashare.field_registry import get_financial_field_registry
+from backtest.financials.ashare.pit_assembler import assemble_pit_frame, enrich_data_map_with_financials
+from backtest.financials.ashare.tushare_loader import TushareFinancialLoader
+
+
+@lru_cache(maxsize=1)
+def get_ashare_financial_runtime() -> MarketFinancialRuntime:
+	"""Return the A-share implementation bundle for the shared financial boundary."""
+	return MarketFinancialRuntime(
+		market="a_share",
+		registry=get_financial_field_registry(),
+		infer_fields_from_prompt=infer_financial_fields_from_prompt,
+		infer_fields_from_source=infer_financial_fields_from_source,
+		infer_fields_from_file=infer_financial_fields_from_file,
+		infer_fields=infer_financial_fields,
+		loader_factory=TushareFinancialLoader,
+		assemble_pit_frame=assemble_pit_frame,
+		enrich_data_map=enrich_data_map_with_financials,
+	)
+
+
+__all__ = ["get_ashare_financial_runtime"]

--- a/agent/backtest/financials/ashare/field_inference.py
+++ b/agent/backtest/financials/ashare/field_inference.py
@@ -1,0 +1,203 @@
+"""Infer required A-share financial fields from prompt text and signal_engine source.
+
+This module is intentionally narrow:
+
+* Prompt inference returns registry-backed field candidates.
+* Source inference extracts string-literal field references from Python AST.
+* Final planning delegates ambiguity handling to the financial field registry.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+import re
+from typing import Iterable, Mapping
+
+from backtest.financials.contracts import FinancialFieldInferenceResult
+
+from backtest.financials.ashare.field_registry import (
+    FinancialQueryPlan,
+    build_financial_query_plan,
+    get_financial_field_registry,
+)
+
+
+def _dedupe(items: Iterable[str]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(item for item in items if item))
+
+
+def _sorted_by_text_order(text: str, positions: Mapping[str, int]) -> tuple[str, ...]:
+    return tuple(
+        field_name
+        for field_name, _ in sorted(
+            positions.items(),
+            key=lambda item: (item[1], item[0]),
+        )
+    )
+
+
+def _contains_non_ascii(text: str) -> bool:
+    return any(ord(char) > 127 for char in text)
+
+
+def _is_unit_like_suffix(text: str) -> bool:
+    candidate = text.strip()
+    if not candidate:
+        return False
+    if re.fullmatch(r"[%/A-Za-z0-9._+-]+", candidate):
+        return True
+    return candidate in {
+        "元",
+        "股",
+        "天",
+        "次",
+        "倍",
+        "年",
+        "月",
+        "日",
+        "周",
+        "万元",
+        "亿元",
+        "万股",
+    }
+
+
+def _normalize_description_alias(description: str) -> tuple[str, ...]:
+    normalized = description.strip()
+    aliases = [normalized]
+
+    stripped = normalized
+    for pattern in (r"（(.*?)）", r"\((.*?)\)"):
+        match = re.search(pattern, stripped)
+        if match and _is_unit_like_suffix(match.group(1)):
+            stripped = re.sub(pattern, "", stripped).strip()
+    if stripped and stripped not in aliases:
+        aliases.append(stripped)
+
+    unit_stripped = re.sub(r"[：:、，,。%/（）()元股\s]+", "", stripped or normalized).strip()
+    if unit_stripped and unit_stripped not in aliases:
+        aliases.append(unit_stripped)
+
+    return tuple(alias for alias in aliases if alias)
+
+
+def _iter_registry_descriptions() -> Iterable[tuple[str, str]]:
+    registry = get_financial_field_registry()
+    for table in registry.tables.values():
+        for field in table.output_fields.values():
+            description = (field.description or "").strip()
+            if description:
+                yield field.name, description
+
+
+def infer_financial_fields_from_prompt(prompt: str) -> tuple[str, ...]:
+    """Infer field candidates from free-form prompt text.
+
+    The first version stays conservative:
+
+    * field-code hits are exact token matches
+    * Chinese description hits are exact substring matches
+    * only fields present in the local registry are returned
+    """
+    text = (prompt or "").strip()
+    if not text:
+        return ()
+
+    registry = get_financial_field_registry()
+    prompt_lower = text.lower()
+    matched_positions: dict[str, int] = {}
+
+    for field_name in registry.field_to_tables:
+        pattern = rf"(?<![A-Za-z0-9_]){re.escape(field_name.lower())}(?![A-Za-z0-9_])"
+        match = re.search(pattern, prompt_lower)
+        if match:
+            matched_positions[field_name] = min(
+                matched_positions.get(field_name, match.start()),
+                match.start(),
+            )
+
+    for field_name, description in _iter_registry_descriptions():
+        if not _contains_non_ascii(description):
+            continue
+        for alias in _normalize_description_alias(description):
+            position = text.find(alias)
+            if position >= 0:
+                matched_positions[field_name] = min(
+                    matched_positions.get(field_name, position),
+                    position,
+                )
+                break
+
+    return _sorted_by_text_order(text, matched_positions)
+
+
+def _extract_string_constants(node: ast.AST) -> Iterable[str]:
+    for child in ast.walk(node):
+        if isinstance(child, ast.Constant) and isinstance(child.value, str):
+            yield child.value
+
+
+def infer_financial_fields_from_source(source: str) -> tuple[str, ...]:
+    """Infer field candidates from Python source.
+
+    This version deliberately keys off string literals in the AST and filters
+    them through the financial field registry. That covers the common patterns:
+
+    * ``df["field"]``
+    * ``row.get("field")``
+    * ``fields = ["field_a", "field_b"]``
+    * ``field = "field"`` followed by dynamic indexing
+    """
+    text = (source or "").strip()
+    if not text:
+        return ()
+
+    tree = ast.parse(text)
+    registry = get_financial_field_registry()
+
+    matched_positions: dict[str, int] = {}
+    for value in _extract_string_constants(tree):
+        if not registry.has_field(value):
+            continue
+        position = text.find(value)
+        matched_positions[value] = min(
+            matched_positions.get(value, position),
+            position,
+        )
+    return _sorted_by_text_order(text, matched_positions)
+
+
+def infer_financial_fields_from_file(file_path: str | Path) -> tuple[str, ...]:
+    """Infer field candidates from a Python source file."""
+    path = Path(file_path)
+    return infer_financial_fields_from_source(path.read_text(encoding="utf-8"))
+
+
+def infer_financial_fields(
+    *,
+    prompt: str = "",
+    source: str = "",
+    preferred_tables: Mapping[str, str] | None = None,
+    include_key_columns: bool = True,
+) -> FinancialFieldInferenceResult:
+    """Run prompt/source inference and build a registry-backed query plan.
+
+    The result keeps prompt candidates and source hits separate so callers can
+    decide whether to trust generated code over natural-language intent.
+    """
+    prompt_fields = infer_financial_fields_from_prompt(prompt)
+    source_fields = infer_financial_fields_from_source(source)
+    combined_fields = _dedupe((*prompt_fields, *source_fields))
+    query_plan = build_financial_query_plan(
+        combined_fields,
+        preferred_tables=preferred_tables,
+        include_key_columns=include_key_columns,
+        strict=False,
+    )
+    return FinancialFieldInferenceResult(
+        prompt_fields=prompt_fields,
+        source_fields=source_fields,
+        combined_fields=combined_fields,
+        query_plan=query_plan,
+    )

--- a/agent/backtest/financials/ashare/field_registry.py
+++ b/agent/backtest/financials/ashare/field_registry.py
@@ -1,0 +1,460 @@
+"""Registry for Tushare A-share financial statement fields.
+
+The registry is built from bundled local Tushare markdown reference files so
+it does not depend on live web docs. It provides three things:
+
+1. Table-level API metadata for the five supported statement tables.
+2. Field-to-table ownership lookup, including ambiguous shared fields.
+3. A minimal query-plan helper that groups requested fields by table.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+import re
+from typing import Iterable, Mapping
+
+from backtest.financials.contracts import FinancialCrossSectionCapability, FinancialQueryPlan
+
+
+SUPPORTED_FINANCIAL_TABLES = (
+    "income",
+    "balancesheet",
+    "cashflow",
+    "express",
+    "fina_indicator",
+)
+
+_REFERENCE_FILES = {
+    "income": "利润表.md",
+    "balancesheet": "资产负债表.md",
+    "cashflow": "现金流量表.md",
+    "express": "业绩快报.md",
+    "fina_indicator": "财务指标数据.md",
+}
+
+_KEY_COLUMN_ORDER = (
+    "ts_code",
+    "ann_date",
+    "f_ann_date",
+    "end_date",
+    "period",
+    "report_type",
+    "comp_type",
+    "end_type",
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_AGENT_ROOT = Path(__file__).resolve().parents[3]
+_SKILLS_ROOT = _AGENT_ROOT / "src" / "skills"
+_REFERENCE_ROOT = _SKILLS_ROOT / "tushare" / "references" / "股票数据" / "财务数据"
+
+
+class FinancialFieldRegistryError(RuntimeError):
+    """Base error for financial field registry issues."""
+
+
+class UnknownFinancialFieldError(KeyError):
+    """Raised when a requested field is absent from the registry."""
+
+
+class AmbiguousFinancialFieldError(ValueError):
+    """Raised when a field belongs to multiple tables and no preference exists."""
+
+
+@dataclass(frozen=True)
+class ParameterMetadata:
+    """Input-parameter metadata for a Tushare table."""
+
+    name: str
+    param_type: str
+    required: bool
+    description: str
+
+
+@dataclass(frozen=True)
+class FieldMetadata:
+    """Output-field metadata for a Tushare table."""
+
+    name: str
+    field_type: str
+    description: str
+    default_visible: bool | None
+
+
+@dataclass(frozen=True)
+class TableMetadata:
+    """Interface metadata for a supported Tushare financial table."""
+
+    name: str
+    api_name: str
+    vip_api_name: str | None
+    description: str
+    min_points: int | None
+    vip_min_points: int | None
+    reference_path: Path
+    repo_path: str
+    mcp_read_file_path: str
+    input_parameters: dict[str, ParameterMetadata]
+    output_fields: dict[str, FieldMetadata]
+    key_columns: tuple[str, ...]
+
+    @property
+    def supports_cross_sectional_query(self) -> bool:
+        """Whether a quarterly full-market query requires a vip endpoint."""
+        return self.vip_api_name is not None
+
+
+@dataclass(frozen=True)
+class FinancialFieldRegistry:
+    """Loaded financial-field registry."""
+
+    tables: dict[str, TableMetadata]
+    field_to_tables: dict[str, tuple[str, ...]]
+
+    def get_table(self, table_name: str) -> TableMetadata:
+        """Return metadata for a single table."""
+        try:
+            return self.tables[table_name]
+        except KeyError as exc:
+            known = ", ".join(sorted(self.tables))
+            raise KeyError(f"Unknown financial table '{table_name}'. Known: {known}") from exc
+
+    def has_field(self, field_name: str) -> bool:
+        """Return whether a field exists in any supported table."""
+        return field_name in self.field_to_tables
+
+    def get_field_tables(self, field_name: str) -> tuple[str, ...]:
+        """Return all owner tables for a field."""
+        return self.field_to_tables.get(field_name, ())
+
+    def assess_cross_sectional_query(
+        self,
+        query_plan: FinancialQueryPlan,
+    ) -> FinancialCrossSectionCapability:
+        """Summarize whether a query plan can run via VIP period cross-sections."""
+        supported_tables: list[str] = []
+        unsupported_tables: list[str] = []
+        required_points_by_table: dict[str, int] = {}
+
+        for table_name in query_plan.query_fields:
+            table = self.get_table(table_name)
+            if not table.supports_cross_sectional_query:
+                unsupported_tables.append(table_name)
+                continue
+
+            supported_tables.append(table_name)
+            required_points_by_table[table_name] = table.vip_min_points or table.min_points or 0
+
+        return FinancialCrossSectionCapability(
+            supported_tables=tuple(supported_tables),
+            unsupported_tables=tuple(unsupported_tables),
+            required_points_by_table=required_points_by_table,
+            required_points=max(required_points_by_table.values(), default=0),
+        )
+
+    def get_field_metadata(
+        self,
+        field_name: str,
+        *,
+        table_name: str | None = None,
+    ) -> FieldMetadata:
+        """Return field metadata, requiring a table for ambiguous fields."""
+        owner_table = table_name
+        if owner_table is None:
+            owners = self.get_field_tables(field_name)
+            if not owners:
+                raise UnknownFinancialFieldError(field_name)
+            if len(owners) > 1:
+                raise AmbiguousFinancialFieldError(
+                    f"Field '{field_name}' belongs to multiple tables: {', '.join(owners)}"
+                )
+            owner_table = owners[0]
+
+        table = self.get_table(owner_table)
+        try:
+            return table.output_fields[field_name]
+        except KeyError as exc:
+            raise UnknownFinancialFieldError(
+                f"Field '{field_name}' is not present in table '{owner_table}'"
+            ) from exc
+
+    def build_query_plan(
+        self,
+        fields: Iterable[str],
+        *,
+        preferred_tables: Mapping[str, str] | None = None,
+        include_key_columns: bool = True,
+        strict: bool = True,
+    ) -> FinancialQueryPlan:
+        """Group fields by table and attach key columns for each query.
+
+        Args:
+            fields: Requested financial fields.
+            preferred_tables: Optional per-field override for ambiguous fields.
+            include_key_columns: Whether to prepend each table's key columns.
+            strict: Whether to raise on unknown or ambiguous fields.
+        """
+        preferred_tables = preferred_tables or {}
+        deduped_fields = tuple(dict.fromkeys(field for field in fields if field))
+
+        requested_fields: dict[str, list[str]] = {}
+        ambiguous_fields: dict[str, tuple[str, ...]] = {}
+        unknown_fields: list[str] = []
+
+        for field_name in deduped_fields:
+            owners = self.get_field_tables(field_name)
+            if not owners:
+                unknown_fields.append(field_name)
+                continue
+
+            preferred_table = preferred_tables.get(field_name)
+            if preferred_table is not None:
+                if preferred_table not in owners:
+                    raise AmbiguousFinancialFieldError(
+                        f"Preferred table '{preferred_table}' does not own field '{field_name}'. "
+                        f"Owners: {', '.join(owners)}"
+                    )
+                chosen_table = preferred_table
+            elif len(owners) == 1:
+                chosen_table = owners[0]
+            else:
+                ambiguous_fields[field_name] = owners
+                continue
+
+            requested_fields.setdefault(chosen_table, []).append(field_name)
+
+        if strict and unknown_fields:
+            raise UnknownFinancialFieldError(
+                f"Unknown financial field(s): {', '.join(unknown_fields)}"
+            )
+        if strict and ambiguous_fields:
+            rendered = "; ".join(
+                f"{name} -> {', '.join(tables)}" for name, tables in ambiguous_fields.items()
+            )
+            raise AmbiguousFinancialFieldError(
+                f"Ambiguous financial field(s): {rendered}"
+            )
+
+        requested_tuples = {
+            table_name: tuple(values)
+            for table_name, values in requested_fields.items()
+        }
+
+        auto_included_keys: dict[str, tuple[str, ...]] = {}
+        query_fields: dict[str, tuple[str, ...]] = {}
+        for table_name, requested in requested_tuples.items():
+            table = self.get_table(table_name)
+            if include_key_columns:
+                keys = tuple(key for key in table.key_columns if key not in requested)
+            else:
+                keys = ()
+            auto_included_keys[table_name] = keys
+            query_fields[table_name] = (*keys, *requested)
+
+        return FinancialQueryPlan(
+            requested_fields=requested_tuples,
+            query_fields=query_fields,
+            auto_included_keys=auto_included_keys,
+            ambiguous_fields=ambiguous_fields,
+            unknown_fields=tuple(unknown_fields),
+        )
+
+
+def _split_markdown_row(line: str) -> list[str]:
+    return [cell.strip() for cell in line.strip().strip("|").split("|")]
+
+
+def _is_separator_row(line: str) -> bool:
+    cells = _split_markdown_row(line)
+    return bool(cells) and all(cell and set(cell) <= {"-", ":"} for cell in cells)
+
+
+def _extract_markdown_table(text: str, section_title: str) -> list[dict[str, str]]:
+    lines = text.splitlines()
+    try:
+        start_index = next(
+            index for index, line in enumerate(lines) if line.strip() == section_title
+        )
+    except StopIteration as exc:
+        raise FinancialFieldRegistryError(
+            f"Section '{section_title}' not found in local reference"
+        ) from exc
+
+    index = start_index + 1
+    while index < len(lines) and not lines[index].strip():
+        index += 1
+    if index >= len(lines):
+        return []
+
+    headers = _split_markdown_row(lines[index])
+    index += 1
+
+    rows: list[dict[str, str]] = []
+    while index < len(lines):
+        line = lines[index].strip()
+        if not line:
+            break
+        if "|" not in line:
+            break
+        if _is_separator_row(line):
+            index += 1
+            continue
+
+        cells = _split_markdown_row(line)
+        if len(cells) < len(headers):
+            cells.extend([""] * (len(headers) - len(cells)))
+        row = {header: cells[pos] for pos, header in enumerate(headers)}
+        rows.append(row)
+        index += 1
+
+    return rows
+
+
+def _parse_points(text: str) -> int | None:
+    match = re.search(r"(?:积分|权限)：.*?至少(\d+)积分", text)
+    if match:
+        return int(match.group(1))
+    return None
+
+
+def _parse_vip_points(text: str) -> int | None:
+    match = re.search(r"需积(?:攒)?(\d+)积分", text)
+    if match:
+        return int(match.group(1))
+    return None
+
+
+def _parse_table_metadata(table_name: str, reference_path: Path) -> TableMetadata:
+    text = reference_path.read_text(encoding="utf-8")
+
+    api_match = re.search(r"接口：([a-zA-Z_][a-zA-Z0-9_]*)", text)
+    if api_match is None:
+        raise FinancialFieldRegistryError(
+            f"Could not parse api name from reference: {reference_path}"
+        )
+    api_name = api_match.group(1)
+
+    description_match = re.search(r"描述：(.+)", text)
+    description = description_match.group(1).strip() if description_match else ""
+
+    vip_match = re.search(r"请使用([a-zA-Z_][a-zA-Z0-9_]*)接口", text)
+    vip_api_name = vip_match.group(1) if vip_match else None
+
+    input_rows = _extract_markdown_table(text, "**输入参数**")
+    output_rows = _extract_markdown_table(text, "**输出参数**")
+
+    input_parameters = {
+        row["名称"]: ParameterMetadata(
+            name=row["名称"],
+            param_type=row.get("类型", ""),
+            required=row.get("必选", "").upper() == "Y",
+            description=row.get("描述", ""),
+        )
+        for row in input_rows
+        if row.get("名称")
+    }
+
+    output_fields = {
+        row["名称"]: FieldMetadata(
+            name=row["名称"],
+            field_type=row.get("类型", ""),
+            description=row.get("描述", ""),
+            default_visible=(
+                None
+                if "默认显示" not in row
+                else row.get("默认显示", "").upper() == "Y"
+            ),
+        )
+        for row in output_rows
+        if row.get("名称")
+    }
+
+    key_columns = tuple(
+        column for column in _KEY_COLUMN_ORDER if column in output_fields
+    )
+    repo_path = reference_path.relative_to(_REPO_ROOT).as_posix()
+    skills_relative = reference_path.relative_to(_SKILLS_ROOT).as_posix()
+
+    return TableMetadata(
+        name=table_name,
+        api_name=api_name,
+        vip_api_name=vip_api_name,
+        description=description,
+        min_points=_parse_points(text),
+        vip_min_points=_parse_vip_points(text),
+        reference_path=reference_path,
+        repo_path=repo_path,
+        mcp_read_file_path=f"skills/{skills_relative}",
+        input_parameters=input_parameters,
+        output_fields=output_fields,
+        key_columns=key_columns,
+    )
+
+
+def _build_registry() -> FinancialFieldRegistry:
+    tables: dict[str, TableMetadata] = {}
+    field_to_tables: dict[str, list[str]] = {}
+
+    for table_name in SUPPORTED_FINANCIAL_TABLES:
+        reference_path = _REFERENCE_ROOT / _REFERENCE_FILES[table_name]
+        if not reference_path.exists():
+            raise FinancialFieldRegistryError(
+                f"Local reference not found for table '{table_name}': {reference_path}"
+            )
+
+        table_metadata = _parse_table_metadata(table_name, reference_path)
+        tables[table_name] = table_metadata
+
+        for field_name in table_metadata.output_fields:
+            owners = field_to_tables.setdefault(field_name, [])
+            owners.append(table_name)
+
+    return FinancialFieldRegistry(
+        tables=tables,
+        field_to_tables={
+            field_name: tuple(owners)
+            for field_name, owners in field_to_tables.items()
+        },
+    )
+
+
+@lru_cache(maxsize=1)
+def get_financial_field_registry() -> FinancialFieldRegistry:
+    """Load and cache the financial field registry."""
+    return _build_registry()
+
+
+def get_table_metadata(table_name: str) -> TableMetadata:
+    """Convenience wrapper for table metadata lookup."""
+    return get_financial_field_registry().get_table(table_name)
+
+
+def get_field_tables(field_name: str) -> tuple[str, ...]:
+    """Convenience wrapper for field ownership lookup."""
+    return get_financial_field_registry().get_field_tables(field_name)
+
+
+def build_financial_query_plan(
+    fields: Iterable[str],
+    *,
+    preferred_tables: Mapping[str, str] | None = None,
+    include_key_columns: bool = True,
+    strict: bool = True,
+) -> FinancialQueryPlan:
+    """Convenience wrapper for grouped query planning."""
+    return get_financial_field_registry().build_query_plan(
+        fields,
+        preferred_tables=preferred_tables,
+        include_key_columns=include_key_columns,
+        strict=strict,
+    )
+
+
+def assess_cross_sectional_query_capability(
+    query_plan: FinancialQueryPlan,
+) -> FinancialCrossSectionCapability:
+    """Convenience wrapper for VIP period cross-sectional capability checks."""
+    return get_financial_field_registry().assess_cross_sectional_query(query_plan)

--- a/agent/backtest/financials/ashare/pit_assembler.py
+++ b/agent/backtest/financials/ashare/pit_assembler.py
@@ -1,0 +1,247 @@
+"""Point-in-time assembler for A-share financial statement fields.
+
+The first version is intentionally narrow and conservative:
+
+* visibility starts on the first trading day strictly after ``ann_date``
+* revisions with different ``ann_date`` values are kept as separate events
+* exact announcement-cycle duplicates are canonicalized before projection
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+import pandas as pd
+
+from backtest.financials.contracts import (
+    FinancialDataMap,
+    FinancialQueryPlan,
+    FinancialTableMap,
+    ReportTypePriorities,
+)
+
+
+_DEFAULT_REPORT_TYPE_PRIORITY = {
+    "1": 120,
+    "2": 110,
+    "3": 100,
+    "4": 90,
+    "5": 80,
+    "6": 70,
+    "7": 60,
+    "8": 50,
+    "9": 40,
+    "10": 30,
+    "11": 20,
+    "12": 10,
+}
+
+
+def _to_timestamp_series(series: pd.Series | None) -> pd.Series:
+    if series is None:
+        return pd.Series(dtype="datetime64[ns]")
+    return pd.to_datetime(series, errors="coerce")
+
+
+def _normalize_priority_key(value: Any) -> str | None:
+    if pd.isna(value):
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _normalize_priority_map(report_type_priority: Mapping[Any, int] | None) -> dict[str, int]:
+    source = report_type_priority or _DEFAULT_REPORT_TYPE_PRIORITY
+    normalized: dict[str, int] = {}
+    for key, priority in source.items():
+        normalized_key = _normalize_priority_key(key)
+        if normalized_key is None:
+            continue
+        normalized[normalized_key] = priority
+    return normalized
+
+
+def _update_flag_priority(series: pd.Series | None) -> pd.Series:
+    if series is None:
+        return pd.Series(dtype="int64")
+    return series.fillna("").astype(str).str.strip().eq("1").astype(int)
+
+
+def _stable_row_signature(frame: pd.DataFrame) -> pd.Series:
+    stable_columns = [column for column in frame.columns if not column.startswith("_")]
+    if not stable_columns:
+        return pd.Series(0, index=frame.index, dtype="uint64")
+    return pd.util.hash_pandas_object(frame[stable_columns], index=False).astype("uint64")
+
+
+def _validate_financial_table_schema(
+    table_name: str,
+    table_rows: pd.DataFrame,
+    requested_fields: tuple[str, ...],
+) -> None:
+    columns = set(table_rows.columns)
+    missing_key_columns = [column for column in ("ts_code", "end_date") if column not in columns]
+    if "ann_date" not in columns and "f_ann_date" not in columns:
+        missing_key_columns.append("ann_date|f_ann_date")
+
+    missing_requested_fields = [field_name for field_name in requested_fields if field_name not in columns]
+    if not missing_key_columns and not missing_requested_fields:
+        return
+
+    details: list[str] = []
+    if missing_key_columns:
+        details.append(f"missing key columns={missing_key_columns}")
+    if missing_requested_fields:
+        details.append(f"missing requested fields={missing_requested_fields}")
+    raise ValueError(f"financial table '{table_name}' has invalid schema: {'; '.join(details)}")
+
+
+def canonicalize_financial_rows(
+    records: pd.DataFrame,
+    *,
+    report_type_priority: Mapping[Any, int] | None = None,
+) -> pd.DataFrame:
+    """Select a single canonical row for each announcement cycle.
+
+    Canonical key:
+    ``ts_code + end_date + visibility_ann_date``
+
+    Rows with different ``ann_date`` values are preserved because they model
+    different market-visible revisions over time.
+    """
+    if records is None or records.empty:
+        return pd.DataFrame(columns=list(records.columns) if records is not None else None)
+
+    frame = records.copy()
+    frame["_ann_date_ts"] = _to_timestamp_series(frame.get("ann_date"))
+    frame["_f_ann_date_ts"] = _to_timestamp_series(frame.get("f_ann_date"))
+    frame["_end_date_ts"] = _to_timestamp_series(frame.get("end_date"))
+    frame["_visibility_ann_date"] = frame["_ann_date_ts"].where(
+        frame["_ann_date_ts"].notna(),
+        frame["_f_ann_date_ts"],
+    )
+    frame = frame[frame["_visibility_ann_date"].notna()].copy()
+    if frame.empty:
+        return frame.drop(columns=[c for c in frame.columns if c.startswith("_")], errors="ignore")
+
+    priority_map = _normalize_priority_map(report_type_priority)
+    report_type_series = frame.get("report_type", pd.Series(index=frame.index, dtype=object))
+    frame["_report_priority"] = report_type_series.map(_normalize_priority_key).map(priority_map).fillna(0)
+    frame["_update_flag_priority"] = _update_flag_priority(frame.get("update_flag"))
+    frame["_row_signature"] = _stable_row_signature(frame)
+
+    sort_columns = [
+        "ts_code",
+        "_end_date_ts",
+        "_visibility_ann_date",
+        "_report_priority",
+        "_update_flag_priority",
+        "_f_ann_date_ts",
+        "_row_signature",
+    ]
+    frame = frame.sort_values(sort_columns, kind="mergesort")
+    deduped = frame.drop_duplicates(
+        subset=["ts_code", "_end_date_ts", "_visibility_ann_date"],
+        keep="last",
+    )
+    deduped = deduped.sort_values(
+        [
+            "ts_code",
+            "_visibility_ann_date",
+            "_end_date_ts",
+            "_report_priority",
+            "_update_flag_priority",
+            "_row_signature",
+        ],
+        kind="mergesort",
+    )
+    return deduped.drop(columns=[c for c in deduped.columns if c.startswith("_")], errors="ignore")
+
+
+def assemble_pit_frame(
+    trade_index: pd.DatetimeIndex,
+    records: pd.DataFrame,
+    *,
+    fields: list[str] | tuple[str, ...],
+    report_type_priority: Mapping[Any, int] | None = None,
+) -> pd.DataFrame:
+    """Project raw financial rows onto a daily trading index.
+
+    For each field, value visibility begins on the first trading day strictly
+    after the row's ``ann_date`` (or ``f_ann_date`` fallback).
+    """
+    normalized_index = pd.DatetimeIndex(pd.to_datetime(trade_index)).sort_values().unique()
+    output = pd.DataFrame(index=normalized_index)
+    if records is None or records.empty or not fields:
+        for field_name in fields:
+            output[field_name] = pd.Series(index=normalized_index, dtype=float)
+        output.index.name = trade_index.name
+        return output
+
+    canonical = canonicalize_financial_rows(records, report_type_priority=report_type_priority)
+    canonical["_ann_date_ts"] = _to_timestamp_series(canonical.get("ann_date"))
+    canonical["_f_ann_date_ts"] = _to_timestamp_series(canonical.get("f_ann_date"))
+    canonical["_visibility_ann_date"] = canonical["_ann_date_ts"].where(
+        canonical["_ann_date_ts"].notna(),
+        canonical["_f_ann_date_ts"],
+    )
+    canonical["_effective_pos"] = normalized_index.searchsorted(
+        canonical["_visibility_ann_date"],
+        side="right",
+    )
+    canonical = canonical[canonical["_effective_pos"] < len(normalized_index)].copy()
+
+    for field_name in fields:
+        field_series = pd.Series(index=normalized_index, dtype=float)
+        if field_name not in canonical.columns:
+            output[field_name] = field_series
+            continue
+
+        field_rows = canonical[canonical[field_name].notna()].copy()
+        field_rows = field_rows.sort_values(
+            ["_effective_pos", "_visibility_ann_date", "end_date"],
+            kind="mergesort",
+        )
+        starts = field_rows["_effective_pos"].tolist()
+        values = field_rows[field_name].tolist()
+        for idx, start in enumerate(starts):
+            end = starts[idx + 1] if idx + 1 < len(starts) else len(normalized_index)
+            field_series.iloc[start:end] = values[idx]
+        output[field_name] = field_series
+
+    output.index.name = trade_index.name
+    return output
+
+
+def enrich_data_map_with_financials(
+    data_map: FinancialDataMap,
+    raw_tables: FinancialTableMap,
+    query_plan: FinancialQueryPlan,
+    *,
+    report_type_priorities: ReportTypePriorities | None = None,
+) -> dict[str, pd.DataFrame]:
+    """Attach PIT financial columns to each symbol's price DataFrame."""
+    report_type_priorities = report_type_priorities or {}
+    enriched: dict[str, pd.DataFrame] = {}
+
+    for code, frame in data_map.items():
+        enriched_frame = frame.copy()
+        for table_name, requested_fields in query_plan.requested_fields.items():
+            table_rows = raw_tables.get(table_name)
+            if table_rows is None or table_rows.empty:
+                continue
+            _validate_financial_table_schema(table_name, table_rows, requested_fields)
+            code_rows = table_rows[table_rows["ts_code"] == code].copy()
+            if code_rows.empty:
+                continue
+            pit = assemble_pit_frame(
+                enriched_frame.index,
+                code_rows,
+                fields=list(requested_fields),
+                report_type_priority=report_type_priorities.get(table_name),
+            )
+            for field_name in requested_fields:
+                enriched_frame[field_name] = pit[field_name].reindex(enriched_frame.index)
+        enriched[code] = enriched_frame
+
+    return enriched

--- a/agent/backtest/financials/ashare/tushare_loader.py
+++ b/agent/backtest/financials/ashare/tushare_loader.py
@@ -1,0 +1,189 @@
+"""Raw Tushare financial statement loader for A-share backtests.
+
+This loader intentionally stays narrow: it fetches raw per-table records using
+the local financial field registry and does not yet perform point-in-time
+projection onto trading calendars.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Mapping
+
+import pandas as pd
+
+from backtest.financials.contracts import FinancialQueryPlan, FinancialTableParams
+from backtest.financials.ashare.field_registry import (
+    get_financial_field_registry,
+)
+
+
+TUSHARE_TOKEN_PLACEHOLDERS = {"", "your-tushare-token"}
+_RESERVED_QUERY_PARAM_KEYS = frozenset({"ts_code", "period", "start_date", "end_date", "fields"})
+
+
+def _normalize_date(value: str | None) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    return text.replace("-", "")
+
+
+def _merge_extra_params(
+    params: dict[str, Any],
+    extra_params: Mapping[str, Any] | None,
+) -> None:
+    if not extra_params:
+        return
+
+    reserved_keys = sorted(
+        key for key, value in extra_params.items()
+        if value is not None and key in _RESERVED_QUERY_PARAM_KEYS
+    )
+    if reserved_keys:
+        raise ValueError(
+            "extra_params may not override reserved financial query keys: "
+            f"{reserved_keys}"
+        )
+
+    params.update({key: value for key, value in extra_params.items() if value is not None})
+
+
+class TushareFinancialLoader:
+    """Fetch raw statement rows from Tushare by table and field plan."""
+
+    def __init__(self, api: Any | None = None) -> None:
+        self.registry = get_financial_field_registry()
+        if api is not None:
+            self.api = api
+            return
+
+        import tushare as ts
+
+        token = os.getenv("TUSHARE_TOKEN", "")
+        self.api = ts.pro_api(token)
+
+    def is_available(self) -> bool:
+        """Available when a non-placeholder TUSHARE_TOKEN is configured."""
+        return os.getenv("TUSHARE_TOKEN", "").strip() not in TUSHARE_TOKEN_PLACEHOLDERS
+
+    def fetch_table(
+        self,
+        table_name: str,
+        *,
+        ts_code: str | None = None,
+        fields: list[str] | tuple[str, ...] | None = None,
+        period: str | None = None,
+        start_date: str | None = None,
+        end_date: str | None = None,
+        use_vip: bool | None = None,
+        extra_params: Mapping[str, Any] | None = None,
+    ) -> pd.DataFrame:
+        """Fetch raw rows for a single financial table.
+
+        Ordinary endpoints require ``ts_code``. Vip endpoints can be used for
+        full-market slices when ``ts_code`` is absent.
+        """
+        table = self.registry.get_table(table_name)
+        query_fields = self._validate_fields(table_name, fields)
+
+        if use_vip is None:
+            use_vip = ts_code is None
+        if use_vip and not table.vip_api_name:
+            raise ValueError(f"table '{table_name}' has no vip endpoint")
+        if not use_vip and not ts_code:
+            raise ValueError(f"table '{table_name}' requires ts_code when not using vip")
+
+        method_name = table.vip_api_name if use_vip else table.api_name
+        api_method = getattr(self.api, method_name)
+
+        params: dict[str, Any] = {}
+        if ts_code:
+            params["ts_code"] = ts_code
+        if period:
+            params["period"] = _normalize_date(period)
+        normalized_start = _normalize_date(start_date)
+        normalized_end = _normalize_date(end_date)
+        if normalized_start:
+            params["start_date"] = normalized_start
+        if normalized_end:
+            params["end_date"] = normalized_end
+        if query_fields:
+            params["fields"] = ",".join(query_fields)
+        _merge_extra_params(params, extra_params)
+
+        result = api_method(**params)
+        if result is None:
+            return pd.DataFrame(columns=list(query_fields))
+        return result.copy()
+
+    def fetch_for_codes(
+        self,
+        query_plan: FinancialQueryPlan,
+        *,
+        codes: list[str],
+        start_date: str | None = None,
+        end_date: str | None = None,
+        table_params: FinancialTableParams | None = None,
+    ) -> dict[str, pd.DataFrame]:
+        """Fetch raw statement history for a concrete list of stock codes."""
+        table_params = table_params or {}
+        result: dict[str, pd.DataFrame] = {}
+        for table_name, fields in query_plan.query_fields.items():
+            frames: list[pd.DataFrame] = []
+            for code in codes:
+                frame = self.fetch_table(
+                    table_name,
+                    ts_code=code,
+                    fields=fields,
+                    start_date=start_date,
+                    end_date=end_date,
+                    use_vip=False,
+                    extra_params=table_params.get(table_name),
+                )
+                if frame is not None and not frame.empty:
+                    frames.append(frame)
+            if frames:
+                result[table_name] = pd.concat(frames, ignore_index=True)
+            else:
+                result[table_name] = pd.DataFrame(columns=list(fields))
+        return result
+
+    def fetch_for_period(
+        self,
+        query_plan: FinancialQueryPlan,
+        *,
+        period: str,
+        table_params: FinancialTableParams | None = None,
+    ) -> dict[str, pd.DataFrame]:
+        """Fetch a full-market cross-section for a report period via vip APIs."""
+        table_params = table_params or {}
+        result: dict[str, pd.DataFrame] = {}
+        for table_name, fields in query_plan.query_fields.items():
+            result[table_name] = self.fetch_table(
+                table_name,
+                period=period,
+                fields=fields,
+                use_vip=True,
+                extra_params=table_params.get(table_name),
+            )
+        return result
+
+    def _validate_fields(
+        self,
+        table_name: str,
+        fields: list[str] | tuple[str, ...] | None,
+    ) -> tuple[str, ...] | None:
+        if fields is None:
+            return None
+
+        table = self.registry.get_table(table_name)
+        deduped = tuple(dict.fromkeys(fields))
+        invalid = [field_name for field_name in deduped if field_name not in table.output_fields]
+        if invalid:
+            raise ValueError(
+                f"fields {invalid!r} do not belong to financial table '{table_name}'"
+            )
+        return deduped

--- a/agent/backtest/financials/contracts.py
+++ b/agent/backtest/financials/contracts.py
@@ -1,0 +1,192 @@
+"""Shared contracts for market-scoped financial data integrations.
+
+These contracts define the smallest cross-market boundary that the runtime
+cares about today:
+
+* registry-backed field lookup and query planning
+* prompt/source inference outputs
+* raw financial loading
+* point-in-time projection back onto price frames
+
+Market packages such as ``backtest.financials.ashare`` implement these
+contracts and expose a single runtime bundle so future markets can slot in
+without depending on A-share module names.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping, Protocol, TypeAlias, runtime_checkable
+
+import pandas as pd
+
+
+FinancialDataMap: TypeAlias = Mapping[str, pd.DataFrame]
+FinancialTableMap: TypeAlias = Mapping[str, pd.DataFrame]
+FinancialTableParams: TypeAlias = Mapping[str, Mapping[str, Any]]
+ReportTypePriorities: TypeAlias = Mapping[str, Mapping[Any, int]]
+
+
+@dataclass(frozen=True)
+class FinancialQueryPlan:
+    """Minimal grouped query plan for requested financial fields."""
+
+    requested_fields: dict[str, tuple[str, ...]]
+    query_fields: dict[str, tuple[str, ...]]
+    auto_included_keys: dict[str, tuple[str, ...]]
+    ambiguous_fields: dict[str, tuple[str, ...]]
+    unknown_fields: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class FinancialFieldInferenceResult:
+    """Inference result from prompt text and/or source analysis."""
+
+    prompt_fields: tuple[str, ...]
+    source_fields: tuple[str, ...]
+    combined_fields: tuple[str, ...]
+    query_plan: FinancialQueryPlan
+
+
+@dataclass(frozen=True)
+class FinancialCrossSectionCapability:
+    """Capability summary for VIP period cross-sectional financial queries."""
+
+    supported_tables: tuple[str, ...]
+    unsupported_tables: tuple[str, ...]
+    required_points_by_table: dict[str, int]
+    required_points: int
+
+    @property
+    def supported(self) -> bool:
+        return not self.unsupported_tables
+
+
+@runtime_checkable
+class FinancialFieldRegistryProtocol(Protocol):
+    """Minimal registry contract shared by market-specific implementations."""
+
+    @property
+    def tables(self) -> Mapping[str, Any]: ...
+
+    @property
+    def field_to_tables(self) -> Mapping[str, tuple[str, ...]]: ...
+
+    def get_table(self, table_name: str) -> Any: ...
+
+    def has_field(self, field_name: str) -> bool: ...
+
+    def get_field_tables(self, field_name: str) -> tuple[str, ...]: ...
+
+    def assess_cross_sectional_query(
+        self,
+        query_plan: FinancialQueryPlan,
+    ) -> FinancialCrossSectionCapability: ...
+
+    def build_query_plan(
+        self,
+        fields: Iterable[str],
+        *,
+        preferred_tables: Mapping[str, str] | None = None,
+        include_key_columns: bool = True,
+        strict: bool = True,
+    ) -> FinancialQueryPlan: ...
+
+
+@runtime_checkable
+class RawFinancialLoaderProtocol(Protocol):
+    """Minimal raw-loader contract for market-scoped financial records."""
+
+    def fetch_for_codes(
+        self,
+        query_plan: FinancialQueryPlan,
+        *,
+        codes: list[str],
+        start_date: str | None = None,
+        end_date: str | None = None,
+        table_params: FinancialTableParams | None = None,
+    ) -> dict[str, pd.DataFrame]: ...
+
+    def fetch_for_period(
+        self,
+        query_plan: FinancialQueryPlan,
+        *,
+        period: str,
+        table_params: FinancialTableParams | None = None,
+    ) -> dict[str, pd.DataFrame]: ...
+
+
+class PromptFieldInferencerProtocol(Protocol):
+    """Callable contract for prompt-to-field inference."""
+
+    def __call__(self, prompt: str) -> tuple[str, ...]: ...
+
+
+class SourceFieldInferencerProtocol(Protocol):
+    """Callable contract for source-to-field inference."""
+
+    def __call__(self, source: str) -> tuple[str, ...]: ...
+
+
+class FileFieldInferencerProtocol(Protocol):
+    """Callable contract for file-to-field inference."""
+
+    def __call__(self, file_path: str | Path) -> tuple[str, ...]: ...
+
+
+class CombinedFieldInferencerProtocol(Protocol):
+    """Callable contract for combined prompt/source inference."""
+
+    def __call__(
+        self,
+        *,
+        prompt: str = "",
+        source: str = "",
+        preferred_tables: Mapping[str, str] | None = None,
+        include_key_columns: bool = True,
+    ) -> FinancialFieldInferenceResult: ...
+
+
+class PitFrameAssemblerProtocol(Protocol):
+    """Callable contract for projecting raw statement rows onto trade dates."""
+
+    def __call__(
+        self,
+        trade_index: pd.DatetimeIndex,
+        records: pd.DataFrame,
+        *,
+        fields: list[str] | tuple[str, ...],
+        report_type_priority: Mapping[Any, int] | None = None,
+    ) -> pd.DataFrame: ...
+
+
+class FinancialDataMapEnricherProtocol(Protocol):
+    """Callable contract for injecting financial columns into price data maps."""
+
+    def __call__(
+        self,
+        data_map: FinancialDataMap,
+        raw_tables: FinancialTableMap,
+        query_plan: FinancialQueryPlan,
+        *,
+        report_type_priorities: ReportTypePriorities | None = None,
+    ) -> dict[str, pd.DataFrame]: ...
+
+
+FinancialLoaderFactory: TypeAlias = Callable[..., RawFinancialLoaderProtocol]
+
+
+@dataclass(frozen=True)
+class MarketFinancialRuntime:
+    """Market-scoped bundle of the financial integration boundary."""
+
+    market: str
+    registry: FinancialFieldRegistryProtocol
+    infer_fields_from_prompt: PromptFieldInferencerProtocol
+    infer_fields_from_source: SourceFieldInferencerProtocol
+    infer_fields_from_file: FileFieldInferencerProtocol
+    infer_fields: CombinedFieldInferencerProtocol
+    loader_factory: FinancialLoaderFactory
+    assemble_pit_frame: PitFrameAssemblerProtocol
+    enrich_data_map: FinancialDataMapEnricherProtocol

--- a/agent/backtest/runner.py
+++ b/agent/backtest/runner.py
@@ -9,8 +9,11 @@ Usage: ``python -m backtest.runner <run_dir>``
 
 import ast
 import importlib.util
+from dataclasses import dataclass
+from functools import lru_cache
 import json
 import logging
+import os
 import re
 import sys
 from pathlib import Path
@@ -32,12 +35,117 @@ from backtest.loaders.registry import (
     resolve_loader,
 )
 from backtest.loaders.base import NoAvailableSourceError
+from backtest.financials.ashare import get_ashare_financial_runtime
+from backtest.financials.ashare.field_registry import (
+    SUPPORTED_FINANCIAL_TABLES,
+)
+from backtest.financials.contracts import MarketFinancialRuntime
 
 logger = logging.getLogger(__name__)
 
 _VALID_INTERVALS = {"1m", "5m", "15m", "30m", "1H", "4H", "1D"}
 _VALID_ENGINES = {"daily", "options"}
 _VALID_SOURCES = {"tushare", "okx", "yfinance", "akshare", "ccxt", "auto"}
+_VALID_FINANCIAL_AVAILABILITY = {"ann_date_next_trade_day"}
+_VALID_UNIVERSE_MARKETS = {"a_share"}
+_VALID_UNIVERSE_SCOPES = {"all_active"}
+_TUSHARE_TOKEN_PLACEHOLDERS = {"", "your-tushare-token"}
+_DEFAULT_FINANCIAL_PERIOD_LOOKBACK_QUARTERS = 4
+_TUSHARE_POINTS_COLUMNS = ("到期积分", "points", "expire_points", "积分")
+
+
+def _get_ashare_financial_runtime() -> MarketFinancialRuntime:
+    """Return the market-scoped A-share financial implementation bundle."""
+    return get_ashare_financial_runtime()
+
+
+@dataclass(frozen=True)
+class FinancialFetchPlan:
+    """Runtime fetch mode for financial raw tables."""
+
+    mode: str
+    periods: tuple[str, ...] = ()
+
+
+class FinancialsConfigSchema(BaseModel):
+    """Validates the optional financial-statement request block."""
+
+    model_config = ConfigDict(extra="allow")
+
+    required: bool = False
+    tables: List[str] = []
+    fields: List[str] = []
+    availability: str = "ann_date_next_trade_day"
+    strict_source: str = "tushare"
+
+    @field_validator("tables")
+    @classmethod
+    def valid_tables(cls, value: List[str]) -> List[str]:
+        unknown = sorted(set(value) - set(SUPPORTED_FINANCIAL_TABLES))
+        if unknown:
+            raise ValueError(
+                f"unsupported financial tables {unknown!r}, must be chosen from {SUPPORTED_FINANCIAL_TABLES}"
+            )
+        return value
+
+    @field_validator("fields")
+    @classmethod
+    def valid_fields(cls, value: List[str]) -> List[str]:
+        registry = _get_ashare_financial_runtime().registry
+        unknown = [field_name for field_name in value if not registry.has_field(field_name)]
+        if unknown:
+            raise ValueError(f"unknown financial fields: {unknown!r}")
+        return value
+
+    @field_validator("availability")
+    @classmethod
+    def valid_availability(cls, value: str) -> str:
+        if value not in _VALID_FINANCIAL_AVAILABILITY:
+            raise ValueError(
+                "unsupported financial availability "
+                f"{value!r}, must be one of {_VALID_FINANCIAL_AVAILABILITY}"
+            )
+        return value
+
+    @field_validator("strict_source")
+    @classmethod
+    def valid_strict_source(cls, value: str) -> str:
+        if value != "tushare":
+            raise ValueError("financials.strict_source must be 'tushare'")
+        return value
+
+    @model_validator(mode="after")
+    def has_query_shape(self) -> "FinancialsConfigSchema":
+        if self.required and not self.tables and not self.fields:
+            raise ValueError("financials.required=true requires at least one table or field")
+        return self
+
+
+class UniverseConfigSchema(BaseModel):
+    """Validates the optional runtime universe selector."""
+
+    model_config = ConfigDict(extra="allow")
+
+    market: str
+    scope: str = "all_active"
+
+    @field_validator("market")
+    @classmethod
+    def valid_market(cls, value: str) -> str:
+        if value not in _VALID_UNIVERSE_MARKETS:
+            raise ValueError(
+                f"unsupported universe market {value!r}, must be one of {_VALID_UNIVERSE_MARKETS}"
+            )
+        return value
+
+    @field_validator("scope")
+    @classmethod
+    def valid_scope(cls, value: str) -> str:
+        if value not in _VALID_UNIVERSE_SCOPES:
+            raise ValueError(
+                f"unsupported universe scope {value!r}, must be one of {_VALID_UNIVERSE_SCOPES}"
+            )
+        return value
 
 
 class BacktestConfigSchema(BaseModel):
@@ -45,18 +153,18 @@ class BacktestConfigSchema(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
-    codes: List[str]
+    codes: List[str] = []
     start_date: str
     end_date: str
     source: str = "tushare"
     interval: str = "1D"
     engine: str = "daily"
+    financials: Optional[FinancialsConfigSchema] = None
+    universe: Optional[UniverseConfigSchema] = None
 
     @field_validator("codes")
     @classmethod
     def codes_not_empty(cls, v: List[str]) -> List[str]:
-        if not v:
-            raise ValueError("codes must be a non-empty list")
         if any(not c.strip() for c in v):
             raise ValueError("codes must not contain empty strings")
         return v
@@ -93,6 +201,8 @@ class BacktestConfigSchema(BaseModel):
 
     @model_validator(mode="after")
     def start_before_end(self) -> "BacktestConfigSchema":
+        if not self.codes and self.universe is None:
+            raise ValueError("codes must be a non-empty list")
         if pd.Timestamp(self.start_date) > pd.Timestamp(self.end_date):
             raise ValueError(
                 f"start_date ({self.start_date}) must be <= end_date ({self.end_date})"
@@ -352,6 +462,416 @@ def _normalize_codes(codes: List[str], source: str) -> List[str]:
     return codes
 
 
+def _financials_requested(config: dict) -> bool:
+    """Whether the config explicitly requests statement-style financial data."""
+    financials = config.get("financials") or {}
+    return bool(
+        financials
+        and (
+            financials.get("required")
+            or financials.get("tables")
+            or financials.get("fields")
+        )
+    )
+
+
+def _uses_runtime_a_share_universe(config: dict) -> bool:
+    """Whether codes were resolved from the runtime A-share all-active universe."""
+    universe = config.get("universe") or {}
+    return bool(
+        config.get("_resolved_codes_from_universe")
+        and universe.get("market") == "a_share"
+        and universe.get("scope", "all_active") == "all_active"
+    )
+
+
+def _format_financial_table_list(table_names: List[str] | tuple[str, ...]) -> str:
+    """Render requested financial tables for user-facing errors."""
+    return ", ".join(sorted(dict.fromkeys(str(name) for name in table_names if name))) or "<none>"
+
+
+def _format_required_points_by_table(required_points_by_table: Dict[str, int]) -> str:
+    """Render per-table VIP point requirements for user-facing errors."""
+    if not required_points_by_table:
+        return "<none>"
+    return ", ".join(
+        f"{table_name}={points}"
+        for table_name, points in sorted(required_points_by_table.items())
+    )
+
+
+def _parse_explicit_tushare_points(config: dict) -> int | None:
+    """Parse an explicit Tushare points override for compatibility fallbacks."""
+    financials = config.get("financials") or {}
+    raw_value = financials.get("tushare_points", os.getenv("TUSHARE_POINTS", "")).strip() if isinstance(financials.get("tushare_points", os.getenv("TUSHARE_POINTS", "")), str) else financials.get("tushare_points", os.getenv("TUSHARE_POINTS", ""))
+    if raw_value in (None, ""):
+        return None
+    try:
+        points = int(raw_value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("financials.tushare_points or TUSHARE_POINTS must be an integer") from exc
+    if points < 0:
+        raise ValueError("financials.tushare_points or TUSHARE_POINTS must be >= 0")
+    return points
+
+
+def _extract_tushare_points_from_user_frame(user_frame: pd.DataFrame) -> int:
+    """Extract current account points from the Tushare user endpoint result."""
+    if user_frame is None or user_frame.empty:
+        raise ValueError("Tushare user endpoint returned no rows")
+
+    points_column = next(
+        (column for column in _TUSHARE_POINTS_COLUMNS if column in user_frame.columns),
+        None,
+    )
+    if points_column is None:
+        raise ValueError(
+            "Tushare user endpoint returned no recognized points column; "
+            f"columns={list(user_frame.columns)!r}"
+        )
+
+    series = pd.to_numeric(user_frame[points_column], errors="coerce")
+    numeric_points = series[series.notna()]
+    if numeric_points.empty:
+        raise ValueError("Tushare user endpoint returned no numeric points")
+
+    total_points = int(numeric_points.sum())
+    if total_points < 0:
+        raise ValueError("Tushare user endpoint returned negative points")
+    return total_points
+
+
+def _resolve_financial_points_by_table(query_plan, *, use_vip_points: bool) -> Dict[str, int]:
+    """Resolve per-table Tushare point requirements for a query plan."""
+    runtime = _get_ashare_financial_runtime()
+    required_points_by_table: Dict[str, int] = {}
+    for table_name in query_plan.query_fields:
+        table = runtime.registry.get_table(table_name)
+        if use_vip_points and table.vip_min_points is not None:
+            required_points_by_table[table_name] = table.vip_min_points
+            continue
+        required_points_by_table[table_name] = table.min_points or 0
+    return required_points_by_table
+
+
+@lru_cache(maxsize=4)
+def _query_tushare_points_from_account(token: str) -> int:
+    """Query Tushare account capability and return currently available points."""
+    import tushare as ts
+
+    api = ts.pro_api(token)
+    user_frame = api.user(token=token)
+    return _extract_tushare_points_from_user_frame(user_frame)
+
+
+def _resolve_tushare_points(config: dict) -> int | None:
+    """Resolve Tushare points for VIP capability checks.
+
+    The primary path queries the account capability from Tushare directly so
+    full-market runtime requests do not require hand-filled point settings.
+    Explicit config or env values remain as a compatibility fallback when the
+    automatic query cannot be completed.
+    """
+    token = os.getenv("TUSHARE_TOKEN", "").strip()
+    if token and token not in _TUSHARE_TOKEN_PLACEHOLDERS:
+        try:
+            return _query_tushare_points_from_account(token)
+        except Exception as exc:
+            fallback_points = _parse_explicit_tushare_points(config)
+            if fallback_points is not None:
+                logger.warning(
+                    "Falling back to explicit Tushare points override after automatic query failed: %s",
+                    exc,
+                )
+                return fallback_points
+            raise ValueError(
+                "unable to query Tushare account points automatically via Tushare user(token=...); "
+                f"reason={type(exc).__name__}: {exc}"
+            ) from exc
+
+    return _parse_explicit_tushare_points(config)
+
+
+def _last_completed_quarter(as_of: pd.Timestamp) -> pd.Period:
+    """Return the latest completed fiscal quarter as of a trade date."""
+    timestamp = pd.Timestamp(as_of).normalize()
+    quarter = timestamp.to_period("Q")
+    if pd.Timestamp(quarter.end_time).normalize() > timestamp:
+        return quarter - 1
+    return quarter
+
+
+def _derive_cross_sectional_financial_periods(
+    start_date: str,
+    end_date: str,
+    *,
+    lookback_quarters: int = _DEFAULT_FINANCIAL_PERIOD_LOOKBACK_QUARTERS,
+) -> tuple[str, ...]:
+    """Derive completed fiscal report periods needed for PIT enrichment."""
+    if lookback_quarters < 1:
+        raise ValueError("financials.period_lookback_quarters must be >= 1")
+
+    start_ts = pd.Timestamp(start_date)
+    end_ts = pd.Timestamp(end_date)
+    if end_ts < start_ts:
+        raise ValueError("end_date must be >= start_date for financial period planning")
+
+    start_anchor = _last_completed_quarter(start_ts)
+    end_anchor = _last_completed_quarter(end_ts)
+    first_period = start_anchor - (lookback_quarters - 1)
+    periods = pd.period_range(start=first_period, end=end_anchor, freq="Q")
+    return tuple(pd.Timestamp(period.end_time).strftime("%Y%m%d") for period in periods)
+
+
+def _has_tushare_token() -> bool:
+    """Return whether a usable TUSHARE_TOKEN is configured."""
+    return os.getenv("TUSHARE_TOKEN", "").strip() not in _TUSHARE_TOKEN_PLACEHOLDERS
+
+
+def _resolve_a_share_universe_codes() -> List[str]:
+    """Resolve the active A-share universe through Tushare stock_basic."""
+    if not _has_tushare_token():
+        raise ValueError("a_share universe resolution requires TUSHARE_TOKEN")
+
+    import tushare as ts
+
+    api = ts.pro_api(os.getenv("TUSHARE_TOKEN", ""))
+    universe = api.stock_basic(exchange="", list_status="L", fields="ts_code")
+    if universe is None or universe.empty or "ts_code" not in universe.columns:
+        raise ValueError("a_share universe resolved to no codes")
+
+    codes = sorted(
+        {
+            code
+            for raw_code in universe["ts_code"].dropna().tolist()
+            for code in [str(raw_code).strip().upper()]
+            if code and _detect_market(code) == "a_share"
+        }
+    )
+    if not codes:
+        raise ValueError("a_share universe resolved to no codes")
+    return codes
+
+
+def _resolve_codes_from_config(config: dict, source: str) -> List[str]:
+    """Resolve the effective code list from explicit codes or a runtime universe."""
+    codes = list(config.get("codes") or [])
+    if codes:
+        return codes
+
+    universe = config.get("universe") or {}
+    if not universe:
+        return []
+
+    if universe.get("market") != "a_share":
+        raise ValueError("runtime universe currently supports only universe.market='a_share'")
+    if source not in {"tushare", "auto"}:
+        raise ValueError("a_share runtime universe currently requires source='tushare' or 'auto'")
+    return _resolve_a_share_universe_codes()
+
+
+def _validate_financials_request(config: dict, source: str, codes: List[str]) -> str:
+    """Validate a strict A-share financial request and normalize the source.
+
+    This gate intentionally fails fast until the dedicated runtime financial
+    loader/assembler is wired into the runner.
+    """
+    if not _financials_requested(config):
+        return source
+
+    markets = {_detect_market(code) for code in codes}
+    if markets != {"a_share"}:
+        raise ValueError(
+            "financials currently support only A-share strategies; "
+            f"detected markets={sorted(markets)}"
+        )
+
+    if source not in {"tushare", "auto"}:
+        raise ValueError(
+            "financials require strict Tushare mode; "
+            f"source must be 'tushare' or 'auto', got {source!r}"
+        )
+
+    if not _has_tushare_token():
+        raise ValueError("financials require TUSHARE_TOKEN")
+
+    if config.get("interval", "1D") != "1D":
+        raise ValueError("financials currently support only interval='1D'")
+
+    return "tushare"
+
+
+def _build_financial_query_plan_from_config(config: dict):
+    """Build the strict financial query plan declared in config."""
+    if not _financials_requested(config):
+        return None
+
+    runtime = _get_ashare_financial_runtime()
+    financials = config.get("financials") or {}
+    fields = tuple(financials.get("fields") or ())
+    if not fields:
+        raise ValueError("financials runtime currently requires explicit financials.fields")
+
+    preferred_tables = financials.get("preferred_tables") or {}
+    query_plan = runtime.registry.build_query_plan(
+        fields,
+        preferred_tables=preferred_tables,
+        include_key_columns=True,
+        strict=True,
+    )
+
+    declared_tables = set(financials.get("tables") or ())
+    unexpected_tables = set(query_plan.requested_fields) - declared_tables
+    if declared_tables and unexpected_tables:
+        raise ValueError(
+            "financials.tables does not cover all requested field owners: "
+            f"{sorted(unexpected_tables)}"
+        )
+
+    return query_plan
+
+
+def _build_financial_fetch_plan(config: dict, query_plan) -> FinancialFetchPlan | None:
+    """Plan whether financial raw tables should use per-code or VIP period fetches."""
+    if query_plan is None:
+        return None
+    if not _uses_runtime_a_share_universe(config):
+        return FinancialFetchPlan(mode="per_code")
+
+    runtime = _get_ashare_financial_runtime()
+    capability = runtime.registry.assess_cross_sectional_query(query_plan)
+    requested_tables = tuple(query_plan.query_fields)
+    requested_tables_text = _format_financial_table_list(requested_tables)
+    if not capability.supported:
+        raise ValueError(
+            "financials full-market cross-section requires VIP period endpoints for every requested table; "
+            f"requested tables={requested_tables_text}; "
+            f"unsupported tables={_format_financial_table_list(capability.unsupported_tables)}; "
+            f"supported tables={_format_financial_table_list(capability.supported_tables)}"
+        )
+
+    ordinary_required_points_by_table = _resolve_financial_points_by_table(
+        query_plan,
+        use_vip_points=False,
+    )
+    ordinary_required_points = max(ordinary_required_points_by_table.values(), default=0)
+    ordinary_required_points_text = _format_required_points_by_table(ordinary_required_points_by_table)
+    vip_required_points_text = _format_required_points_by_table(capability.required_points_by_table)
+
+    available_points = _resolve_tushare_points(config)
+    if available_points is None:
+        raise ValueError(
+            "financials full-market cross-section could not determine Tushare account points; "
+            f"requested tables={requested_tables_text}; "
+            f"required points by table={vip_required_points_text}"
+        )
+    if available_points < ordinary_required_points:
+        raise ValueError(
+            "financials require at least 2000 Tushare points for requested tables; "
+            f"requested tables={requested_tables_text}; "
+            f"current account points={available_points}; "
+            f"ordinary required points={ordinary_required_points}; "
+            f"ordinary required points by table={ordinary_required_points_text}"
+        )
+    if available_points < capability.required_points:
+        logger.warning(
+            "financials full-market cross-section falling back to slower per-code Tushare fetch; "
+            "requested tables=%s; current account points=%s; VIP required points=%s; ordinary required points=%s",
+            requested_tables_text,
+            available_points,
+            capability.required_points,
+            ordinary_required_points,
+        )
+        return FinancialFetchPlan(mode="per_code")
+
+    financials = config.get("financials") or {}
+    raw_lookback = financials.get(
+        "period_lookback_quarters",
+        _DEFAULT_FINANCIAL_PERIOD_LOOKBACK_QUARTERS,
+    )
+    try:
+        lookback_quarters = int(raw_lookback)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("financials.period_lookback_quarters must be an integer") from exc
+
+    return FinancialFetchPlan(
+        mode="cross_section",
+        periods=_derive_cross_sectional_financial_periods(
+            config.get("start_date", ""),
+            config.get("end_date", ""),
+            lookback_quarters=lookback_quarters,
+        ),
+    )
+
+
+def _fetch_cross_sectional_financial_tables(
+    raw_loader,
+    query_plan,
+    *,
+    periods: tuple[str, ...],
+    table_params: dict,
+) -> dict[str, pd.DataFrame]:
+    """Fetch and concatenate VIP period cross-sections for requested tables."""
+    frames_by_table: dict[str, list[pd.DataFrame]] = {
+        table_name: [] for table_name in query_plan.query_fields
+    }
+    for period in periods:
+        period_tables = raw_loader.fetch_for_period(
+            query_plan,
+            period=period,
+            table_params=table_params,
+        )
+        for table_name, frame in period_tables.items():
+            if frame is not None and not frame.empty:
+                frames_by_table.setdefault(table_name, []).append(frame)
+
+    result: dict[str, pd.DataFrame] = {}
+    for table_name, fields in query_plan.query_fields.items():
+        frames = frames_by_table.get(table_name) or []
+        if frames:
+            result[table_name] = pd.concat(frames, ignore_index=True)
+        else:
+            result[table_name] = pd.DataFrame(columns=list(fields))
+    return result
+
+
+def _enrich_price_data_map_with_financials(
+    config: dict,
+    data_map: dict,
+    query_plan,
+    fetch_plan: FinancialFetchPlan | None,
+) -> dict:
+    """Attach PIT financial statement columns to the fetched price data."""
+    if query_plan is None or not data_map:
+        return data_map
+
+    runtime = _get_ashare_financial_runtime()
+    financials = config.get("financials") or {}
+    raw_loader = runtime.loader_factory()
+    table_params = financials.get("table_params") or {}
+    if fetch_plan is not None and fetch_plan.mode == "cross_section":
+        raw_tables = _fetch_cross_sectional_financial_tables(
+            raw_loader,
+            query_plan,
+            periods=fetch_plan.periods,
+            table_params=table_params,
+        )
+    else:
+        raw_tables = raw_loader.fetch_for_codes(
+            query_plan,
+            codes=list(data_map.keys()),
+            start_date=config.get("start_date", ""),
+            end_date=config.get("end_date", ""),
+            table_params=table_params,
+        )
+    return runtime.enrich_data_map(
+        data_map,
+        raw_tables,
+        query_plan,
+        report_type_priorities=financials.get("report_type_priorities") or {},
+    )
+
+
 # --- Main entry ---
 
 def main(run_dir: Path) -> None:
@@ -378,8 +898,16 @@ def main(run_dir: Path) -> None:
         sys.exit(1)
 
     config = raw_config
+    config["_resolved_codes_from_universe"] = not bool(raw_config.get("codes")) and bool(
+        raw_config.get("universe")
+    )
     source = config.get("source", "tushare")
-    codes = config.get("codes", [])
+    try:
+        codes = _resolve_codes_from_config(config, source)
+    except ValueError as exc:
+        print(json.dumps({"error": str(exc)}))
+        sys.exit(1)
+    config["codes"] = codes
 
     # Load signal engine
     signal_path = run_dir / "code" / "signal_engine.py"
@@ -391,6 +919,14 @@ def main(run_dir: Path) -> None:
     engine_cls = getattr(signal_module, "SignalEngine", None)
     if engine_cls is None:
         print(json.dumps({"error": "SignalEngine class not found in signal_engine.py"}))
+        sys.exit(1)
+
+    try:
+        source = _validate_financials_request(config, source, codes)
+        financial_query_plan = _build_financial_query_plan_from_config(config)
+        financial_fetch_plan = _build_financial_fetch_plan(config, financial_query_plan)
+    except ValueError as exc:
+        print(json.dumps({"error": str(exc)}))
         sys.exit(1)
 
     # Data: auto split vs single loader
@@ -411,7 +947,7 @@ def main(run_dir: Path) -> None:
             interval=interval,
         )
         # Runtime fallback: try next sources in chain when primary returns empty
-        if not data_map and codes:
+        if not data_map and codes and not _financials_requested(config):
             market = _detect_market(codes[0])
             for fb_name in FALLBACK_CHAINS.get(market, []):
                 if fb_name == source or fb_name not in LOADER_REGISTRY:
@@ -429,6 +965,12 @@ def main(run_dir: Path) -> None:
                     source = fb_name
                     loader = fb_loader
                     break
+    data_map = _enrich_price_data_map_with_financials(
+        config,
+        data_map,
+        financial_query_plan,
+        financial_fetch_plan,
+    )
     if not data_map:
         print(json.dumps({"error": "No data fetched"}))
         sys.exit(1)
@@ -448,7 +990,7 @@ def main(run_dir: Path) -> None:
         bars_per_year = calc_bars_per_year(interval, effective_source)
 
     # Auto mode: wrap preloaded data in a dummy loader
-    if source == "auto":
+    if source == "auto" or financial_query_plan is not None:
         loader = _AutoLoader(data_map)
 
     if engine_type == "options":

--- a/agent/src/agent/loop.py
+++ b/agent/src/agent/loop.py
@@ -258,7 +258,7 @@ def _normalize_tool_run_dir(args: dict[str, Any], memory_run_dir: str | None) ->
 
     candidate = Path(run_dir_value)
     if not candidate.is_absolute():
-        normalized["run_dir"] = str((Path(memory_run_dir) / candidate).resolve())
+        normalized["run_dir"] = str(Path(memory_run_dir) / candidate)
     return normalized
 
 

--- a/agent/src/skills/ashare-financial-enrichment/SKILL.md
+++ b/agent/src/skills/ashare-financial-enrichment/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: ashare-financial-enrichment
+description: A-share financial statement enrichment flow — gate, plan, and request only the required Tushare financial tables and fields with strict ann_date-based point-in-time visibility.
+category: flow
+---
+# A-share Financial Enrichment
+
+## Purpose
+
+This skill governs how an A-share strategy may use Tushare financial statement data.
+
+It does **not** directly replace `strategy-generate`. Instead, it defines the mandatory gate before a strategy may rely on fields from:
+
+- `income`
+- `balancesheet`
+- `cashflow`
+- `express`
+- `fina_indicator`
+
+## When To Use
+
+Use this skill only when **both** conditions are true:
+
+1. The strategy is for **China A-shares**.
+2. The strategy logic uses at least one field from the five Tushare financial tables above.
+
+Do **not** use this skill when:
+
+- the strategy is not A-share
+- the strategy only uses OHLCV
+- the strategy only uses the existing `daily_basic`-style fields already supported by the backtest loader (`pe`, `pb`, `pe_ttm`, `ps_ttm`, `dv_ttm`, `total_mv`, `circ_mv`, `roe`)
+
+## Mandatory Gate
+
+Before loading or planning any financial statement data, always execute this gate in order.
+
+### Step 1: Confirm market
+
+The strategy must clearly target A-shares.
+
+Accepted indicators include:
+
+- explicit China A-share wording
+- stock codes matching `000001.SZ`, `600519.SH`, `300750.SZ`, and similar patterns
+- `source="tushare"` or an explicit A-share universe
+
+If the strategy is not clearly A-share, stop and ask the user.
+
+### Step 2: Confirm actual need for statement fields
+
+Only continue if the strategy truly needs fields from one or more of these tables:
+
+- `income`
+- `balancesheet`
+- `cashflow`
+- `express`
+- `fina_indicator`
+
+Examples that **do** trigger this flow:
+
+- revenue growth
+- balance-sheet leverage items
+- cash-flow quality items
+- express-based preliminary results
+- profitability or margin fields that come from `fina_indicator`
+
+Examples that **do not** trigger this flow:
+
+- `pe`, `pb`, `pe_ttm`, `roe`, `total_mv` from `daily_basic`
+- technical indicators computed from OHLCV only
+
+### Step 3: Confirm `TUSHARE_TOKEN`
+
+If this flow is triggered, `TUSHARE_TOKEN` is mandatory.
+
+If `TUSHARE_TOKEN` is missing:
+
+- state that A-share financial statement enrichment cannot proceed yet
+- do **not** silently downgrade to AKShare
+- do **not** silently rewrite the strategy into a different data regime
+- wait for the user's decision
+
+### Step 4: Check Tushare points for the planned runtime mode
+
+When this flow is triggered, the point thresholds are:
+
+- below 2000 points: stop, because the ordinary financial table interfaces are not available
+- 2000-4999 points: financial-table backtests may still run, but full-market or universe requests must fall back to slower per-code fetching
+- 5000 points and above: VIP period cross-sections are available and should be preferred for full-market or universe backtests
+
+Implementation note:
+
+- `0` points is a valid parsed account result, but it is below the minimum gate and must not be treated as an unknown capability state
+
+### Step 5: Build a minimal field plan
+
+When the gate passes, request only the necessary tables and fields.
+
+The plan must answer:
+
+- which tables are needed
+- which exact fields are needed from each table
+- whether the strategy also needs ordinary A-share `daily_basic` fields
+- whether the request is expected to run in slower per-code mode or VIP cross-sectional mode based on the current 2000 / 5000 point tier
+
+Never request all columns from all tables by default.
+
+## Supported Tables
+
+This flow covers these five Tushare tables only:
+
+| Table | Tushare Doc | Typical Use |
+|------|-------------|-------------|
+| `income` | `doc_id=33` | revenue, profit, expense, R&D, EBIT/EBITDA |
+| `balancesheet` | `doc_id=36` | assets, liabilities, equity, cash, debt, inventory |
+| `cashflow` | `doc_id=44` | operating / investing / financing cash flow, FCF |
+| `express` | `doc_id=46` | preliminary performance snapshots |
+| `fina_indicator` | `doc_id=79` | profitability, margin, growth, turnover, leverage ratios |
+
+## Authoritative Local References
+
+The current project already includes the field definitions for these tables under the local Tushare reference tree.
+
+When deciding which table a field belongs to, or which columns are available, use these local reference files as the primary source of truth:
+
+- `income`
+  - repo path: `agent/src/skills/tushare/references/股票数据/财务数据/利润表.md`
+  - MCP `read_file` path: `skills/tushare/references/股票数据/财务数据/利润表.md`
+- `balancesheet`
+  - repo path: `agent/src/skills/tushare/references/股票数据/财务数据/资产负债表.md`
+  - MCP `read_file` path: `skills/tushare/references/股票数据/财务数据/资产负债表.md`
+- `cashflow`
+  - repo path: `agent/src/skills/tushare/references/股票数据/财务数据/现金流量表.md`
+  - MCP `read_file` path: `skills/tushare/references/股票数据/财务数据/现金流量表.md`
+- `express`
+  - repo path: `agent/src/skills/tushare/references/股票数据/财务数据/业绩快报.md`
+  - MCP `read_file` path: `skills/tushare/references/股票数据/财务数据/业绩快报.md`
+- `fina_indicator`
+  - repo path: `agent/src/skills/tushare/references/股票数据/财务数据/财务指标数据.md`
+  - MCP `read_file` path: `skills/tushare/references/股票数据/财务数据/财务指标数据.md`
+
+Practical rule:
+
+- Use the local reference files first to confirm field names, parameter names, key columns, and table ownership.
+- When using an MCP client such as opencode, do not assume Markdown link targets will be resolved automatically; use the explicit `MCP read_file` paths above.
+- Use the public Tushare web docs only as a secondary cross-check when the local reference appears outdated or ambiguous.
+- Do not invent field names when a field cannot be found in the local reference.
+
+## ann_date Rule
+
+This is the most important rule in the entire flow.
+
+For every table in this skill, assume:
+
+- financial data becomes visible only **after** its `ann_date`
+- `period` / `end_date` is the report period, not the market availability date
+- two stocks with the same `period` may still become visible on different dates because their `ann_date` values differ
+
+Conservative point-in-time rule:
+
+- treat the data as unavailable before `ann_date`
+- for daily backtests, treat the data as usable only from the **next trading day after `ann_date`**
+
+Never expose a financial field earlier just because a quarter ended on `0331`, `0630`, `0930`, or `1231`.
+
+## Decision Matrix
+
+| Scenario | Action |
+|---------|--------|
+| A-share + no statement fields | Stay in normal strategy flow |
+| A-share + statement fields + token available | Continue with this skill |
+| A-share + statement fields + token missing | Stop, explain, wait for user |
+| Non-A-share + statement fields | Explain current limitation, wait for user |
+
+## Output Requirements For The Planner
+
+When this skill is triggered, the planner should produce a compact plan with:
+
+1. A-share confirmation
+2. required financial tables
+3. required fields per table
+4. confirmation that `TUSHARE_TOKEN` is available
+5. explicit note that point-in-time visibility must follow `ann_date`
+6. explicit note about the current Tushare point tier and whether the run needs slower per-code fallback or can use VIP cross-sections
+
+Example:
+
+```json
+{
+  "market": "a_share",
+  "financial_statement_flow": true,
+  "required_tables": {
+    "income": ["revenue", "operate_profit"],
+    "cashflow": ["n_cashflow_act", "free_cashflow"],
+    "fina_indicator": ["grossprofit_margin", "roe", "ocfps"]
+  },
+  "requires_tushare_token": true,
+  "availability_rule": "ann_date_next_trade_day",
+  "point_tier_note": "2000-4999 points uses slower per-code fetch; 5000+ points can use VIP cross-sections"
+}
+```
+
+## Failure Handling
+
+When blocked, the response must be explicit and must not continue automatically.
+
+### Token missing
+
+Say:
+
+- the strategy requires A-share financial statement data
+- this flow requires `TUSHARE_TOKEN`
+- the current run cannot proceed under the required data regime
+- wait for the user's decision
+
+### Non-A-share request
+
+Say:
+
+- this financial statement enrichment flow currently applies only to A-shares
+- the requested market is not yet supported under this flow
+- wait for the user's decision
+
+## Notes
+
+- This skill is about gating and data planning, not about rewriting the `SignalEngine` contract.
+- The strategy may still use a normal `SignalEngine.generate(data_map)` implementation after the financial fields are prepared by the runtime.
+- Do not collapse this flow back into generic `extra_fields`; the data source semantics are different.

--- a/agent/src/skills/data-routing/SKILL.md
+++ b/agent/src/skills/data-routing/SKILL.md
@@ -22,12 +22,18 @@ Use `source: "auto"` — the runner automatically routes by symbol pattern and f
 
 You do NOT need to specify a concrete data source in config.json unless the user explicitly asks for one.
 
+Exception:
+
+- If the strategy is **A-share** and uses **financial statement fields** from Tushare tables such as `income`, `balancesheet`, `cashflow`, `express`, or `fina_indicator`, do **not** rely on generic fallback routing.
+- In that case, use the gating rules from [ashare-financial-enrichment](../ashare-financial-enrichment/SKILL.md): `TUSHARE_TOKEN` is mandatory, and the flow must not silently downgrade to AKShare.
+
 ### Analysis / Research Scenario (writing Python scripts)
 
 1. Identify the market type from the user's request
 2. Pick the source by priority:
 
 **A-shares**: tushare (if TUSHARE_TOKEN is set) > akshare (free fallback)
+For A-share financial statement enrichment, this fallback rule does **not** apply — use strict Tushare only.
 **US stocks**: yfinance > akshare
 **HK stocks**: yfinance > akshare
 **Crypto**: okx (single exchange) > ccxt (multi-exchange)
@@ -67,3 +73,9 @@ User requests 000001.SZ (A-share)
 ```
 
 This is transparent to the user — they just see results.
+
+Important carve-out:
+
+- The transparent fallback chain is appropriate for price data and simple A-share `daily_basic` fields.
+- It is **not** appropriate for A-share financial statement strategies that depend on `income`, `balancesheet`, `cashflow`, `express`, or `fina_indicator`.
+- For those strategies, if `TUSHARE_TOKEN` is missing, stop and wait for the user's decision instead of routing to AKShare.

--- a/agent/src/skills/fundamental-filter/SKILL.md
+++ b/agent/src/skills/fundamental-filter/SKILL.md
@@ -7,7 +7,11 @@ category: flow
 
 ## Purpose
 
-Filter stocks using fundamental financial data (PE/PB/ROE, etc.) to build value or growth screen signals for backtesting. Supports multiple markets with different data sources.
+Filter stocks using simple fundamental data (PE/PB/ROE, market cap, and similar metrics) to build value or growth screen signals for backtesting. Supports multiple markets with different data sources.
+
+This skill is **not** the entry point for A-share financial statement strategies that depend on Tushare statement tables such as `income`, `balancesheet`, `cashflow`, `express`, or `fina_indicator`.
+
+When an A-share strategy needs fields from those tables, switch to [ashare-financial-enrichment](../ashare-financial-enrichment/SKILL.md) instead of continuing with this simple screening flow.
 
 ## Market Support
 
@@ -16,6 +20,30 @@ Filter stocks using fundamental financial data (PE/PB/ROE, etc.) to build value 
 | A-shares | tushare `daily_basic` | `extra_fields` in config.json | pe, pb, pe_ttm, ps_ttm, dv_ttm, total_mv, circ_mv, roe |
 | US stocks | yfinance `Ticker.info` | Direct API call | trailingPE, forwardPE, priceToBook, returnOnEquity, marketCap, dividendYield |
 | HK stocks | yfinance `Ticker.info` | Direct API call | trailingPE, priceToBook, returnOnEquity, marketCap |
+
+## Scope Boundary
+
+This skill covers only these two data styles:
+
+1. A-share `daily_basic`-style fields already supported by the backtest loader
+2. US/HK `Ticker.info` point-in-time snapshots
+
+This skill does **not** cover:
+
+- A-share fields from `income`
+- A-share fields from `balancesheet`
+- A-share fields from `cashflow`
+- A-share fields from `express`
+- A-share fields from `fina_indicator` when they are being treated as financial statement enrichment rather than simple built-in daily fields
+
+If the strategy is A-share and uses those financial statement fields:
+
+- require `TUSHARE_TOKEN`
+- require at least 2000 Tushare points to pull the financial tables at all
+- treat 5000 points as the preferred threshold for full-market or universe backtests; with 2000-4999 points the runtime can still proceed, but it will fall back to slower per-code fetching
+- do **not** silently degrade to `daily_basic`
+- do **not** continue automatically
+- follow [ashare-financial-enrichment](../ashare-financial-enrichment/SKILL.md)
 
 ## Signal Logic
 
@@ -49,6 +77,10 @@ Filter stocks using fundamental financial data (PE/PB/ROE, etc.) to build value 
 ```
 
 The `extra_fields` columns are automatically merged into the daily DataFrame by the DataLoader.
+
+This is only for the currently supported simple A-share fields such as `pe`, `pb`, `pe_ttm`, `roe`, and `total_mv`.
+
+If you need statement-style fields such as `revenue`, `total_assets`, `n_cashflow_act`, `free_cashflow`, `grossprofit_margin`, `netprofit_margin`, `ocfps`, or similar fields sourced from Tushare financial tables, this skill is no longer sufficient. Use [ashare-financial-enrichment](../ashare-financial-enrichment/SKILL.md).
 
 ## HK/US Stock Usage (yfinance)
 
@@ -115,6 +147,7 @@ results = screen_us_stocks(hk_tickers, criteria)  # Same function works
 - For portfolio strategies: N stocks passing the screen each get weight 1/N
 - yfinance `Ticker.info` is a point-in-time snapshot, not historical time-series — cannot directly use for daily rebalancing backtests on US/HK stocks
 - For US/HK daily fundamental backtests, consider using the screening results as a stock universe, then applying technical signals within that universe
+- Do not confuse simple A-share `daily_basic` fields with the full Tushare financial statement tables. They have different loading rules and different point-in-time semantics.
 
 ## Dependencies
 

--- a/agent/src/skills/strategy-generate/SKILL.md
+++ b/agent/src/skills/strategy-generate/SKILL.md
@@ -23,6 +23,62 @@ Extract the following from the user's description:
 - **Time range**: if the user does not specify dates, default to **10 years back from today** (for example, if today is `2026-03-18`, then `start_date=2016-03-18`, `end_date=2026-03-18`)
 - **Strategy logic**: entry / exit conditions and indicator parameters
 
+### A-share Financial Statement Gating
+
+Before writing `config.json` or `signal_engine.py`, always classify the strategy into one of these three buckets:
+
+1. **Non-A-share strategy**
+2. **A-share strategy using only OHLCV or simple `daily_basic` fields**
+3. **A-share strategy using financial statement fields**
+
+The third bucket is special and must follow the gating rules below.
+
+#### What counts as "financial statement fields"
+
+Fields from any of these Tushare tables count as financial statement fields:
+
+- `income`
+- `balancesheet`
+- `cashflow`
+- `express`
+- `fina_indicator`
+
+Examples: `revenue`, `total_assets`, `n_cashflow_act`, `free_cashflow`, `grossprofit_margin`, `netprofit_margin`, `ocfps`, `roe_yearly`, `yoy_sales`.
+
+These do **not** trigger the financial-statement flow by themselves:
+
+- pure OHLCV
+- the existing A-share `daily_basic` fields already supported by the backtest loader: `pe`, `pb`, `pe_ttm`, `ps_ttm`, `dv_ttm`, `total_mv`, `circ_mv`, `roe`
+
+#### Gating rules
+
+If and only if the strategy is **A-share** and uses **financial statement fields**:
+
+1. You **must** enter the A-share financial enrichment flow.
+2. You **must** first check whether `TUSHARE_TOKEN` is available.
+3. You **must** treat 2000 Tushare points as the minimum gate for financial table access.
+4. You **must** treat 5000 Tushare points as the preferred threshold for full-market or universe A-share backtests; if the account has only 2000-4999 points, the run may proceed but will fall back to slower per-code fetching.
+5. You **must not** assume all fields are needed. Load only the tables and columns actually required by the strategy.
+6. You **must** follow the rules in [ashare-financial-enrichment](../ashare-financial-enrichment/SKILL.md).
+
+If the strategy is **not A-share** but requests financial statement fields:
+
+- Explain that the current financial-statement enrichment flow is only supported for A-shares.
+- Do **not** continue automatically.
+- Wait for the user's decision.
+
+If the strategy **is A-share** and requests financial statement fields but `TUSHARE_TOKEN` is not available:
+
+- Explain that the financial-statement enrichment flow requires `TUSHARE_TOKEN`.
+- Do **not** silently downgrade to AKShare or `daily_basic`.
+- Wait for the user's decision.
+
+If the strategy **is A-share** and requests financial statement fields but the account has fewer than 2000 Tushare points:
+
+- Explain that 2000 points is the minimum requirement for these financial tables.
+- Do **not** continue automatically.
+- Wait for the user's decision.
+
 **If critical information is missing, you must ask the user instead of guessing:**
 - Instrument not specified → ask which instrument they want to backtest (offer several popular suggestions)
 - Strategy description is vague (for example, "help me build a strategy") → provide 2-3 strategy directions for the user to choose from
@@ -41,6 +97,13 @@ Before writing code, think through these 5 questions:
 5. **Validation checklist**: signal consistency (no NaN signals), position check (normalized to prevent leverage), and completeness of generated artifacts
 
 There is no need to output a JSON design document. Express these design decisions directly in code.
+
+When the strategy uses A-share financial statement fields, refine question 1 into four sub-questions before proceeding:
+
+1. Is this definitely an A-share strategy?
+2. Which exact fields are needed from `income` / `balancesheet` / `cashflow` / `express` / `fina_indicator`?
+3. Is `TUSHARE_TOKEN` available right now?
+4. If not, should you stop and ask the user how to proceed?
 
 ## `SignalEngine` Contract
 
@@ -102,7 +165,16 @@ Self-check after writing `signal_engine.py`:
 | `^\d{3,5}\.HK$` | Hong Kong stocks | yfinance | - |
 | `^[A-Z]+-USDT$` | Cryptocurrency | okx | - |
 
-**`extra_fields` selection logic**: only China A-shares (`tushare`) support fundamentals. If the strategy needs `PE/PB/ROE` and similar fields, specify them in `config.json.extra_fields` and `DataLoader` will retrieve them automatically. Hong Kong stocks, US stocks, and crypto do not support `extra_fields`.
+**`extra_fields` selection logic**: only China A-shares (`tushare`) support the current built-in `daily_basic` fundamental fields. If the strategy needs `PE/PB/ROE` and similar `daily_basic` fields, specify them in `config.json.extra_fields` and `DataLoader` will retrieve them automatically.
+
+If the strategy needs fields from A-share financial statements (`income`, `balancesheet`, `cashflow`, `express`, `fina_indicator`):
+
+- do **not** treat them as ordinary `extra_fields`
+- do **not** silently fall back to AKShare
+- do **not** continue unless `TUSHARE_TOKEN` is available
+- follow [ashare-financial-enrichment](../ashare-financial-enrichment/SKILL.md)
+
+Hong Kong stocks, US stocks, and crypto do not support this A-share financial-statement enrichment flow.
 
 ## `config.json` Format
 

--- a/agent/src/tools/shadow_account_tool.py
+++ b/agent/src/tools/shadow_account_tool.py
@@ -51,6 +51,26 @@ def _validate_optional_journal_path(raw: Any) -> str | None:
     return str(safe_user_path(raw))
 
 
+def _validate_extract_journal_path(raw: Any) -> str:
+    """Validate `journal_path` for extraction with a HOME-scoped fallback.
+
+    The primary path policy still uses `safe_user_path()`. For local workflows
+    where the broker export is in the user's home directory, allow paths under
+    HOME as a pragmatic fallback.
+    """
+    if not raw:
+        raise ValueError("journal_path is required")
+
+    try:
+        return str(safe_user_path(raw))
+    except ValueError as exc:
+        resolved = Path(str(raw)).expanduser().resolve()
+        home = Path.home().resolve()
+        if resolved.is_relative_to(home):
+            return str(resolved)
+        raise exc
+
+
 # ---------------- Tool 1: extract ----------------
 
 class ExtractShadowStrategyTool(BaseTool):
@@ -88,10 +108,8 @@ class ExtractShadowStrategyTool(BaseTool):
 
     def execute(self, **kwargs: Any) -> str:
         journal_path = kwargs.get("journal_path")
-        if not journal_path:
-            return _err("journal_path is required")
         try:
-            journal_path = str(safe_user_path(journal_path))
+            journal_path = _validate_extract_journal_path(journal_path)
         except ValueError as exc:
             return _err(str(exc))
         try:

--- a/agent/tests/test_financial_field_inference.py
+++ b/agent/tests/test_financial_field_inference.py
@@ -1,0 +1,92 @@
+"""Tests for financial field inference."""
+
+from __future__ import annotations
+
+import pytest
+
+from backtest.financials.ashare.field_inference import (
+    infer_financial_fields,
+    infer_financial_fields_from_prompt,
+    infer_financial_fields_from_source,
+)
+
+
+class TestPromptInference:
+    def test_matches_pure_chinese_financial_concepts(self) -> None:
+        prompt = "做一个 A 股策略，使用资产总计、有形资产和净债务做排序。"
+
+        assert infer_financial_fields_from_prompt(prompt) == (
+            "total_assets",
+            "tangible_asset",
+            "netdebt",
+        )
+
+    def test_matches_chinese_field_descriptions(self) -> None:
+        prompt = "我需要营业收入、总资产和经营活动产生的现金流量净额。"
+
+        assert infer_financial_fields_from_prompt(prompt) == (
+            "revenue",
+            "total_assets",
+            "n_cashflow_act",
+        )
+
+
+class TestSourceInference:
+    def test_extracts_fields_from_common_string_literal_patterns(self) -> None:
+        source = '''
+class SignalEngine:
+    def generate(self, data_map):
+        result = {}
+        required = ["grossprofit_margin", "ocfps"]
+        selected = "n_cashflow_act"
+        for code, df in data_map.items():
+            score = df["grossprofit_margin"].fillna(0)
+            score = score + df.get(selected, 0)
+            result[code] = score.rank(pct=True)
+        return result
+'''
+
+        assert infer_financial_fields_from_source(source) == (
+            "grossprofit_margin",
+            "ocfps",
+            "n_cashflow_act",
+        )
+
+    def test_syntax_error_is_not_silenced(self) -> None:
+        with pytest.raises(SyntaxError):
+            infer_financial_fields_from_source("class SignalEngine(:\n    pass\n")
+
+
+class TestCombinedInference:
+    def test_combines_prompt_and_source_and_preserves_ambiguity(self) -> None:
+        prompt = "策略需要营业收入和总资产。"
+        source = '''
+class SignalEngine:
+    def generate(self, data_map):
+        return {code: df["grossprofit_margin"] for code, df in data_map.items()}
+'''
+
+        result = infer_financial_fields(prompt=prompt, source=source)
+
+        assert result.prompt_fields == ("revenue", "total_assets")
+        assert result.source_fields == ("grossprofit_margin",)
+        assert result.combined_fields == ("revenue", "total_assets", "grossprofit_margin")
+        assert result.query_plan.requested_fields == {"fina_indicator": ("grossprofit_margin",)}
+        assert result.query_plan.ambiguous_fields == {
+            "revenue": ("income", "express"),
+            "total_assets": ("balancesheet", "express"),
+        }
+
+    def test_preferred_tables_resolve_query_plan(self) -> None:
+        result = infer_financial_fields(
+            prompt="策略需要营业收入和总资产。",
+            preferred_tables={
+                "revenue": "income",
+                "total_assets": "balancesheet",
+            },
+        )
+
+        assert result.query_plan.requested_fields == {
+            "income": ("revenue",),
+            "balancesheet": ("total_assets",),
+        }

--- a/agent/tests/test_financial_field_registry.py
+++ b/agent/tests/test_financial_field_registry.py
@@ -1,0 +1,106 @@
+"""Tests for the A-share financial field registry."""
+
+from __future__ import annotations
+
+import pytest
+
+from backtest.financials.ashare.field_registry import (
+    AmbiguousFinancialFieldError,
+    SUPPORTED_FINANCIAL_TABLES,
+    UnknownFinancialFieldError,
+    build_financial_query_plan,
+    get_field_tables,
+    get_financial_field_registry,
+    get_table_metadata,
+)
+
+
+class TestFinancialFieldRegistry:
+    def test_loads_all_supported_tables(self) -> None:
+        registry = get_financial_field_registry()
+
+        assert set(registry.tables) == set(SUPPORTED_FINANCIAL_TABLES)
+
+    def test_income_metadata_contains_vip_and_points(self) -> None:
+        income = get_table_metadata("income")
+
+        assert income.api_name == "income"
+        assert income.vip_api_name == "income_vip"
+        assert income.min_points == 2000
+        assert income.vip_min_points == 5000
+        assert income.supports_cross_sectional_query is True
+        assert income.mcp_read_file_path == "skills/tushare/references/股票数据/财务数据/利润表.md"
+        assert income.key_columns[:3] == ("ts_code", "ann_date", "f_ann_date")
+
+    def test_field_ownership_supports_unique_and_shared_fields(self) -> None:
+        assert get_field_tables("grossprofit_margin") == ("fina_indicator",)
+        assert get_field_tables("n_cashflow_act") == ("cashflow",)
+        assert get_field_tables("revenue") == ("income", "express")
+        assert get_field_tables("total_assets") == ("balancesheet", "express")
+
+    def test_unknown_field_returns_empty_owner_tuple(self) -> None:
+        assert get_field_tables("not_a_real_financial_field") == ()
+
+    def test_assesses_cross_sectional_capability_for_query_plan(self) -> None:
+        registry = get_financial_field_registry()
+        plan = build_financial_query_plan(
+            ["revenue"],
+            preferred_tables={"revenue": "income"},
+        )
+
+        capability = registry.assess_cross_sectional_query(plan)
+
+        assert capability.supported is True
+        assert capability.supported_tables == ("income",)
+        assert capability.unsupported_tables == ()
+        assert capability.required_points_by_table == {"income": 5000}
+        assert capability.required_points == 5000
+
+
+class TestFinancialQueryPlan:
+    def test_groups_unique_fields_and_auto_adds_keys(self) -> None:
+        plan = build_financial_query_plan([
+            "grossprofit_margin",
+            "n_cashflow_act",
+            "ocfps",
+        ])
+
+        assert plan.requested_fields == {
+            "fina_indicator": ("grossprofit_margin", "ocfps"),
+            "cashflow": ("n_cashflow_act",),
+        }
+        assert plan.auto_included_keys["fina_indicator"] == ("ts_code", "ann_date", "end_date")
+        assert plan.auto_included_keys["cashflow"][:3] == ("ts_code", "ann_date", "f_ann_date")
+        assert plan.query_fields["fina_indicator"][:3] == ("ts_code", "ann_date", "end_date")
+
+    def test_ambiguous_field_raises_without_preference(self) -> None:
+        with pytest.raises(AmbiguousFinancialFieldError):
+            build_financial_query_plan(["revenue"])
+
+    def test_preferred_table_resolves_ambiguous_field(self) -> None:
+        plan = build_financial_query_plan(
+            ["revenue", "total_assets"],
+            preferred_tables={
+                "revenue": "express",
+                "total_assets": "balancesheet",
+            },
+        )
+
+        assert plan.requested_fields == {
+            "express": ("revenue",),
+            "balancesheet": ("total_assets",),
+        }
+
+    def test_unknown_field_raises_in_strict_mode(self) -> None:
+        with pytest.raises(UnknownFinancialFieldError):
+            build_financial_query_plan(["grossprofit_margin", "not_a_real_financial_field"])
+
+    def test_unknown_and_ambiguous_fields_are_reported_in_non_strict_mode(self) -> None:
+        plan = build_financial_query_plan(
+            ["revenue", "not_a_real_financial_field", "grossprofit_margin"],
+            strict=False,
+        )
+
+        assert plan.requested_fields == {"fina_indicator": ("grossprofit_margin",)}
+        assert plan.ambiguous_fields == {"revenue": ("income", "express")}
+        assert plan.unknown_fields == ("not_a_real_financial_field",)

--- a/agent/tests/test_financial_runtime_contracts.py
+++ b/agent/tests/test_financial_runtime_contracts.py
@@ -1,0 +1,28 @@
+"""Tests for the shared market-scoped financial runtime contracts."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from backtest.financials.ashare import get_ashare_financial_runtime
+from backtest.financials.contracts import (
+    FinancialFieldRegistryProtocol,
+    RawFinancialLoaderProtocol,
+)
+
+
+class TestAshareFinancialRuntime:
+    def test_exposes_minimal_runtime_bundle(self) -> None:
+        runtime = get_ashare_financial_runtime()
+
+        assert runtime.market == "a_share"
+        assert isinstance(runtime.registry, FinancialFieldRegistryProtocol)
+        assert runtime.infer_fields_from_prompt("资产总计、有形资产") == (
+            "total_assets",
+            "tangible_asset",
+        )
+
+        loader = runtime.loader_factory(api=MagicMock())
+        assert isinstance(loader, RawFinancialLoaderProtocol)
+        assert callable(runtime.assemble_pit_frame)
+        assert callable(runtime.enrich_data_map)

--- a/agent/tests/test_pit_financial_assembler.py
+++ b/agent/tests/test_pit_financial_assembler.py
@@ -1,0 +1,153 @@
+"""Tests for point-in-time financial field assembly."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from backtest.financials.ashare.field_registry import build_financial_query_plan
+from backtest.financials.ashare.pit_assembler import (
+    assemble_pit_frame,
+    canonicalize_financial_rows,
+    enrich_data_map_with_financials,
+)
+
+
+def _trade_index() -> pd.DatetimeIndex:
+    return pd.DatetimeIndex(
+        [
+            "2024-05-02",
+            "2024-05-03",
+            "2024-05-06",
+            "2024-05-07",
+        ],
+        name="trade_date",
+    )
+
+
+def _price_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {"close": [1.0, 1.0, 1.0, 1.0]},
+        index=_trade_index(),
+    )
+
+
+class TestAssemblePitFrame:
+    def test_ann_date_becomes_visible_next_trade_day(self) -> None:
+        records = pd.DataFrame(
+            {
+                "ts_code": ["600519.SH", "600519.SH"],
+                "ann_date": ["20240502", "20240505"],
+                "f_ann_date": ["20240502", "20240505"],
+                "end_date": ["20240331", "20240630"],
+                "revenue": [100.0, 120.0],
+            }
+        )
+
+        pit = assemble_pit_frame(_trade_index(), records, fields=["revenue"])
+
+        assert pd.isna(pit.loc[pd.Timestamp("2024-05-02"), "revenue"])
+        assert pit.loc[pd.Timestamp("2024-05-03"), "revenue"] == 100.0
+        assert pit.loc[pd.Timestamp("2024-05-06"), "revenue"] == 120.0
+        assert pit.loc[pd.Timestamp("2024-05-07"), "revenue"] == 120.0
+
+    def test_canonicalize_keeps_distinct_revisions_but_dedups_same_cycle(self) -> None:
+        records = pd.DataFrame(
+            {
+                "ts_code": ["600519.SH", "600519.SH", "600519.SH"],
+                "ann_date": ["20240430", "20240430", "20240510"],
+                "f_ann_date": ["20240430", "20240501", "20240510"],
+                "end_date": ["20240331", "20240331", "20240331"],
+                "report_type": [1, 1, 1],
+                "revenue": [100.0, 101.0, 110.0],
+            }
+        )
+
+        canonical = canonicalize_financial_rows(records)
+
+        assert len(canonical) == 2
+        assert canonical.iloc[0]["revenue"] == 101.0
+        assert canonical.iloc[1]["revenue"] == 110.0
+
+    def test_report_type_priority_breaks_same_cycle_tie(self) -> None:
+        records = pd.DataFrame(
+            {
+                "ts_code": ["600519.SH", "600519.SH"],
+                "ann_date": ["20240430", "20240430"],
+                "f_ann_date": ["20240430", "20240430"],
+                "end_date": ["20240331", "20240331"],
+                "report_type": [1, 2],
+                "grossprofit_margin": [88.0, 91.5],
+            }
+        )
+
+        canonical = canonicalize_financial_rows(records, report_type_priority={1: 0, 2: 10})
+
+        assert len(canonical) == 1
+        assert canonical.iloc[0]["grossprofit_margin"] == 91.5
+
+    def test_default_priority_is_order_independent(self) -> None:
+        records = pd.DataFrame(
+            {
+                "ts_code": ["600519.SH", "600519.SH"],
+                "ann_date": ["20240430", "20240430"],
+                "f_ann_date": ["20240430", "20240430"],
+                "end_date": ["20240331", "20240331"],
+                "report_type": [1, 2],
+                "grossprofit_margin": [88.0, 91.5],
+            }
+        )
+
+        forward = canonicalize_financial_rows(records)
+        reversed_rows = canonicalize_financial_rows(records.iloc[::-1].reset_index(drop=True))
+
+        assert len(forward) == 1
+        assert len(reversed_rows) == 1
+        assert forward.iloc[0]["report_type"] == 1
+        assert reversed_rows.iloc[0]["report_type"] == 1
+        assert forward.iloc[0]["grossprofit_margin"] == 88.0
+        assert reversed_rows.iloc[0]["grossprofit_margin"] == 88.0
+
+
+class TestEnrichDataMap:
+    def test_per_stock_visibility_dates_remain_independent(self) -> None:
+        data_map = {
+            "600519.SH": _price_frame(),
+            "000001.SZ": _price_frame(),
+        }
+        raw_tables = {
+            "income": pd.DataFrame(
+                {
+                    "ts_code": ["600519.SH", "000001.SZ"],
+                    "ann_date": ["20240502", "20240506"],
+                    "f_ann_date": ["20240502", "20240506"],
+                    "end_date": ["20240331", "20240331"],
+                    "revenue": [100.0, 200.0],
+                }
+            )
+        }
+        plan = build_financial_query_plan(["revenue"], preferred_tables={"revenue": "income"})
+
+        enriched = enrich_data_map_with_financials(data_map, raw_tables, plan)
+
+        assert enriched["600519.SH"].loc[pd.Timestamp("2024-05-03"), "revenue"] == 100.0
+        assert pd.isna(enriched["000001.SZ"].loc[pd.Timestamp("2024-05-03"), "revenue"])
+        assert enriched["000001.SZ"].loc[pd.Timestamp("2024-05-07"), "revenue"] == 200.0
+
+    def test_rejects_invalid_raw_table_schema(self) -> None:
+        data_map = {"600519.SH": _price_frame()}
+        raw_tables = {
+            "income": pd.DataFrame(
+                {
+                    "ann_date": ["20240502"],
+                    "end_date": ["20240331"],
+                    "revenue": [100.0],
+                }
+            )
+        }
+        plan = build_financial_query_plan(["revenue"], preferred_tables={"revenue": "income"})
+
+        with pytest.raises(ValueError, match="missing key columns") as exc_info:
+            enrich_data_map_with_financials(data_map, raw_tables, plan)
+
+        assert "financial table 'income' has invalid schema" in str(exc_info.value)

--- a/agent/tests/test_runner_financials.py
+++ b/agent/tests/test_runner_financials.py
@@ -1,0 +1,471 @@
+"""Tests for runner-side financial statement gating."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from backtest.financials.ashare import get_ashare_financial_runtime
+from backtest.financials.ashare.field_registry import get_financial_field_registry
+from backtest.financials.contracts import FinancialCrossSectionCapability, MarketFinancialRuntime
+from backtest.runner import (
+    BacktestConfigSchema,
+    FinancialsConfigSchema,
+    UniverseConfigSchema,
+    _build_financial_fetch_plan,
+    _resolve_a_share_universe_codes,
+    _build_financial_query_plan_from_config,
+    _derive_cross_sectional_financial_periods,
+    _extract_tushare_points_from_user_frame,
+    _resolve_tushare_points,
+    _validate_financials_request,
+    main,
+)
+
+
+def _write_run_dir(tmp_path: Path, config: dict) -> Path:
+    run_dir = tmp_path / "run"
+    (run_dir / "code").mkdir(parents=True)
+    (run_dir / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    (run_dir / "code" / "signal_engine.py").write_text(
+        "class SignalEngine:\n"
+        "    def generate(self, data_map):\n"
+        "        return {}\n",
+        encoding="utf-8",
+    )
+    return run_dir
+
+
+class TestFinancialConfigSchema:
+    def test_accepts_valid_financials_block(self) -> None:
+        cfg = BacktestConfigSchema(
+            codes=["600519.SH"],
+            start_date="2025-01-01",
+            end_date="2025-06-01",
+            source="tushare",
+            financials=FinancialsConfigSchema(
+                required=True,
+                tables=["income"],
+                fields=["revenue"],
+            ),
+        )
+
+        assert cfg.financials is not None
+        assert cfg.financials.tables == ["income"]
+        assert cfg.financials.fields == ["revenue"]
+
+    def test_rejects_unknown_financial_table(self) -> None:
+        with pytest.raises(Exception, match="unsupported financial tables"):
+            BacktestConfigSchema(
+                codes=["600519.SH"],
+                start_date="2025-01-01",
+                end_date="2025-06-01",
+                financials=FinancialsConfigSchema(required=True, tables=["made_up_table"]),
+            )
+
+    def test_rejects_unknown_financial_field(self) -> None:
+        with pytest.raises(Exception, match="unknown financial fields"):
+            BacktestConfigSchema(
+                codes=["600519.SH"],
+                start_date="2025-01-01",
+                end_date="2025-06-01",
+                financials=FinancialsConfigSchema(required=True, fields=["made_up_field"]),
+            )
+
+    def test_accepts_a_share_universe_without_codes(self) -> None:
+        cfg = BacktestConfigSchema(
+            start_date="2025-01-01",
+            end_date="2025-06-01",
+            universe=UniverseConfigSchema(market="a_share"),
+        )
+
+        assert cfg.codes == []
+        assert cfg.universe is not None
+        assert cfg.universe.market == "a_share"
+
+
+class TestFinancialRunnerGate:
+    def test_resolve_a_share_universe_codes(self, monkeypatch) -> None:
+        monkeypatch.setenv("TUSHARE_TOKEN", "ts-token")
+        fake_api = MagicMock()
+        fake_api.stock_basic.return_value = pd.DataFrame(
+            {"ts_code": ["600519.SH", "000001.SZ", "AAPL.US", None]}
+        )
+        monkeypatch.setitem(sys.modules, "tushare", SimpleNamespace(pro_api=lambda token: fake_api))
+
+        codes = _resolve_a_share_universe_codes()
+
+        assert codes == ["000001.SZ", "600519.SH"]
+
+    def test_normalizes_auto_source_to_tushare(self, monkeypatch) -> None:
+        monkeypatch.setenv("TUSHARE_TOKEN", "ts-token")
+        source = _validate_financials_request(
+            {
+                "financials": {
+                    "required": True,
+                    "fields": ["grossprofit_margin"],
+                }
+            },
+            "auto",
+            ["600519.SH"],
+        )
+
+        assert source == "tushare"
+
+    def test_rejects_non_a_share_request(self, monkeypatch) -> None:
+        monkeypatch.setenv("TUSHARE_TOKEN", "ts-token")
+        with pytest.raises(ValueError, match="only A-share strategies"):
+            _validate_financials_request(
+                {"financials": {"required": True, "fields": ["grossprofit_margin"]}},
+                "tushare",
+                ["AAPL.US"],
+            )
+
+    def test_rejects_missing_tushare_token(self, monkeypatch) -> None:
+        monkeypatch.delenv("TUSHARE_TOKEN", raising=False)
+        with pytest.raises(ValueError, match="TUSHARE_TOKEN"):
+            _validate_financials_request(
+                {"financials": {"required": True, "fields": ["grossprofit_margin"]}},
+                "tushare",
+                ["600519.SH"],
+            )
+
+    def test_rejects_non_tushare_source(self, monkeypatch) -> None:
+        monkeypatch.setenv("TUSHARE_TOKEN", "ts-token")
+        with pytest.raises(ValueError, match="strict Tushare mode"):
+            _validate_financials_request(
+                {"financials": {"required": True, "fields": ["grossprofit_margin"]}},
+                "akshare",
+                ["600519.SH"],
+            )
+
+    def test_rejects_non_daily_interval(self, monkeypatch) -> None:
+        monkeypatch.setenv("TUSHARE_TOKEN", "ts-token")
+        with pytest.raises(ValueError, match="interval='1D'"):
+            _validate_financials_request(
+                {
+                    "interval": "1m",
+                    "financials": {"required": True, "fields": ["grossprofit_margin"]},
+                },
+                "tushare",
+                ["600519.SH"],
+            )
+
+    def test_build_query_plan_requires_explicit_fields(self) -> None:
+        with pytest.raises(ValueError, match="explicit financials.fields"):
+            _build_financial_query_plan_from_config(
+                {"financials": {"required": True, "tables": ["income"]}}
+            )
+
+    def test_derives_cross_sectional_periods_with_quarter_lookback(self) -> None:
+        periods = _derive_cross_sectional_financial_periods(
+            "2025-05-01",
+            "2025-05-07",
+        )
+
+        assert periods == ("20240630", "20240930", "20241231", "20250331")
+
+    def test_resolve_tushare_points_queries_account_automatically(self, monkeypatch) -> None:
+        monkeypatch.setenv("TUSHARE_TOKEN", "ts-token-points")
+        fake_api = MagicMock()
+        fake_api.user.return_value = pd.DataFrame(
+            {
+                "user_id": [1, 1],
+                "到期时间": ["2027-04-14", "2027-04-13"],
+                "到期积分": [2880.0, 2000.0],
+            }
+        )
+        monkeypatch.setitem(sys.modules, "tushare", SimpleNamespace(pro_api=lambda token: fake_api))
+
+        assert _resolve_tushare_points({}) == 4880
+        fake_api.user.assert_called_once_with(token="ts-token-points")
+
+    def test_extract_tushare_points_accepts_zero_total(self) -> None:
+        user_frame = pd.DataFrame({"到期积分": [0.0]})
+
+        assert _extract_tushare_points_from_user_frame(user_frame) == 0
+
+    def test_build_fetch_plan_raises_when_account_points_query_fails(self, monkeypatch) -> None:
+        monkeypatch.setenv("TUSHARE_TOKEN", "ts-token-fail")
+        fake_api = MagicMock()
+        fake_api.user.side_effect = RuntimeError("user endpoint unavailable")
+        monkeypatch.setitem(sys.modules, "tushare", SimpleNamespace(pro_api=lambda token: fake_api))
+
+        config = {
+            "start_date": "2025-05-01",
+            "end_date": "2025-05-07",
+            "financials": {
+                "required": True,
+                "fields": ["grossprofit_margin"],
+            },
+            "universe": {
+                "market": "a_share",
+            },
+            "_resolved_codes_from_universe": True,
+        }
+        query_plan = _build_financial_query_plan_from_config(config)
+
+        with pytest.raises(ValueError, match=r"user\(token=\.\.\.\)") as exc_info:
+            _build_financial_fetch_plan(config, query_plan)
+
+        message = str(exc_info.value)
+        assert "RuntimeError: user endpoint unavailable" in message
+
+    def test_build_fetch_plan_rejects_unsupported_cross_section_tables(self, monkeypatch) -> None:
+        config = {
+            "start_date": "2025-05-01",
+            "end_date": "2025-05-07",
+            "financials": {
+                "required": True,
+                "fields": ["grossprofit_margin"],
+            },
+            "universe": {
+                "market": "a_share",
+            },
+            "_resolved_codes_from_universe": True,
+        }
+        query_plan = _build_financial_query_plan_from_config(config)
+        real_runtime = get_ashare_financial_runtime()
+
+        class _UnsupportedCrossSectionRegistry:
+            @property
+            def tables(self):
+                return {}
+
+            @property
+            def field_to_tables(self):
+                return {}
+
+            def get_table(self, table_name: str):
+                raise AssertionError("get_table should not be called in this test")
+
+            def has_field(self, field_name: str) -> bool:
+                return False
+
+            def get_field_tables(self, field_name: str):
+                return ()
+
+            def assess_cross_sectional_query(self, query_plan):
+                return FinancialCrossSectionCapability(
+                    supported_tables=(),
+                    unsupported_tables=("fina_indicator",),
+                    required_points_by_table={},
+                    required_points=0,
+                )
+
+            def build_query_plan(self, fields, *, preferred_tables=None, include_key_columns=True, strict=True):
+                raise AssertionError("build_query_plan should not be called in this test")
+
+        runtime = MarketFinancialRuntime(
+            market="a_share",
+            registry=_UnsupportedCrossSectionRegistry(),
+            infer_fields_from_prompt=real_runtime.infer_fields_from_prompt,
+            infer_fields_from_source=real_runtime.infer_fields_from_source,
+            infer_fields_from_file=real_runtime.infer_fields_from_file,
+            infer_fields=real_runtime.infer_fields,
+            loader_factory=real_runtime.loader_factory,
+            assemble_pit_frame=real_runtime.assemble_pit_frame,
+            enrich_data_map=real_runtime.enrich_data_map,
+        )
+        monkeypatch.setattr("backtest.runner._get_ashare_financial_runtime", lambda: runtime)
+
+        with pytest.raises(ValueError, match="unsupported tables=fina_indicator") as exc_info:
+            _build_financial_fetch_plan(config, query_plan)
+
+        message = str(exc_info.value)
+        assert "requested tables=fina_indicator" in message
+        assert "supported tables=<none>" in message
+
+    def test_build_fetch_plan_downgrades_to_per_code_when_only_ordinary_points_available(self, monkeypatch, caplog) -> None:
+        monkeypatch.setenv("TUSHARE_TOKEN", "ts-token-insufficient")
+        fake_api = MagicMock()
+        fake_api.user.return_value = pd.DataFrame(
+            {
+                "user_id": [1],
+                "到期时间": ["2027-04-14"],
+                "到期积分": [2880.0],
+            }
+        )
+        monkeypatch.setitem(sys.modules, "tushare", SimpleNamespace(pro_api=lambda token: fake_api))
+
+        config = {
+            "start_date": "2025-05-01",
+            "end_date": "2025-05-07",
+            "financials": {
+                "required": True,
+                "fields": ["grossprofit_margin"],
+            },
+            "universe": {
+                "market": "a_share",
+            },
+            "_resolved_codes_from_universe": True,
+        }
+        query_plan = _build_financial_query_plan_from_config(config)
+
+        plan = _build_financial_fetch_plan(config, query_plan)
+
+        assert plan.mode == "per_code"
+        assert "falling back to slower per-code Tushare fetch" in caplog.text
+        assert "current account points=2880" in caplog.text
+
+    def test_build_fetch_plan_rejects_points_below_ordinary_minimum(self, monkeypatch) -> None:
+        monkeypatch.setenv("TUSHARE_TOKEN", "ts-token-too-low")
+        fake_api = MagicMock()
+        fake_api.user.return_value = pd.DataFrame(
+            {
+                "user_id": [1],
+                "到期时间": ["2027-04-14"],
+                "到期积分": [0.0],
+            }
+        )
+        monkeypatch.setitem(sys.modules, "tushare", SimpleNamespace(pro_api=lambda token: fake_api))
+
+        config = {
+            "start_date": "2025-05-01",
+            "end_date": "2025-05-07",
+            "financials": {
+                "required": True,
+                "fields": ["grossprofit_margin"],
+            },
+            "universe": {
+                "market": "a_share",
+            },
+            "_resolved_codes_from_universe": True,
+        }
+        query_plan = _build_financial_query_plan_from_config(config)
+
+        with pytest.raises(ValueError, match="at least 2000 Tushare points") as exc_info:
+            _build_financial_fetch_plan(config, query_plan)
+
+        message = str(exc_info.value)
+        assert "requested tables=fina_indicator" in message
+        assert "current account points=0" in message
+        assert "ordinary required points=2000" in message
+
+    def test_main_enriches_data_map_before_engine_run(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setenv("TUSHARE_TOKEN", "ts-token-main")
+        run_dir = _write_run_dir(
+            tmp_path,
+            {
+                "start_date": "2025-05-01",
+                "end_date": "2025-05-07",
+                "source": "tushare",
+                "universe": {
+                    "market": "a_share",
+                },
+                "financials": {
+                    "required": True,
+                    "fields": ["grossprofit_margin"],
+                },
+            },
+        )
+
+        trade_index = pd.DatetimeIndex(["2025-05-02", "2025-05-05", "2025-05-06"], name="trade_date")
+        price_frame = pd.DataFrame(
+            {"open": [1.0, 1.0, 1.0], "high": [1.0, 1.0, 1.0], "low": [1.0, 1.0, 1.0], "close": [1.0, 1.0, 1.0], "volume": [1.0, 1.0, 1.0]},
+            index=trade_index,
+        )
+
+        class _FakePriceLoader:
+            name = "tushare"
+            markets = {"a_share"}
+            requires_auth = True
+
+            def is_available(self) -> bool:
+                return True
+
+            def fetch(self, codes, start_date, end_date, *, interval="1D", fields=None):
+                return {"600519.SH": price_frame.copy()}
+
+        fake_raw_loader = MagicMock()
+
+        def _fetch_for_period(query_plan, *, period, table_params=None):
+            if period == "20250331":
+                return {
+                    "fina_indicator": pd.DataFrame(
+                        {
+                            "ts_code": ["600519.SH"],
+                            "ann_date": ["20250502"],
+                            "end_date": ["20250331"],
+                            "grossprofit_margin": [91.5],
+                        }
+                    )
+                }
+            return {
+                table_name: pd.DataFrame(columns=list(fields))
+                for table_name, fields in query_plan.query_fields.items()
+            }
+
+        fake_raw_loader.fetch_for_period.side_effect = _fetch_for_period
+
+        class _FakeSignalEngine:
+            def generate(self, data_map):
+                return {code: df["close"] * 0 for code, df in data_map.items()}
+
+        fake_engine = SimpleNamespace(observed=None)
+
+        def _fake_run_backtest(config, loader, signal_engine, run_dir, bars_per_year=252):
+            fake_engine.observed = loader.fetch(
+                config["codes"],
+                config["start_date"],
+                config["end_date"],
+                interval=config.get("interval", "1D"),
+                fields=config.get("extra_fields"),
+            )
+            return {}
+
+        monkeypatch.setattr(
+            "backtest.runner._get_loader",
+            lambda source: _FakePriceLoader,
+        )
+        fake_universe_api = MagicMock()
+        fake_universe_api.stock_basic.return_value = pd.DataFrame({"ts_code": ["600519.SH"]})
+        fake_universe_api.user.return_value = pd.DataFrame(
+            {
+                "user_id": [1, 1],
+                "到期时间": ["2027-04-14", "2027-04-13"],
+                "到期积分": [2880.0, 3000.0],
+            }
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "tushare",
+            SimpleNamespace(pro_api=lambda token: fake_universe_api),
+        )
+        real_runtime = get_ashare_financial_runtime()
+        runtime = MarketFinancialRuntime(
+            market="a_share",
+            registry=get_financial_field_registry(),
+            infer_fields_from_prompt=real_runtime.infer_fields_from_prompt,
+            infer_fields_from_source=real_runtime.infer_fields_from_source,
+            infer_fields_from_file=real_runtime.infer_fields_from_file,
+            infer_fields=real_runtime.infer_fields,
+            loader_factory=lambda: fake_raw_loader,
+            assemble_pit_frame=real_runtime.assemble_pit_frame,
+            enrich_data_map=real_runtime.enrich_data_map,
+        )
+        monkeypatch.setattr("backtest.runner._get_ashare_financial_runtime", lambda: runtime)
+        monkeypatch.setattr(
+            "backtest.runner._load_module_from_file",
+            lambda path, module_name: SimpleNamespace(SignalEngine=_FakeSignalEngine),
+        )
+        monkeypatch.setattr(
+            "backtest.runner._create_market_engine",
+            lambda source, config, codes: SimpleNamespace(run_backtest=_fake_run_backtest),
+        )
+
+        main(run_dir)
+
+        observed = fake_engine.observed["600519.SH"]
+        fake_raw_loader.fetch_for_codes.assert_not_called()
+        assert [
+            call.kwargs["period"] for call in fake_raw_loader.fetch_for_period.call_args_list
+        ] == ["20240630", "20240930", "20241231", "20250331"]
+        assert pd.isna(observed.loc[pd.Timestamp("2025-05-02"), "grossprofit_margin"])
+        assert observed.loc[pd.Timestamp("2025-05-05"), "grossprofit_margin"] == 91.5

--- a/agent/tests/test_tushare_financial_loader.py
+++ b/agent/tests/test_tushare_financial_loader.py
@@ -1,0 +1,137 @@
+"""Tests for the raw Tushare financial statement loader."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from backtest.financials.ashare.field_registry import build_financial_query_plan
+from backtest.financials.ashare.tushare_loader import TushareFinancialLoader
+
+
+def _stub_income_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "ts_code": ["600519.SH"],
+            "ann_date": ["20240430"],
+            "f_ann_date": ["20240430"],
+            "end_date": ["20240331"],
+            "report_type": [1],
+            "comp_type": [1],
+            "end_type": ["Q1"],
+            "revenue": [123.0],
+        }
+    )
+
+
+def _stub_fina_indicator_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "ts_code": ["600519.SH"],
+            "ann_date": ["20240430"],
+            "end_date": ["20240331"],
+            "grossprofit_margin": [91.5],
+        }
+    )
+
+
+class TestFetchTable:
+    def test_fetch_table_uses_ordinary_api_with_ts_code(self) -> None:
+        api = MagicMock()
+        api.income.return_value = _stub_income_frame()
+        loader = TushareFinancialLoader(api=api)
+
+        frame = loader.fetch_table(
+            "income",
+            ts_code="600519.SH",
+            fields=["ts_code", "ann_date", "revenue"],
+            start_date="2024-01-01",
+            end_date="2024-06-01",
+        )
+
+        api.income.assert_called_once_with(
+            ts_code="600519.SH",
+            start_date="20240101",
+            end_date="20240601",
+            fields="ts_code,ann_date,revenue",
+        )
+        assert list(frame.columns) == list(_stub_income_frame().columns)
+
+    def test_fetch_table_uses_vip_api_for_cross_section(self) -> None:
+        api = MagicMock()
+        api.income_vip.return_value = _stub_income_frame()
+        loader = TushareFinancialLoader(api=api)
+
+        loader.fetch_table(
+            "income",
+            period="2024-03-31",
+            fields=["ts_code", "ann_date", "revenue"],
+            use_vip=True,
+        )
+
+        api.income_vip.assert_called_once_with(
+            period="20240331",
+            fields="ts_code,ann_date,revenue",
+        )
+
+    def test_fetch_table_rejects_foreign_fields(self) -> None:
+        loader = TushareFinancialLoader(api=MagicMock())
+        with pytest.raises(ValueError, match="do not belong"):
+            loader.fetch_table("income", ts_code="600519.SH", fields=["grossprofit_margin"])
+
+    def test_fetch_table_rejects_reserved_extra_params(self) -> None:
+        api = MagicMock()
+        loader = TushareFinancialLoader(api=api)
+
+        with pytest.raises(ValueError, match="reserved financial query keys"):
+            loader.fetch_table(
+                "income",
+                ts_code="600519.SH",
+                fields=["ts_code", "ann_date", "revenue"],
+                extra_params={"fields": "revenue", "ts_code": "000001.SZ"},
+            )
+
+        api.income.assert_not_called()
+
+
+class TestFetchByPlan:
+    def test_fetch_for_codes_groups_by_table_and_concatenates(self) -> None:
+        api = MagicMock()
+        api.income.return_value = _stub_income_frame()
+        api.fina_indicator.return_value = _stub_fina_indicator_frame()
+        loader = TushareFinancialLoader(api=api)
+        plan = build_financial_query_plan(
+            ["revenue", "grossprofit_margin"],
+            preferred_tables={"revenue": "income"},
+        )
+
+        result = loader.fetch_for_codes(
+            plan,
+            codes=["600519.SH"],
+            start_date="2024-01-01",
+            end_date="2024-06-01",
+        )
+
+        assert set(result) == {"income", "fina_indicator"}
+        assert api.income.call_count == 1
+        assert api.fina_indicator.call_count == 1
+        assert "revenue" in result["income"].columns
+        assert "grossprofit_margin" in result["fina_indicator"].columns
+
+    def test_fetch_for_period_uses_vip_endpoints(self) -> None:
+        api = MagicMock()
+        api.income_vip.return_value = _stub_income_frame()
+        api.fina_indicator_vip.return_value = _stub_fina_indicator_frame()
+        loader = TushareFinancialLoader(api=api)
+        plan = build_financial_query_plan(
+            ["revenue", "grossprofit_margin"],
+            preferred_tables={"revenue": "income"},
+        )
+
+        result = loader.fetch_for_period(plan, period="2024-03-31")
+
+        assert set(result) == {"income", "fina_indicator"}
+        api.income_vip.assert_called_once()
+        api.fina_indicator_vip.assert_called_once()


### PR DESCRIPTION
## Summary
- 新增 A 股基本面回测所需的财务数据增强模块，覆盖字段推断、字段注册、PIT 组装与 tushare 财务加载。
- 在回测执行链路中接入财务运行时契约，支持策略侧稳定消费财务因子。
- 补充并更新相关技能与测试，确保财务增强能力可用且可回归验证。

## Why
- 现有回测链路对财务数据支持不足，难以稳定支撑 A 股基本面策略构建与筛选。
- 需要统一财务字段语义和运行时契约，降低数据路由与策略生成之间的耦合。
- 通过补充测试覆盖关键路径，降低后续演进风险。


## Changes
1.新增财务模块与 A 股子模块：
 - field inference
 - field registry
 - PIT assembler
 - tushare financial loader
 - runtime contracts
2. 修改 backtest runner 以接入财务增强运行流程。
3. 新增技能：ashare-financial-enrichment。
4. 更新技能：data-routing、fundamental-filter、strategy-generate。
5. 新增 6 个财务相关测试文件，覆盖字段推断、字段注册、契约、PIT 组装、runner 集成与 tushare loader。

## Test Plan

- [ ] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [x] New tests added (if applicable)
- [ ] Tested manually (describe below)

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Documentation updated (if user-facing change)
