### PR TITLE
fix(mcp_server): pre-warm skills loader to avoid same tools/call deadlock

### DIFF
--- a/agent/mcp_server.py
+++ b/agent/mcp_server.py
@@ -711,6 +711,7 @@ def main():
     _include_shell_tools = True if args.transport == "stdio" else _env_shell_tools_enabled()
     _registry = None
     _get_registry()  # pre-warm: avoids deadlock when first tools/call lazy-inits inside FastMCP worker thread
+    _get_skills_loader()  # pre-warm: same deadlock mitigation — list_skills/load_skill must not lazy-init in worker thread
 
     if args.transport == "sse":
         mcp.run(transport="sse", port=args.port)


### PR DESCRIPTION
## Summary

- Mirrors the registry pre-warm fix from [#85](https://github.com/HKUDS/Vibe-Trading/pull/85) for the *other* lazy-init singleton in `mcp_server.py`.
- One-line addition in `main()`; idempotent; preserves all existing behaviour.

## Why

[#85](https://github.com/HKUDS/Vibe-Trading/pull/85) fixed a deadlock where `_get_registry()` lazy-built inside FastMCP's worker thread on the first `tools/call`. `_get_skills_loader()` (`mcp_server.py:60-65`) follows the *same* pattern — it lazy-builds `SkillsLoader()` and is invoked by `list_skills` (line 87) and `load_skill` (line 103). If a client's first `tools/call` happens to hit one of those before any registry-touching tool, the lazy `SkillsLoader` build runs in the worker thread and the same deadlock applies. `initialize` and `tools/list` still succeed because they don't touch the loader, masking the bug exactly the way #85's variant was masked.

In practice the registry pre-warm in #85 already imports the modules `SkillsLoader` depends on, so the user-visible deadlock is rare today. But the *pattern* is still there — a future refactor that decouples those imports re-exposes it. Pre-warming the loader explicitly removes the foot-gun.

## Fix

```python
_include_shell_tools = True if args.transport == "stdio" else _env_shell_tools_enabled()
_registry = None
_get_registry()           # PR #85
_get_skills_loader()      # this PR — same mitigation, second singleton
```

`_get_skills_loader()` is idempotent (`if _skills_loader is None` guard), so existing call sites at lines 87 and 103 are unaffected.

## Test plan

- [x] `pytest --ignore=agent/tests/e2e_backtest --tb=line -q` passes (866 passed, 0 failed on Windows / Py 3.12 with #88 applied; on the unfixed tree, the same 3 pre-existing Windows failures appear and are unrelated).
- [x] The smoke test added in [#86](https://github.com/HKUDS/Vibe-Trading/pull/86) (`test_mcp_server_smoke.py`) still passes — it covers the registry pre-warm path; this PR is additive, not destructive.

## Checklist

- [x] No changes to protected areas (`agent/src/agent/`, `agent/src/session/`, `agent/src/providers/`) — only `agent/mcp_server.py`.
- [x] No hardcoded values.
- [x] Code follows `CONTRIBUTING.md` (Conventional Commit prefix, no comment-preserved code).
- [x] Documentation updated — N/A.
