### PR TITLE
fix(providers): normalize remote Ollama base URLs without /v1

### DIFF
--- a/agent/.env.example
+++ b/agent/.env.example
@@ -79,7 +79,7 @@ OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 # --- Ollama (local) ---
 # LANGCHAIN_PROVIDER=ollama
 # LANGCHAIN_MODEL_NAME=qwen2.5:32b
-# OLLAMA_BASE_URL=http://localhost:11434/v1
+# OLLAMA_BASE_URL=http://localhost:11434
 
 # LLM parameters
 LANGCHAIN_TEMPERATURE=0.0

--- a/agent/cli.py
+++ b/agent/cli.py
@@ -2490,7 +2490,7 @@ _PROVIDER_CHOICES: list[dict[str, str | None]] = [
         "provider": "ollama",
         "key_env": None,
         "base_env": "OLLAMA_BASE_URL",
-        "base_url": "http://localhost:11434/v1",
+        "base_url": "http://localhost:11434",
         "model": "qwen2.5:32b",
         "key_prefix": None,
         "key_placeholder": None,

--- a/agent/src/providers/llm.py
+++ b/agent/src/providers/llm.py
@@ -190,6 +190,16 @@ def _ensure_dotenv() -> None:
     )
 
 
+def _normalize_ollama_base_url(base_url: str) -> str:
+    """Append ``/v1`` when missing so ChatOpenAI hits Ollama's OpenAI-compatible API."""
+    url = base_url.strip().rstrip("/")
+    if not url:
+        return url
+    if url.endswith("/v1"):
+        return url
+    return f"{url}/v1"
+
+
 def _sync_provider_env() -> None:
     """Map provider-specific env vars to OPENAI_* for ChatOpenAI.
 
@@ -235,6 +245,8 @@ def _sync_provider_env() -> None:
 
     # Resolve base URL: provider-specific env → OPENAI_BASE_URL fallback
     base_url = os.getenv(base_env, "") or os.getenv("OPENAI_BASE_URL", "") or os.getenv("OPENAI_API_BASE", "")
+    if provider == "ollama" and base_url:
+        base_url = _normalize_ollama_base_url(base_url)
 
     if api_key:
         os.environ["OPENAI_API_KEY"] = api_key

--- a/agent/src/providers/llm_providers.json
+++ b/agent/src/providers/llm_providers.json
@@ -124,7 +124,7 @@
     "api_key_env": null,
     "base_url_env": "OLLAMA_BASE_URL",
     "default_model": "qwen2.5:32b",
-    "default_base_url": "http://localhost:11434/v1",
+    "default_base_url": "http://localhost:11434",
     "api_key_required": false
   }
 ]

--- a/agent/tests/test_cli_init.py
+++ b/agent/tests/test_cli_init.py
@@ -86,7 +86,7 @@ class TestCliInit:
                  cli.Prompt,
                  "ask",
                  side_effect=[
-                     "http://localhost:11434/v1",
+                     "http://localhost:11434",
                      "qwen2.5:32b",
                      "",
                      "",
@@ -97,7 +97,7 @@ class TestCliInit:
         assert result == 0
         content = env_path.read_text(encoding="utf-8")
         assert "LANGCHAIN_PROVIDER=ollama" in content
-        assert "OLLAMA_BASE_URL=http://localhost:11434/v1" in content
+        assert "OLLAMA_BASE_URL=http://localhost:11434" in content
         assert "LANGCHAIN_MODEL_NAME=qwen2.5:32b" in content
         assert "OPENAI_API_KEY=" not in content
         assert "OPENROUTER_API_KEY=" not in content

--- a/agent/tests/test_llm.py
+++ b/agent/tests/test_llm.py
@@ -73,7 +73,15 @@ class TestSyncProviderEnv:
         })
         # Ollama uses "ollama" as fallback key
         assert result["OPENAI_API_KEY"] in ("ollama", "")
-        assert "localhost" in result["OPENAI_API_BASE"]
+        assert result["OPENAI_API_BASE"] == "http://localhost:11434/v1"
+
+    def test_ollama_base_url_appends_v1(self) -> None:
+        result = self._run_sync({
+            "LANGCHAIN_PROVIDER": "ollama",
+            "OLLAMA_BASE_URL": "http://23.152.56.42:11434/",
+        })
+        assert result["OPENAI_API_BASE"] == "http://23.152.56.42:11434/v1"
+        assert result["OPENAI_BASE_URL"] == "http://23.152.56.42:11434/v1"
 
     def test_qwen_alias_to_dashscope(self) -> None:
         result = self._run_sync({


### PR DESCRIPTION
Append /v1 automatically when `LANGCHAIN_PROVIDER=ollama` so remote hosts like `http://host:11434` work with ChatOpenAI without manual path suffixes.

## Summary

- Auto-append `/v1` to `OLLAMA_BASE_URL` when the path is missing, so Ollama’s OpenAI-compatible API is used correctly.
- Update Ollama defaults and `.env.example` to use host:port only (e.g. `http://localhost:11434`).
- Add unit tests for local and remote Ollama base URLs.

## Why

Bare Ollama URLs (e.g. `http://host:11434/`) cause ChatOpenAI requests to hit the wrong path and return `404 page not found`. Users should not need to remember the `/v1` suffix for remote Ollama servers.

## Changes

- `agent/src/providers/llm.py`: `_normalize_ollama_base_url()` + apply in `_sync_provider_env()` for `ollama`
- `agent/cli.py`, `agent/src/providers/llm_providers.json`, `agent/.env.example`: default URL without `/v1`
- `agent/tests/test_llm.py`, `agent/tests/test_cli_init.py`: coverage for URL normalization

## Test Plan

- [ ] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [x] New tests added (`test_ollama_base_url_appends_v1`, updated init/ollama tests)
- [ ] Tested manually: `OLLAMA_BASE_URL=http://<remote-host>:11434` (no `/v1`), run `vibe-trading`, confirm chat works

## Checklist

- [x] Minimal change in `src/providers/llm.py` only (provider env mapping)
- [x] No hardcoded API keys or secrets
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Documentation updated (`.env.example`, provider defaults)

