### PR TITLE
fix: fail fast on Tushare fundamental enrichment errors

### DIFF
--- a/agent/backtest/engines/base.py
+++ b/agent/backtest/engines/base.py
@@ -14,6 +14,7 @@ import logging
 import re as _re
 import sys
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
@@ -136,14 +137,29 @@ def _load_optimizer(config: Dict[str, Any]) -> Optional[Callable]:
 
 def _normalise_fundamental_fields(config: Dict[str, Any]) -> dict[str, list[str]]:
     """Read the optional statement-table field map from backtest config."""
-    raw_fields = config.get("fundamental_fields") or {}
-    if not isinstance(raw_fields, dict):
+    raw_fields = config.get("fundamental_fields")
+    if raw_fields in (None, {}):
         return {}
-    return {
-        str(table): list(fields)
-        for table, fields in raw_fields.items()
-        if fields
-    }
+    if not isinstance(raw_fields, dict):
+        raise ValueError("fundamental_fields must map table names to field-name lists")
+
+    normalized: dict[str, list[str]] = {}
+    for table, fields in raw_fields.items():
+        if not isinstance(table, str) or not table.strip():
+            raise ValueError("fundamental_fields table names must be non-empty strings")
+        if fields is None:
+            continue
+        if isinstance(fields, str) or not isinstance(fields, Iterable):
+            raise ValueError(f"fundamental_fields[{table!r}] must be a list of field names")
+
+        field_list = list(fields)
+        if not field_list:
+            continue
+        invalid = [field for field in field_list if not isinstance(field, str) or not field.strip()]
+        if invalid:
+            raise ValueError(f"fundamental_fields[{table!r}] contains invalid field names")
+        normalized[table.strip()] = field_list
+    return normalized
 
 
 def _maybe_enrich_fundamentals(
@@ -156,16 +172,18 @@ def _maybe_enrich_fundamentals(
         return data_map
 
     try:
+        provider = TushareFundamentalProvider()
         return enrich_price_frames_with_fundamentals(
             data_map,
-            TushareFundamentalProvider(),
+            provider,
             fields_by_table,
             as_of=config.get("end_date", ""),
             periods=config.get("fundamental_periods"),
         )
     except Exception as exc:
-        print(f"[WARN] failed to enrich Tushare fundamentals: {exc}")
-        return data_map
+        raise RuntimeError(
+            f"fundamental_fields requested but Tushare enrichment failed: {exc}"
+        ) from exc
 
 
 # ─── Base Engine ───

--- a/agent/backtest/runner.py
+++ b/agent/backtest/runner.py
@@ -14,7 +14,7 @@ import logging
 import re
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 import pandas as pd
 from pydantic import BaseModel, ConfigDict, model_validator, field_validator
@@ -51,6 +51,7 @@ class BacktestConfigSchema(BaseModel):
     source: str = "tushare"
     interval: str = "1D"
     engine: str = "daily"
+    fundamental_fields: Optional[Dict[str, List[str]]] = None
 
     @field_validator("codes")
     @classmethod
@@ -89,6 +90,21 @@ class BacktestConfigSchema(BaseModel):
     def valid_source(cls, v: str) -> str:
         if v not in _VALID_SOURCES:
             raise ValueError(f"unsupported source {v!r}, must be one of {_VALID_SOURCES}")
+        return v
+
+    @field_validator("fundamental_fields")
+    @classmethod
+    def valid_fundamental_fields(
+        cls,
+        v: Optional[Dict[str, List[str]]],
+    ) -> Optional[Dict[str, List[str]]]:
+        if v is None:
+            return v
+        for table, fields in v.items():
+            if not table.strip():
+                raise ValueError("fundamental_fields table names must be non-empty strings")
+            if any(not field.strip() for field in fields):
+                raise ValueError("fundamental_fields field names must be non-empty strings")
         return v
 
     @model_validator(mode="after")
@@ -646,6 +662,6 @@ class _AutoLoader:
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print(f"Usage: python -m backtest.runner <run_dir>")
+        print("Usage: python -m backtest.runner <run_dir>")
         sys.exit(1)
     main(Path(sys.argv[1]))

--- a/agent/tests/test_engine_robustness.py
+++ b/agent/tests/test_engine_robustness.py
@@ -241,6 +241,29 @@ class TestSymbolIsolation:
         assert metrics["benchmark_ticker"] == "000300.SH"
         assert metrics["benchmark_return"] == 0.00495
 
+    def test_configured_fundamental_enrichment_failure_is_not_silent(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Explicit statement-field requests should fail rather than degrade silently."""
+        dates = pd.bdate_range("2024-04-01", periods=1)
+        bars = pd.DataFrame({"close": [10.0]}, index=dates)
+
+        def fake_enrich(*args, **kwargs):
+            raise RuntimeError("provider failed")
+
+        monkeypatch.setattr(base_engine, "TushareFundamentalProvider", lambda: object(), raising=False)
+        monkeypatch.setattr(base_engine, "enrich_price_frames_with_fundamentals", fake_enrich, raising=False)
+
+        with pytest.raises(RuntimeError, match="fundamental_fields.*provider failed"):
+            base_engine._maybe_enrich_fundamentals(
+                {"000001.SZ": bars},
+                {
+                    "end_date": "2024-04-30",
+                    "fundamental_fields": {"income": ["total_revenue"]},
+                },
+            )
+
 
 # ---------------------------------------------------------------------------
 # 3. Config schema validation (pydantic)
@@ -257,6 +280,15 @@ class TestBacktestConfigSchema:
         assert c.codes == ["AAPL.US"]
         assert c.interval == "1D"
         assert c.engine == "daily"
+
+    def test_fundamental_fields_must_be_table_to_field_list_mapping(self) -> None:
+        with pytest.raises(ValueError, match="fundamental_fields"):
+            BacktestConfigSchema(
+                codes=["000001.SZ"],
+                start_date="2025-01-01",
+                end_date="2025-06-01",
+                fundamental_fields={"income": "total_revenue"},
+            )
 
     def test_empty_codes_rejected(self) -> None:
         with pytest.raises(Exception, match="codes must be a non-empty list"):


### PR DESCRIPTION
Follow-up hardening for #76 by @mrbob-git. This keeps the new `fundamental_fields` Tushare statement enrichment feature credited to that PR while tightening the failure semantics around explicit statement-field requests.

## Summary
- validate `fundamental_fields` as a table-to-field-list config shape
- fail fast when configured Tushare fundamental enrichment raises, instead of silently continuing with raw price bars
- add regressions for provider failure and malformed config

## Validation
- `python -m pytest agent/tests/test_engine_robustness.py agent/tests/test_tushare_fundamentals_provider.py agent/tests/test_fundamental_filter_example.py -q`
- `python -m ruff check agent/backtest/engines/base.py agent/backtest/runner.py agent/tests/test_engine_robustness.py agent/tests/test_tushare_fundamentals_provider.py agent/tests/test_fundamental_filter_example.py`
- `python -m py_compile agent/backtest/engines/base.py agent/backtest/runner.py agent/tests/test_engine_robustness.py agent/tests/test_tushare_fundamentals_provider.py agent/tests/test_fundamental_filter_example.py`
- `git diff --check`