### PR TITLE
fix: persist swarm worker reports and improve summary extraction

### DIFF
--- a/agent/src/swarm/presets/commodity_research_team.yaml
+++ b/agent/src/swarm/presets/commodity_research_team.yaml
@@ -32,7 +32,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, read_url]
     skills: [commodity-analysis, web-reader, geopolitical-risk]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: demand_analyst
@@ -65,7 +65,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, read_url]
     skills: [commodity-analysis, seasonal, global-macro]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: cycle_strategist
@@ -100,7 +100,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, backtest]
     skills: [commodity-analysis, seasonal, strategy-generate]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
 tasks:

--- a/agent/src/swarm/presets/convertible_bond_team.yaml
+++ b/agent/src/swarm/presets/convertible_bond_team.yaml
@@ -29,7 +29,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill]
     skills: [convertible-bond, fundamental-filter, credit-analysis]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: equity_analyst
@@ -59,7 +59,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, factor_analysis]
     skills: [convertible-bond, technical-basic, valuation-model]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: option_analyst
@@ -89,7 +89,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, options_pricing]
     skills: [options-strategy, volatility, convertible-bond, options-payoff]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: cb_strategist
@@ -121,7 +121,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, backtest]
     skills: [convertible-bond, strategy-generate]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
 tasks:

--- a/agent/src/swarm/presets/credit_research_team.yaml
+++ b/agent/src/swarm/presets/credit_research_team.yaml
@@ -48,7 +48,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, factor_analysis]
     skills: [credit-analysis, financial-statement]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: rate_analyst
@@ -98,7 +98,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, read_url]
     skills: [credit-analysis, macro-analysis]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: sector_credit_analyst
@@ -151,7 +151,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, read_url]
     skills: [credit-analysis, sector-rotation, regulatory-knowledge]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: fixed_income_strategist
@@ -204,7 +204,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, backtest]
     skills: [credit-analysis, strategy-generate, risk-analysis]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
 tasks:

--- a/agent/src/swarm/presets/crypto_research_lab.yaml
+++ b/agent/src/swarm/presets/crypto_research_lab.yaml
@@ -63,7 +63,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill]
     skills: [onchain-analysis, okx-market, stablecoin-flow]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: defi_analyst
@@ -114,7 +114,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, read_url]
     skills: [crypto-derivatives, defi-yield, token-unlock-treasury, web-reader]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: crypto_sentiment_analyst
@@ -175,7 +175,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, read_url]
     skills: [sentiment-analysis, okx-market, perp-funding-basis, liquidation-heatmap]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: alpha_synthesizer
@@ -225,7 +225,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill]
     skills: [asset-allocation, risk-analysis]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
 tasks:

--- a/agent/src/swarm/presets/crypto_trading_desk.yaml
+++ b/agent/src/swarm/presets/crypto_trading_desk.yaml
@@ -41,7 +41,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill]
     skills: [perp-funding-basis, okx-market, crypto-derivatives]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: liquidation_analyst
@@ -82,7 +82,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, read_url]
     skills: [liquidation-heatmap, market-microstructure, execution-model]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: flow_analyst
@@ -118,7 +118,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, read_url]
     skills: [stablecoin-flow, onchain-analysis, token-unlock-treasury, defi-yield]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: desk_risk_manager
@@ -167,7 +167,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill]
     skills: [risk-analysis, asset-allocation, volatility, hedging-strategy]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
 tasks:

--- a/agent/src/swarm/presets/derivatives_strategy_desk.yaml
+++ b/agent/src/swarm/presets/derivatives_strategy_desk.yaml
@@ -55,7 +55,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, options_pricing]
     skills: [volatility, options-advanced]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: strategy_designer
@@ -120,7 +120,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, options_pricing]
     skills: [options-strategy, options-advanced, hedging-strategy, options-payoff]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: greeks_manager
@@ -181,7 +181,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, options_pricing]
     skills: [options-advanced, risk-analysis, volatility, options-payoff]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
 tasks:

--- a/agent/src/swarm/presets/earnings_research_desk.yaml
+++ b/agent/src/swarm/presets/earnings_research_desk.yaml
@@ -43,7 +43,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, read_url]
     skills: [edgar-sec-filings, financial-statement, yfinance, fundamental-filter, valuation-model]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: revision_tracker
@@ -84,7 +84,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, read_url]
     skills: [earnings-revision, earnings-forecast]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: event_options_analyst
@@ -127,7 +127,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill]
     skills: [options-advanced, options-strategy, event-driven, volatility]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: earnings_strategist
@@ -176,7 +176,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, backtest]
     skills: [strategy-generate, risk-analysis, report-generate]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
 tasks:

--- a/agent/src/swarm/presets/equity_research_team.yaml
+++ b/agent/src/swarm/presets/equity_research_team.yaml
@@ -25,7 +25,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, read_url]
     skills: [tushare, okx-market, yfinance, web-reader, global-macro]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 900
     max_retries: 1
 
   - id: sector_analyst
@@ -50,7 +50,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, factor_analysis]
     skills: [tushare, yfinance, fundamental-filter, multi-factor, us-etf-flow, sector-rotation]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 900
     max_retries: 1
 
   - id: stock_picker
@@ -76,7 +76,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, backtest, factor_analysis]
     skills: [tushare, yfinance, strategy-generate, technical-basic, multi-factor, earnings-revision]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 900
     max_retries: 1
 
   - id: aggregator
@@ -102,7 +102,7 @@ agents:
     tools: [bash, read_file, write_file]
     skills: [report-generate]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 900
     max_retries: 1
 
 tasks:

--- a/agent/src/swarm/presets/equity_research_team.yaml
+++ b/agent/src/swarm/presets/equity_research_team.yaml
@@ -25,7 +25,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, read_url]
     skills: [tushare, okx-market, yfinance, web-reader, global-macro]
     max_iterations: 50
-    timeout_seconds: 900
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: sector_analyst
@@ -50,7 +50,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, factor_analysis]
     skills: [tushare, yfinance, fundamental-filter, multi-factor, us-etf-flow, sector-rotation]
     max_iterations: 50
-    timeout_seconds: 900
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: stock_picker
@@ -76,7 +76,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, backtest, factor_analysis]
     skills: [tushare, yfinance, strategy-generate, technical-basic, multi-factor, earnings-revision]
     max_iterations: 50
-    timeout_seconds: 900
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: aggregator
@@ -102,7 +102,7 @@ agents:
     tools: [bash, read_file, write_file]
     skills: [report-generate]
     max_iterations: 50
-    timeout_seconds: 900
+    timeout_seconds: 1800
     max_retries: 1
 
 tasks:

--- a/agent/src/swarm/presets/etf_allocation_desk.yaml
+++ b/agent/src/swarm/presets/etf_allocation_desk.yaml
@@ -68,7 +68,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, factor_analysis]
     skills: [etf-analysis, fund-analysis, tushare]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: macro_allocator
@@ -127,7 +127,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, read_url]
     skills: [macro-analysis, asset-allocation, global-macro]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: risk_budgeter
@@ -191,7 +191,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill]
     skills: [risk-analysis, volatility, etf-analysis]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: portfolio_optimizer
@@ -244,7 +244,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, backtest]
     skills: [etf-analysis, strategy-generate, asset-allocation]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
 tasks:

--- a/agent/src/swarm/presets/event_driven_task_force.yaml
+++ b/agent/src/swarm/presets/event_driven_task_force.yaml
@@ -37,7 +37,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, read_url]
     skills: [event-driven, corporate-events, web-reader, geopolitical-risk]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: impact_analyst
@@ -84,7 +84,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, factor_analysis]
     skills: [corporate-events, sentiment-analysis, valuation-model]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: strategy_builder
@@ -121,7 +121,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, backtest]
     skills: [event-driven, strategy-generate]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
 tasks:

--- a/agent/src/swarm/presets/factor_research_committee.yaml
+++ b/agent/src/swarm/presets/factor_research_committee.yaml
@@ -48,7 +48,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, factor_analysis]
     skills: [factor-research, multi-factor]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: factor_validator
@@ -97,7 +97,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, factor_analysis]
     skills: [quant-statistics, factor-research]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: factor_combiner
@@ -145,7 +145,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, factor_analysis, backtest]
     skills: [multi-factor, strategy-generate]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: backtest_reviewer
@@ -196,7 +196,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill]
     skills: [backtest-diagnose, quant-statistics]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
 tasks:

--- a/agent/src/swarm/presets/fund_selection_panel.yaml
+++ b/agent/src/swarm/presets/fund_selection_panel.yaml
@@ -33,7 +33,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, factor_analysis]
     skills: [fund-analysis, fundamental-filter]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: attribution_analyst
@@ -83,7 +83,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, factor_analysis]
     skills: [performance-attribution, fund-analysis, multi-factor]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: fof_optimizer
@@ -135,7 +135,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, backtest]
     skills: [asset-allocation, risk-analysis, strategy-generate, etf-analysis]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
 tasks:

--- a/agent/src/swarm/presets/fundamental_research_team.yaml
+++ b/agent/src/swarm/presets/fundamental_research_team.yaml
@@ -45,7 +45,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, factor_analysis]
     skills: [financial-statement, fundamental-filter]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: valuation_analyst
@@ -95,7 +95,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, factor_analysis]
     skills: [valuation-model, earnings-forecast]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: quality_analyst
@@ -145,7 +145,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, read_url]
     skills: [fundamental-filter, web-reader]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: report_editor
@@ -179,7 +179,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill]
     skills: [report-generate]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
 tasks:

--- a/agent/src/swarm/presets/geopolitical_war_room.yaml
+++ b/agent/src/swarm/presets/geopolitical_war_room.yaml
@@ -49,7 +49,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, read_url]
     skills: [geopolitical-risk, web-reader, global-macro]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: energy_analyst
@@ -104,7 +104,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, read_url]
     skills: [commodity-analysis, geopolitical-risk]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: supply_chain_analyst
@@ -161,7 +161,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, read_url]
     skills: [geopolitical-risk, sector-rotation, event-driven]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: chief_strategist
@@ -222,7 +222,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill]
     skills: [asset-allocation, risk-analysis, hedging-strategy]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
 tasks:

--- a/agent/src/swarm/presets/global_allocation_committee.yaml
+++ b/agent/src/swarm/presets/global_allocation_committee.yaml
@@ -26,7 +26,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, factor_analysis]
     skills: [tushare, technical-basic, fundamental-filter, hk-connect-flow, sector-rotation, multi-factor]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: crypto_analyst
@@ -51,7 +51,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill]
     skills: [okx-market, perp-funding-basis, stablecoin-flow, crypto-derivatives, volatility, onchain-analysis]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: us_hk_analyst
@@ -76,7 +76,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, read_url]
     skills: [yfinance, us-etf-flow, earnings-revision, adr-hshare, hk-connect-flow, technical-basic]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: allocator
@@ -109,7 +109,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, backtest]
     skills: [asset-allocation, risk-analysis, correlation-analysis, strategy-generate]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
 tasks:

--- a/agent/src/swarm/presets/global_equities_desk.yaml
+++ b/agent/src/swarm/presets/global_equities_desk.yaml
@@ -43,7 +43,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, factor_analysis]
     skills: [tushare, fundamental-filter, hk-connect-flow, technical-basic, multi-factor, sector-rotation]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: us_hk_researcher
@@ -91,7 +91,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, read_url]
     skills: [yfinance, edgar-sec-filings, earnings-revision, us-etf-flow, adr-hshare, hk-connect-flow, technical-basic]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: crypto_researcher
@@ -129,7 +129,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill]
     skills: [okx-market, perp-funding-basis, stablecoin-flow, onchain-analysis, crypto-derivatives]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: global_strategist
@@ -173,7 +173,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, backtest]
     skills: [asset-allocation, risk-analysis, strategy-generate, correlation-analysis]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
 tasks:

--- a/agent/src/swarm/presets/investment_committee.yaml
+++ b/agent/src/swarm/presets/investment_committee.yaml
@@ -47,7 +47,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, factor_analysis]
     skills: [technical-basic, fundamental-filter, yfinance, earnings-revision, sentiment-analysis]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: bear_advocate
@@ -100,7 +100,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, factor_analysis]
     skills: [technical-basic, fundamental-filter, yfinance, risk-analysis, volatility]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: risk_officer
@@ -152,7 +152,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill]
     skills: [risk-analysis, volatility, correlation-analysis]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: portfolio_manager
@@ -199,7 +199,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, backtest]
     skills: [strategy-generate, asset-allocation]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
 tasks:

--- a/agent/src/swarm/presets/macro_rates_fx_desk.yaml
+++ b/agent/src/swarm/presets/macro_rates_fx_desk.yaml
@@ -49,7 +49,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, read_url]
     skills: [macro-analysis, global-macro, credit-analysis]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: fx_strategist
@@ -94,7 +94,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, read_url]
     skills: [global-macro, macro-analysis, yfinance]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: commodity_inflation_analyst
@@ -133,7 +133,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, read_url]
     skills: [commodity-analysis, global-macro, seasonal]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: macro_pm
@@ -185,7 +185,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, backtest]
     skills: [asset-allocation, risk-analysis, hedging-strategy, strategy-generate]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
 tasks:

--- a/agent/src/swarm/presets/macro_strategy_forum.yaml
+++ b/agent/src/swarm/presets/macro_strategy_forum.yaml
@@ -50,7 +50,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, read_url]
     skills: [global-macro, web-reader, geopolitical-risk]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: domestic_economist
@@ -101,7 +101,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, read_url]
     skills: [macro-analysis, tushare]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: policy_analyst
@@ -152,7 +152,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, read_url]
     skills: [regulatory-knowledge, sector-rotation, web-reader]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: chief_strategist
@@ -198,7 +198,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill]
     skills: [asset-allocation, macro-analysis]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
 tasks:

--- a/agent/src/swarm/presets/ml_quant_lab.yaml
+++ b/agent/src/swarm/presets/ml_quant_lab.yaml
@@ -35,7 +35,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, factor_analysis]
     skills: [ml-strategy, factor-research, multi-factor]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: data_scientist
@@ -69,7 +69,7 @@ agents:
     tools: [bash, read_file, write_file, edit_file, load_skill]
     skills: [ml-strategy, quant-statistics]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: backtest_engineer
@@ -106,7 +106,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, backtest]
     skills: [strategy-generate, backtest-diagnose, quant-statistics]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
 tasks:

--- a/agent/src/swarm/presets/pairs_research_lab.yaml
+++ b/agent/src/swarm/presets/pairs_research_lab.yaml
@@ -57,7 +57,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, factor_analysis]
     skills: [correlation-analysis, pair-trading, multi-factor]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: cointegration_tester
@@ -127,7 +127,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, factor_analysis]
     skills: [correlation-analysis, quant-statistics]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: pair_strategist
@@ -190,7 +190,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, backtest]
     skills: [pair-trading, correlation-analysis, strategy-generate]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: microstructure_reviewer
@@ -254,7 +254,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill]
     skills: [market-microstructure, execution-model]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
 tasks:

--- a/agent/src/swarm/presets/portfolio_review_board.yaml
+++ b/agent/src/swarm/presets/portfolio_review_board.yaml
@@ -37,7 +37,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, factor_analysis]
     skills: [performance-attribution, multi-factor]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: risk_inspector
@@ -81,7 +81,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill]
     skills: [risk-analysis, volatility]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: execution_analyst
@@ -124,7 +124,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill]
     skills: [execution-model, market-microstructure]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: chief_investment_officer
@@ -162,7 +162,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill]
     skills: [asset-allocation, risk-analysis]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
 tasks:

--- a/agent/src/swarm/presets/quant_strategy_desk.yaml
+++ b/agent/src/swarm/presets/quant_strategy_desk.yaml
@@ -24,7 +24,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, factor_analysis]
     skills: [tushare, fundamental-filter]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: factor_miner
@@ -48,7 +48,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, factor_analysis]
     skills: [multi-factor, factor-research]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: backtester
@@ -72,7 +72,7 @@ agents:
     tools: [bash, read_file, write_file, edit_file, load_skill, backtest]
     skills: [strategy-generate, technical-basic]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: risk_auditor
@@ -96,7 +96,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill]
     skills: [volatility]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
 tasks:

--- a/agent/src/swarm/presets/risk_committee.yaml
+++ b/agent/src/swarm/presets/risk_committee.yaml
@@ -24,7 +24,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill]
     skills: [volatility]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: tail_risk_analyst
@@ -48,7 +48,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill]
     skills: [volatility]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: regime_detector
@@ -72,7 +72,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill]
     skills: [volatility, technical-basic]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: aggregator
@@ -98,7 +98,7 @@ agents:
     tools: [bash, read_file, write_file]
     skills: []
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
 tasks:

--- a/agent/src/swarm/presets/sector_rotation_team.yaml
+++ b/agent/src/swarm/presets/sector_rotation_team.yaml
@@ -54,7 +54,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill]
     skills: [macro-analysis, seasonal]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: prosperity_analyst
@@ -108,7 +108,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, factor_analysis]
     skills: [sector-rotation, fundamental-filter, multi-factor]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: flow_analyst
@@ -161,7 +161,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill]
     skills: [tushare, sentiment-analysis]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: rotation_strategist
@@ -207,7 +207,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, backtest]
     skills: [strategy-generate, sector-rotation]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
 tasks:

--- a/agent/src/swarm/presets/sentiment_intelligence_team.yaml
+++ b/agent/src/swarm/presets/sentiment_intelligence_team.yaml
@@ -30,7 +30,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, read_url]
     skills: [web-reader, sentiment-analysis, social-media-intelligence]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: social_analyst
@@ -60,7 +60,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, read_url]
     skills: [behavioral-finance, sentiment-analysis, social-media-intelligence]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: flow_analyst
@@ -90,7 +90,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill]
     skills: [tushare, sentiment-analysis]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: signal_synthesizer
@@ -122,7 +122,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill]
     skills: [behavioral-finance, risk-analysis]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
 tasks:

--- a/agent/src/swarm/presets/social_alpha_team.yaml
+++ b/agent/src/swarm/presets/social_alpha_team.yaml
@@ -56,7 +56,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, read_url]
     skills: [social-media-intelligence, sentiment-analysis]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: telegram_analyst
@@ -119,7 +119,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, read_url]
     skills: [social-media-intelligence, sentiment-analysis, onchain-analysis]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: reddit_analyst
@@ -178,7 +178,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, read_url]
     skills: [social-media-intelligence, behavioral-finance, sentiment-analysis]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: alpha_synthesizer
@@ -241,7 +241,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, factor_analysis]
     skills: [social-media-intelligence, factor-research, quant-statistics]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
 tasks:

--- a/agent/src/swarm/presets/statistical_arbitrage_desk.yaml
+++ b/agent/src/swarm/presets/statistical_arbitrage_desk.yaml
@@ -45,7 +45,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, factor_analysis]
     skills: [pair-trading, quant-statistics, correlation-analysis]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: microstructure_analyst
@@ -86,7 +86,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill]
     skills: [market-microstructure, execution-model]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: arb_strategist
@@ -134,7 +134,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, backtest]
     skills: [pair-trading, strategy-generate, quant-statistics]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: risk_monitor
@@ -184,7 +184,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill]
     skills: [risk-analysis, volatility]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
 tasks:

--- a/agent/src/swarm/presets/technical_analysis_panel.yaml
+++ b/agent/src/swarm/presets/technical_analysis_panel.yaml
@@ -69,7 +69,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill]
     skills: [technical-basic, candlestick]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: ichimoku_analyst
@@ -121,7 +121,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill]
     skills: [ichimoku]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: harmonic_analyst
@@ -166,7 +166,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, pattern]
     skills: [harmonic]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: wave_analyst
@@ -218,7 +218,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill, pattern]
     skills: [elliott-wave, chanlun]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: smc_analyst
@@ -265,7 +265,7 @@ agents:
     tools: [bash, read_file, write_file, load_skill]
     skills: [smc, minute-analysis]
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
   - id: signal_aggregator
@@ -323,7 +323,7 @@ agents:
     tools: [bash, read_file, write_file]
     skills: []
     max_iterations: 50
-    timeout_seconds: 600
+    timeout_seconds: 1800
     max_retries: 1
 
 tasks:

--- a/agent/src/swarm/worker.py
+++ b/agent/src/swarm/worker.py
@@ -299,6 +299,7 @@ def run_worker(
         elapsed = time.monotonic() - t0
         if elapsed > timeout:
             summary = _best_summary(messages, last_assistant_content) or f"Worker timed out after {elapsed:.0f}s ({iteration} iterations)"
+            summary = _resolve_summary(artifact_dir, summary)
             _emit(event_callback, "worker_timeout", agent_id, task_id, {"elapsed": elapsed})
             _write_summary(artifact_dir, summary)
             _persist_messages(artifact_dir, messages)
@@ -315,6 +316,7 @@ def run_worker(
         token_estimate = len(json.dumps(messages, ensure_ascii=False)) // 4
         if token_estimate > _MAX_TOKEN_ESTIMATE:
             summary = last_assistant_content or f"Worker context too large (~{token_estimate} tokens, {iteration} iterations)"
+            summary = _resolve_summary(artifact_dir, summary)
             _emit(event_callback, "worker_token_limit", agent_id, task_id, {"tokens": token_estimate})
             _write_summary(artifact_dir, summary)
             return WorkerResult(
@@ -363,7 +365,7 @@ def run_worker(
             _emit(event_callback, "worker_failed", agent_id, task_id, {"error": error_msg})
             return WorkerResult(
                 status="failed",
-                summary=last_assistant_content or "",
+                summary=_resolve_summary(artifact_dir, last_assistant_content or ""),
                 artifact_paths=_collect_artifacts(artifact_dir),
                 iterations=iteration,
                 error=error_msg,
@@ -383,6 +385,7 @@ def run_worker(
         # If no tool calls, this is the final response
         if not response.has_tool_calls:
             summary = response.content or last_assistant_content or "(no summary)"
+            summary = _resolve_summary(artifact_dir, summary)
             _emit(event_callback, "worker_completed", agent_id, task_id, {"iterations": iteration + 1})
             _write_summary(artifact_dir, summary)
             return WorkerResult(
@@ -408,7 +411,7 @@ def run_worker(
             _emit(
                 event_callback, "tool_call", agent_id, task_id,
                 {"tool": tc.name, "iteration": iteration,
-                 "arguments": {k: v for k, v in tc.arguments.items() if k != "run_dir"}},
+                 "arguments": {k: (v if len(str(v)) <= 200 else str(v)[:200] + "...") for k, v in tc.arguments.items() if k != "run_dir"}},
             )
             tc_start = time.monotonic()
             args = {**tc.arguments, "run_dir": str(artifact_dir)}
@@ -418,7 +421,7 @@ def run_worker(
                 event_callback, "tool_result", agent_id, task_id,
                 {"tool": tc.name, "elapsed_ms": int(tc_elapsed * 1000),
                  "status": "ok", "iteration": iteration,
-                 "result": str(result)[:5000]},
+                 "result_preview": str(result)[:500]},
             )
             messages.append(
                 ContextBuilder.format_tool_result(tc.id, tc.name, result[:10_000])
@@ -426,6 +429,7 @@ def run_worker(
 
     # Hit iteration limit — use last meaningful content as summary
     summary = _best_summary(messages, last_assistant_content) or f"Worker hit iteration limit ({max_iterations} iterations)"
+    summary = _resolve_summary(artifact_dir, summary)
     _emit(event_callback, "worker_iteration_limit", agent_id, task_id)
     _write_summary(artifact_dir, summary)
     _persist_messages(artifact_dir, messages)
@@ -448,6 +452,19 @@ def _best_summary(messages: list[dict], fallback: str) -> str:
     ]
     if texts:
         return max(texts, key=len)
+    return fallback
+
+
+def _resolve_summary(artifact_dir: Path, fallback: str) -> str:
+    """Return report.md content if it exists, otherwise fall back to text."""
+    report_path = artifact_dir / "report.md"
+    try:
+        if report_path.is_file():
+            content = report_path.read_text(encoding="utf-8").strip()
+            if content:
+                return content
+    except Exception:
+        logger.warning("Failed to read report.md from %s", artifact_dir, exc_info=True)
     return fallback
 
 

--- a/agent/src/swarm/worker.py
+++ b/agent/src/swarm/worker.py
@@ -30,6 +30,17 @@ logger = logging.getLogger(__name__)
 _DEFAULT_MAX_ITERATIONS = int(os.getenv("SWARM_WORKER_MAX_ITER", "50"))
 _DEFAULT_TIMEOUT_SECONDS = int(os.getenv("SWARM_WORKER_TIMEOUT", "300"))
 _MAX_TOKEN_ESTIMATE = 60_000
+_SENSITIVE_TOOL_ARGUMENT_KEYS = {
+    "api_key",
+    "authorization",
+    "content",
+    "env",
+    "headers",
+    "passphrase",
+    "password",
+    "secret",
+    "token",
+}
 
 
 def _emit(
@@ -335,8 +346,8 @@ def run_worker(
                 "role": "user",
                 "content": (
                     f"[SYSTEM] You have {remaining} iterations remaining. "
-                    "Stop calling tools and immediately output your final analysis summary as plain text. "
-                    "Do not call any more tools."
+                    "If report.md is not written yet, make one final write_file call for report.md. "
+                    "Otherwise stop calling tools and output your final analysis summary as plain text."
                 ),
             })
 
@@ -411,7 +422,7 @@ def run_worker(
             _emit(
                 event_callback, "tool_call", agent_id, task_id,
                 {"tool": tc.name, "iteration": iteration,
-                 "arguments": {k: (v if len(str(v)) <= 200 else str(v)[:200] + "...") for k, v in tc.arguments.items() if k != "run_dir"}},
+                 "arguments": _preview_tool_arguments(tc.arguments)},
             )
             tc_start = time.monotonic()
             args = {**tc.arguments, "run_dir": str(artifact_dir)}
@@ -421,7 +432,7 @@ def run_worker(
                 event_callback, "tool_result", agent_id, task_id,
                 {"tool": tc.name, "elapsed_ms": int(tc_elapsed * 1000),
                  "status": "ok", "iteration": iteration,
-                 "result_preview": str(result)[:500]},
+                 "result_preview": str(result)[:200]},
             )
             messages.append(
                 ContextBuilder.format_tool_result(tc.id, tc.name, result[:10_000])
@@ -453,6 +464,29 @@ def _best_summary(messages: list[dict], fallback: str) -> str:
     if texts:
         return max(texts, key=len)
     return fallback
+
+
+def _preview_tool_arguments(arguments: dict) -> dict[str, str]:
+    """Return a short, redacted argument preview for streamed events."""
+    preview: dict[str, str] = {}
+    for key, value in arguments.items():
+        if key == "run_dir":
+            continue
+        if _is_sensitive_tool_argument(key):
+            preview[key] = "[redacted]"
+            continue
+        text = str(value)
+        preview[key] = text if len(text) <= 200 else text[:200] + "..."
+    return preview
+
+
+def _is_sensitive_tool_argument(key: str) -> bool:
+    """Return whether a tool argument name should be redacted in events."""
+    normalized = key.strip().lower()
+    return normalized in _SENSITIVE_TOOL_ARGUMENT_KEYS or any(
+        marker in normalized
+        for marker in ("api_key", "authorization", "password", "secret", "token")
+    )
 
 
 def _resolve_summary(artifact_dir: Path, fallback: str) -> str:

--- a/agent/src/swarm/worker.py
+++ b/agent/src/swarm/worker.py
@@ -179,9 +179,11 @@ def build_worker_prompt(
         "- Do NOT write long Python code inside bash. Use write_file + bash.\n"
         "- Do NOT fetch data with curl/requests. Use the patterns from load_skill (yfinance, OKX API via Python).\n"
         "- If a script fails, read the error, fix with `edit_file`, re-run. Max 2 retries per script.\n\n"
-        "**Phase 3 — Summarize (0 tool calls):**\n"
-        "- Write your final findings as a concise markdown summary directly in your response.\n"
-        "- Include specific numbers, dates, and actionable conclusions.\n"
+        "**Phase 3 — Summarize (MUST use write_file):**\n"
+        "- You MUST call `write_file` with path `report.md` to save your final report as a markdown file.\n"
+        "- This is REQUIRED, not optional. Your final response MUST include a write_file call for report.md.\n"
+        "- The report must include specific numbers, dates, and actionable conclusions.\n"
+        "- After writing report.md, output a brief 2-3 sentence summary in your text response.\n"
         "- Respond in the same language as the task prompt."
     )
 
@@ -296,9 +298,10 @@ def run_worker(
         # Check timeout
         elapsed = time.monotonic() - t0
         if elapsed > timeout:
-            summary = last_assistant_content or f"Worker timed out after {elapsed:.0f}s ({iteration} iterations)"
+            summary = _best_summary(messages, last_assistant_content) or f"Worker timed out after {elapsed:.0f}s ({iteration} iterations)"
             _emit(event_callback, "worker_timeout", agent_id, task_id, {"elapsed": elapsed})
             _write_summary(artifact_dir, summary)
+            _persist_messages(artifact_dir, messages)
             return WorkerResult(
                 status="timeout",
                 summary=summary,
@@ -404,7 +407,8 @@ def run_worker(
         for tc in response.tool_calls:
             _emit(
                 event_callback, "tool_call", agent_id, task_id,
-                {"tool": tc.name, "iteration": iteration},
+                {"tool": tc.name, "iteration": iteration,
+                 "arguments": {k: v for k, v in tc.arguments.items() if k != "run_dir"}},
             )
             tc_start = time.monotonic()
             args = {**tc.arguments, "run_dir": str(artifact_dir)}
@@ -413,16 +417,18 @@ def run_worker(
             _emit(
                 event_callback, "tool_result", agent_id, task_id,
                 {"tool": tc.name, "elapsed_ms": int(tc_elapsed * 1000),
-                 "status": "ok", "iteration": iteration},
+                 "status": "ok", "iteration": iteration,
+                 "result": str(result)[:5000]},
             )
             messages.append(
                 ContextBuilder.format_tool_result(tc.id, tc.name, result[:10_000])
             )
 
     # Hit iteration limit — use last meaningful content as summary
-    summary = last_assistant_content or f"Worker hit iteration limit ({max_iterations} iterations)"
+    summary = _best_summary(messages, last_assistant_content) or f"Worker hit iteration limit ({max_iterations} iterations)"
     _emit(event_callback, "worker_iteration_limit", agent_id, task_id)
     _write_summary(artifact_dir, summary)
+    _persist_messages(artifact_dir, messages)
     return WorkerResult(
         status="completed",
         summary=summary,
@@ -431,6 +437,30 @@ def run_worker(
         input_tokens=total_input_tokens,
         output_tokens=total_output_tokens,
     )
+
+
+def _best_summary(messages: list[dict], fallback: str) -> str:
+    """Extract the best summary from all assistant messages."""
+    texts = [
+        m["content"] for m in messages
+        if m.get("role") == "assistant" and m.get("content")
+        and len(m["content"].strip()) > 100
+    ]
+    if texts:
+        return max(texts, key=len)
+    return fallback
+
+
+def _persist_messages(artifact_dir: Path, messages: list[dict]) -> None:
+    """Persist messages to disk for post-mortem analysis."""
+    try:
+        path = artifact_dir / "messages.json"
+        path.write_text(
+            json.dumps(messages, ensure_ascii=False, indent=2, default=str),
+            encoding="utf-8",
+        )
+    except Exception:
+        logger.warning("Failed to persist messages to %s", artifact_dir, exc_info=True)
 
 
 def _write_summary(artifact_dir: Path, summary: str) -> None:

--- a/agent/src/tools/path_utils.py
+++ b/agent/src/tools/path_utils.py
@@ -94,6 +94,7 @@ def _default_run_roots() -> list[Path]:
     agent_root = _agent_root()
     return [
         agent_root / "runs",
+        agent_root / ".swarm" / "runs",
         cwd / "runs",
         home / ".vibe-trading" / "shadow_runs",
     ]

--- a/agent/tests/test_swarm_worker_report.py
+++ b/agent/tests/test_swarm_worker_report.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
-from unittest.mock import MagicMock
 
-from src.swarm.worker import _resolve_summary, _best_summary, WorkerResult
+from src.swarm.worker import _preview_tool_arguments, _resolve_summary, _best_summary
 
 
 def test_resolve_summary_reads_report_md(tmp_path: Path) -> None:
@@ -54,3 +52,27 @@ def test_resolve_summary_handles_read_error(tmp_path: Path) -> None:
     """_resolve_summary returns fallback if reading report.md fails."""
     result = _resolve_summary(Path("/nonexistent/path/xyz"), "fallback")
     assert result == "fallback"
+
+
+def test_preview_tool_arguments_redacts_sensitive_values() -> None:
+    """Event previews should not leak file bodies or credentials."""
+    preview = _preview_tool_arguments({
+        "path": "report.md",
+        "content": "# very long confidential report",
+        "headers": {"Authorization": "Bearer secret-token"},
+        "api_token": "secret-token",
+        "run_dir": "/tmp/hidden",
+    })
+
+    assert preview == {
+        "path": "report.md",
+        "content": "[redacted]",
+        "headers": "[redacted]",
+        "api_token": "[redacted]",
+    }
+
+
+def test_preview_tool_arguments_truncates_non_sensitive_values() -> None:
+    """Non-sensitive event previews stay short."""
+    preview = _preview_tool_arguments({"query": "A" * 250})
+    assert preview["query"] == "A" * 200 + "..."

--- a/agent/tests/test_swarm_worker_report.py
+++ b/agent/tests/test_swarm_worker_report.py
@@ -1,0 +1,56 @@
+"""Tests for swarm worker report.md → summary handoff."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from src.swarm.worker import _resolve_summary, _best_summary, WorkerResult
+
+
+def test_resolve_summary_reads_report_md(tmp_path: Path) -> None:
+    """When report.md exists in artifact dir, _resolve_summary returns its content."""
+    report_content = "# Analysis Report\n\nKey finding: bullish."
+    (tmp_path / "report.md").write_text(report_content, encoding="utf-8")
+
+    result = _resolve_summary(tmp_path, "short fallback")
+    assert result == report_content
+
+
+def test_resolve_summary_falls_back_when_no_report(tmp_path: Path) -> None:
+    """When report.md does not exist, _resolve_summary returns the fallback."""
+    result = _resolve_summary(tmp_path, "short fallback")
+    assert result == "short fallback"
+
+
+def test_resolve_summary_falls_back_when_empty_report(tmp_path: Path) -> None:
+    """When report.md is empty/whitespace, _resolve_summary returns the fallback."""
+    (tmp_path / "report.md").write_text("   \n\n  ", encoding="utf-8")
+
+    result = _resolve_summary(tmp_path, "short fallback")
+    assert result == "short fallback"
+
+
+def test_best_summary_picks_longest_assistant_text() -> None:
+    """_best_summary returns the longest assistant message over 100 chars."""
+    messages = [
+        {"role": "assistant", "content": "Short text"},
+        {"role": "assistant", "content": "A" * 200},
+        {"role": "assistant", "content": "B" * 300},
+    ]
+    result = _best_summary(messages, "fallback")
+    assert result == "B" * 300
+
+
+def test_best_summary_falls_back() -> None:
+    """_best_summary returns fallback when no assistant messages qualify."""
+    messages = [{"role": "user", "content": "hello"}]
+    result = _best_summary(messages, "fallback")
+    assert result == "fallback"
+
+
+def test_resolve_summary_handles_read_error(tmp_path: Path) -> None:
+    """_resolve_summary returns fallback if reading report.md fails."""
+    result = _resolve_summary(Path("/nonexistent/path/xyz"), "fallback")
+    assert result == "fallback"


### PR DESCRIPTION
Swarm workers frequently produced no usable output because:
- The Execution Rules prompt asked agents to write summaries "directly in your response," but the worker only captured `last_assistant_content` (often a mid-process message like "let me fix the script").
- On timeout/iteration limit, all in-memory messages were discarded.
- Event logging recorded only tool names and elapsed time, not I/O.

Changes to worker.py:
- Force agents to write final reports via `write_file report.md` (Phase 3), decoupling report persistence from the in-memory message lifecycle.
- Add `_best_summary()` to extract the longest assistant message (>100 chars) instead of relying on the last fragment.
- Add `_persist_messages()` to save full conversation to messages.json on timeout/iteration-limit for post-mortem debugging.
- Include tool arguments in tool_call events and result content (up to 5000 chars) in tool_result events for better observability.

Changes to equity_research_team.yaml:
- Increase timeout_seconds from 600 to 900 for all four agents, as the aggregator previously timed out at 615s.

## Summary

<!-- What does this PR do? 1-3 bullet points. -->

-

## Why

<!-- What problem does it solve? Link related issues with "Closes #123". -->

## Changes

<!-- List key changes. For new skills/presets, describe what they cover. -->

-

## Test Plan

- [ ] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [ ] New tests added (if applicable)
- [ ] Tested manually (describe below)

## Checklist

- [ ] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [ ] No hardcoded values (API keys, file paths, magic numbers)
- [ ] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] Documentation updated (if user-facing change)
