### PR TITLE
feat(providers): add Claude Code (Pro/Max subscription) provider via claude-agent-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ vibe-trading-mcp               # start MCP server (stdio)
 - **Docker** for Path A
 - OpenAI Codex can also be used with ChatGPT OAuth: set `LANGCHAIN_PROVIDER=openai-codex`, then run `vibe-trading provider login openai-codex`. This does not use `OPENAI_API_KEY`.
 
-> **Supported LLM providers:** OpenRouter, OpenAI, DeepSeek, Gemini, Groq, DashScope/Qwen, Zhipu, Moonshot/Kimi, MiniMax, Xiaomi MIMO, Z.ai, Ollama (local). See `.env.example` for config.
+> **Supported LLM providers:** OpenRouter, OpenAI, OpenAI Codex (ChatGPT OAuth), Claude Code (Pro/Max subscription), DeepSeek, Gemini, Groq, DashScope/Qwen, Zhipu, Moonshot/Kimi, MiniMax, Xiaomi MIMO, Z.ai, Ollama (local). See `.env.example` for config.
 
 > **Tip:** All markets work without any API keys thanks to automatic fallback. yfinance (HK/US), OKX (crypto), and AKShare (A-shares, US, HK, futures, forex) are all free. Tushare token is optional — AKShare covers A-shares as a free fallback.
 

--- a/README_ar.md
+++ b/README_ar.md
@@ -321,7 +321,7 @@ vibe-trading-mcp               # start MCP server (stdio)
 - **Docker** للمسار A
 - يمكن استخدام OpenAI Codex أيضاً عبر ChatGPT OAuth: اضبط `LANGCHAIN_PROVIDER=openai-codex`، ثم شغل `vibe-trading provider login openai-codex`. هذا لا يستخدم `OPENAI_API_KEY`.
 
-> **مزودو LLM المدعومون:** OpenRouter, OpenAI, DeepSeek, Gemini, Groq, DashScope/Qwen, Zhipu, Moonshot/Kimi, MiniMax, Xiaomi MIMO, Z.ai, Ollama (local). راجع `.env.example` للإعداد.
+> **مزودو LLM المدعومون:** OpenRouter, OpenAI, OpenAI Codex (ChatGPT OAuth), Claude Code (اشتراك Pro/Max), DeepSeek, Gemini, Groq, DashScope/Qwen, Zhipu, Moonshot/Kimi, MiniMax, Xiaomi MIMO, Z.ai, Ollama (local). راجع `.env.example` للإعداد.
 
 > **نصيحة:** تعمل كل الأسواق دون مفاتيح API بفضل fallback التلقائي. yfinance (HK/US)، وOKX (crypto)، وAKShare (A-shares, US, HK, futures, forex) مجانية. رمز Tushare اختياري، إذ يغطي AKShare أسهم A كبديل مجاني.
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -321,7 +321,7 @@ vibe-trading-mcp               # start MCP server (stdio)
 - Path A では **Docker**
 - OpenAI Codex は ChatGPT OAuth でも利用できます。`LANGCHAIN_PROVIDER=openai-codex` を設定し、`vibe-trading provider login openai-codex` を実行してください。`OPENAI_API_KEY` は使いません。
 
-> **Supported LLM providers:** OpenRouter、OpenAI、DeepSeek、Gemini、Groq、DashScope/Qwen、Zhipu、Moonshot/Kimi、MiniMax、Xiaomi MIMO、Z.ai、Ollama（local）。設定は `.env.example` を参照してください。
+> **Supported LLM providers:** OpenRouter、OpenAI、OpenAI Codex（ChatGPT OAuth）、Claude Code（Pro/Max サブスクリプション）、DeepSeek、Gemini、Groq、DashScope/Qwen、Zhipu、Moonshot/Kimi、MiniMax、Xiaomi MIMO、Z.ai、Ollama（local）。設定は `.env.example` を参照してください。
 
 > **Tip:** 自動フォールバックにより、すべての市場は API key なしで利用できます。yfinance（HK/US）、OKX（crypto）、AKShare（A-shares、US、HK、futures、forex）はすべて無料です。Tushare token は任意で、A-shares は AKShare が無料 fallback としてカバーします。
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -321,7 +321,7 @@ vibe-trading-mcp               # start MCP server (stdio)
 - 경로 A용 **Docker**
 - OpenAI Codex도 ChatGPT OAuth로 사용할 수 있습니다. `LANGCHAIN_PROVIDER=openai-codex`를 설정한 뒤 `vibe-trading provider login openai-codex`를 실행하세요. 이 방식은 `OPENAI_API_KEY`를 사용하지 않습니다.
 
-> **지원 LLM provider:** OpenRouter, OpenAI, DeepSeek, Gemini, Groq, DashScope/Qwen, Zhipu, Moonshot/Kimi, MiniMax, Xiaomi MIMO, Z.ai, Ollama(local). 설정은 `.env.example`을 참고하세요.
+> **지원 LLM provider:** OpenRouter, OpenAI, OpenAI Codex(ChatGPT OAuth), Claude Code(Pro/Max 구독), DeepSeek, Gemini, Groq, DashScope/Qwen, Zhipu, Moonshot/Kimi, MiniMax, Xiaomi MIMO, Z.ai, Ollama(local). 설정은 `.env.example`을 참고하세요.
 
 > **팁:** 자동 fallback 덕분에 모든 시장은 API key 없이도 작동합니다. yfinance(HK/US), OKX(crypto), AKShare(A주, US, HK, futures, forex)는 모두 무료입니다. Tushare token은 선택 사항이며 AKShare가 A주 무료 fallback을 제공합니다.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -321,7 +321,7 @@ vibe-trading-mcp               # start MCP server (stdio)
 - 路径 A 需要 **Docker**
 - OpenAI Codex 也可通过 ChatGPT OAuth 使用：设置 `LANGCHAIN_PROVIDER=openai-codex`，然后运行 `vibe-trading provider login openai-codex`。它不使用 `OPENAI_API_KEY`。
 
-> **支持的 LLM providers：** OpenRouter、OpenAI、DeepSeek、Gemini、Groq、DashScope/Qwen、Zhipu、Moonshot/Kimi、MiniMax、Xiaomi MIMO、Z.ai、Ollama（本地）。配置见 `.env.example`。
+> **支持的 LLM providers：** OpenRouter、OpenAI、OpenAI Codex（ChatGPT OAuth）、Claude Code（Pro/Max 订阅）、DeepSeek、Gemini、Groq、DashScope/Qwen、Zhipu、Moonshot/Kimi、MiniMax、Xiaomi MIMO、Z.ai、Ollama（本地）。配置见 `.env.example`。
 
 > **提示：** 由于自动 fallback，所有市场都可以在没有任何 API key 的情况下工作。yfinance（港/美股）、OKX（加密）和 AKShare（A 股、美股、港股、期货、外汇）都是免费的。Tushare token 是可选项，AKShare 可作为 A 股免费 fallback。
 

--- a/agent/.env.example
+++ b/agent/.env.example
@@ -21,6 +21,24 @@ OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 # LANGCHAIN_MODEL_NAME=openai-codex/gpt-5.3-codex
 # OPENAI_CODEX_BASE_URL=https://chatgpt.com/backend-api/codex/responses
 
+# --- Claude Code (Pro/Max subscription via claude-agent-sdk) ---
+# Login first: claude login
+# Uses your Claude Pro/Max subscription instead of a paid API key. Auth is
+# managed by the Claude Code CLI (`claude login`); no API key needed here.
+# Requires the optional dependency:  pip install 'vibe-trading-ai[claude-code]'
+# (or: pip install claude-agent-sdk).
+# LIMITATION (v1): text completion only — tool calling is not yet supported
+# because Claude Agent SDK auto-executes tools in its own agent loop. Workflows
+# that need backtests/skills/etc. via tool calls should stay on
+# LANGCHAIN_PROVIDER=anthropic or =openrouter for now.
+# LANGCHAIN_PROVIDER=claude-code
+# LANGCHAIN_MODEL_NAME=                 # empty = use Claude Code CLI default
+# Optional: pin a model. Examples: claude-opus-4-7, claude-sonnet-4-6, claude-haiku-4-5
+# LANGCHAIN_MODEL_NAME=claude-sonnet-4-6
+# Optional: isolate the SDK's working directory so a project-level CLAUDE.md
+# doesn't bleed into agent responses. Defaults to a fresh temp dir.
+# CLAUDE_CODE_CWD=/tmp/vibe-trading-claude-code
+
 # --- DeepSeek ---
 # LANGCHAIN_PROVIDER=deepseek
 # LANGCHAIN_MODEL_NAME=deepseek-chat

--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -9,6 +9,10 @@ langgraph-checkpoint>=2.0.0
 python-dotenv>=1.0.0
 httpx>=0.28.0
 oauth-cli-kit>=0.1.3
+# Optional, opt-in dep for LANGCHAIN_PROVIDER=claude-code (Claude Pro/Max
+# subscription via claude-agent-sdk). ~58 MB. Install with:
+#   pip install 'vibe-trading-ai[claude-code]'
+# claude-agent-sdk>=0.1.81
 
 # Data & Computation
 pandas>=2.0.0

--- a/agent/src/providers/claude_code.py
+++ b/agent/src/providers/claude_code.py
@@ -1,0 +1,293 @@
+"""Claude Code (claude-agent-sdk) provider.
+
+This provider routes LLM calls through the user's Claude Code subscription
+(Pro / Max plan) instead of an Anthropic API key. It is intentionally
+separate from a regular Anthropic API integration because Claude Code's auth
+is OAuth-based (managed by ``claude login``) and its billing draws on the
+subscription's monthly credit pool, not on per-token API charges. Direct
+OAuth-token-as-API-bearer-key reuse is prohibited by Anthropic's Feb-2026
+ToS update; ``claude-agent-sdk`` is the supported path.
+
+Architecturally this is closest to the existing ``openai-codex`` provider
+(also OAuth-backed, also a separate code path because the auth flow is
+unrelated to the standard API-key path).
+
+**v1 scope (this module)**: text completion only. ``bind_tools`` raises a
+clear error pointing at the limitation — adding tool calling requires
+inverting Vibe-Trading's ReAct loop to fit Claude Agent SDK's auto-execute
+model, which is deferred to a follow-up PR. Single-turn, no streaming
+fan-out, no MCP wiring.
+
+Requires ``pip install claude-agent-sdk`` and a prior ``claude login``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Optional
+
+try:
+    import claude_agent_sdk as _cas
+except ImportError:
+    _cas = None  # type: ignore
+
+
+SUPPORTS_TOOL_CALLS_HINT = (
+    "The claude-code provider does not yet support tool calling — Claude Agent "
+    "SDK auto-executes tools in its own agent loop, which clashes with "
+    "Vibe-Trading's ReAct loop. Use LANGCHAIN_PROVIDER=anthropic or "
+    "LANGCHAIN_PROVIDER=openrouter for tool-using workflows. Tracking issue: TBD."
+)
+
+
+@dataclass
+class ClaudeCodeMessage:
+    """Minimal LangChain-like message returned by :class:`ClaudeCodeLLM`.
+
+    Matches the shape ``ChatLLM._parse_response`` reads from: ``content`` is a
+    string, ``tool_calls`` is a list, ``additional_kwargs`` carries reasoning
+    content (Claude Agent SDK exposes thinking blocks the same way the
+    Anthropic API does), ``response_metadata`` carries ``finish_reason``, and
+    ``usage_metadata`` is the per-turn usage dict the SDK reports.
+    """
+
+    content: str = ""
+    tool_calls: list[dict[str, Any]] = field(default_factory=list)
+    additional_kwargs: dict[str, Any] = field(default_factory=dict)
+    response_metadata: dict[str, Any] = field(default_factory=lambda: {"finish_reason": "stop"})
+    usage_metadata: Optional[dict[str, int]] = None
+
+    def __add__(self, other: "ClaudeCodeMessage") -> "ClaudeCodeMessage":
+        # Stream chunks aggregate via __add__ in chat.py; mirror the
+        # ChatOpenAI semantics so the rest of the codebase Just Works.
+        finish_reason = other.response_metadata.get(
+            "finish_reason",
+            self.response_metadata.get("finish_reason", "stop"),
+        )
+        reasoning = (
+            (self.additional_kwargs.get("reasoning_content") or "")
+            + (other.additional_kwargs.get("reasoning_content") or "")
+        )
+        usage = other.usage_metadata or self.usage_metadata
+        merged_kwargs = {**self.additional_kwargs, **other.additional_kwargs}
+        if reasoning:
+            merged_kwargs["reasoning_content"] = reasoning
+        return ClaudeCodeMessage(
+            content=(self.content or "") + (other.content or ""),
+            tool_calls=[*self.tool_calls, *other.tool_calls],
+            additional_kwargs=merged_kwargs,
+            response_metadata={"finish_reason": finish_reason},
+            usage_metadata=usage,
+        )
+
+
+_STOP_REASON_MAP = {
+    "end_turn": "stop",
+    "tool_use": "tool_calls",
+    "stop_sequence": "stop",
+    "max_tokens": "length",
+    "pause_turn": "stop",
+    "refusal": "content_filter",
+}
+
+
+def _flatten_messages_to_prompt(messages: list[dict[str, Any]]) -> tuple[str, str]:
+    """Split an OpenAI-style message list into (system_prompt, user_prompt).
+
+    Claude Agent SDK takes a single ``prompt`` string plus an optional
+    ``system_prompt`` override. We hoist any ``system`` role messages into
+    the system prompt and concatenate the rest with role markers so multi-turn
+    history is preserved as plain text. This is a v1 simplification —
+    multi-turn fidelity is best-effort because the SDK is not designed as a
+    drop-in single-turn LLM surface.
+    """
+    system_parts: list[str] = []
+    body_parts: list[str] = []
+    for msg in messages:
+        role = msg.get("role")
+        raw_content = msg.get("content")
+        if isinstance(raw_content, list):
+            # Best-effort: extract text segments from a structured content list.
+            text_parts: list[str] = []
+            for block in raw_content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    text_parts.append(block.get("text", ""))
+                elif isinstance(block, str):
+                    text_parts.append(block)
+            content = "\n".join(text_parts)
+        else:
+            content = str(raw_content or "")
+        if role == "system":
+            system_parts.append(content)
+        elif role == "user":
+            body_parts.append(f"[USER]\n{content}")
+        elif role == "assistant":
+            body_parts.append(f"[ASSISTANT]\n{content}")
+        elif role == "tool":
+            body_parts.append(f"[TOOL_RESULT]\n{content}")
+    system_prompt = "\n\n".join(p for p in system_parts if p)
+    user_prompt = "\n\n".join(body_parts) if body_parts else ""
+    return system_prompt, user_prompt
+
+
+def _extract_usage(usage: dict[str, Any] | None) -> Optional[dict[str, int]]:
+    """Normalise the SDK's usage dict to LangChain's ``UsageMetadata`` shape."""
+    if not usage:
+        return None
+    try:
+        return {
+            "input_tokens": int(usage.get("input_tokens", 0) or 0),
+            "output_tokens": int(usage.get("output_tokens", 0) or 0),
+            "total_tokens": int(
+                (usage.get("input_tokens", 0) or 0) + (usage.get("output_tokens", 0) or 0)
+            ),
+        }
+    except (TypeError, ValueError):
+        return None
+
+
+class ClaudeCodeLLM:
+    """Adapter for ``claude-agent-sdk``.
+
+    Mirrors the small ``invoke`` / ``ainvoke`` / ``stream`` / ``bind_tools``
+    surface :class:`OpenAICodexLLM` exposes — enough for Vibe-Trading's
+    :class:`ChatLLM` to drive without changes.
+
+    Args:
+        model: Claude model identifier. ``None`` keeps Claude Code's CLI
+            default (whatever the user has set).
+        temperature: Forwarded as a hint via ``extra_args`` (the SDK does not
+            currently expose a typed ``temperature`` knob — but Claude itself
+            still honours sampling parameters when present).
+        timeout: Per-call wall clock cap, seconds.
+        max_turns: Hard cap on the SDK's internal agent loop. Defaults to 1
+            so this acts as a single-turn LLM call.
+        cwd: Working directory the SDK runs in. Defaults to a fresh temp dir
+            so the user's project-level ``CLAUDE.md`` / CogniLayer hooks do
+            not bleed into agent responses.
+    """
+
+    def __init__(
+        self,
+        *,
+        model: Optional[str] = None,
+        temperature: float = 0.0,
+        timeout: int = 120,
+        max_turns: int = 1,
+        cwd: Optional[str] = None,
+    ) -> None:
+        if _cas is None:
+            raise RuntimeError(
+                "claude-agent-sdk is not installed. Run: pip install claude-agent-sdk "
+                "(or pip install 'vibe-trading-ai[claude-code]'). Also requires a prior "
+                "`claude login` so the SDK can use your Claude Pro/Max subscription."
+            )
+        self.model = model
+        self.temperature = temperature
+        self.timeout = timeout
+        self.max_turns = max_turns
+        # An isolated cwd avoids the user's project CLAUDE.md / plugin hooks
+        # bleeding into the system prompt the SDK builds.
+        self._cwd = cwd or tempfile.gettempdir()
+
+    def bind_tools(self, tools: list[dict[str, Any]]) -> "ClaudeCodeLLM":
+        """Refuse tool binding in v1 with a clear pointer.
+
+        Claude Agent SDK auto-executes tools inside its own agent loop, which
+        does not compose with Vibe-Trading's ReAct loop. A follow-up PR will
+        intercept tool calls via the SDK's PreToolUse hook + custom MCP server
+        to surface them to ``ChatLLM`` as ``response.tool_calls``.
+        """
+        if tools:
+            raise NotImplementedError(SUPPORTS_TOOL_CALLS_HINT)
+        return self
+
+    def _build_options(self, system_prompt: str) -> Any:
+        options = _cas.ClaudeAgentOptions(
+            tools=[],  # disable every built-in Claude Code tool (Read/Write/Bash/...)
+            allowed_tools=[],
+            mcp_servers={},
+            strict_mcp_config=True,
+            permission_mode="dontAsk",
+            max_turns=self.max_turns,
+            cwd=self._cwd,
+            include_partial_messages=False,
+            include_hook_events=False,
+        )
+        if self.model:
+            options.model = self.model
+        if system_prompt:
+            options.system_prompt = system_prompt
+        return options
+
+    async def _ainvoke_impl(self, messages: list[dict[str, Any]]) -> ClaudeCodeMessage:
+        system_prompt, user_prompt = _flatten_messages_to_prompt(messages)
+        if not user_prompt:
+            # Nothing to ask — return an empty response rather than calling out.
+            return ClaudeCodeMessage(content="")
+
+        options = self._build_options(system_prompt)
+        text_parts: list[str] = []
+        thinking_parts: list[str] = []
+        usage: Optional[dict[str, int]] = None
+        finish_reason = "stop"
+
+        async def _collect() -> None:
+            nonlocal usage, finish_reason
+            async for message in _cas.query(prompt=user_prompt, options=options):
+                if isinstance(message, _cas.AssistantMessage):
+                    for block in message.content or []:
+                        if isinstance(block, _cas.TextBlock):
+                            text_parts.append(block.text)
+                        elif isinstance(block, _cas.ThinkingBlock):
+                            thinking_parts.append(block.thinking or "")
+                    if message.usage:
+                        normalized = _extract_usage(message.usage)
+                        if normalized is not None:
+                            usage = normalized
+                elif isinstance(message, _cas.ResultMessage):
+                    stop_reason = message.stop_reason or ""
+                    finish_reason = _STOP_REASON_MAP.get(stop_reason, stop_reason or "stop")
+                    if message.usage:
+                        normalized = _extract_usage(message.usage)
+                        if normalized is not None:
+                            usage = normalized
+
+        await asyncio.wait_for(_collect(), timeout=self.timeout)
+
+        msg = ClaudeCodeMessage(
+            content="".join(text_parts),
+            response_metadata={"finish_reason": finish_reason},
+            usage_metadata=usage,
+        )
+        if thinking_parts:
+            msg.additional_kwargs["reasoning_content"] = "".join(thinking_parts)
+        return msg
+
+    def invoke(
+        self,
+        messages: list[dict[str, Any]],
+        config: Optional[dict[str, Any]] = None,
+    ) -> ClaudeCodeMessage:
+        return asyncio.run(self._ainvoke_impl(messages))
+
+    async def ainvoke(
+        self,
+        messages: list[dict[str, Any]],
+        config: Optional[dict[str, Any]] = None,
+    ) -> ClaudeCodeMessage:
+        return await self._ainvoke_impl(messages)
+
+    def stream(
+        self,
+        messages: list[dict[str, Any]],
+        config: Optional[dict[str, Any]] = None,
+    ) -> Iterable[ClaudeCodeMessage]:
+        # v1: emit the single completed message as one chunk so the existing
+        # stream-then-aggregate path in chat.py works without special-casing.
+        # Real token-level streaming via include_partial_messages=True is a
+        # follow-up — chunk shape needs additional careful handling.
+        yield self.invoke(messages, config=config)

--- a/agent/src/providers/llm.py
+++ b/agent/src/providers/llm.py
@@ -142,6 +142,13 @@ def _sync_provider_env() -> None:
         os.environ.pop("OPENAI_API_KEY", None)
         return
 
+    if provider in {"claude-code", "claude_code"}:
+        # claude-agent-sdk reads auth from `claude login` (Pro/Max subscription).
+        # No env projection needed — and explicitly do NOT touch OPENAI_API_KEY
+        # so the standard OpenAI key cannot leak into a Claude Code call path
+        # on a later provider switch within the same process.
+        return
+
     # (api_key_env, base_url_env)
     _PROVIDER_MAP: dict[str, tuple[str | None, str]] = {
         "openai":     ("OPENAI_API_KEY",     "OPENAI_BASE_URL"),
@@ -193,10 +200,13 @@ def build_llm(*, model_name: Optional[str] = None, callbacks: Any = None) -> Any
     """
     _sync_provider_env()
     name = model_name or os.getenv("LANGCHAIN_MODEL_NAME", "").strip()
-    if not name:
-        raise RuntimeError("LANGCHAIN_MODEL_NAME is not set")
     temperature = float(os.getenv("LANGCHAIN_TEMPERATURE", "0.0"))
     provider = os.getenv("LANGCHAIN_PROVIDER", "openai").lower()
+    # claude-code lets the SDK pick the model from the user's Claude Code CLI
+    # default when LANGCHAIN_MODEL_NAME is empty. Every other provider requires
+    # an explicit model name.
+    if not name and provider not in {"claude-code", "claude_code"}:
+        raise RuntimeError("LANGCHAIN_MODEL_NAME is not set")
     if provider in {"openai-codex", "openai_codex"}:
         from src.providers.openai_codex import OpenAICodexLLM
 
@@ -206,6 +216,16 @@ def build_llm(*, model_name: Optional[str] = None, callbacks: Any = None) -> Any
             temperature=temperature,
             timeout=int(os.getenv("TIMEOUT_SECONDS", "120")),
             reasoning_effort=effort or None,
+        )
+
+    if provider in {"claude-code", "claude_code"}:
+        from src.providers.claude_code import ClaudeCodeLLM
+
+        return ClaudeCodeLLM(
+            model=name or None,
+            temperature=temperature,
+            timeout=int(os.getenv("TIMEOUT_SECONDS", "120")),
+            cwd=os.getenv("CLAUDE_CODE_CWD", "").strip() or None,
         )
 
     if ChatOpenAI is None:

--- a/agent/src/providers/llm_providers.json
+++ b/agent/src/providers/llm_providers.json
@@ -29,6 +29,17 @@
     "login_command": "vibe-trading provider login openai-codex"
   },
   {
+    "name": "claude-code",
+    "label": "Claude Code (Pro/Max subscription)",
+    "api_key_env": null,
+    "base_url_env": "",
+    "default_model": "",
+    "default_base_url": "",
+    "api_key_required": false,
+    "auth_type": "oauth",
+    "login_command": "claude login"
+  },
+  {
     "name": "deepseek",
     "label": "DeepSeek",
     "api_key_env": "DEEPSEEK_API_KEY",

--- a/agent/tests/integration/README.md
+++ b/agent/tests/integration/README.md
@@ -1,0 +1,35 @@
+# Integration / live smoke tests
+
+These tests **call out to a real provider** and require credentials. They
+are opt-in only — the default `pytest agent/tests/` run skips them.
+
+## Claude Code (Pro/Max subscription)
+
+`test_claude_code_smoke.py` exercises `LANGCHAIN_PROVIDER=claude-code` end
+to end through the real `claude-agent-sdk` against the user's Claude Code
+subscription. No API key is required, but the user must have:
+
+1. Run `claude login` at some point.
+2. Installed the optional dependency: `pip install 'vibe-trading-ai[claude-code]'`
+   (or `pip install claude-agent-sdk`).
+
+To enable the smoke, export an opt-in flag (so accidental CI checkouts
+don't fire it):
+
+```bash
+export VIBE_TRADING_CLAUDE_CODE_SMOKE=1
+python -m pytest agent/tests/integration/test_claude_code_smoke.py -v -s --no-header
+```
+
+Without `VIBE_TRADING_CLAUDE_CODE_SMOKE=1` the test skips cleanly.
+
+The smoke prints the actual response text and the SDK's usage block to
+stdout via `print(...)` — capture-friendly for attaching to a PR.
+
+## Why isn't this a unit test?
+
+Mocking the SDK is already covered in `agent/tests/test_claude_code_provider.py`.
+The smoke is the only place that verifies our adapter actually matches the
+real SDK's runtime shape — message types, content blocks, stop_reason
+strings. It guards against drift when `claude-agent-sdk` releases a new
+version.

--- a/agent/tests/integration/test_claude_code_smoke.py
+++ b/agent/tests/integration/test_claude_code_smoke.py
@@ -1,0 +1,84 @@
+"""Live smoke test for ``LANGCHAIN_PROVIDER=claude-code``.
+
+**Opt-in only.** Skipped unless ``VIBE_TRADING_CLAUDE_CODE_SMOKE=1`` is
+exported AND the optional ``claude-agent-sdk`` dependency is installed
+AND the user has previously run ``claude login`` so the SDK can use their
+Claude Pro/Max subscription.
+
+Run:
+    pip install 'vibe-trading-ai[claude-code]'
+    claude login
+    export VIBE_TRADING_CLAUDE_CODE_SMOKE=1
+    python -m pytest agent/tests/integration/test_claude_code_smoke.py -v --no-header -s
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+def _sdk_importable() -> bool:
+    try:
+        import claude_agent_sdk  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+pytestmark = [
+    pytest.mark.skipif(
+        os.getenv("VIBE_TRADING_CLAUDE_CODE_SMOKE") != "1",
+        reason="VIBE_TRADING_CLAUDE_CODE_SMOKE=1 not set — opt-in only",
+    ),
+    pytest.mark.skipif(
+        not _sdk_importable(),
+        reason="claude-agent-sdk not installed (pip install 'vibe-trading-ai[claude-code]')",
+    ),
+]
+
+
+def test_basic_chat_via_claude_code_subscription() -> None:
+    """End-to-end through the real SDK: verify the adapter's response-shape
+    contract against the actual ``claude-agent-sdk`` runtime.
+
+    Asserts the four guarantees ``ChatLLM._parse_response`` depends on:
+    - ``response.content`` is a non-empty str.
+    - ``response.has_tool_calls`` is False (we don't pass any tools).
+    - ``response.finish_reason`` is the OpenAI-style ``"stop"`` (mapped from
+      Anthropic's ``"end_turn"``).
+    - ``response.usage_metadata`` is populated.
+    """
+    import src.providers.llm as llm_mod
+    llm_mod._dotenv_loaded = True
+    from src.providers.chat import ChatLLM
+
+    env = {
+        "LANGCHAIN_PROVIDER": "claude-code",
+        "LANGCHAIN_MODEL_NAME": os.getenv("VIBE_TRADING_CLAUDE_CODE_SMOKE_MODEL", ""),
+        "TIMEOUT_SECONDS": "180",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        client = ChatLLM()
+        response = client.chat([
+            {"role": "system", "content": "Reply in exactly one short sentence."},
+            {"role": "user", "content": "In one sentence: what is 2 + 2?"},
+        ])
+
+    assert isinstance(response.content, str), "content must be a str (wrapper flatten contract)"
+    assert response.content, "expected non-empty response from Claude"
+    assert response.has_tool_calls is False
+    assert response.finish_reason in {"stop", "length"}, (
+        f"unexpected finish_reason {response.finish_reason!r} — stop_reason mapping may be off"
+    )
+    assert response.usage_metadata is not None, "usage_metadata must flow through"
+    assert response.usage_metadata.get("input_tokens", 0) > 0
+    assert response.usage_metadata.get("output_tokens", 0) > 0
+
+    print(
+        f"\n[claude-code smoke] finish={response.finish_reason} "
+        f"usage={response.usage_metadata} "
+        f"content[:140]={response.content[:140]!r}"
+    )

--- a/agent/tests/test_claude_code_provider.py
+++ b/agent/tests/test_claude_code_provider.py
@@ -1,0 +1,371 @@
+"""Tests for the Claude Code (claude-agent-sdk) provider adapter.
+
+Mirrors :mod:`tests.test_openai_codex` in shape: mock the SDK boundary, cover
+env wiring, build_llm dispatch, the documented v1 tool-calling limitation,
+and the response-shape contract :class:`ChatLLM._parse_response` depends on.
+
+No live calls. The opt-in smoke harness lives at
+``agent/tests/integration/test_claude_code_smoke.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.providers import llm as llm_mod
+
+
+def _install_fake_sdk(monkeypatch: pytest.MonkeyPatch, *, assistant_text: str,
+                      thinking: str = "", stop_reason: str = "end_turn",
+                      usage: dict | None = None, captured: dict | None = None) -> types.ModuleType:
+    """Install a stand-in ``claude_agent_sdk`` module that yields a fixed reply.
+
+    Returns the fake module so individual tests can inspect call args.
+    Mutates the captured dict (if provided) with ``options`` + ``prompt``
+    seen by the most recent ``query`` call — this is how we assert that
+    ``_build_options`` produces an isolated, no-tools, strict-MCP session.
+    """
+    captured = captured if captured is not None else {}
+
+    class _TextBlock:
+        def __init__(self, text: str) -> None:
+            self.text = text
+
+    class _ThinkingBlock:
+        def __init__(self, thinking: str) -> None:
+            self.thinking = thinking
+
+    class _AssistantMessage:
+        def __init__(self, content, usage_in=None) -> None:
+            self.content = content
+            self.usage = usage_in
+
+    class _ResultMessage:
+        def __init__(self, stop_reason_in: str, usage_in: dict | None) -> None:
+            self.stop_reason = stop_reason_in
+            self.usage = usage_in
+
+    class _Options:
+        # Use a plain class to allow attribute assignment; the real SDK uses a
+        # dataclass — what we care about is "did the adapter set these
+        # attributes correctly?", not the precise type.
+        def __init__(self, **kwargs) -> None:
+            self.__dict__.update(kwargs)
+
+    async def _fake_query(*, prompt, options):
+        captured["prompt"] = prompt
+        captured["options"] = options
+        blocks = []
+        if thinking:
+            blocks.append(_ThinkingBlock(thinking))
+        if assistant_text:
+            blocks.append(_TextBlock(assistant_text))
+        yield _AssistantMessage(content=blocks, usage_in=usage)
+        yield _ResultMessage(stop_reason_in=stop_reason, usage_in=usage)
+
+    fake = types.ModuleType("claude_agent_sdk")
+    fake.query = _fake_query
+    fake.AssistantMessage = _AssistantMessage
+    fake.TextBlock = _TextBlock
+    fake.ThinkingBlock = _ThinkingBlock
+    fake.ResultMessage = _ResultMessage
+    fake.ClaudeAgentOptions = _Options
+
+    monkeypatch.setitem(sys.modules, "claude_agent_sdk", fake)
+    # The provider module caches the import at top-level — patch its reference too.
+    from src.providers import claude_code as cc_mod
+    monkeypatch.setattr(cc_mod, "_cas", fake)
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# llm_providers.json: claude-code entry shape
+# ---------------------------------------------------------------------------
+
+
+def test_claude_code_listed_in_llm_providers_json() -> None:
+    providers_path = Path(__file__).resolve().parents[1] / "src" / "providers" / "llm_providers.json"
+    providers = json.loads(providers_path.read_text(encoding="utf-8"))
+    entry = next((p for p in providers if p["name"] == "claude-code"), None)
+
+    assert entry is not None
+    # Subscription-backed: no API key path.
+    assert entry["api_key_env"] is None
+    assert entry["api_key_required"] is False
+    # Settings UI distinguishes this from api_key auth so it can prompt the
+    # `claude login` command instead of asking for a key.
+    assert entry["auth_type"] == "oauth"
+    assert entry["login_command"] == "claude login"
+    # Subscription-managed endpoint — no user-configurable base URL.
+    assert entry["base_url_env"] == ""
+    assert entry["default_base_url"] == ""
+
+
+# ---------------------------------------------------------------------------
+# _sync_provider_env: claude-code short-circuit
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeCodeProviderEnv:
+    """The claude-code branch must NOT touch OPENAI_API_KEY. Mirrors the
+    isolation rule the openai-codex provider already enforces — leaking any
+    key into OPENAI_API_KEY would route it to OpenAI-compat clients on a
+    later provider switch within the same process.
+    """
+
+    def _run_sync(self, env: dict[str, str]) -> dict[str, str]:
+        llm_mod._dotenv_loaded = True
+        clean = {k: v for k, v in os.environ.items() if not k.startswith(("OPENAI_", "LANGCHAIN_"))}
+        clean.update(env)
+        with patch.dict(os.environ, clean, clear=True):
+            llm_mod._sync_provider_env()
+            return {
+                "OPENAI_API_KEY": os.environ.get("OPENAI_API_KEY", ""),
+                "OPENAI_API_BASE": os.environ.get("OPENAI_API_BASE", ""),
+                "OPENAI_BASE_URL": os.environ.get("OPENAI_BASE_URL", ""),
+            }
+
+    def test_claude_code_does_not_touch_openai_envs(self) -> None:
+        result = self._run_sync({"LANGCHAIN_PROVIDER": "claude-code"})
+        assert result["OPENAI_API_KEY"] == ""
+        assert result["OPENAI_API_BASE"] == ""
+
+    def test_underscore_alias_routes_to_claude_code_branch(self) -> None:
+        result = self._run_sync({"LANGCHAIN_PROVIDER": "claude_code"})
+        assert result["OPENAI_API_KEY"] == ""
+
+    def test_preexisting_openai_key_not_clobbered_under_claude_code(self) -> None:
+        # The short-circuit returns before the projection block, so an OPENAI_API_KEY
+        # the user happens to have set stays exactly where it was.
+        result = self._run_sync({
+            "LANGCHAIN_PROVIDER": "claude-code",
+            "OPENAI_API_KEY": "sk-leftover-from-earlier",
+        })
+        assert result["OPENAI_API_KEY"] == "sk-leftover-from-earlier"
+
+
+# ---------------------------------------------------------------------------
+# build_llm: dispatch + error paths
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeCodeBuildLlm:
+    def setup_method(self) -> None:
+        llm_mod._dotenv_loaded = True
+
+    def test_build_llm_returns_claude_code_adapter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _install_fake_sdk(monkeypatch, assistant_text="ok")
+        env = {
+            "LANGCHAIN_PROVIDER": "claude-code",
+            "LANGCHAIN_MODEL_NAME": "claude-sonnet-4-6",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            adapter = llm_mod.build_llm()
+
+        from src.providers.claude_code import ClaudeCodeLLM
+        assert isinstance(adapter, ClaudeCodeLLM)
+        assert adapter.model == "claude-sonnet-4-6"
+
+    def test_build_llm_allows_empty_model_for_claude_code(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Unlike every other provider, an empty LANGCHAIN_MODEL_NAME is valid
+        # here — the SDK falls back to the Claude Code CLI's default model.
+        _install_fake_sdk(monkeypatch, assistant_text="ok")
+        env = {"LANGCHAIN_PROVIDER": "claude-code"}
+        with patch.dict(os.environ, env, clear=True):
+            adapter = llm_mod.build_llm()
+        assert adapter.model is None
+
+    def test_build_llm_still_requires_model_name_for_other_providers(self) -> None:
+        env = {"LANGCHAIN_PROVIDER": "openai"}
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(RuntimeError, match="LANGCHAIN_MODEL_NAME is not set"):
+                llm_mod.build_llm()
+
+    def test_missing_sdk_raises_install_hint(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from src.providers import claude_code as cc_mod
+        monkeypatch.setattr(cc_mod, "_cas", None)
+        with patch.dict(os.environ, {"LANGCHAIN_PROVIDER": "claude-code"}, clear=True):
+            with pytest.raises(RuntimeError, match=r"claude-agent-sdk is not installed"):
+                llm_mod.build_llm()
+
+
+# ---------------------------------------------------------------------------
+# ClaudeCodeLLM.invoke: response shape + isolation guards
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeCodeInvoke:
+    def setup_method(self) -> None:
+        llm_mod._dotenv_loaded = True
+
+    def test_invoke_returns_flattened_text_and_finish_reason(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _install_fake_sdk(
+            monkeypatch,
+            assistant_text="Hello from Claude.",
+            stop_reason="end_turn",
+            usage={"input_tokens": 12, "output_tokens": 5},
+        )
+        from src.providers.claude_code import ClaudeCodeLLM
+        adapter = ClaudeCodeLLM(model="claude-sonnet-4-6")
+
+        msg = adapter.invoke([
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": "Say hi."},
+        ])
+
+        assert msg.content == "Hello from Claude."
+        assert msg.response_metadata["finish_reason"] == "stop"
+        assert msg.usage_metadata == {"input_tokens": 12, "output_tokens": 5, "total_tokens": 17}
+        assert msg.tool_calls == []
+
+    def test_invoke_surfaces_thinking_via_reasoning_content(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _install_fake_sdk(
+            monkeypatch,
+            assistant_text="42.",
+            thinking="Let me reason step by step...",
+            stop_reason="end_turn",
+        )
+        from src.providers.claude_code import ClaudeCodeLLM
+        adapter = ClaudeCodeLLM(model="claude-sonnet-4-6")
+
+        msg = adapter.invoke([{"role": "user", "content": "what is the answer?"}])
+
+        assert msg.content == "42."
+        assert msg.additional_kwargs["reasoning_content"] == "Let me reason step by step..."
+
+    def test_invoke_maps_stop_reason_tool_use_to_tool_calls_finish_reason(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _install_fake_sdk(monkeypatch, assistant_text="...", stop_reason="tool_use")
+        from src.providers.claude_code import ClaudeCodeLLM
+        adapter = ClaudeCodeLLM()
+
+        msg = adapter.invoke([{"role": "user", "content": "x"}])
+        assert msg.response_metadata["finish_reason"] == "tool_calls"
+
+    def test_invoke_maps_max_tokens_to_length(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _install_fake_sdk(monkeypatch, assistant_text="...", stop_reason="max_tokens")
+        from src.providers.claude_code import ClaudeCodeLLM
+        adapter = ClaudeCodeLLM()
+        msg = adapter.invoke([{"role": "user", "content": "x"}])
+        assert msg.response_metadata["finish_reason"] == "length"
+
+    def test_invoke_with_empty_messages_returns_empty_without_calling_sdk(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict = {}
+        _install_fake_sdk(monkeypatch, assistant_text="should not be called", captured=captured)
+        from src.providers.claude_code import ClaudeCodeLLM
+        adapter = ClaudeCodeLLM()
+
+        msg = adapter.invoke([{"role": "system", "content": "system only, no user turn"}])
+        assert msg.content == ""
+        assert "prompt" not in captured  # SDK was never called
+
+    def test_options_disable_builtin_tools_and_strict_mcp(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Isolation guarantee: the SDK MUST be configured so the user's
+        # Claude Code plugins / MCP servers / CLAUDE.md cannot bleed in.
+        captured: dict = {}
+        _install_fake_sdk(monkeypatch, assistant_text="ok", captured=captured)
+        from src.providers.claude_code import ClaudeCodeLLM
+        adapter = ClaudeCodeLLM(model="claude-sonnet-4-6")
+
+        adapter.invoke([{"role": "user", "content": "hi"}])
+
+        opts = captured["options"]
+        assert opts.tools == []
+        assert opts.allowed_tools == []
+        assert opts.mcp_servers == {}
+        assert opts.strict_mcp_config is True
+        assert opts.max_turns == 1
+        assert opts.permission_mode == "dontAsk"
+        assert opts.model == "claude-sonnet-4-6"
+
+    def test_options_carry_system_prompt_from_system_message(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict = {}
+        _install_fake_sdk(monkeypatch, assistant_text="ok", captured=captured)
+        from src.providers.claude_code import ClaudeCodeLLM
+        adapter = ClaudeCodeLLM()
+
+        adapter.invoke([
+            {"role": "system", "content": "You are a trading agent."},
+            {"role": "user", "content": "buy BTC"},
+        ])
+
+        opts = captured["options"]
+        assert opts.system_prompt == "You are a trading agent."
+        assert "[USER]" in captured["prompt"]
+        assert "buy BTC" in captured["prompt"]
+
+    def test_cwd_defaults_to_temp_dir(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # An isolated cwd is the second half of the no-bleed guarantee — if
+        # the SDK ran in the user's project root, their CLAUDE.md would be
+        # auto-included in the system prompt.
+        import tempfile
+        captured: dict = {}
+        _install_fake_sdk(monkeypatch, assistant_text="ok", captured=captured)
+        from src.providers.claude_code import ClaudeCodeLLM
+        adapter = ClaudeCodeLLM()
+
+        adapter.invoke([{"role": "user", "content": "hi"}])
+
+        opts = captured["options"]
+        assert opts.cwd == tempfile.gettempdir()
+
+    def test_custom_cwd_passed_through(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict = {}
+        _install_fake_sdk(monkeypatch, assistant_text="ok", captured=captured)
+        from src.providers.claude_code import ClaudeCodeLLM
+        adapter = ClaudeCodeLLM(cwd="/tmp/custom-cc-cwd")
+
+        adapter.invoke([{"role": "user", "content": "hi"}])
+
+        assert captured["options"].cwd == "/tmp/custom-cc-cwd"
+
+
+# ---------------------------------------------------------------------------
+# bind_tools: v1 must reject tools with a clear hint
+# ---------------------------------------------------------------------------
+
+
+class TestBindToolsRejection:
+    def test_bind_tools_with_tools_raises_not_implemented(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _install_fake_sdk(monkeypatch, assistant_text="ok")
+        from src.providers.claude_code import ClaudeCodeLLM, SUPPORTS_TOOL_CALLS_HINT
+        adapter = ClaudeCodeLLM()
+
+        with pytest.raises(NotImplementedError, match="tool calling"):
+            adapter.bind_tools([{"type": "function", "function": {"name": "x"}}])
+        assert "Claude Agent SDK" in SUPPORTS_TOOL_CALLS_HINT
+
+    def test_bind_tools_with_empty_list_returns_self(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # ``ChatLLM.chat(..., tools=None)`` never calls ``bind_tools``, but
+        # ``bind_tools([])`` should still work as a no-op so callers don't have
+        # to special-case empty lists.
+        _install_fake_sdk(monkeypatch, assistant_text="ok")
+        from src.providers.claude_code import ClaudeCodeLLM
+        adapter = ClaudeCodeLLM()
+        assert adapter.bind_tools([]) is adapter
+
+
+# ---------------------------------------------------------------------------
+# Stream wrapper: yields one aggregated message
+# ---------------------------------------------------------------------------
+
+
+class TestStream:
+    def test_stream_yields_single_completed_message(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # v1 simplification: stream() yields the fully aggregated message as
+        # one chunk so the stream-then-aggregate code path in chat.py still
+        # works without provider-specific branching.
+        _install_fake_sdk(monkeypatch, assistant_text="Hi.", stop_reason="end_turn")
+        from src.providers.claude_code import ClaudeCodeLLM
+        adapter = ClaudeCodeLLM()
+
+        chunks = list(adapter.stream([{"role": "user", "content": "hi"}]))
+        assert len(chunks) == 1
+        assert chunks[0].content == "Hi."
+        assert chunks[0].response_metadata["finish_reason"] == "stop"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,12 @@ dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
 ]
+# LANGCHAIN_PROVIDER=claude-code dependency. ~58 MB; opt-in only so the
+# default `pip install vibe-trading-ai` stays lightweight. Requires a prior
+# `claude login` to use the user's Pro/Max subscription.
+claude-code = [
+    "claude-agent-sdk>=0.1.81",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["agent/tests"]


### PR DESCRIPTION
## Summary

Adds a new `LANGCHAIN_PROVIDER=claude-code` provider that routes LLM calls through the user's **Claude Pro/Max subscription** instead of a paid Anthropic API key. Uses the official `claude-agent-sdk` Python package, which delegates auth to `claude login`. Independent of #105 — sits alongside the existing 13 providers as a fresh code path.

**Why a separate provider?** Anthropic's Feb-2026 ToS update prohibits direct OAuth-token-as-API-bearer reuse, and `claude-agent-sdk` is the supported path for programmatic Claude Max usage. Auth, billing, and the transport layer are all different from the regular Anthropic API path — analogous to the existing `openai-codex` precedent in this repo (also OAuth, also a separate adapter).

## v1 scope (deliberate)

- **Text completion only.** `bind_tools()` raises `NotImplementedError` with a clear pointer.
- **Tool calling deferred.** Claude Agent SDK auto-executes tools inside its own agent loop, which doesn't compose with Vibe-Trading's ReAct loop. Inverting that to surface tool calls as `response.tool_calls` needs the SDK's PreToolUse hook + a custom MCP server — non-trivial, follow-up PR.
- **Recommendation in docs:** Workflows that need backtests/skills/etc. via tool calls should stay on `LANGCHAIN_PROVIDER=anthropic` or `=openrouter`. The `claude-code` provider is useful today for swarm reports, doc summarization, single-turn chat — anywhere tools aren't required.

## Isolation guarantees

The SDK is built to *be* Claude Code, not to be a thin LLM wrapper. The adapter clamps every escape hatch:

- `_sync_provider_env` short-circuits for `claude-code`/`claude_code` **before** touching `OPENAI_*`, so the user's standard OpenAI key can't leak into a Claude Code call path on a later provider switch within the same process (same pattern as `openai-codex`).
- `ClaudeCodeLLM._build_options` sets `tools=[]`, `allowed_tools=[]`, `mcp_servers={}`, `strict_mcp_config=True`, `permission_mode=\"dontAsk\"`, `max_turns=1`, and isolates `cwd` (defaults to a fresh temp dir). Together this prevents the user's Claude Code plugins, MCP servers, and project-level `CLAUDE.md` from bleeding into Vibe-Trading agent responses.
- The system message from the OpenAI-style message list is hoisted into the SDK's `system_prompt` so the model sees exactly the prompt Vibe-Trading constructed.

## Response-shape contract

The adapter returns a `ClaudeCodeMessage` shaped exactly like what `ChatLLM._parse_response` consumes:

- `content` flattened to a string (concatenated `TextBlock` content).
- Thinking surfaces via `additional_kwargs[\"reasoning_content\"]` (same key Moonshot/DeepSeek use — parser works unchanged).
- `stop_reason` mapped to OpenAI-style `finish_reason`: `end_turn`→`stop`, `tool_use`→`tool_calls`, `stop_sequence`→`stop`, `max_tokens`→`length`, `pause_turn`→`stop`, `refusal`→`content_filter`.
- `usage_metadata` normalized to LangChain's `{input_tokens, output_tokens, total_tokens}` shape.

## Optional dependency

`claude-agent-sdk` is ~58 MB. To keep the default install lightweight, it lives in a new `claude-code` extra:

```bash
pip install 'vibe-trading-ai[claude-code]'  # or: pip install claude-agent-sdk
claude login                                  # then this
export LANGCHAIN_PROVIDER=claude-code
```

`agent/.env.example` documents the model knob (`LANGCHAIN_MODEL_NAME` is optional — empty defers to the Claude Code CLI default; `claude-opus-4-7` / `claude-sonnet-4-6` / `claude-haiku-4-5` are valid).

## Test plan

**20 new mock tests + 1 opt-in live smoke. Full default suite: 973 passed.**

- [x] `llm_providers.json` claude-code entry shape (subscription auth + no base URL)
- [x] `_sync_provider_env` does not touch `OPENAI_*` (3 cases incl. preserving pre-existing OpenAI key)
- [x] `build_llm` dispatch + missing-SDK error path + empty-`LANGCHAIN_MODEL_NAME` allowed for claude-code (still required for every other provider)
- [x] `invoke()`: flatten contract, reasoning_content extraction, all 4 main stop_reason mappings, empty-messages short-circuit
- [x] Options isolation: `tools=[]`, `strict_mcp_config=True`, `max_turns=1`, `permission_mode=dontAsk`, system_prompt hoist, cwd defaults + override
- [x] `bind_tools` rejects non-empty tools; no-ops on `[]`
- [x] `stream()` yields one aggregated message (v1 simplification — real token-level streaming is a follow-up)

**Live smoke** at `agent/tests/integration/test_claude_code_smoke.py`. Gated on `VIBE_TRADING_CLAUDE_CODE_SMOKE=1` + `claude-agent-sdk` importable, so default CI stays mock-only with no credentials.

Verified locally against the contributor's Claude Max plan:

```
[claude-code smoke] finish=stop usage={'input_tokens': 6, 'output_tokens': 16, 'total_tokens': 22} content[:140]='2 + 2 equals 4.'
```

```bash
# Default CI suite (no API keys, no claude login):
python -m pytest agent/tests/ --ignore=agent/tests/integration  # 973 passed

# Live smoke (requires claude login + the [claude-code] extra):
pip install 'vibe-trading-ai[claude-code]'
claude login
VIBE_TRADING_CLAUDE_CODE_SMOKE=1 python -m pytest agent/tests/integration/test_claude_code_smoke.py -v -s
```

## Docs

- README + 4 localized READMEs updated to list Claude Code in the supported-providers line.
- `.env.example` block with prerequisites + the v1 tool-calling limitation called out explicitly.
- `pyproject.toml` `claude-code` extra pinning `claude-agent-sdk>=0.1.81`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)