### PR TITLE
test: make path-handling tests pass on Windows runners

### DIFF
--- a/agent/tests/test_backtest_runner_security.py
+++ b/agent/tests/test_backtest_runner_security.py
@@ -16,12 +16,17 @@ def _module_name() -> str:
 
 def test_signal_engine_rejects_top_level_execution(tmp_path) -> None:
     artifact = tmp_path / "top_level_rce"
+    # ``Path.as_posix()`` so the embedded path uses forward slashes; the raw
+    # Windows form ``C:\Users\...`` looks like ``\U`` (a unicode escape) when
+    # interpolated into Python source and breaks ``ast.parse`` before the
+    # security scrubber under test ever runs.
+    artifact_str = artifact.as_posix()
     signal_file = tmp_path / "signal_engine.py"
     signal_file.write_text(
         "\n".join(
             [
                 "import os",
-                f"os.system('touch {artifact}')",
+                f"os.system('touch {artifact_str}')",
                 "class SignalEngine:",
                 "    def generate(self, *args, **kwargs):",
                 "        return []",
@@ -38,13 +43,14 @@ def test_signal_engine_rejects_top_level_execution(tmp_path) -> None:
 
 def test_signal_engine_rejects_class_level_execution(tmp_path) -> None:
     artifact = tmp_path / "class_level_rce"
+    artifact_str = artifact.as_posix()  # see top_level test for rationale
     signal_file = tmp_path / "signal_engine.py"
     signal_file.write_text(
         "\n".join(
             [
                 "import os",
                 "class SignalEngine:",
-                f"    os.system('touch {artifact}')",
+                f"    os.system('touch {artifact_str}')",
                 "    def generate(self, *args, **kwargs):",
                 "        return []",
             ]

--- a/agent/tests/test_loop_helpers.py
+++ b/agent/tests/test_loop_helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -274,6 +275,13 @@ class TestNormalizeToolRunDir:
         assert out["run_dir"] == str((Path("/tmp/run_123") / "risk_parity_run").resolve())
 
     def test_preserves_absolute_run_dir(self) -> None:
-        args = {"run_dir": "/var/tmp/custom_run"}
+        # ``os.path.abspath`` produces a platform-correct absolute path: on
+        # POSIX it stays ``/var/tmp/custom_run``; on Windows it becomes
+        # ``C:\var\tmp\custom_run``. ``Path.is_absolute()`` only treats the
+        # latter as absolute on Windows, so the bare Unix-style literal would
+        # otherwise be classified as relative and resolved against
+        # ``memory_run_dir`` — defeating the point of the test.
+        absolute_run_dir = os.path.abspath("/var/tmp/custom_run")
+        args = {"run_dir": absolute_run_dir}
         out = _normalize_tool_run_dir(args, "/tmp/run_123")
-        assert out["run_dir"] == "/var/tmp/custom_run"
+        assert out["run_dir"] == absolute_run_dir


### PR DESCRIPTION
## Summary

- Fixes three pre-existing tests that pass on Linux CI but fail on Windows because of test-side platform assumptions, not application bugs.
- Touches only `agent/tests/` — no production code changes.
- After this PR: full pytest sweep on Windows goes from `3 failed, 863 passed` to `866 passed, 0 failed`.

## Why

A Windows contributor running `pytest --ignore=agent/tests/e2e_backtest --tb=short -q` against `main` hits these three failures:

```
FAILED agent/tests/test_backtest_runner_security.py::test_signal_engine_rejects_top_level_execution
FAILED agent/tests/test_backtest_runner_security.py::test_signal_engine_rejects_class_level_execution
FAILED agent/tests/test_loop_helpers.py::TestNormalizeToolRunDir::test_preserves_absolute_run_dir
```

Linux CI is unaffected, so the failures didn't surface in [#80](https://github.com/HKUDS/Vibe-Trading/pull/80) / [#82](https://github.com/HKUDS/Vibe-Trading/pull/82) / etc. The behaviour the tests *exercise* is correct on both platforms; only the test inputs make POSIX-specific assumptions.

## What was actually wrong

### 1. `test_backtest_runner_security.py` — RCE path interpolation

Both failing tests build a `signal_engine.py` whose source contains `pytest`'s `tmp_path` formatted into an `os.system('touch ...')` call. On Windows `tmp_path` resolves to e.g. `C:\Users\teera\AppData\Local\Temp\pytest-25\...`. Interpolated into a single-quoted Python string literal, the leading `\U` is interpreted as a (truncated) unicode escape:

```
ValueError: Invalid signal_engine.py syntax:
(unicode error) 'unicodeescape' codec can't decode bytes in position 8-9:
truncated \UXXXXXXXX escape
```

`ast.parse` raises `SyntaxError` *before* the security scrubber under test ever runs — so the test fails for the wrong reason on Windows, while passing on Linux because the path uses forward slashes there.

**Fix:** switch the interpolation to `Path.as_posix()`. Forward-slash paths survive Python source escaping intact while still pointing at the same filesystem location on every OS, so the scrubber gets a chance to see the actual class- / top-level statement and reject it as the test originally intended.

### 2. `test_loop_helpers.py::TestNormalizeToolRunDir::test_preserves_absolute_run_dir`

The test passed the literal `"/var/tmp/custom_run"` and expected it back unchanged from `_normalize_tool_run_dir`:

```python
args = {"run_dir": "/var/tmp/custom_run"}
out = _normalize_tool_run_dir(args, "/tmp/run_123")
assert out["run_dir"] == "/var/tmp/custom_run"
```

`_normalize_tool_run_dir` calls `Path.is_absolute()`, which on Windows returns `False` for a bare drive-less path. The function then correctly treats the input as relative and joins it with `memory_run_dir`, yielding `C:\var\tmp\custom_run`. The function is doing the right thing — the test asserted POSIX semantics on a cross-platform helper.

**Fix:** resolve the test input through `os.path.abspath` before handing it to the function, so the input is the platform's actual absolute form (`/var/tmp/custom_run` on POSIX, `C:\var\tmp\custom_run` on Windows). The assertion then holds on both.

## Verification

Before (on Windows / Python 3.12):

```
3 failed, 863 passed, 1 skipped, 2 warnings in 13.54s
```

After (same machine):

```
866 passed, 1 skipped, 2 warnings in 12.33s
```

The three previously-failing tests now pass without changing any production code. Linux CI continues to pass (the patches are no-ops on POSIX where forward slashes are already the path separator and `/var/tmp/custom_run` is already an absolute path).

## Test plan

- [x] Targeted run — the three previously-failing tests pass: `pytest agent/tests/test_backtest_runner_security.py::test_signal_engine_rejects_top_level_execution agent/tests/test_backtest_runner_security.py::test_signal_engine_rejects_class_level_execution agent/tests/test_loop_helpers.py::TestNormalizeToolRunDir::test_preserves_absolute_run_dir -v` → 3 passed.
- [x] Full sweep on Windows — `pytest --ignore=agent/tests/e2e_backtest --tb=line -q` → `866 passed, 0 failed`.
- [x] Linux behaviour preserved — `Path.as_posix()` on POSIX is a no-op, and `os.path.abspath('/var/tmp/custom_run')` returns `/var/tmp/custom_run` unchanged.

## Checklist

- [x] No changes to protected areas (`agent/src/agent/`, `agent/src/session/`, `agent/src/providers/`) — only `agent/tests/`.
- [x] No production code touched.
- [x] No hardcoded secrets / paths.
- [x] Code follows `CONTRIBUTING.md` (Conventional Commit prefix `test:`, Google-style docstrings via comments).
- [x] Documentation updated — N/A.
