### PR TITLE
feat(memory): harden PersistentMemory.add() for control bytes, length, empty names

### DIFF
--- a/agent/src/memory/persistent.py
+++ b/agent/src/memory/persistent.py
@@ -10,6 +10,7 @@ Storage layout:
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import re
 from dataclasses import dataclass
@@ -81,6 +82,33 @@ def _tokenize(text: str) -> set[str]:
         Set of tokens.
     """
     return set(_TOKEN_RE.findall(text.lower()))
+
+
+# Strip C0 (U+0000-U+001F except \t \n) and C1 (U+0080-U+009F) bytes from
+# user-supplied body content. These never carry useful payload from agent
+# writes but can be replayed back through `memory show` to inject ANSI
+# escape sequences into the user's terminal (see issue #108).
+_CONTROL_CHAR_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
+
+# Truncation marker appended when content exceeds MAX_ENTRY_CHARS. Read
+# semantics are unchanged (clipped at MAX_ENTRY_CHARS), but the marker
+# makes the silent clip surfaceable to anyone inspecting the file directly
+# (see issue #109).
+_TRUNCATION_MARKER = "\n\n[truncated at {limit} chars]\n"
+
+
+def _sanitize_body(content: str) -> str:
+    """Strip C0/C1 control bytes from `content` while keeping ``\n`` and ``\t``."""
+    return _CONTROL_CHAR_RE.sub("", content)
+
+
+def _truncate_body(content: str, limit: int = None) -> str:
+    """Clip `content` to `limit` chars, appending a visible marker if clipped."""
+    if limit is None:
+        limit = MAX_ENTRY_CHARS
+    if len(content) <= limit:
+        return content
+    return content[:limit] + _TRUNCATION_MARKER.format(limit=limit)
 
 
 def _coerce_str(value: object, default: str = "") -> str:
@@ -230,32 +258,58 @@ class PersistentMemory:
         """Save a new memory entry and update the index.
 
         Args:
-            name: Memory name (used as filename slug).
-            content: Memory body text.
+            name: Memory name (used as filename slug). Empty or whitespace-
+                only names are rejected.
+            content: Memory body text. C0/C1 control bytes (other than
+                ``\n`` and ``\t``) are stripped; the body is truncated to
+                ``MAX_ENTRY_CHARS`` with a visible marker.
             memory_type: One of user/feedback/project/reference.
             description: One-line description for retrieval scoring.
 
         Returns:
             Path to the created memory file.
+
+        Raises:
+            ValueError: If `name` is empty or whitespace-only.
         """
+        # Reject empty / whitespace-only names so they cannot all collapse
+        # to the same `{type}_.md` filename and silently overwrite each
+        # other (issue #110).
+        stripped_name = name.strip()
+        if not stripped_name:
+            raise ValueError("memory name must not be empty or whitespace-only")
+
         # Preserve non-Latin script characters in the slug — collapsing
         # them all to ``_`` caused two same-length non-Latin names to share a
-        # filename and silently overwrite each other (see PR #95 for CJK;
-        # this generalizes to Thai/Arabic/Hebrew/Cyrillic).
-        slug = _SLUG_DISALLOWED_RE.sub("_", name.lower().strip())[:60]
+        # filename and silently overwrite each other (PR #95 + #104).
+        slug = _SLUG_DISALLOWED_RE.sub("_", stripped_name.lower())[:60]
+
+        # If the slug normalized to all underscores (emoji-only, punctuation-
+        # only, etc.) the on-disk filename would still collide between any
+        # two such names. Append a short deterministic hash so distinct
+        # inputs produce distinct files (issue #110).
+        if slug.strip("_") == "":
+            digest = hashlib.sha256(stripped_name.encode("utf-8")).hexdigest()[:6]
+            slug = f"{slug}_{digest}" if slug else digest
+
         filename = f"{memory_type}_{slug}.md"
         path = self._dir / filename
 
-        safe_name = name.replace("\n", " ").replace("\r", " ")
-        safe_desc = (description or name).replace("\n", " ").replace("\r", " ")
+        safe_name = stripped_name.replace("\n", " ").replace("\r", " ")
+        safe_desc = (description or stripped_name).replace("\n", " ").replace("\r", " ")
+
+        # Strip control bytes (#108) before truncation (#109) so the marker
+        # is computed against the user-visible content length.
+        clean_content = _truncate_body(_sanitize_body(content))
+
         frontmatter = (
             f"---\nname: {safe_name}\n"
             f"description: {safe_desc}\n"
             f"type: {memory_type}\n---\n\n"
-            f"{content}"
+            f"{clean_content}"
         )
         path.write_text(frontmatter, encoding="utf-8")
-        self._update_index(name, filename, description or name)
+        self._update_index(stripped_name, filename, description or stripped_name)
         return path
 
     def remove(self, name: str) -> bool:

--- a/agent/src/memory/persistent.py
+++ b/agent/src/memory/persistent.py
@@ -103,12 +103,21 @@ def _sanitize_body(content: str) -> str:
 
 
 def _truncate_body(content: str, limit: int = None) -> str:
-    """Clip `content` to `limit` chars, appending a visible marker if clipped."""
+    """Clip `content` to `limit` chars total, leaving room for the marker.
+
+    The marker is reserved inside the limit (not appended on top) so the on-
+    disk body length stays <= MAX_ENTRY_CHARS and the marker survives the
+    matching read-side clip in `_scan_entries`. Callers that inspect
+    `entry.body` see the marker; the original tail content past the head
+    window is dropped.
+    """
     if limit is None:
         limit = MAX_ENTRY_CHARS
     if len(content) <= limit:
         return content
-    return content[:limit] + _TRUNCATION_MARKER.format(limit=limit)
+    marker = _TRUNCATION_MARKER.format(limit=limit)
+    head_len = max(0, limit - len(marker))
+    return content[:head_len] + marker
 
 
 def _coerce_str(value: object, default: str = "") -> str:

--- a/agent/tests/test_persistent_memory.py
+++ b/agent/tests/test_persistent_memory.py
@@ -6,7 +6,15 @@ from pathlib import Path
 
 import pytest
 
-from src.memory.persistent import PersistentMemory, MemoryEntry, _coerce_str, _tokenize
+from src.memory.persistent import (
+    MAX_ENTRY_CHARS,
+    MemoryEntry,
+    PersistentMemory,
+    _coerce_str,
+    _sanitize_body,
+    _tokenize,
+    _truncate_body,
+)
 
 
 class TestCoerceStr:
@@ -312,3 +320,116 @@ class TestSnapshot:
     def test_empty_dir_snapshot(self, tmp_path: Path) -> None:
         pm = PersistentMemory(memory_dir=tmp_path)
         assert pm.snapshot == ""
+
+
+class TestSanitizeBody:
+    """Regression for #108 — strip C0/C1 control bytes from agent-supplied content."""
+
+    def test_strips_ansi_escape(self) -> None:
+        assert _sanitize_body("hello\x1b[31mred\x1b[0m world") == "hello[31mred[0m world"
+
+    def test_strips_null_and_bell(self) -> None:
+        assert _sanitize_body("a\x00b\x07c") == "abc"
+
+    def test_preserves_tab_and_newline(self) -> None:
+        assert _sanitize_body("line1\nline2\tindented") == "line1\nline2\tindented"
+
+    def test_strips_c1_range(self) -> None:
+        # U+0080 to U+009F are C1 controls (PAD, NEL, etc.)
+        assert _sanitize_body("a\x80b\x9fc") == "abc"
+
+    def test_empty_passthrough(self) -> None:
+        assert _sanitize_body("") == ""
+
+
+class TestTruncateBody:
+    """Regression for #109 — enforce MAX_ENTRY_CHARS at write with visible marker."""
+
+    def test_short_passthrough(self) -> None:
+        assert _truncate_body("short") == "short"
+
+    def test_at_limit_passthrough(self) -> None:
+        text = "x" * MAX_ENTRY_CHARS
+        assert _truncate_body(text) == text
+
+    def test_over_limit_truncated_with_marker(self) -> None:
+        text = "x" * (MAX_ENTRY_CHARS + 100)
+        out = _truncate_body(text)
+        assert out.startswith("x" * MAX_ENTRY_CHARS)
+        assert "[truncated at" in out
+        assert str(MAX_ENTRY_CHARS) in out
+
+    def test_custom_limit(self) -> None:
+        out = _truncate_body("abcdef", limit=3)
+        assert out.startswith("abc")
+        assert "[truncated at 3 chars]" in out
+
+
+class TestAddRejectsEmptyName:
+    """Regression for #110 — reject empty / whitespace-only names."""
+
+    def test_empty_raises(self, tmp_path: Path) -> None:
+        pm = PersistentMemory(memory_dir=tmp_path)
+        with pytest.raises(ValueError, match="empty or whitespace"):
+            pm.add("", "body", "user")
+
+    def test_whitespace_only_raises(self, tmp_path: Path) -> None:
+        pm = PersistentMemory(memory_dir=tmp_path)
+        with pytest.raises(ValueError, match="empty or whitespace"):
+            pm.add("   ", "body", "user")
+
+    def test_tab_only_raises(self, tmp_path: Path) -> None:
+        pm = PersistentMemory(memory_dir=tmp_path)
+        with pytest.raises(ValueError):
+            pm.add("\t\n  ", "body", "user")
+
+
+class TestAddHashSuffixForCollapsedSlug:
+    """Regression for #110 — distinct emoji-only / punctuation-only names must
+    produce distinct files via deterministic hash suffix."""
+
+    def test_two_distinct_emoji_names_no_collision(self, tmp_path: Path) -> None:
+        pm = PersistentMemory(memory_dir=tmp_path)
+        p1 = pm.add("🚀", "rocket body", "reference")  # 🚀
+        p2 = pm.add("🎯", "target body", "reference")  # 🎯
+        assert p1 != p2
+        assert "rocket body" in p1.read_text(encoding="utf-8")
+        assert "target body" in p2.read_text(encoding="utf-8")
+
+    def test_hash_is_deterministic(self, tmp_path: Path) -> None:
+        pm = PersistentMemory(memory_dir=tmp_path)
+        p1 = pm.add("🚀", "v1", "reference")
+        p2 = pm.add("🚀", "v2", "reference")
+        # Same name → same slug → overwrite (this is expected and desired
+        # for the "edit memory" workflow).
+        assert p1 == p2
+        assert "v2" in p1.read_text(encoding="utf-8")
+
+    def test_punctuation_only_name_gets_hash(self, tmp_path: Path) -> None:
+        pm = PersistentMemory(memory_dir=tmp_path)
+        path = pm.add("???", "body", "user")
+        # Slug ??? -> _ after sanitization; hash appended.
+        # File name must not be just "user_.md".
+        assert path.name != "user_.md"
+        assert path.exists()
+
+
+class TestAddSanitizesAndTruncates:
+    """Regression for #108 + #109 wired into `PersistentMemory.add()`."""
+
+    def test_add_strips_control_bytes_in_body(self, tmp_path: Path) -> None:
+        pm = PersistentMemory(memory_dir=tmp_path)
+        path = pm.add("ctrl-test", "before\x1b[31mred\x1b[0mafter", "user")
+        body_on_disk = path.read_text(encoding="utf-8")
+        # ESC byte must be gone; surrounding text preserved.
+        assert "\x1b" not in body_on_disk
+        assert "before" in body_on_disk and "after" in body_on_disk
+        assert "[31m" in body_on_disk  # the textual remainder is fine
+
+    def test_add_truncates_long_body_with_marker(self, tmp_path: Path) -> None:
+        pm = PersistentMemory(memory_dir=tmp_path)
+        path = pm.add("long-content", "x" * (MAX_ENTRY_CHARS + 500), "reference")
+        body_on_disk = path.read_text(encoding="utf-8").split("---\n\n", 1)[1]
+        assert len(body_on_disk) <= MAX_ENTRY_CHARS + len("\n\n[truncated at  chars]\n") + 20
+        assert "[truncated at" in body_on_disk
+

--- a/agent/tests/test_persistent_memory.py
+++ b/agent/tests/test_persistent_memory.py
@@ -355,14 +355,22 @@ class TestTruncateBody:
     def test_over_limit_truncated_with_marker(self) -> None:
         text = "x" * (MAX_ENTRY_CHARS + 100)
         out = _truncate_body(text)
-        assert out.startswith("x" * MAX_ENTRY_CHARS)
+        # Total body length stays within MAX_ENTRY_CHARS so the marker survives
+        # the read-side clip in _scan_entries.
+        assert len(out) <= MAX_ENTRY_CHARS
+        # Marker is at the tail; head still starts with content.
+        assert out.startswith("x")
+        assert out.endswith("chars]\n")
         assert "[truncated at" in out
         assert str(MAX_ENTRY_CHARS) in out
 
     def test_custom_limit(self) -> None:
-        out = _truncate_body("abcdef", limit=3)
+        # Custom limit must be large enough to fit the marker plus some head.
+        text = "abcdef" * 100  # 600 chars
+        out = _truncate_body(text, limit=100)
+        assert len(out) <= 100
         assert out.startswith("abc")
-        assert "[truncated at 3 chars]" in out
+        assert "[truncated at 100 chars]" in out
 
 
 class TestAddRejectsEmptyName:
@@ -432,4 +440,3 @@ class TestAddSanitizesAndTruncates:
         body_on_disk = path.read_text(encoding="utf-8").split("---\n\n", 1)[1]
         assert len(body_on_disk) <= MAX_ENTRY_CHARS + len("\n\n[truncated at  chars]\n") + 20
         assert "[truncated at" in body_on_disk
-


### PR DESCRIPTION
## Summary

Bundles three follow-up fixes for `PersistentMemory.add()`, all in the
same module and complementary, per @warren618's invitation on #108,
#109, and #110:

> "It can also be bundled with [other two] as one small `PersistentMemory`
> hardening PR if that is easier to review as one coherent change."

Closes #108, #109, #110.

## What changed

### #109 — Asymmetric write/read truncation (highest priority)

`add()` previously wrote the full body to disk; `_scan_entries()` clipped
reads at `MAX_ENTRY_CHARS = 8000`. Content past the limit was "saved but
invisible" from inside Vibe-Trading (recall, search, and `memory show`
all silently missed it).

**Fix:** enforce the limit at write time. The body now ends with a
`[truncated at 8000 chars]\n` marker that is **reserved inside** the
limit (head + marker ≤ MAX_ENTRY_CHARS), so the marker survives the
read-side clip in `_scan_entries`. Trade-off: when content exceeds the
limit, ~28 chars of head content are dropped to make room for the
marker — intentional, because surfacing the truncation event is more
valuable than retaining 28 invisible bytes.

(The first commit appended the marker AFTER the limit; heavy E2E showed
the marker still landed outside the read window. The second commit moves
the marker inside the limit.)

Implements your preferred direction:
> "make the limit explicit, either by enforcing it at write time with
> a clear warning/truncation marker..."

### #110 — Empty / whitespace / emoji-only slug collisions

Empty, whitespace-only, and emoji/punctuation-only names previously all
collapsed to the same `{type}_.md` filename, silently overwriting each
other.

**Fix (two parts):**

1. Empty / whitespace-only names now raise `ValueError`. This matches
   your direction:
   > "The minimum fix should reject empty / whitespace-only memory names."
2. Names whose sanitized slug normalizes to just underscores (emoji,
   punctuation) get a deterministic 6-char SHA-256 suffix:
   > "...append a short disambiguator such as a hash or counter suffix..."

Same input still produces the same filename, so the "edit memory"
workflow is unaffected (overwriting your own previous note still works).

### #108 — Control-byte replay

Strip C0 (`U+0000-U+001F` except `\t` and `\n`) and C1 (`U+0080-U+009F`)
control bytes from agent-supplied content before persisting. Without
this, `vibe-trading memory show` could replay ANSI sequences back into
the user's terminal (e.g., color changes, cursor moves) on entries
saved by agents whose tool-call JSON layer decoded `` to raw ESC.

Implements:
> "sanitize C0/C1 control bytes at write time in `PersistentMemory.add()`,
> while preserving ordinary `\n` and `\t` content."

## Implementation

`agent/src/memory/persistent.py`:

- New `_CONTROL_CHAR_RE` regex constant + `_TRUNCATION_MARKER` template.
- New pure helpers `_sanitize_body(content)` and `_truncate_body(content,
  limit=None)` — small, regression-tested in isolation.
- `add()` rewritten to: (1) reject empty/whitespace names, (2) hash-suffix
  collapsed slugs, (3) sanitize then truncate the body before writing.
- Sanitization runs **before** truncation so the marker is computed
  against user-visible content length, not against bytes that would have
  been stripped anyway.

`agent/tests/test_persistent_memory.py` — 17 new tests:

- 5 unit tests for `_sanitize_body` (ANSI ESC, NUL/BEL, `\n`/`\t`
  preservation, C1 range, empty input).
- 4 unit tests for `_truncate_body` (short passthrough, at-limit,
  over-limit with marker, custom limit).
- 3 tests for empty/whitespace/tab-only name rejection.
- 3 tests for hash-suffix slug disambiguation.
- 2 integration tests through `add()` (control byte stripped on disk,
  long body truncated with marker on disk).

## Commits

This branch is two commits to keep the marker-semantics fix from heavy
E2E reviewable on its own:

| Commit | What |
|---|---|
| `28e692b` feat(memory): harden PersistentMemory.add() ... | Initial three-fix bundle |
| `fc27bfd` fix(memory): reserve truncation marker space ... | Move marker inside limit so it survives `_scan_entries` read-side clip; surfaced by file-level + LLM-driven E2E that asserted `entry.body` (not just the on-disk file) contained the marker |

## Test plan

- [x] `pytest agent/tests/test_persistent_memory.py agent/tests/test_cli_memory.py agent/tests/test_remember_tool.py agent/tests/test_cli_init.py` → **107 pass**
- [x] `pytest agent/tests/ --ignore=agent/tests/e2e_backtest` from repo root → **978 pass, 1 skipped**
- [x] `ruff check agent/src/memory/persistent.py agent/tests/test_persistent_memory.py` — net **-1 error** vs upstream
- [x] **Heavy E2E (file-level, 9 phases, 57 sub-checks)**: regression for each issue, backward compat (ASCII/CJK/Thai/Arabic/4 memory types/overwrite/recall), `remember_tool` contract, CLI integration (list/show/search/forget with marker visible), performance (50× add @ 2ms each, 20× find_relevant @ 9ms each), edge cases (long names, newlines, empty body, bracketed description, recycle).
- [x] **Heavy E2E (LLM-driven, 4 sub-checks)**: real agent uses `remember` with a `[31m`-laced content payload via `https://ai.psu.blue/v1` (deepseek-chat); ESC bytes verified absent from disk via raw byte inspection, textual `[31m` preserved, cross-session recall of the trading rule still works in a fresh agent process.
- [x] **Backward compat verified**: CJK slug preservation (PR #95/#104), Thai slug (PR #104), all 4 memory types, `remember_tool` test suite (16/16 green), existing non-empty / non-collapsing names produce byte-identical filenames to before.

## Out of scope

- The session FTS sanitizer in `agent/src/session/search.py` uses the
  same legacy CJK-only tokenizer that PR #104 fixed for memory. A
  separate small PR can consume the now-shared `_NON_LATIN_SCRIPT_RANGES`
  constant.
- Existing on-disk memory files whose body already exceeds 8000 chars
  (saved before this PR) keep their full bytes on disk — only the visible
  read window changes shape on the next overwrite.

## Checklist

- [x] No changes to protected modules (`src/agent/`, `src/session/`, `src/providers/`)
- [x] No hardcoded values
- [x] Follows `CONTRIBUTING.md`
- [x] Tests added and passing
- [x] Existing memory files on disk remain readable (no schema change)