### PR TITLE
fix(memory): treat underscores as word boundaries in _tokenize

### DIFF
--- a/agent/src/memory/persistent.py
+++ b/agent/src/memory/persistent.py
@@ -48,7 +48,10 @@ class MemoryEntry:
 def _tokenize(text: str) -> set[str]:
     """Split text into searchable tokens.
 
-    ASCII words >= 3 chars + CJK individual characters.
+    ASCII words >= 3 chars + CJK individual characters. Underscores are
+    treated as word boundaries so snake_case titles (e.g. ``mcp_wiring_test``)
+    match natural-language queries (``"mcp wiring"``) as well as verbatim
+    lookups.
 
     Args:
         text: Input text.
@@ -56,7 +59,7 @@ def _tokenize(text: str) -> set[str]:
     Returns:
         Set of tokens.
     """
-    ascii_tokens = set(re.findall(r"[a-zA-Z0-9_]{3,}", text.lower()))
+    ascii_tokens = set(re.findall(r"[a-zA-Z0-9]{3,}", text.lower()))
     cjk_tokens = set(re.findall(r"[\u4e00-\u9fff\u3400-\u4dbf]", text))
     return ascii_tokens | cjk_tokens
 

--- a/agent/tests/test_persistent_memory.py
+++ b/agent/tests/test_persistent_memory.py
@@ -42,6 +42,14 @@ class TestTokenize:
     def test_empty(self) -> None:
         assert _tokenize("") == set()
 
+    def test_underscores_split(self) -> None:
+        # snake_case titles must match natural-language queries.
+        # Regression: previously _tokenize treated underscores as word chars,
+        # so "mcp_wiring_test" became a single token and queries like
+        # "mcp wiring" never matched.
+        tokens = _tokenize("mcp_wiring_test")
+        assert tokens == {"mcp", "wiring", "test"}
+
 
 # ---------------------------------------------------------------------------
 # PersistentMemory.add


### PR DESCRIPTION
## Problem

`_tokenize` in `agent/src/memory/persistent.py` uses the regex
`[a-zA-Z0-9_]{3,}`, which treats `_` as a word character. Memory titles
saved through `RememberTool` are slugified to snake_case (e.g.
`mcp_wiring_test`), so they collapse into a *single* token. A natural-
language `recall` query like `"mcp wiring"` produces tokens
`{"mcp", "wiring"}` and never intersects `{"mcp_wiring_test"}` —
recall returns 0 results despite the memory existing on disk.

## Repro

1. `remember(action="save", title="mcp_wiring_test", content="…")`
2. `remember(action="recall", query="mcp wiring")` → `count: 0`
3. `remember(action="forget", title="mcp_wiring_test")` → succeeds (proves the memory was on disk)

## Fix

Drop `_` from the character class so underscores act as token boundaries.
`mcp_wiring_test` now tokenizes to `{"mcp", "wiring", "test"}`. Verbatim
queries (`"mcp_wiring_test"` as a single string) still work because they
split into the same three tokens on both sides of the comparison.

## Tests

- All five existing `TestTokenize` cases still pass.
- New `test_underscores_split` covers the regression scenario directly.