### PR TITLE
fix(wiki): 移除 _redirects 中导致 /docs/ 跳回首页的根路径重定向

### DIFF
--- a/wiki/_redirects
+++ b/wiki/_redirects
@@ -1,4 +1,3 @@
-/ /home/ 302
 /docs /docs/latest/getting-started/vibe-trading-overview 302
 /docs/ /docs/latest/getting-started/vibe-trading-overview 302
 /docs/latest/* /docs/index.html 200


### PR DESCRIPTION
## 问题

`_redirects` 中的 `/ /home/ 302` 规则导致 `/docs/` 路径发生二次跳转回首页：
```
/docs/ → 302 → /docs/latest/…  → （目标仍是 / 开头）
       → 302 → /home/
```

其他路径（`/tutorials/`、`/alpha-library/`）不受影响，因为它们的重定向只是尾部斜杠标准化，不会产生第二轮命中 `/` 的跳转。

## 根因

`/docs/` 的 302 跳转目标 `/docs/latest/…` 同样以 `/` 开头，在规则链中会二次命中 `/ /home/ 302`，最终被重定向回首页。

## 修复

删除 `/ /home/ 302` 规则。根路径到首页的跳转已由 `wiki/index.html` 中的 `<meta http-equiv="refresh">` 和 `location.replace("/home/")` 双重处理，`_redirects` 中的这条规则既冗余又有害。

## 修复后效果

- `/docs/` → 正常访问文档 SPA
- `/` → 仍通过 `index.html` 正常跳转到 `/home/`