### PR TITLE
fix(mcp_server): pre-warm registry in main thread to avoid tools/call deadlock

### DIFF
--- a/agent/mcp_server.py
+++ b/agent/mcp_server.py
@@ -710,6 +710,7 @@ def main():
     args = parser.parse_args()
     _include_shell_tools = True if args.transport == "stdio" else _env_shell_tools_enabled()
     _registry = None
+    _get_registry()  # pre-warm: avoids deadlock when first tools/call lazy-inits inside FastMCP worker thread
 
     if args.transport == "sse":
         mcp.run(transport="sse", port=args.port)


### PR DESCRIPTION
## Summary

- Fixes a deadlock where every `tools/call` against `vibe-trading-mcp` hangs indefinitely while `initialize` and `tools/list` succeed.
- Pre-warms the tool registry in the main thread before `mcp.run()` so the first `tools/call` doesn't trigger heavy lazy imports inside FastMCP's asyncio worker thread.
- Affects all MCP clients (Claude Code, Cursor, etc.) — not specific to any one client.

## Why

`agent/mcp_server.py:68` — `_get_registry()` lazy-imports `src.tools.build_registry` and constructs the registry on first call. All 14 call sites in this file are FastMCP tool handlers, so the first `tools/call` triggers the lazy init *inside FastMCP's asyncio worker thread*. The import chain — specifically loading `src.tools.shell.*` — deadlocks in that thread context.

`initialize` and `tools/list` succeed because they don't touch the registry, which makes the bug confusing to diagnose: the server appears healthy until the first tool call, then hangs forever with no error.

## Fix

One line in `main()`, right after `_registry = None`:

```python
_include_shell_tools = True if args.transport == "stdio" else _env_shell_tools_enabled()
_registry = None
_get_registry()  # pre-warm: avoids deadlock when first tools/call lazy-inits inside FastMCP worker thread
```

`_include_shell_tools` is set on the line above, so the pre-warm builds the registry with the correct value for the chosen transport. `_get_registry()` is idempotent (`if _registry is None` guard at line 70), so the 14 existing call sites still hit the cached instance — unaffected.

## Differential test (deterministic before/after)

Verified on Python 3.13, Windows 11, fastmcp 3.2.4 with a raw stdio MCP client:

| Run | Patch state | initialize | tools/call analyze_options |
|-----|-------------|------------|---------------------------|
| 1   | applied     | 8.63s ok   | 0.01s ok                  |
| 2   | reverted    | 3.23s ok   | **15s timeout — HANG**    |
| 3   | re-applied  | 6.94s ok   | 0.01s ok                  |

Toggling the single line on/off flips behavior every time — root cause is conclusive.

## Side effects

- No functional change to any tool's behavior or output.
- Errors during registry build now surface at startup (fail-fast) instead of at first tool call.
- Slight startup-time shift: cost previously paid on first `tools/call` is now paid during `initialize`. Net total unchanged.
- For SSE transport: HTTP server begins listening ~5–8s later. Flagging in case it matters for any healthcheck-sensitive deployment.

## Test plan

- [x] Differential test (table above) — deterministic before/after on raw stdio
- [x] End-to-end via Claude Code MCP client — `tools/call get_market_data` and `tools/call analyze_options` both return in <2s
- [x] Both stdio and SSE entry paths pick up the fix (pre-warm runs before either `mcp.run(...)` branch)

## Checklist

- [x] No changes to protected areas (`agent/src/agent/`, `agent/src/session/`, `agent/src/providers/`) — only `agent/mcp_server.py`.
- [x] No hardcoded values.
- [x] Code follows `CONTRIBUTING.md` (Conventional Commit title, no comment-preserved code).
- [x] Documentation updated — N/A (no user-facing behavior change beyond bug fix).
