### PR TITLE
[codex] add Tushare fundamental provider contract

### DIFF
--- a/agent/backtest/loaders/tushare_fundamentals.py
+++ b/agent/backtest/loaders/tushare_fundamentals.py
@@ -1,0 +1,204 @@
+"""Tushare fundamental data provider with point-in-time safeguards."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+import pandas as pd
+
+
+class DataProviderError(Exception):
+    """Base error for fundamental provider failures."""
+
+
+class UnknownTableError(DataProviderError):
+    """Raised when a requested fundamental table is not supported."""
+
+
+class SchemaValidationError(DataProviderError):
+    """Raised when provider output is missing required columns."""
+
+
+@dataclass(frozen=True)
+class ColumnSchema:
+    """Machine-readable column metadata for a provider table."""
+
+    name: str
+    dtype: str
+    required: bool = False
+
+
+@dataclass(frozen=True)
+class TableSchema:
+    """Machine-readable metadata for a Tushare fundamental table."""
+
+    name: str
+    api_name: str
+    point_in_time_column: str
+    columns: tuple[ColumnSchema, ...]
+
+    @property
+    def required_columns(self) -> tuple[str, ...]:
+        return tuple(column.name for column in self.columns if column.required)
+
+
+_SCHEMAS: dict[str, TableSchema] = {
+    "balancesheet": TableSchema(
+        name="balancesheet",
+        api_name="balancesheet",
+        point_in_time_column="f_ann_date",
+        columns=(
+            ColumnSchema("ts_code", "str", required=True),
+            ColumnSchema("ann_date", "date", required=True),
+            ColumnSchema("f_ann_date", "date", required=False),
+            ColumnSchema("end_date", "date", required=True),
+            ColumnSchema("total_assets", "float"),
+            ColumnSchema("total_liab", "float"),
+            ColumnSchema("total_hldr_eqy_exc_min_int", "float"),
+        ),
+    ),
+    "cashflow": TableSchema(
+        name="cashflow",
+        api_name="cashflow",
+        point_in_time_column="f_ann_date",
+        columns=(
+            ColumnSchema("ts_code", "str", required=True),
+            ColumnSchema("ann_date", "date", required=True),
+            ColumnSchema("f_ann_date", "date", required=False),
+            ColumnSchema("end_date", "date", required=True),
+            ColumnSchema("net_profit", "float"),
+            ColumnSchema("n_cashflow_act", "float"),
+            ColumnSchema("c_cash_equ_end_period", "float"),
+        ),
+    ),
+    "fina_indicator": TableSchema(
+        name="fina_indicator",
+        api_name="fina_indicator",
+        point_in_time_column="ann_date",
+        columns=(
+            ColumnSchema("ts_code", "str", required=True),
+            ColumnSchema("ann_date", "date", required=True),
+            ColumnSchema("end_date", "date", required=True),
+            ColumnSchema("eps", "float"),
+            ColumnSchema("grossprofit_margin", "float"),
+            ColumnSchema("netprofit_margin", "float"),
+            ColumnSchema("roe", "float"),
+            ColumnSchema("debt_to_assets", "float"),
+        ),
+    ),
+    "income": TableSchema(
+        name="income",
+        api_name="income",
+        point_in_time_column="f_ann_date",
+        columns=(
+            ColumnSchema("ts_code", "str", required=True),
+            ColumnSchema("ann_date", "date", required=True),
+            ColumnSchema("f_ann_date", "date", required=False),
+            ColumnSchema("end_date", "date", required=True),
+            ColumnSchema("total_revenue", "float"),
+            ColumnSchema("revenue", "float"),
+            ColumnSchema("operate_profit", "float"),
+            ColumnSchema("n_income", "float"),
+        ),
+    ),
+}
+
+
+class TushareFundamentalProvider:
+    """Small DataProvider contract for Tushare financial statement tables."""
+
+    def __init__(self, api: Any | None = None) -> None:
+        if api is None:
+            import tushare as ts
+
+            api = ts.pro_api()
+        self.api = api
+
+    def list_tables(self) -> list[str]:
+        """Return supported fundamental tables in stable order."""
+        return sorted(_SCHEMAS)
+
+    def describe_table(self, table: str) -> TableSchema:
+        """Return schema metadata for a supported table."""
+        try:
+            return _SCHEMAS[table]
+        except KeyError as exc:
+            raise UnknownTableError(f"Unsupported Tushare fundamental table: {table}") from exc
+
+    def query_fundamentals(
+        self,
+        table: str,
+        codes: Iterable[str],
+        *,
+        as_of: str | pd.Timestamp,
+        periods: Iterable[str] | None = None,
+        fields: Iterable[str] | None = None,
+    ) -> pd.DataFrame:
+        """Query a fundamental table and filter out rows unpublished by ``as_of``."""
+        schema = self.describe_table(table)
+        requested_periods = set(periods or [])
+        frames: list[pd.DataFrame] = []
+
+        api_method = getattr(self.api, schema.api_name, None)
+        if api_method is None:
+            raise DataProviderError(f"Tushare API object has no method: {schema.api_name}")
+
+        for code in codes:
+            frame = api_method(ts_code=code, period=None)
+            if frame is not None and not frame.empty:
+                frames.append(frame.copy())
+
+        if not frames:
+            return self._empty_frame(schema, fields)
+
+        result = pd.concat(frames, ignore_index=True)
+        self._validate_schema(schema, result)
+
+        if requested_periods:
+            result = result[result["end_date"].astype(str).isin(requested_periods)]
+
+        pit_column = schema.point_in_time_column
+        if pit_column not in result.columns or result[pit_column].isna().all():
+            pit_column = "ann_date"
+        as_of_date = _parse_tushare_date(as_of)
+        pit_values = result[pit_column]
+        if pit_column != "ann_date" and "ann_date" in result.columns:
+            pit_values = pit_values.where(pit_values.notna(), result["ann_date"])
+        pit_dates = pit_values.map(_parse_tushare_date)
+        result = result[pit_dates <= as_of_date]
+
+        output_columns = self._output_columns(schema, result, fields)
+        result = result.loc[:, output_columns].sort_values(["ts_code", "end_date"]).reset_index(drop=True)
+        return result
+
+    def _validate_schema(self, schema: TableSchema, frame: pd.DataFrame) -> None:
+        missing = [column for column in schema.required_columns if column not in frame.columns]
+        if missing:
+            raise SchemaValidationError(f"{schema.name} missing required columns: {', '.join(missing)}")
+
+    def _output_columns(
+        self,
+        schema: TableSchema,
+        frame: pd.DataFrame,
+        fields: Iterable[str] | None,
+    ) -> list[str]:
+        identity = ["ts_code", "end_date", "ann_date"]
+        if schema.point_in_time_column in frame.columns and schema.point_in_time_column not in identity:
+            identity.append(schema.point_in_time_column)
+        wanted = identity + list(fields or [])
+        return [column for column in dict.fromkeys(wanted) if column in frame.columns]
+
+    def _empty_frame(self, schema: TableSchema, fields: Iterable[str] | None) -> pd.DataFrame:
+        columns = self._output_columns(schema, pd.DataFrame(columns=[c.name for c in schema.columns]), fields)
+        return pd.DataFrame(columns=columns)
+
+
+def _parse_tushare_date(value: str | pd.Timestamp) -> pd.Timestamp:
+    """Parse Tushare YYYYMMDD strings and common timestamp/date strings."""
+    if isinstance(value, pd.Timestamp):
+        return value.normalize()
+    text = str(value)
+    if len(text) == 8 and text.isdigit():
+        return pd.to_datetime(text, format="%Y%m%d")
+    return pd.to_datetime(text).normalize()

--- a/agent/backtest/loaders/tushare_fundamentals.py
+++ b/agent/backtest/loaders/tushare_fundamentals.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from typing import Any, Iterable
 
 import pandas as pd
+
+TUSHARE_TOKEN_PLACEHOLDERS = {"", "your-tushare-token"}
 
 
 class DataProviderError(Exception):
@@ -112,7 +115,10 @@ class TushareFundamentalProvider:
         if api is None:
             import tushare as ts
 
-            api = ts.pro_api()
+            token = os.getenv("TUSHARE_TOKEN", "").strip()
+            if token in TUSHARE_TOKEN_PLACEHOLDERS:
+                token = ""
+            api = ts.pro_api(token)
         self.api = api
 
     def list_tables(self) -> list[str]:

--- a/agent/tests/test_tushare_fundamentals_provider.py
+++ b/agent/tests/test_tushare_fundamentals_provider.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from backtest.loaders.tushare_fundamentals import (
+    SchemaValidationError,
+    TushareFundamentalProvider,
+    UnknownTableError,
+)
+
+
+class _FakeTushareApi:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    def income(self, **kwargs: object) -> pd.DataFrame:
+        self.calls.append(("income", kwargs))
+        return pd.DataFrame(
+            [
+                {
+                    "ts_code": kwargs["ts_code"],
+                    "end_date": "20231231",
+                    "ann_date": "20240401",
+                    "f_ann_date": "20240402",
+                    "total_revenue": 100.0,
+                },
+                {
+                    "ts_code": kwargs["ts_code"],
+                    "end_date": "20240331",
+                    "ann_date": "20240425",
+                    "f_ann_date": "20240506",
+                    "total_revenue": 120.0,
+                },
+            ]
+        )
+
+
+def test_provider_exposes_first_milestone_financial_table_metadata() -> None:
+    provider = TushareFundamentalProvider(api=_FakeTushareApi())
+
+    assert provider.list_tables() == ["balancesheet", "cashflow", "fina_indicator", "income"]
+
+    schema = provider.describe_table("income")
+    assert schema.api_name == "income"
+    assert schema.point_in_time_column == "f_ann_date"
+    assert {"ts_code", "end_date", "ann_date", "f_ann_date", "total_revenue"} <= {
+        column.name for column in schema.columns
+    }
+
+
+def test_query_fundamentals_returns_pit_safe_dataframe() -> None:
+    api = _FakeTushareApi()
+    provider = TushareFundamentalProvider(api=api)
+
+    result = provider.query_fundamentals(
+        "income",
+        ["000001.SZ", "600000.SH"],
+        as_of="2024-04-30",
+        periods=["20231231", "20240331"],
+        fields=["total_revenue"],
+    )
+
+    assert list(result["ts_code"]) == ["000001.SZ", "600000.SH"]
+    assert list(result["end_date"]) == ["20231231", "20231231"]
+    assert list(result["f_ann_date"]) == ["20240402", "20240402"]
+    assert list(result["total_revenue"]) == [100.0, 100.0]
+    assert api.calls == [
+        ("income", {"ts_code": "000001.SZ", "period": None}),
+        ("income", {"ts_code": "600000.SH", "period": None}),
+    ]
+
+
+def test_query_fundamentals_falls_back_to_ann_date_per_row() -> None:
+    class SparseDisclosureApi:
+        def balancesheet(self, **kwargs: object) -> pd.DataFrame:
+            return pd.DataFrame(
+                [
+                    {
+                        "ts_code": kwargs["ts_code"],
+                        "end_date": "20231231",
+                        "ann_date": "20240401",
+                        "f_ann_date": None,
+                        "total_assets": 100.0,
+                    },
+                    {
+                        "ts_code": kwargs["ts_code"],
+                        "end_date": "20240331",
+                        "ann_date": "20240420",
+                        "f_ann_date": "20240506",
+                        "total_assets": 110.0,
+                    },
+                ]
+            )
+
+    provider = TushareFundamentalProvider(api=SparseDisclosureApi())
+
+    result = provider.query_fundamentals(
+        "balancesheet",
+        ["000001.SZ"],
+        as_of="2024-04-30",
+        fields=["total_assets"],
+    )
+
+    assert list(result["end_date"]) == ["20231231"]
+    assert list(result["total_assets"]) == [100.0]
+
+
+def test_query_fundamentals_rejects_unknown_tables() -> None:
+    provider = TushareFundamentalProvider(api=_FakeTushareApi())
+
+    with pytest.raises(UnknownTableError):
+        provider.query_fundamentals("daily_basic", ["000001.SZ"], as_of="2024-04-30")
+
+
+def test_query_fundamentals_validates_required_schema_columns() -> None:
+    class BadApi:
+        def fina_indicator(self, **kwargs: object) -> pd.DataFrame:
+            return pd.DataFrame([{"ts_code": kwargs["ts_code"], "ann_date": "20240401"}])
+
+    provider = TushareFundamentalProvider(api=BadApi())
+
+    with pytest.raises(SchemaValidationError, match="end_date"):
+        provider.query_fundamentals("fina_indicator", ["000001.SZ"], as_of="2024-04-30")

--- a/agent/tests/test_tushare_fundamentals_provider.py
+++ b/agent/tests/test_tushare_fundamentals_provider.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import sys
+from types import SimpleNamespace
+
 import pandas as pd
 import pytest
 
@@ -47,6 +50,23 @@ def test_provider_exposes_first_milestone_financial_table_metadata() -> None:
     assert {"ts_code", "end_date", "ann_date", "f_ann_date", "total_revenue"} <= {
         column.name for column in schema.columns
     }
+
+
+def test_default_constructor_uses_project_tushare_token_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+    fake_api = _FakeTushareApi()
+
+    def pro_api(token: str = "") -> _FakeTushareApi:
+        calls.append(token)
+        return fake_api
+
+    monkeypatch.setenv("TUSHARE_TOKEN", "ts-secret-token")
+    monkeypatch.setitem(sys.modules, "tushare", SimpleNamespace(pro_api=pro_api))
+
+    provider = TushareFundamentalProvider()
+
+    assert provider.api is fake_api
+    assert calls == ["ts-secret-token"]
 
 
 def test_query_fundamentals_returns_pit_safe_dataframe() -> None:


### PR DESCRIPTION
## Summary
- add a small TushareFundamentalProvider for the first DataProvider milestone in #62
- expose schema metadata for fina_indicator, income, balancesheet, and cashflow
- return standardized pandas DataFrames with schema validation and point-in-time filtering via f_ann_date/ann_date

## Validation
- uv run --no-sync pytest agent/tests/test_tushare_fundamentals_provider.py -q
- python -m py_compile agent/backtest/loaders/tushare_fundamentals.py agent/tests/test_tushare_fundamentals_provider.py
- git diff --check

Fixes #62