### PR TITLE
[codex] Pass proxy environment to CCXT loader

### DIFF
--- a/agent/backtest/loaders/ccxt_loader.py
+++ b/agent/backtest/loaders/ccxt_loader.py
@@ -37,6 +37,28 @@ _CCXT_TIMEOUT_MS = int(os.getenv("CCXT_TIMEOUT_MS", "15000"))
 _CCXT_FETCH_BUDGET_S = float(os.getenv("CCXT_FETCH_BUDGET_S", "60"))
 
 
+def _first_proxy_env(*names: str) -> str:
+    for name in names:
+        value = os.getenv(name, "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _ccxt_proxy_config() -> dict[str, str]:
+    """Build CCXT proxy settings from conventional proxy environment variables."""
+    all_proxy = _first_proxy_env("ALL_PROXY", "all_proxy")
+    http_proxy = _first_proxy_env("HTTP_PROXY", "http_proxy") or all_proxy
+    https_proxy = _first_proxy_env("HTTPS_PROXY", "https_proxy") or all_proxy or http_proxy
+
+    proxies: dict[str, str] = {}
+    if http_proxy:
+        proxies["http"] = http_proxy
+    if https_proxy:
+        proxies["https"] = https_proxy
+    return proxies
+
+
 @register
 class DataLoader:
     """CCXT-backed crypto OHLCV loader (100+ exchanges)."""
@@ -64,7 +86,12 @@ class DataLoader:
         if exchange_cls is None:
             logger.warning("Unknown CCXT exchange %s, falling back to binance", exchange_id)
             exchange_cls = ccxt.binance
-        return exchange_cls({"enableRateLimit": True, "timeout": _CCXT_TIMEOUT_MS})
+
+        config = {"enableRateLimit": True, "timeout": _CCXT_TIMEOUT_MS}
+        proxies = _ccxt_proxy_config()
+        if proxies:
+            config["proxies"] = proxies
+        return exchange_cls(config)
 
     def fetch(
         self,

--- a/agent/tests/test_ccxt_loader_proxy.py
+++ b/agent/tests/test_ccxt_loader_proxy.py
@@ -38,6 +38,22 @@ def test_get_exchange_passes_all_proxy_to_ccxt(monkeypatch):
     }
 
 
+def test_get_exchange_prefers_explicit_http_and_https_proxy_over_all_proxy(monkeypatch):
+    _clear_proxy_env(monkeypatch)
+    monkeypatch.setenv("CCXT_EXCHANGE", "binance")
+    monkeypatch.setenv("ALL_PROXY", "socks5h://127.0.0.1:1088")
+    monkeypatch.setenv("HTTP_PROXY", "http://127.0.0.1:8080")
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:8443")
+    monkeypatch.setattr(ccxt, "binance", _FakeExchange)
+
+    exchange = DataLoader()._get_exchange()
+
+    assert exchange.config["proxies"] == {
+        "http": "http://127.0.0.1:8080",
+        "https": "http://127.0.0.1:8443",
+    }
+
+
 def test_get_exchange_omits_proxy_config_when_env_absent(monkeypatch):
     _clear_proxy_env(monkeypatch)
     monkeypatch.setenv("CCXT_EXCHANGE", "binance")

--- a/agent/tests/test_ccxt_loader_proxy.py
+++ b/agent/tests/test_ccxt_loader_proxy.py
@@ -1,0 +1,48 @@
+"""Regression tests for CCXT proxy environment handling."""
+
+from __future__ import annotations
+
+import ccxt
+
+from backtest.loaders.ccxt_loader import DataLoader
+
+
+class _FakeExchange:
+    def __init__(self, config):
+        self.config = config
+
+
+def _clear_proxy_env(monkeypatch):
+    for name in (
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "all_proxy",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_get_exchange_passes_all_proxy_to_ccxt(monkeypatch):
+    _clear_proxy_env(monkeypatch)
+    monkeypatch.setenv("CCXT_EXCHANGE", "binance")
+    monkeypatch.setenv("ALL_PROXY", "socks5h://127.0.0.1:1088")
+    monkeypatch.setattr(ccxt, "binance", _FakeExchange)
+
+    exchange = DataLoader()._get_exchange()
+
+    assert exchange.config["proxies"] == {
+        "http": "socks5h://127.0.0.1:1088",
+        "https": "socks5h://127.0.0.1:1088",
+    }
+
+
+def test_get_exchange_omits_proxy_config_when_env_absent(monkeypatch):
+    _clear_proxy_env(monkeypatch)
+    monkeypatch.setenv("CCXT_EXCHANGE", "binance")
+    monkeypatch.setattr(ccxt, "binance", _FakeExchange)
+
+    exchange = DataLoader()._get_exchange()
+
+    assert "proxies" not in exchange.config


### PR DESCRIPTION
## Summary

- Read conventional proxy environment variables when constructing the CCXT exchange client.
- Pass the resulting `proxies` config to CCXT so public exchange data can be fetched from restricted networks.
- Add regression coverage for `ALL_PROXY` and for the no-proxy case.

## Why

Requests-based loaders already inherit proxy environment variables, but CCXT does not reliably do so through this loader's current constructor path. In restricted network environments, Binance/OKX public market data can time out unless the proxy is passed explicitly to CCXT.

This change only uses environment variable names and never logs proxy values or credentials.

## Tests

```bash
/Users/barry/Desktop/alevinno/src/vibe-trading-research/.venv/bin/python -m pytest agent/tests/test_ccxt_loader_proxy.py agent/tests/test_ccxt_loader_bounded.py agent/tests/test_get_market_data_unresolved.py -q
```

Result: `13 passed`.
