### PR TITLE
feat(swarm): record provider/model on SwarmRun for cost audit + debug

### DIFF
--- a/agent/src/swarm/models.py
+++ b/agent/src/swarm/models.py
@@ -166,6 +166,14 @@ class SwarmRun(BaseModel):
         final_report: Final aggregated report text.
         total_input_tokens: Cumulative input tokens across all workers.
         total_output_tokens: Cumulative output tokens across all workers.
+        provider: LLM provider name in effect when the run started
+            (e.g. ``"openai"``, ``"anthropic"``, ``"deepseek"``). Captured from
+            ``LANGCHAIN_PROVIDER`` at run-creation time. ``None`` if the
+            provider could not be resolved. Per-agent overrides — declared via
+            :attr:`SwarmAgentSpec.model_name` — are not reflected here; this
+            field is the run-level default.
+        model: LLM model name in effect when the run started, captured from
+            ``LANGCHAIN_MODEL_NAME``. Same scoping rules as :attr:`provider`.
     """
 
     id: str
@@ -179,6 +187,8 @@ class SwarmRun(BaseModel):
     final_report: str | None = None
     total_input_tokens: int = 0
     total_output_tokens: int = 0
+    provider: str | None = None
+    model: str | None = None
 
 
 class WorkerResult(BaseModel):

--- a/agent/src/swarm/runtime.py
+++ b/agent/src/swarm/runtime.py
@@ -8,6 +8,7 @@ with cancellation and event callback support.
 from __future__ import annotations
 
 import logging
+import os
 import threading
 from concurrent.futures import (
     Future,
@@ -91,6 +92,16 @@ class SwarmRuntime:
         """
         run = build_run_from_preset(preset_name, user_vars)
         validate_dag(run.tasks)
+
+        # Capture which provider/model the run was launched against so the
+        # serialized run.json carries enough context for cost audits and
+        # post-hoc debugging. Read directly from the same env vars the
+        # provider layer uses (src/providers/llm.py:136,195) — that way an
+        # override applied via os.environ still shows up. Per-agent overrides
+        # remain visible on SwarmAgentSpec.model_name.
+        run.provider = (os.getenv("LANGCHAIN_PROVIDER") or "").strip().lower() or None
+        run.model = (os.getenv("LANGCHAIN_MODEL_NAME") or "").strip() or None
+
         self._store.create_run(run)
 
         cancel_event = threading.Event()

--- a/agent/tests/test_swarm_run_metadata.py
+++ b/agent/tests/test_swarm_run_metadata.py
@@ -1,0 +1,83 @@
+"""Unit tests for run-level provider/model metadata on SwarmRun.
+
+The fields capture which LLM provider/model the swarm was launched against
+so ``.swarm/runs/<id>/run.json`` carries enough context for cost audits
+and post-hoc debugging. The tests assert the new fields are accepted,
+default cleanly, and that legacy run.json files (which predate the
+fields) still parse — important because existing on-disk runs will be
+re-read by ``SwarmStore.list_runs`` after this change.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.swarm.models import SwarmRun
+
+
+def _base_kwargs() -> dict:
+    """Required-only kwargs for a SwarmRun instance."""
+    return {
+        "id": "swarm-test",
+        "preset_name": "dummy_preset",
+        "created_at": "2026-05-09T00:00:00+00:00",
+    }
+
+
+def test_provider_and_model_persist_on_construction() -> None:
+    """Explicitly-supplied provider/model should appear in serialization."""
+    run = SwarmRun(**_base_kwargs(), provider="openai", model="gpt-4o")
+
+    assert run.provider == "openai"
+    assert run.model == "gpt-4o"
+
+    # Round-trip through JSON to mirror the .swarm/runs/<id>/run.json path.
+    blob = run.model_dump_json()
+    rehydrated = SwarmRun.model_validate_json(blob)
+    assert rehydrated.provider == "openai"
+    assert rehydrated.model == "gpt-4o"
+
+
+def test_provider_and_model_default_to_none() -> None:
+    """Both fields are optional and default to None."""
+    run = SwarmRun(**_base_kwargs())
+
+    assert run.provider is None
+    assert run.model is None
+
+
+def test_legacy_run_json_without_provider_model_still_parses() -> None:
+    """Existing run.json files predate provider/model and must still load.
+
+    SwarmStore.get_run / list_runs reads on-disk JSON via
+    ``SwarmRun.model_validate_json``. Adding required fields would silently
+    break those flows; we want absent keys to deserialize to the default.
+    """
+    legacy_blob = (
+        '{"id":"legacy-run","preset_name":"old","status":"completed",'
+        '"created_at":"2026-01-01T00:00:00+00:00",'
+        '"total_input_tokens":12345,"total_output_tokens":678}'
+    )
+    run = SwarmRun.model_validate_json(legacy_blob)
+
+    assert run.id == "legacy-run"
+    assert run.provider is None
+    assert run.model is None
+    # Untouched fields still come through.
+    assert run.total_input_tokens == 12345
+    assert run.total_output_tokens == 678
+
+
+@pytest.mark.parametrize(
+    ("provider", "model"),
+    [
+        ("anthropic", "claude-sonnet-4-5"),
+        ("deepseek", "deepseek-v3"),
+        ("openrouter", "openai/gpt-5"),
+    ],
+)
+def test_accepts_other_providers(provider: str, model: str) -> None:
+    """Field accepts any string — provider list is not enumerated at runtime."""
+    run = SwarmRun(**_base_kwargs(), provider=provider, model=model)
+    assert run.provider == provider
+    assert run.model == model


### PR DESCRIPTION
## Summary

- Adds two optional fields to `SwarmRun` — `provider` and `model` — and populates them from the active `LANGCHAIN_PROVIDER` / `LANGCHAIN_MODEL_NAME` env vars at run-creation time.
- Closes a small but useful observability gap: every `.swarm/runs/<id>/run.json` written from this point forward records which LLM the run was actually executed against.
- Backward-compatible: existing on-disk `run.json` files lack the keys and continue to deserialise (default `None`).

## Why

`run.json` currently has no field describing which provider / model the swarm was launched against. `SwarmAgentSpec.model_name` carries per-agent overrides but defaults to `None` ("use the global config"), and that resolved config is never captured anywhere.

This makes three things harder than they should be:

1. **Cost auditing** — the persisted `total_input_tokens` / `total_output_tokens` are meaningless without knowing the model's price-per-token.
2. **Side-by-side experiments** — comparing `kimi-k2.5` vs `gpt-4o` on the same preset requires manually correlating timestamps with `.env` history.
3. **Post-hoc bug triage** — "this run produced garbage" is much faster to diagnose if the run state shows it ran on the wrong model.

## Changes

### `agent/src/swarm/models.py`
Two `Optional[str]` fields on `SwarmRun`, both defaulting to `None`:

```python
provider: str | None = None  # lowercased LANGCHAIN_PROVIDER
model: str | None = None     # raw LANGCHAIN_MODEL_NAME (case-sensitive)
```

The docstring spells out the scoping rule: this is the run-level default; per-agent overrides remain visible on `SwarmAgentSpec.model_name`.

### `agent/src/swarm/runtime.py`
In `SwarmRuntime.start_run`, read the same env vars `src/providers/llm.py:136,195` reads when constructing `ChatLLM`, and assign them on the run before `_store.create_run` persists `run.json`. Empty / unset env produces `None`, not the empty string.

```python
run.provider = (os.getenv("LANGCHAIN_PROVIDER") or "").strip().lower() or None
run.model = (os.getenv("LANGCHAIN_MODEL_NAME") or "").strip() or None
```

### `agent/tests/test_swarm_run_metadata.py` (new)
Six unit tests covering the new behaviour:

- Construction + JSON round-trip with explicit values
- Default-to-`None` behaviour
- Backward compat: legacy `run.json` (no `provider` / `model` keys) still parses, untouched fields preserved
- Parametrised acceptance of multiple provider names (`anthropic`, `deepseek`, `openrouter`)

## Out of scope

- Per-call (per-iteration) model tracking — workers can already override via `SwarmAgentSpec.model_name`. That field is unchanged.
- Real token counting — `worker.py:_estimate_tokens` is still a character-count heuristic. That's a separate gap worth addressing but it doesn't depend on this PR.
- Frontend display — the new fields are now in `run.json`; surfacing them in the UI is a follow-up.

## Test plan

- [x] `pytest agent/tests/test_swarm_run_metadata.py -v` — 6/6 pass.
- [x] `pytest --ignore=agent/tests/e2e_backtest --tb=line -q` — full sweep: same baseline pass count + 6 new tests, no regressions.
- [x] `pytest agent/tests/test_swarm_preset_inspect.py agent/tests/test_swarm_presets_packaging.py agent/tests/test_models.py -v` — adjacent swarm tests still green (17/17).

## Checklist

- [x] No changes to protected areas (`agent/src/agent/`, `agent/src/session/`, `agent/src/providers/`).
- [x] No hardcoded values; reuses the existing `LANGCHAIN_*` env-var contract.
- [x] Code follows `CONTRIBUTING.md` (Conventional Commit prefix, Google-style docstrings, regression test added).
- [x] Backward-compatible — existing on-disk `run.json` parses without modification.
