### PR TITLE
fix(session): handle corrupted JSONL lines and harden message writes

### DIFF
--- a/agent/src/session/store.py
+++ b/agent/src/session/store.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import json
+import logging
+import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from src.session.models import Attempt, Message, Session
+
+logger = logging.getLogger(__name__)
 
 
 class SessionStore:
@@ -145,6 +149,8 @@ class SessionStore:
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("a", encoding="utf-8") as f:
             f.write(json.dumps(message.to_dict(), ensure_ascii=False) + "\n")
+            f.flush()
+            os.fsync(f.fileno())
 
     def get_messages(self, session_id: str, limit: int = 100) -> List[Message]:
         """Read all messages for a session.
@@ -162,7 +168,14 @@ class SessionStore:
         messages: List[Message] = []
         for line in path.read_text(encoding="utf-8").strip().splitlines():
             if line.strip():
-                messages.append(Message.from_dict(json.loads(line)))
+                try:
+                    messages.append(Message.from_dict(json.loads(line)))
+                except json.JSONDecodeError:
+                    logger.warning(
+                        "Skipping corrupted message line in session %s: %s",
+                        session_id,
+                        line[:200],
+                    )
         return messages[-limit:]
 
     # ---- Attempt CRUD ----


### PR DESCRIPTION
## Summary

- **Fix 500 crash** on `GET /sessions/{id}/messages` caused by corrupted JSONL lines (truncated JSON from process crash mid-write)
- **Harden writes** with `flush()` + `os.fsync()` after each message append to ensure AI API responses are fully persisted to disk before continuing
- **Graceful read recovery**: skip unparseable lines with a warning log (includes first 200 chars for manual recovery) instead of crashing the entire endpoint

## Context

When the server process is killed mid-write (OOM, restart, disk full), the JSONL message log can end up with a truncated line. Previously, this caused `json.JSONDecodeError` on the next read — returning 500 for **all** messages in that session, not just the corrupted one.

AI API responses are expensive and non-reproducible, so the write-side hardening (`fsync`) is critical to minimize the corruption window.

## Changes

- `agent/src/session/store.py`
  - `append_message()`: add `f.flush()` + `os.fsync()` after write
  - `get_messages()`: wrap `json.loads()` in try/except, log corrupted lines, continue loading

## Test plan

- [x] `python -m py_compile agent/src/session/store.py` — syntax OK
- [x] `pytest agent/tests/ -k session --tb=short -q` — existing tests pass
- [x] Manual: corrupt a line in a session's `messages.jsonl`, verify endpoint returns remaining messages + server logs warning
- [x] Manual: kill server mid-response, verify message file is not truncated after restart
