### PR TITLE
fix(loop): populate reason field on AgentLoop cancelled / max-iter exits

### DIFF
--- a/agent/src/agent/loop.py
+++ b/agent/src/agent/loop.py
@@ -435,27 +435,46 @@ class AgentLoop:
                 "react_trace": react_trace,
             }
 
-        # Determine final status
+        # Determine final status. The reason is also propagated into the
+        # returned dict so SessionService can surface a meaningful UI
+        # message instead of "Execution failed: unknown" (issue #114).
+        final_reason: str | None = None
         if self._cancelled:
-            state_store.mark_failure(run_dir, "cancelled by user")
+            final_reason = "cancelled by user"
+            state_store.mark_failure(run_dir, final_reason)
             final_status = "cancelled"
         elif (run_dir / "artifacts" / "metrics.csv").exists() or final_content:
             state_store.mark_success(run_dir)
             final_status = "success"
         else:
-            state_store.mark_failure(run_dir, "pipeline did not complete")
+            final_reason = (
+                f"reached max iterations ({self.max_iterations}) without final answer"
+            )
+            state_store.mark_failure(run_dir, final_reason)
             final_status = "failed"
 
-        trace.write({"type": "end", "status": final_status, "iterations": iteration})
+        end_event: dict[str, Any] = {
+            "type": "end",
+            "status": final_status,
+            "iterations": iteration,
+        }
+        if final_reason is not None:
+            end_event["reason"] = final_reason
+        trace.write(end_event)
         trace.close()
 
-        return {
+        result: dict[str, Any] = {
             "status": final_status,
             "run_dir": str(run_dir),
             "run_id": run_dir.name,
             "content": final_content,
             "react_trace": react_trace,
+            "iterations": iteration,
+            "max_iterations": self.max_iterations,
         }
+        if final_reason is not None:
+            result["reason"] = final_reason
+        return result
 
     # -- Tool execution with read/write batching --------------------------------
 

--- a/agent/tests/test_agent_loop_terminal_state.py
+++ b/agent/tests/test_agent_loop_terminal_state.py
@@ -1,0 +1,140 @@
+"""Regression tests for AgentLoop terminal-state result dict (issue #114).
+
+Before the fix, AgentLoop.run() returned a dict missing the `reason` field
+on the cancelled and max-iter-failed branches even though state.json on
+disk recorded a useful reason. SessionService then surfaced
+'Execution failed: unknown' to the chat UI.
+
+These tests exercise both terminal paths with a stubbed LLM so the loop
+exits without hitting any real API.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+
+from src.agent.loop import AgentLoop
+
+
+class _StubLLMResponse:
+    """Minimal stand-in for ChatLLM's response object."""
+
+    def __init__(self) -> None:
+        self.content = ""
+        self.tool_calls: list[Any] = []
+        self.reasoning_content: str | None = None
+        self.has_tool_calls = False
+
+
+class _StubLLMNoFinal:
+    """LLM stub that always returns an empty answer with no tool calls.
+
+    Triggers the 'pipeline did not complete' branch on the first iteration
+    because `final_content` stays empty and no `metrics.csv` is written.
+    """
+
+    def stream_chat(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[Any] | None = None,
+        on_text_chunk: Callable[[str], None] | None = None,
+    ) -> _StubLLMResponse:
+        return _StubLLMResponse()
+
+    def chat(self, messages: list[dict[str, Any]], **_: Any) -> _StubLLMResponse:
+        return _StubLLMResponse()
+
+
+class _StubLLMCancelMidStream:
+    """LLM stub that cancels the loop from inside the LLM call.
+
+    Mimics the user pressing the cancel button while waiting on the
+    provider; the loop must surface 'cancelled by user' to the UI.
+    """
+
+    def __init__(self, agent_ref: "list[AgentLoop]") -> None:
+        self._agent_ref = agent_ref
+
+    def stream_chat(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[Any] | None = None,
+        on_text_chunk: Callable[[str], None] | None = None,
+    ) -> _StubLLMResponse:
+        # Set _cancelled on the bound agent so the next loop iteration check
+        # picks it up.  We still need a valid response so the current
+        # iteration completes cleanly.
+        self._agent_ref[0]._cancelled = True
+        return _StubLLMResponse()
+
+    def chat(self, messages: list[dict[str, Any]], **_: Any) -> _StubLLMResponse:
+        return _StubLLMResponse()
+
+
+def _build_agent(llm: Any, max_iter: int = 3, tmp_run_dir: Path | None = None) -> AgentLoop:
+    """Build an AgentLoop with a real (but empty) registry and a stub LLM."""
+    from src.tools import build_registry
+    from src.memory.persistent import PersistentMemory
+
+    pm = PersistentMemory()
+    agent = AgentLoop(
+        registry=build_registry(persistent_memory=pm, include_shell_tools=False),
+        llm=llm,
+        event_callback=None,
+        max_iterations=max_iter,
+        persistent_memory=pm,
+    )
+    if tmp_run_dir is not None:
+        tmp_run_dir.mkdir(parents=True, exist_ok=True)
+        agent.memory.run_dir = str(tmp_run_dir)
+    return agent
+
+
+def test_failed_terminal_returns_reason_iterations_and_max_iterations(
+    tmp_path: Path,
+) -> None:
+    """When the loop exits without a final answer or metrics.csv, the
+    returned dict must carry `reason`, `iterations`, and `max_iterations`
+    so SessionService can render an actionable error message."""
+    agent = _build_agent(_StubLLMNoFinal(), max_iter=3, tmp_run_dir=tmp_path / "run")
+
+    result = agent.run(user_message="anything")
+
+    assert result["status"] == "failed"
+    assert result["reason"] == "reached max iterations (3) without final answer"
+    assert result["iterations"] >= 1
+    assert result["max_iterations"] == 3
+
+
+def test_cancelled_terminal_returns_reason(tmp_path: Path) -> None:
+    """Cancelled-by-user runs must also surface a meaningful reason."""
+    agent_ref: list[AgentLoop] = []
+    agent = _build_agent(
+        _StubLLMCancelMidStream(agent_ref),
+        max_iter=3,
+        tmp_run_dir=tmp_path / "run",
+    )
+    agent_ref.append(agent)
+
+    result = agent.run(user_message="anything")
+
+    assert result["status"] == "cancelled"
+    assert result["reason"] == "cancelled by user"
+    assert result["max_iterations"] == 3
+
+
+def test_session_service_renders_meaningful_error_from_result(tmp_path: Path) -> None:
+    """End-to-end guard for the original UI symptom in #114: with the new
+    `reason` field populated, `result.get('reason', 'unknown')` returns the
+    meaningful string SessionService passes to attempt.mark_failed."""
+    agent = _build_agent(_StubLLMNoFinal(), max_iter=2, tmp_run_dir=tmp_path / "run")
+
+    result = agent.run(user_message="anything")
+    ui_error = result.get("reason", "unknown")
+
+    assert ui_error != "unknown"
+    assert "max iterations" in ui_error
+    assert "2" in ui_error


### PR DESCRIPTION
## Summary

Closes #114. Reporter @ruok808 saw \`Execution failed: unknown\` in the session UI when an AgentLoop run hit max_iterations without producing a final answer.

The run's \`state.json\` correctly recorded \`reason="pipeline did not complete"\`, but \`AgentLoop.run()\`'s returned dict omitted the \`reason\` key entirely on the cancelled and max-iter-failed branches. Only the exception path populated it. SessionService then did \`result.get("reason", "unknown")\` and got \`"unknown"\`.

## Fix

- Compute \`final_reason\` on the cancelled and failed branches and propagate it into both the trace \`end\` event and the returned result dict
- Use the more actionable phrasing the reporter suggested: \`"reached max iterations (N) without final answer"\` instead of \`"pipeline did not complete"\`
- Include \`iterations\` and \`max_iterations\` in the result dict per the issue's optional suggestion, so the UI can render counts without re-parsing the trace

## Test plan

3 new tests in \`test_agent_loop_terminal_state.py\` covering:
- Max-iter failed branch: \`reason\`, \`iterations\`, \`max_iterations\` all present with correct values
- Cancelled mid-stream: \`status="cancelled"\`, \`reason="cancelled by user"\`
- End-to-end guard mirroring SessionService's call: \`result.get("reason", "unknown") != "unknown"\`

Adjacent suites green locally (47 passed):

\`\`\`bash
python -m pytest tests/test_loop_helpers.py tests/test_agent_loop_terminal_state.py tests/test_path_safety.py -q
\`\`\`

## UX before / after

Before:
\`\`\`
Execution failed: unknown
\`\`\`

After:
\`\`\`
Execution failed: reached max iterations (50) without final answer
\`\`\`