### PR TITLE
fix(loop): graceful exit on max iterations with wrap-up nudge + forced text-only

### DIFF
--- a/agent/src/agent/loop.py
+++ b/agent/src/agent/loop.py
@@ -365,6 +365,7 @@ class AgentLoop:
         final_content = ""
         goal_continuations = 0
         goal_last_progress: tuple[int, int] | None = None
+        wrap_up_at = max(1, int(self.max_iterations * 0.8))
 
         try:
             while iteration < self.max_iterations:
@@ -399,6 +400,19 @@ class AgentLoop:
 
                 logger.info(f"ReAct iteration {iteration}/{self.max_iterations}")
 
+                # Inject wrap-up nudge when approaching iteration limit
+                if iteration == wrap_up_at:
+                    remaining = self.max_iterations - iteration
+                    messages.append({
+                        "role": "user",
+                        "content": (
+                            f"[SYSTEM] You have {remaining} iterations remaining out of "
+                            f"{self.max_iterations}. Please wrap up your work. "
+                            "Stop calling tools and provide your final answer as plain text. "
+                            "If you have partial results, summarize what you have so far."
+                        ),
+                    })
+
                 # Streaming output + collect thinking text
                 thinking_chunks: List[str] = []
 
@@ -406,9 +420,15 @@ class AgentLoop:
                     thinking_chunks.append(delta)
                     self._emit("text_delta", {"delta": delta, "iter": iteration})
 
+                # On last iteration, drop tool definitions to force text output
+                is_last_iteration = (iteration == self.max_iterations)
+                tool_defs = None if is_last_iteration else self.registry.get_definitions()
+                if is_last_iteration:
+                    trace.write({"type": "forced_text_only", "iter": iteration})
+
                 response = self.llm.stream_chat(
                     messages,
-                    tools=self.registry.get_definitions(),
+                    tools=tool_defs,
                     on_text_chunk=_on_text_chunk,
                 )
                 usage = getattr(response, "usage_metadata", None) or {}

--- a/agent/tests/test_agent_loop_terminal_state.py
+++ b/agent/tests/test_agent_loop_terminal_state.py
@@ -138,3 +138,44 @@ def test_session_service_renders_meaningful_error_from_result(tmp_path: Path) ->
     assert ui_error != "unknown"
     assert "max iterations" in ui_error
     assert "2" in ui_error
+
+
+class _StubLLMAlwaysToolCalls:
+    """LLM stub that returns tool calls until tools=None forces text."""
+
+    def __init__(self) -> None:
+        self._counter = 0
+
+    def stream_chat(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[Any] | None = None,
+        on_text_chunk: Callable[[str], None] | None = None,
+    ) -> _StubLLMResponse:
+        resp = _StubLLMResponse()
+        if tools is not None:
+            self._counter += 1
+            resp.has_tool_calls = True
+            resp.tool_calls = [
+                type("TC", (), {"id": f"tc_{self._counter}", "name": "compact", "arguments": {}})()
+            ]
+        else:
+            resp.content = "Final answer from forced text-only."
+            resp.has_tool_calls = False
+        return resp
+
+    def chat(self, messages: list[dict[str, Any]], **_: Any) -> _StubLLMResponse:
+        return _StubLLMResponse()
+
+
+def test_force_text_only_on_last_iteration(tmp_path: Path) -> None:
+    """When the LLM keeps calling tools, the last iteration forces text-only
+    output by passing tools=None, producing a final answer instead of failure."""
+    agent = _build_agent(
+        _StubLLMAlwaysToolCalls(), max_iter=5, tmp_run_dir=tmp_path / "run"
+    )
+    result = agent.run(user_message="do something")
+
+    assert result["status"] == "success"
+    assert "Final answer" in result["content"]
+    assert result["iterations"] == 5


### PR DESCRIPTION
## Summary

- **Problem:** `AgentLoop` could exhaust all 50 iterations when the LLM kept calling tools endlessly, resulting in `status="failed"` with no useful output returned to the user.
- **Fix:** Mirror the swarm worker's proven approach — inject a wrap-up nudge at 80% of the iteration budget and drop tool definitions on the last iteration to force a text response.
- **Test:** Added `test_force_text_only_on_last_iteration` validating that an LLM which always returns tool calls now produces `status="success"` instead of `status="failed"`.

## Changes

### `agent/src/agent/loop.py`
1. Calculate `wrap_up_at = max(1, int(self.max_iterations * 0.8))` before the main loop
2. At 80% of iteration budget, inject a `[SYSTEM]` user message nudging the LLM to stop calling tools and produce a final answer
3. On the last iteration, pass `tools=None` to `stream_chat` — the LLM cannot request tool calls and must produce text output, guaranteeing a final answer

### `agent/tests/test_agent_loop_terminal_state.py`
- Added `_StubLLMAlwaysToolCalls` — LLM stub that returns `compact` tool calls until `tools=None` forces text
- Added `test_force_text_only_on_last_iteration` — verifies the forced text-only last iteration produces `status="success"` with content

## How it works

The swarm worker (`agent/src/swarm/worker.py`) already had both mechanisms (lines 363-426). This PR brings the same pattern to `AgentLoop`:

| Mechanism | Swarm Worker | AgentLoop (before) | AgentLoop (after) |
|-----------|-------------|--------------------|--------------------|
| Wrap-up nudge at 80% | Yes | No | Yes |
| Force text-only on last iter | Yes | No | Yes |

## Test plan

- [x] Existing 3 tests in `test_agent_loop_terminal_state.py` pass unchanged
- [x] New `test_force_text_only_on_last_iteration` passes
- [x] `ruff check` passes
- [x] `python -m py_compile` passes
