### PR TITLE
fix(backtest): pre-flight validation for LLM-generated signal engines

### DIFF
--- a/agent/backtest/engines/base.py
+++ b/agent/backtest/engines/base.py
@@ -351,6 +351,20 @@ class BaseEngine(ABC):
 
         # 2. Generate signals
         signal_map = signal_engine.generate(data_map)
+        if not isinstance(signal_map, dict):
+            print(json.dumps({"error": (
+                f"SignalEngine.generate() must return Dict[str, pd.Series], "
+                f"got {type(signal_map).__name__}. "
+                "Return a dict mapping symbol codes to pandas Series of signals."
+            )}))
+            sys.exit(1)
+        for _code, _sig in signal_map.items():
+            if not isinstance(_sig, pd.Series):
+                print(json.dumps({"error": (
+                    f"SignalEngine.generate() returned {type(_sig).__name__} for '{_code}', "
+                    "expected pd.Series. Each value must be a pandas Series with DatetimeIndex."
+                )}))
+                sys.exit(1)
         valid_codes = sorted(c for c in signal_map if c in data_map)
         if not valid_codes:
             print(json.dumps({"error": "No valid signals generated"}))

--- a/agent/backtest/runner.py
+++ b/agent/backtest/runner.py
@@ -9,6 +9,7 @@ Usage: ``python -m backtest.runner <run_dir>``
 
 import ast
 import importlib.util
+import inspect
 import json
 import logging
 import sys
@@ -233,6 +234,11 @@ def _validate_signal_engine_source(file_path: Path) -> None:
     for node in tree.body:
         if isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant):
             continue
+        if isinstance(node, ast.ImportFrom) and node.module == "signal_engine":
+            raise ValueError(
+                "Circular import: 'from signal_engine import ...' imports the file from itself. "
+                "Remove this import — SignalEngine is defined in this same file."
+            )
         if isinstance(node, (ast.Import, ast.ImportFrom)):
             continue
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
@@ -245,6 +251,26 @@ def _validate_signal_engine_source(file_path: Path) -> None:
             continue
         raise ValueError(
             f"Executable top-level statement {type(node).__name__} is not allowed"
+        )
+
+
+def _validate_signal_engine_class(engine_cls) -> None:
+    """Pre-flight check: SignalEngine can be instantiated with no args and has generate()."""
+    sig = inspect.signature(engine_cls.__init__)
+    required = [
+        p.name for p in sig.parameters.values()
+        if p.name != "self" and p.default is inspect.Parameter.empty
+        and p.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+    ]
+    if required:
+        raise ValueError(
+            f"SignalEngine.__init__() has required arguments {required}. "
+            "All parameters must have default values so the runner can call SignalEngine()."
+        )
+    if not callable(getattr(engine_cls, "generate", None)):
+        raise ValueError(
+            "SignalEngine must have a callable 'generate' method. "
+            "Expected: def generate(self, data_map: Dict[str, pd.DataFrame]) -> Dict[str, pd.Series]"
         )
 
 
@@ -400,6 +426,12 @@ def main(run_dir: Path) -> None:
     engine_cls = getattr(signal_module, "SignalEngine", None)
     if engine_cls is None:
         print(json.dumps({"error": "SignalEngine class not found in signal_engine.py"}))
+        sys.exit(1)
+
+    try:
+        _validate_signal_engine_class(engine_cls)
+    except ValueError as exc:
+        print(json.dumps({"error": f"SignalEngine interface error: {exc}"}))
         sys.exit(1)
 
     # Data: auto split vs single loader


### PR DESCRIPTION
## Summary
- Add pre-flight validation for LLM-generated `SignalEngine` classes in the backtest runner, catching interface errors before execution with actionable JSON error messages instead of raw Python tracebacks
- Detect circular self-imports (`from signal_engine import SignalEngine`), required `__init__` args, missing `generate()` method, and wrong return types (`list` instead of `Dict[str, pd.Series]`)
- Fixes 5 distinct recurring crash patterns observed in production

## Test plan
- [x] All 2844 existing tests pass (`pytest`, excluding e2e)
- [x] `py_compile` passes on both modified files
- [x] `ruff check` passes on both modified files
- [ ] Deploy and verify LLM agent receives actionable JSON errors on malformed signal engines instead of tracebacks
- [ ] Verify valid signal engines still instantiate and run backtests normally

## Changes
| File | Change |
|------|--------|
| `agent/backtest/runner.py` | Circular import detection in AST validator, `_validate_signal_engine_class()` for init/generate checks, wired into `main()` |
| `agent/backtest/engines/base.py` | Return-type validation after `signal_engine.generate()` call |

## Errors addressed
| Error | Root Cause |
|-------|-----------|
| `SignalEngine.__init__() missing 1 required positional argument: 'config'` | LLM wrote `__init__(self, config)` without default |
| `'SignalEngine' object has no attribute 'generate'` | LLM omitted required method |
| `'list' object has no attribute 'reindex'` | `generate()` returned list instead of Dict[str, pd.Series] |
| `ImportError: cannot import name 'SignalEngine' from 'signal_engine'` | Circular self-import |
| `BacktestConfigSchema: start_date/end_date Field required` | Already caught by existing Pydantic validation; no code change needed |