### PR TITLE
fix(ui): always show Full Report link when runId exists in session history

### DIFF
--- a/frontend/src/pages/Agent.tsx
+++ b/frontend/src/pages/Agent.tsx
@@ -338,7 +338,7 @@ export function Agent() {
               const runData = await api.getRun(runId);
               if (isReportWorthyRun(runData)) {
                 fetchedMetrics = runData.metrics;
-                fetchedCurve = runData.equity_curve?.map((e) => ({ time: e.time, equity: e.equity }));
+                fetchedCurve = runData.equity_curve?.map((e) => ({ time: e.time, equity: Number(e.equity) }));
               }
             } catch { /* run may be unavailable — still show link */ }
             agentMsgs.push({
@@ -476,7 +476,7 @@ export function Agent() {
             const runData = await api.getRun(runId);
             if (isReportWorthyRun(runData)) {
               runMetrics = runData.metrics;
-              runCurve = runData.equity_curve?.map(e => ({ time: e.time, equity: e.equity }));
+              runCurve = runData.equity_curve?.map(e => ({ time: e.time, equity: Number(e.equity) }));
             }
           } catch { /* run data unavailable — still show link */ }
           s.addMessage({

--- a/frontend/src/pages/Agent.tsx
+++ b/frontend/src/pages/Agent.tsx
@@ -331,25 +331,33 @@ export function Agent() {
           if (metrics && Object.keys(metrics).length > 0) {
             agentMsgs.push({ id: m.message_id, type: "run_complete", content: "", runId, metrics, timestamp: ts + 1 });
           } else {
-            // Always show card when runId exists; enrich with fetched data if available
+            // Fetch run data to check report-worthiness; show fallback card if fetch fails
             let fetchedMetrics: Record<string, number> | undefined;
             let fetchedCurve: Array<{ time: string; equity: number }> | undefined;
+            let showCard = false;
             try {
               const runData = await api.getRun(runId);
               if (isReportWorthyRun(runData)) {
                 fetchedMetrics = runData.metrics;
                 fetchedCurve = runData.equity_curve?.map((e) => ({ time: e.time, equity: Number(e.equity) }));
+                showCard = true;
               }
-            } catch { /* run may be unavailable — still show link */ }
-            agentMsgs.push({
-              id: m.message_id,
-              type: "run_complete",
-              content: "",
-              runId,
-              metrics: fetchedMetrics,
-              equityCurve: fetchedCurve,
-              timestamp: ts + 1,
-            });
+              // succeeded but not report-worthy (plain chat turn) → skip card
+            } catch {
+              // fetch failed (auth/404/network) → can't tell, show link as fallback
+              showCard = true;
+            }
+            if (showCard) {
+              agentMsgs.push({
+                id: m.message_id,
+                type: "run_complete",
+                content: "",
+                runId,
+                metrics: fetchedMetrics,
+                equityCurve: fetchedCurve,
+                timestamp: ts + 1,
+              });
+            }
           }
         } else {
           agentMsgs.push({ id: m.message_id, type: "answer", content: m.content, timestamp: ts });
@@ -472,20 +480,26 @@ export function Agent() {
         if (runId) {
           let runMetrics: Record<string, number> | undefined;
           let runCurve: Array<{ time: string; equity: number }> | undefined;
+          let showCard = false;
           try {
             const runData = await api.getRun(runId);
             if (isReportWorthyRun(runData)) {
               runMetrics = runData.metrics;
               runCurve = runData.equity_curve?.map(e => ({ time: e.time, equity: Number(e.equity) }));
+              showCard = true;
             }
-          } catch { /* run data unavailable — still show link */ }
-          s.addMessage({
-            id: "", type: "run_complete", content: "", runId,
-            metrics: runMetrics,
-            equityCurve: runCurve,
-            shadowId,
-            timestamp: Date.now(),
-          });
+          } catch {
+            showCard = true; // fetch failed → show link as fallback
+          }
+          if (showCard || shadowId) {
+            s.addMessage({
+              id: "", type: "run_complete", content: "", runId,
+              metrics: showCard ? runMetrics : undefined,
+              equityCurve: showCard ? runCurve : undefined,
+              shadowId,
+              timestamp: Date.now(),
+            });
+          }
         } else if (shadowId) {
           s.addMessage({ id: "", type: "run_complete", content: "", shadowId, timestamp: Date.now() });
         }

--- a/frontend/src/pages/Agent.tsx
+++ b/frontend/src/pages/Agent.tsx
@@ -331,20 +331,25 @@ export function Agent() {
           if (metrics && Object.keys(metrics).length > 0) {
             agentMsgs.push({ id: m.message_id, type: "run_complete", content: "", runId, metrics, timestamp: ts + 1 });
           } else {
+            // Always show card when runId exists; enrich with fetched data if available
+            let fetchedMetrics: Record<string, number> | undefined;
+            let fetchedCurve: Array<{ time: string; equity: number }> | undefined;
             try {
               const runData = await api.getRun(runId);
               if (isReportWorthyRun(runData)) {
-                agentMsgs.push({
-                  id: m.message_id,
-                  type: "run_complete",
-                  content: "",
-                  runId,
-                  metrics: runData.metrics,
-                  equityCurve: runData.equity_curve?.map((e) => ({ time: e.time, equity: e.equity })),
-                  timestamp: ts + 1,
-                });
+                fetchedMetrics = runData.metrics;
+                fetchedCurve = runData.equity_curve?.map((e) => ({ time: e.time, equity: e.equity }));
               }
-            } catch { /* ignore non-report attempt directories */ }
+            } catch { /* run may be unavailable — still show link */ }
+            agentMsgs.push({
+              id: m.message_id,
+              type: "run_complete",
+              content: "",
+              runId,
+              metrics: fetchedMetrics,
+              equityCurve: fetchedCurve,
+              timestamp: ts + 1,
+            });
           }
         } else {
           agentMsgs.push({ id: m.message_id, type: "answer", content: m.content, timestamp: ts });
@@ -465,19 +470,22 @@ export function Agent() {
 
         // Show RunCompleteCard when the turn produced backtest metrics or a shadow report
         if (runId) {
+          let runMetrics: Record<string, number> | undefined;
+          let runCurve: Array<{ time: string; equity: number }> | undefined;
           try {
             const runData = await api.getRun(runId);
-            const hasReport = isReportWorthyRun(runData);
-            if (hasReport || shadowId) {
-              s.addMessage({
-                id: "", type: "run_complete", content: "", runId,
-                metrics: hasReport ? runData.metrics : undefined,
-                equityCurve: runData.equity_curve?.map(e => ({ time: e.time, equity: e.equity })),
-                shadowId,
-                timestamp: Date.now(),
-              });
+            if (isReportWorthyRun(runData)) {
+              runMetrics = runData.metrics;
+              runCurve = runData.equity_curve?.map(e => ({ time: e.time, equity: e.equity }));
             }
-          } catch { /* ignore */ }
+          } catch { /* run data unavailable — still show link */ }
+          s.addMessage({
+            id: "", type: "run_complete", content: "", runId,
+            metrics: runMetrics,
+            equityCurve: runCurve,
+            shadowId,
+            timestamp: Date.now(),
+          });
         } else if (shadowId) {
           s.addMessage({ id: "", type: "run_complete", content: "", shadowId, timestamp: Date.now() });
         }

--- a/frontend/src/pages/RunDetail.tsx
+++ b/frontend/src/pages/RunDetail.tsx
@@ -97,7 +97,21 @@ export function RunDetail() {
       </div>
     );
   }
-  if (!run) return <div className="p-8 text-red-500">Run not found</div>;
+  if (!run) return (
+    <div className="p-8 space-y-2">
+      <p className="text-red-500 font-medium">Run not found</p>
+      <p className="text-sm text-muted-foreground">
+        The run directory may have been removed, or your browser may not have API access configured.
+        Check that the API authentication key is set in Settings if accessing remotely.
+      </p>
+      <button
+        onClick={() => navigate(-1)}
+        className="text-sm text-primary hover:underline inline-flex items-center gap-1.5"
+      >
+        <ArrowLeft className="h-3.5 w-3.5" /> Go back
+      </button>
+    </div>
+  );
 
   const ok = run.status === "success";
 


### PR DESCRIPTION
### Summary
- Fix "Full Report" link disappearing when loading sessions from a different browser or remote device
- `loadSessionMessages` and SSE handler now always render the `run_complete` card when `runId` exists in message metadata, even if `api.getRun()` fails (auth error, 404, network issue)
- Improve RunDetail error page with diagnostic hints (API auth, run directory) and a back button

### Root Cause
When reloading a session from history, if `metrics` was missing from message metadata, the code called `api.getRun(runId)` to fetch run data. If that call failed (common for remote/cross-browser access due to auth), the error was silently caught and the card was never added — so the "Full Report" link disappeared entirely. The original browser still showed it because the card was cached in Zustand's in-memory store from the live SSE session.

### Test plan
- [x] Open a session with completed backtest runs in the original browser — verify "Full Report" link still appears with metrics/chart
- [x] Open the same session in a new browser (or incognito) — verify "Full Report" link now appears
- [x] Click "Full Report" when run data is available — verify RunDetail page loads normally
- [x] Click "Full Report" when run data is unavailable — verify improved error page with hints and back button
- [x] `cd frontend && npx vite build` passes

<img width="1648" height="774" alt="CleanShot 2026-05-30 at 11 55 24@2x" src="https://github.com/user-attachments/assets/2d035208-df65-4186-a401-5a6393cea11d" />
