### PR TITLE
Add Trust Layer run cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@
 
 ## 📰 News
 
+- **2026-05-12** 🧾 **Trust Layer run cards**: Backtests now emit reproducible `run_card.json` and `run_card.md` files alongside artifacts, capturing config and strategy hashes, data sources, scalar metrics, validation payloads, warnings, and artifact checksums. The backtest tool also returns the run-card paths so CLI/API callers can surface the evidence package directly.
 - **2026-05-11** 🧭 **Memory slugs, swarm accounting, and CLI preflight**: Persistent memory now preserves CJK characters when generating file slugs, preventing silent filename collisions for Chinese/Japanese/Korean notes ([#95](https://github.com/HKUDS/Vibe-Trading/pull/95), thanks @voidborne-d). Swarm run totals now prefer provider-reported token usage with the existing estimate fallback ([#94](https://github.com/HKUDS/Vibe-Trading/pull/94), thanks @Teerapat-Vatpitak), and the CLI run UI gained a startup preflight check for common environment issues ([#96](https://github.com/HKUDS/Vibe-Trading/pull/96), thanks @ykykj).
 - **2026-05-10** 🧱 **Regression guardrails + run metadata**: Memory recall now treats underscores as token boundaries, so snake_case saved memories such as `mcp_wiring_test` match natural-language queries like "mcp wiring" ([#87](https://github.com/HKUDS/Vibe-Trading/pull/87), thanks @hp083625). The MCP server has a subprocess smoke test covering initialize → `tools/list` → `tools/call` to guard the first-call deadlock path ([#86](https://github.com/HKUDS/Vibe-Trading/pull/86)), while low-risk hardening landed for Windows path-sensitive tests, API best-effort exception handling, backtest `run_dir` allowed-root validation, and SwarmRun provider/model metadata ([#88](https://github.com/HKUDS/Vibe-Trading/pull/88), [#90](https://github.com/HKUDS/Vibe-Trading/pull/90), [#91](https://github.com/HKUDS/Vibe-Trading/pull/91), [#92](https://github.com/HKUDS/Vibe-Trading/pull/92), thanks @Teerapat-Vatpitak).
 - **2026-05-09** 🛡️ **API path hardening + MCP server stability**: API run/session routes now validate path IDs before lookup, rejecting malformed newline-containing parameters and pinning the behavior in the auth/security regression suite ([#80](https://github.com/HKUDS/Vibe-Trading/pull/80), thanks @SJoon99). The MCP server now pre-warms the tool registry on the main thread before serving `tools/call`, avoiding a first-call deadlock in lazy tool discovery ([#85](https://github.com/HKUDS/Vibe-Trading/pull/85), thanks @Teerapat-Vatpitak). The Vite dev proxy also honors `VITE_API_URL` for non-default backend targets ([#82](https://github.com/HKUDS/Vibe-Trading/pull/82), thanks @voidborne-d).
@@ -725,7 +726,7 @@ Vibe-Trading is part of the **[HKUDS](https://github.com/HKUDS)** agent ecosyste
 | **Portfolio Studio** | Risk x-ray, constraints, turnover-aware optimizer, rebalance notes | Planned |
 | **Alpha Zoo** | Alpha101 / Alpha158 / Alpha191 factor libraries with screening + IC tests | Planned |
 | **Research Delivery** | Scheduled briefs to Slack / Telegram / email-style channels | Planned |
-| **Trust Layer** | Reproducible run cards: tool trace, data sources, assumptions, citations | Planned |
+| **Trust Layer** | Reproducible run cards: tool trace, data sources, assumptions, citations | In Progress |
 | **Community** | Shareable skills, presets, and strategy cards | Exploring |
 
 ---

--- a/agent/backtest/engines/base.py
+++ b/agent/backtest/engines/base.py
@@ -34,6 +34,22 @@ from backtest.models import EquitySnapshot, Position, TradeRecord
 logger = logging.getLogger(__name__)
 
 
+def _run_card_data_sources(config: Dict[str, Any], loader: Any) -> List[str]:
+    """Return source names for run-card evidence."""
+    configured = config.get("_run_card_effective_sources")
+    if isinstance(configured, list):
+        return [str(source) for source in configured if str(source).strip()]
+    if isinstance(configured, str) and configured.strip():
+        return [configured.strip()]
+
+    loader_name = getattr(loader, "name", None)
+    if loader_name:
+        return [str(loader_name)]
+
+    source = config.get("source")
+    return [str(source)] if source else []
+
+
 # ─── Market detection (lightweight, for signal alignment only) ───
 
 _CRYPTO_RE = _re.compile(r"^[A-Z]+-USDT$|^[A-Z]+/USDT$", _re.I)
@@ -403,6 +419,16 @@ class BaseEngine(ABC):
         self._write_artifacts(
             run_dir, data_map, dates, equity_series, bench_equity, bench_ret,
             target_pos, m, valid_codes,
+        )
+
+        # 9. Trust Layer run card
+        from backtest.run_card import write_run_card
+        write_run_card(
+            run_dir,
+            config,
+            m,
+            data_sources=_run_card_data_sources(config, loader),
+            strategy_path=run_dir / "code" / "signal_engine.py",
         )
 
         # Print scalar metrics (skip nested dicts for JSON compat)

--- a/agent/backtest/engines/options_portfolio.py
+++ b/agent/backtest/engines/options_portfolio.py
@@ -16,7 +16,6 @@ Artifacts: equity.csv, metrics.csv, trades.csv, greeks.csv.
 
 import json
 import sys
-from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -290,7 +289,6 @@ def run_options_backtest(
     commission = config.get("commission", 0.001)
     options_cfg = config.get("options_config", {})
     risk_free_rate = options_cfg.get("risk_free_rate", 0.05)
-    iv_source = options_cfg.get("iv_source", "historical")
     contract_multiplier = options_cfg.get("contract_multiplier", 1.0)
     exercise_style = options_cfg.get("exercise_style", "european")  # v2: "european" or "american"
     iv_skew = options_cfg.get("iv_skew", 0.0)         # v2: smile skew param (0 = flat)
@@ -553,6 +551,15 @@ def run_options_backtest(
 
     pd.DataFrame(greeks_records).to_csv(out / "greeks.csv", index=False)
     pd.DataFrame([metrics]).to_csv(out / "metrics.csv", index=False)
+
+    from backtest.run_card import write_run_card
+    write_run_card(
+        run_dir,
+        config,
+        metrics,
+        data_sources=[str(getattr(loader, "name", config.get("source", "")))],
+        strategy_path=run_dir / "code" / "signal_engine.py",
+    )
 
     print(json.dumps(metrics, indent=2))
     return metrics

--- a/agent/backtest/run_card.py
+++ b/agent/backtest/run_card.py
@@ -1,0 +1,200 @@
+"""Trust Layer run card generator for backtest runs."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+SCHEMA_VERSION = "0.1"
+BACKTEST_SUMMARY_KEYS = (
+    "codes",
+    "start_date",
+    "end_date",
+    "interval",
+    "engine",
+    "initial_cash",
+    "source",
+)
+
+
+def write_run_card(
+    run_dir: Path,
+    config: Mapping[str, Any],
+    metrics: Mapping[str, Any],
+    *,
+    data_sources: Sequence[str] | None = None,
+    strategy_path: Path | None = None,
+    warnings: Sequence[str] | None = None,
+) -> dict[str, Any]:
+    """Write JSON and Markdown run cards for a backtest run.
+
+    Args:
+        run_dir: Directory where run_card.json and run_card.md are written.
+        config: Full backtest configuration. Only a summary and hash are stored.
+        metrics: Backtest metrics. Scalar values are stored; ``validation`` is
+            stored separately when present.
+        data_sources: Data sources used by the run.
+        strategy_path: Optional strategy source file to hash for reproducibility.
+        warnings: Optional warnings to include in the card.
+
+    Returns:
+        The run card payload written to ``run_card.json``.
+    """
+    run_dir = Path(run_dir)
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    config_file = run_dir / "config.json"
+    reproducibility: dict[str, Any] = {
+        "config_hash": _file_hash(config_file) if config_file.exists() else _json_hash(config),
+    }
+    if strategy_path is not None:
+        strategy_file = Path(strategy_path)
+        if strategy_file.exists() and strategy_file.is_file():
+            reproducibility["strategy_hash"] = _file_hash(strategy_file)
+
+    card: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": _utc_now(),
+        "run_dir": str(run_dir),
+        "backtest": _backtest_summary(config),
+        "reproducibility": reproducibility,
+        "data_sources": list(data_sources or []),
+        "metrics": _scalar_metrics(metrics),
+        "warnings": list(warnings or []),
+        "artifacts": _list_artifacts(run_dir),
+    }
+    if "validation" in metrics:
+        card["validation"] = metrics["validation"]
+
+    json_path = run_dir / "run_card.json"
+    md_path = run_dir / "run_card.md"
+    json_path.write_text(
+        json.dumps(card, ensure_ascii=False, indent=2, sort_keys=True, default=str) + "\n",
+        encoding="utf-8",
+    )
+    md_path.write_text(_render_markdown(card), encoding="utf-8")
+    return card
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _json_hash(value: Mapping[str, Any]) -> str:
+    payload = json.dumps(
+        {key: val for key, val in value.items() if not str(key).startswith("_")},
+        sort_keys=True,
+        default=str,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _file_hash(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _backtest_summary(config: Mapping[str, Any]) -> dict[str, Any]:
+    return {key: config.get(key) for key in BACKTEST_SUMMARY_KEYS if key in config}
+
+
+def _scalar_metrics(metrics: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        key: value
+        for key, value in metrics.items()
+        if key != "validation" and _is_scalar(value)
+    }
+
+
+def _is_scalar(value: Any) -> bool:
+    return value is None or isinstance(value, (str, int, float, bool))
+
+
+def _list_artifacts(run_dir: Path) -> list[dict[str, Any]]:
+    candidates: list[Path] = []
+    for relative in (Path("config.json"), Path("code/signal_engine.py")):
+        path = run_dir / relative
+        if path.exists() and path.is_file():
+            candidates.append(path)
+
+    artifacts_dir = run_dir / "artifacts"
+    if artifacts_dir.exists() and artifacts_dir.is_dir():
+        candidates.extend(path for path in artifacts_dir.rglob("*") if path.is_file())
+
+    artifacts = []
+    for path in sorted(candidates, key=lambda item: item.relative_to(run_dir).as_posix()):
+        artifacts.append(
+            {
+                "path": path.relative_to(run_dir).as_posix(),
+                "size_bytes": path.stat().st_size,
+                "sha256": _file_hash(path),
+            }
+        )
+    return artifacts
+
+
+def _render_markdown(card: Mapping[str, Any]) -> str:
+    lines = [
+        "# Backtest Run Card",
+        "",
+        f"Generated: {card['generated_at']}",
+        f"Run directory: `{card['run_dir']}`",
+        "",
+        "## Backtest Summary",
+    ]
+
+    backtest = card.get("backtest", {})
+    if backtest:
+        lines.extend(f"- {key}: {value}" for key, value in backtest.items())
+    else:
+        lines.append("- No backtest summary fields provided.")
+
+    lines.extend(["", "## Reproducibility"])
+    reproducibility = card.get("reproducibility", {})
+    lines.append(f"- config_hash: `{reproducibility.get('config_hash', '')}`")
+    if "strategy_hash" in reproducibility:
+        lines.append(f"- strategy_hash: `{reproducibility['strategy_hash']}`")
+
+    lines.extend(["", "## Data Sources"])
+    data_sources = card.get("data_sources", [])
+    lines.extend(f"- {source}" for source in data_sources) if data_sources else lines.append("- None recorded.")
+
+    lines.extend(["", "## Metrics"])
+    metric_values = card.get("metrics", {})
+    lines.extend(f"- {key}: {value}" for key, value in metric_values.items()) if metric_values else lines.append("- No scalar metrics recorded.")
+
+    lines.extend(["", "## Validation"])
+    if "validation" in card:
+        validation = card["validation"]
+        if isinstance(validation, Mapping):
+            lines.extend(f"- {key}: {value}" for key, value in validation.items())
+        else:
+            lines.append(f"- {validation}")
+    else:
+        lines.append("- Not present.")
+
+    warnings = card.get("warnings", [])
+    if warnings:
+        lines.extend(["", "## Warnings"])
+        lines.extend(f"- {warning}" for warning in warnings)
+
+    lines.extend(["", "## Artifacts"])
+    artifacts = card.get("artifacts", [])
+    if artifacts:
+        lines.extend(
+            f"- `{artifact['path']}` ({artifact['size_bytes']} bytes, sha256 `{artifact['sha256']}`)"
+            for artifact in artifacts
+        )
+    else:
+        lines.append("- None found.")
+
+    return "\n".join(lines) + "\n"

--- a/agent/backtest/runner.py
+++ b/agent/backtest/runner.py
@@ -466,6 +466,11 @@ def main(run_dir: Path) -> None:
         print(json.dumps({"error": "No data fetched"}))
         sys.exit(1)
 
+    if source == "auto":
+        config["_run_card_effective_sources"] = sorted(_group_codes_by_source(codes))
+    else:
+        config["_run_card_effective_sources"] = [source]
+
     # Engine
     engine_type = config.get("engine", "daily")
     signal_engine = engine_cls()

--- a/agent/src/core/runner.py
+++ b/agent/src/core/runner.py
@@ -73,6 +73,8 @@ _ARTIFACTS_SPEC = {
         "metrics": {"schema": "metrics_csv", "path": "artifacts/metrics.csv"},
         "trades": {"schema": "trade_log", "path": "artifacts/trades.csv"},
         "positions": {"schema": "positions_csv", "path": "artifacts/positions.csv"},
+        "run_card_json": {"schema": "json", "path": "run_card.json"},
+        "run_card_md": {"schema": "markdown", "path": "run_card.md"},
     },
 }
 

--- a/agent/tests/test_engine_robustness.py
+++ b/agent/tests/test_engine_robustness.py
@@ -9,6 +9,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Dict
@@ -240,6 +241,15 @@ class TestSymbolIsolation:
 
         assert metrics["benchmark_ticker"] == "000300.SH"
         assert metrics["benchmark_return"] == 0.00495
+
+        run_card_path = tmp_path / "run_card.json"
+        assert run_card_path.exists()
+        run_card = json.loads(run_card_path.read_text(encoding="utf-8"))
+        assert run_card["schema_version"] == "0.1"
+        assert run_card["backtest"]["codes"] == ["000001.SZ"]
+        assert run_card["data_sources"] == ["tushare"]
+        assert run_card["metrics"]["benchmark_return"] == 0.00495
+        assert (tmp_path / "run_card.md").exists()
 
     def test_configured_fundamental_enrichment_failure_is_not_silent(
         self,

--- a/agent/tests/test_run_card.py
+++ b/agent/tests/test_run_card.py
@@ -1,0 +1,193 @@
+"""Tests for Trust Layer run card generation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from backtest.run_card import write_run_card
+from src.core.runner import Runner
+
+
+def test_config_hash_is_deterministic_independent_of_key_order(tmp_path: Path) -> None:
+    config_a = {
+        "codes": ["AAPL", "MSFT"],
+        "start_date": "2025-01-01",
+        "end_date": "2025-03-01",
+        "interval": "1D",
+        "engine": "global_equity",
+        "initial_cash": 100000,
+        "source": "auto",
+        "nested": {"b": 2, "a": 1},
+    }
+    config_b = {
+        "nested": {"a": 1, "b": 2},
+        "source": "auto",
+        "initial_cash": 100000,
+        "engine": "global_equity",
+        "interval": "1D",
+        "end_date": "2025-03-01",
+        "start_date": "2025-01-01",
+        "codes": ["AAPL", "MSFT"],
+    }
+
+    card_a = write_run_card(tmp_path / "a", config_a, {"sharpe": 1.2})
+    card_b = write_run_card(tmp_path / "b", config_b, {"sharpe": 1.2})
+
+    assert card_a["reproducibility"]["config_hash"] == card_b["reproducibility"]["config_hash"]
+    assert "nested" not in card_a["backtest"]
+
+
+def test_strategy_hash_is_included_when_strategy_path_exists(tmp_path: Path) -> None:
+    strategy_path = tmp_path / "strategy.py"
+    strategy_path.write_text("def signal():\n    return 1\n", encoding="utf-8")
+
+    card = write_run_card(
+        tmp_path / "run",
+        {"codes": ["BTC-USDT"], "engine": "crypto"},
+        {"return_pct": 0.15},
+        strategy_path=strategy_path,
+    )
+
+    expected_hash = hashlib.sha256(strategy_path.read_bytes()).hexdigest()
+    assert card["reproducibility"]["strategy_hash"] == expected_hash
+
+
+def test_artifact_listing_includes_expected_existing_files(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    (run_dir / "code").mkdir(parents=True)
+    (run_dir / "artifacts" / "nested").mkdir(parents=True)
+    (run_dir / "config.json").write_text('{"ok": true}\n', encoding="utf-8")
+    (run_dir / "code" / "signal_engine.py").write_text("SIGNAL = 1\n", encoding="utf-8")
+    (run_dir / "artifacts" / "equity.csv").write_text("date,equity\n", encoding="utf-8")
+    (run_dir / "artifacts" / "nested" / "trades.csv").write_text("id,pnl\n", encoding="utf-8")
+
+    card = write_run_card(run_dir, {"codes": ["000001.SZ"]}, {"sharpe": 1.0})
+
+    artifacts = {artifact["path"]: artifact for artifact in card["artifacts"]}
+    assert card["reproducibility"]["config_hash"] == hashlib.sha256(
+        (run_dir / "config.json").read_bytes()
+    ).hexdigest()
+    assert list(artifacts) == [
+        "artifacts/equity.csv",
+        "artifacts/nested/trades.csv",
+        "code/signal_engine.py",
+        "config.json",
+    ]
+    for relative_path, artifact in artifacts.items():
+        path = run_dir / relative_path
+        assert artifact["size_bytes"] == path.stat().st_size
+        assert artifact["sha256"] == hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_json_and_markdown_files_are_written(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    metrics = {
+        "sharpe": 1.23,
+        "max_drawdown": -0.08,
+        "validation": {"n_windows": 5, "consistency_rate": 0.8},
+        "curve": [1, 2, 3],
+    }
+
+    card = write_run_card(
+        run_dir,
+        {
+            "codes": ["AAPL"],
+            "start_date": "2025-01-01",
+            "end_date": "2025-02-01",
+            "interval": "1D",
+            "engine": "global_equity",
+            "initial_cash": 50000,
+            "source": "yfinance",
+            "secret": "not copied raw",
+        },
+        metrics,
+        data_sources=["yfinance"],
+        warnings=["sample warning"],
+    )
+
+    json_path = run_dir / "run_card.json"
+    md_path = run_dir / "run_card.md"
+    loaded = json.loads(json_path.read_text(encoding="utf-8"))
+    markdown = md_path.read_text(encoding="utf-8")
+
+    assert loaded == card
+    assert loaded["schema_version"] == "0.1"
+    assert loaded["generated_at"].endswith("Z")
+    assert loaded["metrics"] == {"max_drawdown": -0.08, "sharpe": 1.23}
+    assert loaded["validation"] == {"consistency_rate": 0.8, "n_windows": 5}
+    assert "secret" not in json.dumps(loaded)
+    assert "# Backtest Run Card" in markdown
+    assert "Validation" in markdown
+    assert "sample warning" in markdown
+
+
+def test_runner_artifact_spec_surfaces_run_card_paths() -> None:
+    runner = Runner()
+
+    assert runner.artifact_entries["run_card_json"]["path"] == "run_card.json"
+    assert runner.artifact_entries["run_card_json"]["required"] is False
+    assert runner.artifact_entries["run_card_md"]["path"] == "run_card.md"
+    assert runner.artifact_entries["run_card_md"]["required"] is False
+
+
+def test_options_backtest_writes_run_card(tmp_path: Path) -> None:
+    from backtest.engines.options_portfolio import run_options_backtest
+
+    dates = pd.bdate_range("2025-01-01", periods=4)
+    bars = pd.DataFrame(
+        {
+            "open": [100.0, 101.0, 102.0, 103.0],
+            "high": [101.0, 102.0, 103.0, 104.0],
+            "low": [99.0, 100.0, 101.0, 102.0],
+            "close": [100.5, 101.5, 102.5, 103.5],
+            "volume": [1000, 1100, 1200, 1300],
+        },
+        index=dates,
+    )
+
+    class FakeLoader:
+        name = "yfinance"
+
+        def fetch(self, codes, start_date, end_date):
+            return {"SPY": bars.copy()}
+
+    class SignalEngine:
+        def generate(self, data_map):
+            return [
+                {
+                    "date": "2025-01-01",
+                    "action": "open",
+                    "underlying": "SPY",
+                    "legs": [{"type": "call", "strike": 101.0, "expiry": "2025-03-21", "qty": 1}],
+                },
+                {
+                    "date": "2025-01-03",
+                    "action": "close",
+                    "underlying": "SPY",
+                    "legs": [{"type": "call", "strike": 101.0, "expiry": "2025-03-21", "qty": 1}],
+                },
+            ]
+
+    run_options_backtest(
+        {
+            "codes": ["SPY"],
+            "start_date": "2025-01-01",
+            "end_date": "2025-01-06",
+            "source": "yfinance",
+            "engine": "options",
+            "initial_cash": 100_000,
+        },
+        FakeLoader(),
+        SignalEngine(),
+        tmp_path,
+    )
+
+    card = json.loads((tmp_path / "run_card.json").read_text(encoding="utf-8"))
+    assert card["backtest"]["engine"] == "options"
+    assert card["data_sources"] == ["yfinance"]
+    assert "greeks.csv" in {Path(artifact["path"]).name for artifact in card["artifacts"]}
+    assert (tmp_path / "run_card.md").exists()


### PR DESCRIPTION
## Summary
- add a Trust Layer run-card generator that writes run_card.json and run_card.md for backtest runs
- wire daily/base and options backtests to emit run cards after artifacts are written
- surface run-card paths through the runner artifact spec and update README roadmap/news

## Validation
- python -m pytest tests/test_run_card.py tests/test_engine_robustness.py tests/test_file_tool_sandbox_security.py -q
- python -m py_compile backtest/run_card.py backtest/engines/base.py backtest/engines/options_portfolio.py backtest/runner.py src/core/runner.py tests/test_run_card.py tests/test_engine_robustness.py
- python -m ruff check backtest/run_card.py tests/test_run_card.py backtest/engines/base.py backtest/engines/options_portfolio.py backtest/runner.py src/core/runner.py tests/test_engine_robustness.py
- python -m tests.e2e_backtest.test_engines_e2e
- git diff --check && git diff --cached --check