### PR TITLE
fix(api): accept short universe names in alpha list endpoint

### DIFF
--- a/agent/src/api/alpha_routes.py
+++ b/agent/src/api/alpha_routes.py
@@ -282,6 +282,9 @@ def register_alpha_routes(
                 status_code=400,
                 detail=f"unknown theme {theme!r}; expected one of {sorted(_VALID_THEMES)}",
             )
+        if universe is not None:
+            _ALIAS = {"csi300": "equity_cn", "sp500": "equity_us", "btc-usdt": "crypto"}
+            universe = _ALIAS.get(universe, universe)
         if universe is not None and universe not in _VALID_UNIVERSES:
             raise HTTPException(
                 status_code=400,


### PR DESCRIPTION
## Summary

- Normalize short universe aliases (`csi300`/`sp500`/`btc-usdt`) to canonical names in `GET /alpha/list`
- Fixes `unknown universe 'csi300'` error when filtering alphas from the frontend

## Why

The frontend bench form and filter dropdown share the same universe values (`csi300`, `sp500`, `btc-usdt`). The bench endpoint has a built-in mapping, but the list endpoint requires canonical names (`equity_cn`, `equity_us`, `crypto`), causing a 400 error when users filter alphas by universe.

## Changes

- `agent/src/api/alpha_routes.py` — add 3-line alias map before `_VALID_UNIVERSES` check in `list_alphas`

## Test Plan

- [ ] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [ ] New tests added (if applicable) — N/A
- [x] Tested manually — universe filter in AlphaZoo page no longer returns 400

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`)
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Documentation updated — N/A