### PR TITLE
Fix IME Enter submission handling

### DIFF
--- a/frontend/src/pages/Agent.tsx
+++ b/frontend/src/pages/Agent.tsx
@@ -84,6 +84,8 @@ export function Agent() {
   const [searchParams, setSearchParams] = useSearchParams();
   const listRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const isComposingRef = useRef(false);
+  const lastCompositionEndRef = useRef(0);
   const sseSessionRef = useRef<string | null>(null);
   const prevSseStatusRef = useRef<string>("disconnected");
   const genRef = useRef(0);
@@ -905,6 +907,13 @@ export function Agent() {
               value={input}
               rows={1}
               onChange={(e) => setInput(e.target.value)}
+              onCompositionStart={() => {
+                isComposingRef.current = true;
+              }}
+              onCompositionEnd={() => {
+                isComposingRef.current = false;
+                lastCompositionEndRef.current = Date.now();
+              }}
               onInput={(e) => {
                 const el = e.target as HTMLTextAreaElement;
                 el.style.height = "auto";
@@ -912,6 +921,15 @@ export function Agent() {
               }}
               onKeyDown={(e) => {
                 if (e.key === "Enter" && !e.shiftKey) {
+                  const nativeEvent = e.nativeEvent as KeyboardEvent & { isComposing?: boolean };
+                  const justFinishedComposing = Date.now() - lastCompositionEndRef.current < 80;
+                  if (isComposingRef.current || nativeEvent.isComposing || nativeEvent.keyCode === 229) {
+                    return;
+                  }
+                  if (justFinishedComposing) {
+                    e.preventDefault();
+                    return;
+                  }
                   e.preventDefault();
                   runPrompt(input.trim());
                 }


### PR DESCRIPTION
## Summary

- Fix IME Enter handling in the Agent chat input.
- Prevent accidental session submission while text composition is active or has just ended.

## Why

When using Chinese/Japanese/Korean IMEs, pressing Enter can be used to confirm composition. The chat input previously treated that Enter as a submit action, which could accidentally trigger a session before the user finished typing.

## Changes

- Track IME composition state with `onCompositionStart` and `onCompositionEnd`.
- Ignore Enter submit while composition is active.
- Add a short guard after composition ends to avoid browser event-order edge cases.

## Test Plan

- [ ] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [ ] New tests added (if applicable)
- [x] Tested manually (describe below)

Manual test:
- Verified that pressing Enter while using an IME to confirm text does not submit the Agent chat.
- Verified that normal Enter still submits after composition has completed.

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] Documentation updated (if user-facing change)