### PR TITLE
fix(correlation): normalize timestamps for cross-market asset alignment

### DIFF
--- a/agent/backtest/correlation.py
+++ b/agent/backtest/correlation.py
@@ -70,6 +70,10 @@ def _rolling_correlation_matrix(
 
     for code in codes:
         ts = closes[code]
+        # Normalize to date-only (midnight) so that cross-market assets
+        # (e.g. crypto via OKX/CCXT at UTC midnight vs US equity via
+        # yfinance at EDT midnight = 04:00 UTC) align correctly.
+        ts.index = ts.index.normalize()
         rets = ts.pct_change().dropna()
         rets.name = code
         returns_frames.append(rets)
@@ -77,7 +81,15 @@ def _rolling_correlation_matrix(
     # Align all series to a common index (inner join)
     aligned = pd.concat(returns_frames, axis=1).dropna()
     if aligned.empty:
-        raise ValueError("No overlapping return data between assets")
+        ranges = {
+            code: f"{closes[code].index.min()} .. {closes[code].index.max()}"
+            for code in codes
+            if len(closes[code]) > 0
+        }
+        raise ValueError(
+            f"No overlapping return data between assets. "
+            f"Date ranges: {ranges}"
+        )
 
     # Apply the trailing window — only use the last `window` rows of aligned data
     if len(aligned) > window:


### PR DESCRIPTION
## Problem

Computing correlation between assets from different markets (e.g. `BTC-USDT` vs `MSTR`) always fails with:

```
No overlapping return data between assets
```

## Root Cause

Different data loaders produce `DatetimeIndex` values at different UTC offsets:

| Loader | Market | Timestamp example |
|--------|--------|-------------------|
| OKX / CCXT | crypto | `2025-05-30 00:00:00` (UTC midnight) |
| yfinance | US equity | `2025-05-30 04:00:00` (EDT midnight → 04:00 UTC, then `tz_localize(None)` preserves the offset) |

The inner join on these indices produces **zero overlapping rows**.

## Fix

- Call `.index.normalize()` on each close series before computing returns, collapsing all timestamps to midnight (`00:00:00`) regardless of data source.
- Improve the "No overlapping return data" error message to include actual date ranges per asset for easier debugging.

## Verified

```
# Simulated test: crypto at midnight vs equity at 4am
WITHOUT normalize: aligned rows = 0
WITH normalize:    aligned rows = 6
SUCCESS: Cross-market correlation now works!
```