### PR TITLE
fix(backtest): validate run_dir in CLI entry against allowed run roots

### DIFF
--- a/agent/backtest/runner.py
+++ b/agent/backtest/runner.py
@@ -377,7 +377,24 @@ def main(run_dir: Path) -> None:
 
     Args:
         run_dir: Run directory containing ``config.json`` and ``code/signal_engine.py``.
+            The path is validated against the allowed run roots
+            (``VIBE_TRADING_ALLOWED_RUN_ROOTS`` plus the defaults) before any
+            file is read so an arbitrary filesystem location cannot be used
+            to source ``code/signal_engine.py``.
     """
+    # Guard the CLI entry point with the same root whitelist the MCP
+    # ``backtest`` tool already uses (src/tools/backtest_tool.py:23). Without
+    # this, ``python -m backtest.runner /tmp/attacker_path`` would happily
+    # import ``signal_engine.py`` from anywhere on disk; the AST scrubber
+    # below blocks executable top-level statements but a method body still
+    # runs on instantiation. See ``safe_run_dir`` for the policy.
+    from src.tools.path_utils import safe_run_dir
+    try:
+        run_dir = safe_run_dir(str(run_dir))
+    except ValueError as exc:
+        print(json.dumps({"error": str(exc)}))
+        sys.exit(1)
+
     config_path = run_dir / "config.json"
     if not config_path.exists():
         print(json.dumps({"error": "config.json not found"}))


### PR DESCRIPTION
## Summary

- Adds `safe_run_dir` validation to the `python -m backtest.runner <run_dir>` CLI entry point so it honours the same `VIBE_TRADING_ALLOWED_RUN_ROOTS` whitelist the MCP `backtest` tool already enforces.
- One file touched (`agent/backtest/runner.py`), 17 lines added, no behaviour change for legitimate callers.

## Why

`backtest.runner.main()` previously accepted any `Path` it was handed and went straight to reading `config.json` + importing `code/signal_engine.py` from that location. The MCP path goes through `safe_run_dir` (`src/tools/backtest_tool.py:23`), but the CLI did not — meaning a contributor or agent that can drop `config.json` + `code/signal_engine.py` anywhere on disk could have the runner load and instantiate it.

The AST scrubber at `runner.py:217-239` (which I'm not touching here) blocks executable top-level statements, but any function or method body still runs on instantiation or method call (`BaseEngine.run_backtest` → `SignalEngine().__init__` → `.generate(...)`). The AST guard is not a substitute for a path boundary.

## Fix

Reuse the existing `safe_run_dir` (`agent/src/tools/path_utils.py:190`) at the top of `main()`. Errors are surfaced through the existing `{"error": "..."}` JSON-on-stdout + `sys.exit(1)` convention this entry point already uses, matching the existing `config.json not found` and `Invalid config: ...` paths immediately below.

```python
def main(run_dir: Path) -> None:
    from src.tools.path_utils import safe_run_dir
    try:
        run_dir = safe_run_dir(str(run_dir))
    except ValueError as exc:
        print(json.dumps({"error": str(exc)}))
        sys.exit(1)
    ...
```

## Test plan

- [x] Existing `test_path_safety.py` (17 tests) still passes — exercises `safe_run_dir` directly; this PR just calls it.
- [x] Manual: `python -c "from backtest.runner import main; main(Path('/tmp/attacker_path'))"` with `VIBE_TRADING_ALLOWED_RUN_ROOTS` unset prints `{"error": "run_dir '/tmp/attacker_path' is outside allowed run roots. Set VIBE_TRADING_ALLOWED_RUN_ROOTS to add a run directory."}` and exits 1.
- [x] Manual: a path under one of the default roots (`agent/runs`, `$cwd/runs`, `~/.vibe-trading/shadow_runs`) or any path listed in `VIBE_TRADING_ALLOWED_RUN_ROOTS` proceeds unchanged.
- [x] Full `pytest --ignore=agent/tests/e2e_backtest --tb=line -q` sweep — same baseline pass count.

## Checklist

- [x] No changes to protected areas (`agent/src/agent/`, `agent/src/session/`, `agent/src/providers/`) — only `agent/backtest/runner.py`.
- [x] No hardcoded values; uses the existing whitelist API.
- [x] Code follows `CONTRIBUTING.md` (Conventional Commit prefix, docstring updated).
- [x] Documentation updated — the existing `VIBE_TRADING_ALLOWED_RUN_ROOTS` docs in `README.md:341` already cover this; the docstring on `main()` now points at the env var.
