### PR TITLE
fix(api_server): replace bare except: with specific exception types

### DIFF
--- a/agent/api_server.py
+++ b/agent/api_server.py
@@ -1012,14 +1012,14 @@ async def list_runs(limit: int = 20):
             try:
                 req_data = json.loads(req_file.read_text(encoding="utf-8"))
                 prompt = req_data.get("prompt")
-            except:
+            except (json.JSONDecodeError, OSError):
                 pass
-        
+
         if not prompt and planner_file.exists():
             try:
                 planner_data = json.loads(planner_file.read_text(encoding="utf-8"))
                 prompt = planner_data.get("user_goal") or planner_data.get("goal")
-            except:
+            except (json.JSONDecodeError, OSError):
                 pass
             
         if not prompt:
@@ -1039,7 +1039,7 @@ async def list_runs(limit: int = 20):
                         total_return = float(row.get('total_return', 0) or 0)
                         sharpe = float(row.get('sharpe', 0) or 0)
                         break
-            except:
+            except (OSError, ValueError):
                 pass
         
         run_context = load_run_context(d)


### PR DESCRIPTION
## Summary

- Replaces three bare `except:` clauses in `agent/api_server.py` with explicit exception classes.
- Pure code-quality change; no behaviour change for the failures these blocks are meant to swallow; `KeyboardInterrupt` / `SystemExit` / programming bugs now propagate as they should.

## Why

Three blocks in `api_server.py` use bare `except:` — which catches `BaseException` subclasses including `KeyboardInterrupt`, `SystemExit`, and `GeneratorExit`. That makes the API server unresponsive to Ctrl+C inside these blocks and silently hides real bugs (`NameError`, `AttributeError`) as no-op passes.

The blocks themselves are best-effort metadata extraction from per-run artifact files where falling through with the default value is the right behaviour — but only for the specific I/O / parse failures these blocks can actually produce. Tightening the catch surface preserves that intent while removing the foot-gun.

## Changes

| Line | Block | Before | After |
|---|---|---|---|
| 1015 | `req.json` prompt extraction | `except:` | `except (json.JSONDecodeError, OSError):` |
| 1022 | `planner_output.json` prompt extraction | `except:` | `except (json.JSONDecodeError, OSError):` |
| 1042 | `metrics.csv` numeric parse | `except:` | `except (OSError, ValueError):` |

The other `except Exception:` clauses in this file (e.g. lines 638, 730, 745) already exclude `BaseException` and are out of scope for this PR.

## Test plan

- [x] `pytest --ignore=agent/tests/e2e_backtest --tb=line -q` passes — `test_settings_api`, `test_security_auth_api`, and `test_upload_api` all still green.
- [x] `grep -nE '^\s+except:\s*$' agent/api_server.py` returns no matches.

## Checklist

- [x] No changes to protected areas.
- [x] No new dependencies / hardcoded values.
- [x] Code follows `CONTRIBUTING.md` (Conventional Commit prefix `fix:`, no comment-preserved code).
- [x] Documentation updated — N/A.
