### PR TITLE
feat(swarm): universal data-citation discipline in worker prompt

### DIFF
--- a/agent/src/swarm/worker.py
+++ b/agent/src/swarm/worker.py
@@ -192,6 +192,36 @@ def build_worker_prompt(
         # instruction to prefer these prices over training data.
         prompt_parts.append(grounding_block)
 
+    # Universal anti-fabrication rule. The grounding_block carries a similar
+    # instruction but only renders when user_vars supplies explicit symbols.
+    # Free-form prompts ("look at A-share short-term sentiment") otherwise
+    # leave the worker with no guardrail and it cheerfully cites training-data
+    # prices and sector weights. This block applies the rule unconditionally
+    # — including to aggregator / synthesis agents that have no data tools
+    # and previously had no instruction against inventing numbers.
+    prompt_parts.append(
+        "## Data Citation Discipline (HARD RULE)\n\n"
+        "Every specific number you cite in your output — prices, percentages, "
+        "volumes, fund flows, market-cap rankings, sector weights, ETF codes, "
+        "ticker recommendations — MUST be traceable to one of:\n"
+        "  (a) a tool call result obtained in THIS run,\n"
+        "  (b) the Ground Truth block above (if present),\n"
+        "  (c) the Upstream Context above (if present and the upstream agent "
+        "itself sourced it from (a) or (b)).\n\n"
+        "You may NOT cite numbers from memory or training data. Markets have "
+        "moved since your cutoff; any specific price/percentage you recall is "
+        "wrong by default.\n\n"
+        "If you cannot back a number with (a), (b), or (c), you have two "
+        "choices:\n"
+        "  - call a data tool to fetch it (preferred), or\n"
+        "  - omit the number and qualify the statement (e.g. \"directional "
+        "only — not verified against live data\").\n\n"
+        "This rule applies equally to synthesis / aggregator / editor roles "
+        "that lack data tools. If upstream did not provide a specific number, "
+        "do NOT introduce one from training data — say the upstream omitted "
+        "it and proceed without."
+    )
+
     prompt_parts.append(
         "## Execution Rules\n\n"
         "You have a HARD LIMIT of 20 tool calls. After that you will be cut off. Work efficiently.\n\n"

--- a/agent/tests/test_swarm_grounding.py
+++ b/agent/tests/test_swarm_grounding.py
@@ -205,7 +205,45 @@ def test_worker_prompt_includes_grounding_block_when_provided() -> None:
 
 def test_worker_prompt_omits_grounding_section_when_block_empty() -> None:
     prompt = build_worker_prompt(_spec(), {}, "(no matching skills)")
-    assert "Ground Truth" not in prompt
+    # No rendered Ground Truth section. The Data Citation Discipline below
+    # may reference "Ground Truth block above (if present)" as a referent;
+    # that's fine. What must not appear is the actual section header.
+    assert "## Ground Truth" not in prompt
+
+
+def test_worker_prompt_always_includes_data_citation_discipline() -> None:
+    """Universal anti-fabrication rule: must appear regardless of whether
+    grounding_block or upstream_summaries were provided.  Issue #106 reported
+    swarm reports citing prices the agent never actually fetched; the
+    grounding-block rule only covered runs with explicit symbols in user_vars."""
+    bare = build_worker_prompt(_spec(), {}, "(no matching skills)")
+    assert "Data Citation Discipline" in bare
+    assert "HARD RULE" in bare
+    assert "may NOT cite numbers from memory or training data" in bare
+
+    with_grounding = build_worker_prompt(
+        _spec(), {}, "(no matching skills)",
+        grounding_block="## Ground Truth — Recent Market Data\n\nNVDA.US ...",
+    )
+    assert with_grounding.count("Data Citation Discipline") == 1
+
+
+def test_worker_prompt_data_citation_discipline_precedes_execution_rules() -> None:
+    """The discipline must be in scope before Phase 1/2/3 execution rules
+    so the worker sees it while planning the first tool call."""
+    prompt = build_worker_prompt(_spec(), {}, "(no matching skills)")
+    assert prompt.index("Data Citation Discipline") < prompt.index("## Execution Rules")
+
+
+def test_worker_prompt_data_citation_rule_targets_aggregator_roles() -> None:
+    """The rule must explicitly address synthesis / aggregator agents
+    that lack data tools, since those were the worst-case path in #106
+    (equity_research_team aggregator has [bash, read_file, write_file] only)."""
+    prompt = build_worker_prompt(_spec(), {}, "(no matching skills)")
+    # Aggregators must be told not to invent numbers upstream omitted.
+    lowered = prompt.lower()
+    assert "synthesis" in lowered or "aggregator" in lowered
+    assert "upstream did not provide" in prompt
 
 
 def test_runtime_threads_grounding_block_into_layer_workers(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Fixes #106. Swarm reports were citing prices, ETF codes, and sector weights the agent never actually fetched — the LLM filled in numbers from training data when no grounding constraint was in scope.

## Root cause

The anti-fabrication rule lived inside `grounding.py`'s "Ground Truth" block, which only renders when `user_vars` carries an explicit symbol the loader can resolve. Free-form prompts like *"看看 A 股短线情绪，推荐一只 ETF"* never trigger grounding, so the worker had no instruction against citing training-data numbers.

Worse, aggregator / synthesizer agents in presets like `equity_research_team` have `tools=[bash, read_file, write_file]` with **zero data tools** — they synthesize whatever upstream passed via `{upstream_context}` and previously had no defense against inventing numbers that upstream omitted.

## Fix

Lift the citation rule into `build_worker_prompt` as a universal **Data Citation Discipline** section:

- Renders unconditionally (even when `grounding_block` is empty)
- Placed before Execution Rules so it's in scope when the worker plans its first tool call
- Explicitly addresses synthesis / aggregator / editor roles that lack data tools
- Numbers must trace to (a) a tool call in this run, (b) the Ground Truth block above, or (c) Upstream Context that itself sourced from (a) or (b) — otherwise omit or qualify

Applies to **all 29 shipped swarm presets automatically** via the central worker prompt builder; no per-preset YAML edits needed.

## Verification

I ran the reporter's exact failure shape locally before writing the fix:

```
python cli.py run --no-rich --max-iter 15 -p "根据今天的A股短线情绪和最新行情数据，推荐1只值得短线关注的ETF..."
```

`deepseek-v4-pro` already fetched real akshare data (9 bash + 4 web_search calls). Final report cited 上证 5/15 close = **4,135.39 (-1.02%)**; akshare ground truth = **4135.389 (-1.02%)**. The current default config is already healthy for single-agent. This PR hardens the prompt so:

- Weaker models the reporter mentioned (glm4.7 / deepseek3.2 / kimi2.6) hit a hard rule, not a soft hint
- Long-context aggregator roles can't introduce numbers upstream omitted
- Free-form queries (no explicit symbol → no grounding block) still get the constraint

## Test plan

- [x] 4 new tests in `test_swarm_grounding.py` covering: discipline always present, single occurrence when grounding present, ordering before Execution Rules, explicit aggregator-role coverage
- [x] Tightened `test_worker_prompt_omits_grounding_section_when_block_empty` to assert against the section header `## Ground Truth` rather than the bare string (the new discipline mentions "Ground Truth block above" as a referent, which is intentional)
- [x] Full swarm test suite green locally (35/35 in 1.09s)

```bash
python -m pytest tests/test_swarm_grounding.py tests/test_swarm_worker_report.py tests/test_swarm_preset_inspect.py tests/test_swarm_presets_packaging.py -q
```

## Follow-ups (deferred)

Beyond this PR's scope but worth tracking:
- **Aggregator preset YAML** in `equity_research_team` and similar — give the aggregator role a `factor_analysis` / data-fetch tool so it can sanity-check upstream numbers rather than only synthesize
- **Pre-fetch agent in swarm DAG** — a controller agent that intercepts the user prompt, infers required data, fetches it, and threads results into downstream `{upstream_context}`. Bigger design change, separate PR.