### PR TITLE
fix(frontend): show Thinking… placeholder between Send and first SSE event

### DIFF
--- a/frontend/src/pages/Agent.tsx
+++ b/frontend/src/pages/Agent.tsx
@@ -472,6 +472,17 @@ export function Agent() {
             );
           })}
 
+          {/* Pre-stream placeholder: visible after Send, before first SSE event */}
+          {status === "streaming" && !streamingText && toolCalls.length === 0 && (
+            <div className="flex gap-3">
+              <AgentAvatar />
+              <div className="flex-1 min-w-0 flex items-center gap-2 text-xs text-muted-foreground pt-1">
+                <Loader2 className="h-3 w-3 animate-spin text-primary shrink-0" />
+                <span>Thinking…</span>
+              </div>
+            </div>
+          )}
+
           {/* Live streaming area: text + tool status */}
           {(streamingText || (status === "streaming" && toolCalls.length > 0)) && (
             <div className="flex gap-3">


### PR DESCRIPTION
## Summary

Closes #127.

`Agent.tsx`'s live streaming area only rendered when `streamingText` was non-empty or `toolCalls` had at least one entry. The window between `handleSubmit` flipping `status` to `"streaming"` and the first SSE event arriving left the chat body visually blank, so on slow networks or during long agent "thinking" time the UI appeared unresponsive.

Adds a `Thinking…` placeholder that renders exactly during that gap and disappears the instant either streaming-state source becomes non-empty.

## Change

- `frontend/src/pages/Agent.tsx`: new conditional block before the existing live streaming area, gated on `status === "streaming" && !streamingText && toolCalls.length === 0`. Reuses the existing `AgentAvatar`, `Loader2` spinner, and muted-foreground typography for visual consistency.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] State-machine trace verified (idle → streaming → first event → streaming text/tool, and 90s safety-timeout reset all transition cleanly)
- [ ] Manual smoke: send a prompt with a slow provider; spinner should appear immediately and seamlessly hand off when first token / tool call lands