### PR TITLE
fix: reliable session status + swarm real data enforcement

### DIFF
--- a/agent/api_server.py
+++ b/agent/api_server.py
@@ -2237,6 +2237,38 @@ async def cancel_swarm_run(run_id: str):
     return {"status": "cancelled"}
 
 
+@app.post("/swarm/runs/{run_id}/retry", dependencies=[Depends(require_auth)])
+async def retry_swarm_run(run_id: str, http_request: Request):
+    """Retry a failed, stale, or cancelled swarm run.
+
+    Creates a new run with the same preset and user_vars as the original.
+    """
+    _validate_path_param(run_id, "run_id")
+    runtime = _get_swarm_runtime()
+    loaded = runtime._store.load_run(run_id)
+    if not loaded:
+        raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
+
+    # Allow retry for any non-running status
+    from src.swarm.models import RunStatus
+    reconciled = runtime._store.reconcile_run(loaded, write=True)
+    if reconciled.status == RunStatus.running:
+        raise HTTPException(status_code=409, detail="Cannot retry a running run. Cancel it first.")
+
+    # Re-create with same preset and user_vars
+    try:
+        new_run = runtime.start_run(
+            reconciled.preset_name,
+            reconciled.user_vars or {},
+            include_shell_tools=_shell_tools_enabled_for_request(http_request),
+        )
+        return {"id": new_run.id, "status": new_run.status.value, "preset_name": new_run.preset_name}
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
 # ============================================================================
 # Live trading channel — consent commit + kill switch
 # ============================================================================

--- a/agent/backtest/correlation.py
+++ b/agent/backtest/correlation.py
@@ -70,6 +70,10 @@ def _rolling_correlation_matrix(
 
     for code in codes:
         ts = closes[code]
+        # Normalize to date-only (midnight) so that cross-market assets
+        # (e.g. crypto via OKX/CCXT at UTC midnight vs US equity via
+        # yfinance at EDT midnight = 04:00 UTC) align correctly.
+        ts.index = ts.index.normalize()
         rets = ts.pct_change().dropna()
         rets.name = code
         returns_frames.append(rets)
@@ -77,7 +81,15 @@ def _rolling_correlation_matrix(
     # Align all series to a common index (inner join)
     aligned = pd.concat(returns_frames, axis=1).dropna()
     if aligned.empty:
-        raise ValueError("No overlapping return data between assets")
+        ranges = {
+            code: f"{closes[code].index.min()} .. {closes[code].index.max()}"
+            for code in codes
+            if len(closes[code]) > 0
+        }
+        raise ValueError(
+            f"No overlapping return data between assets. "
+            f"Date ranges: {ranges}"
+        )
 
     # Apply the trailing window — only use the last `window` rows of aligned data
     if len(aligned) > window:

--- a/agent/src/providers/llm.py
+++ b/agent/src/providers/llm.py
@@ -281,7 +281,7 @@ def build_llm(*, model_name: Optional[str] = None, callbacks: Any = None) -> Any
         return OpenAICodexLLM(
             model=name,
             temperature=temperature,
-            timeout=int(os.getenv("TIMEOUT_SECONDS", "120")),
+            timeout=int(os.getenv("TIMEOUT_SECONDS", "300")),
             reasoning_effort=effort or None,
         )
 
@@ -297,7 +297,7 @@ def build_llm(*, model_name: Optional[str] = None, callbacks: Any = None) -> Any
     return ChatOpenAIWithReasoning(
         model=name,
         temperature=temperature,
-        timeout=int(os.getenv("TIMEOUT_SECONDS", "120")),
+        timeout=int(os.getenv("TIMEOUT_SECONDS", "300")),
         max_retries=int(os.getenv("MAX_RETRIES", "2")),
         callbacks=callbacks,
         extra_body={"reasoning": {"effort": effort}} if effort else None,

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -31,7 +31,7 @@ export function Layout() {
   const activeSessionId = searchParams.get("session");
   const agentStatus = useAgentStore(s => s.status);
   const agentSessionId = useAgentStore(s => s.sessionId);
-  const isAgentStreaming = agentStatus === "streaming" && agentSessionId === activeSessionId;
+  const isAnySessionStreaming = agentStatus === "streaming" && !!agentSessionId;
 
   useEffect(() => {
     localStorage.setItem("qa-sidebar", collapsed ? "collapsed" : "expanded");
@@ -163,7 +163,7 @@ export function Layout() {
                         title={s.title || s.session_id}
                       >
                         <span className="flex items-center gap-1.5">
-                          {isActive && isAgentStreaming ? (
+                          {isAnySessionStreaming && agentSessionId === s.session_id ? (
                             <Loader2 className="h-3 w-3 shrink-0 animate-spin text-primary" />
                           ) : (
                             <span className={cn(

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -29,9 +29,7 @@ export function Layout() {
   const [collapsed, setCollapsed] = useState(() => localStorage.getItem("qa-sidebar") === "collapsed");
 
   const activeSessionId = searchParams.get("session");
-  const agentStatus = useAgentStore(s => s.status);
-  const agentSessionId = useAgentStore(s => s.sessionId);
-  const isAnySessionStreaming = agentStatus === "streaming" && !!agentSessionId;
+  const streamingSessionId = useAgentStore(s => s.streamingSessionId);
 
   useEffect(() => {
     localStorage.setItem("qa-sidebar", collapsed ? "collapsed" : "expanded");
@@ -163,7 +161,7 @@ export function Layout() {
                         title={s.title || s.session_id}
                       >
                         <span className="flex items-center gap-1.5">
-                          {isAnySessionStreaming && agentSessionId === s.session_id ? (
+                          {streamingSessionId === s.session_id ? (
                             <Loader2 className="h-3 w-3 shrink-0 animate-spin text-primary" />
                           ) : (
                             <span className={cn(

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,6 +1,6 @@
 ﻿import { useEffect, useState } from "react";
 import { Link, Outlet, useLocation, useSearchParams } from "react-router-dom";
-import { BarChart3, Bot, Moon, Sun, Plus, Trash2, Pencil, MessageSquare, ChevronsLeft, ChevronsRight, Settings, Layers } from "lucide-react";
+import { BarChart3, Bot, Moon, Sun, Plus, Trash2, Pencil, MessageSquare, ChevronsLeft, ChevronsRight, Settings, Layers, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useDarkMode } from "@/hooks/useDarkMode";
 import { api, type SessionItem } from "@/lib/api";
@@ -29,6 +29,9 @@ export function Layout() {
   const [collapsed, setCollapsed] = useState(() => localStorage.getItem("qa-sidebar") === "collapsed");
 
   const activeSessionId = searchParams.get("session");
+  const agentStatus = useAgentStore(s => s.status);
+  const agentSessionId = useAgentStore(s => s.sessionId);
+  const isAgentStreaming = agentStatus === "streaming" && agentSessionId === activeSessionId;
 
   useEffect(() => {
     localStorage.setItem("qa-sidebar", collapsed ? "collapsed" : "expanded");
@@ -160,10 +163,14 @@ export function Layout() {
                         title={s.title || s.session_id}
                       >
                         <span className="flex items-center gap-1.5">
-                          <span className={cn(
-                            "h-1.5 w-1.5 rounded-full shrink-0",
-                            s.status === "failed" ? "bg-danger" : isActive ? "bg-warning" : "bg-success/60"
-                          )} />
+                          {isActive && isAgentStreaming ? (
+                            <Loader2 className="h-3 w-3 shrink-0 animate-spin text-primary" />
+                          ) : (
+                            <span className={cn(
+                              "h-1.5 w-1.5 rounded-full shrink-0",
+                              isActive ? "bg-primary/70" : "bg-muted-foreground/40"
+                            )} />
+                          )}
                           {s.title || s.session_id.slice(0, 16)}
                         </span>
                       </Link>

--- a/frontend/src/hooks/useSSE.ts
+++ b/frontend/src/hooks/useSSE.ts
@@ -81,7 +81,8 @@ export function useSSE(config?: SSEConfig) {
     // Only subscribe to event types the backend actually emits
     const knownTypes = [
       "text_delta", "thinking_done", "tool_call", "tool_result", "compact",
-      "attempt.completed", "attempt.failed",
+      "attempt.created", "attempt.started", "attempt.completed", "attempt.failed",
+      "message.received", "session.created",
       "goal.created", "goal.evidence", "goal.updated",
       "mandate.proposal", "mandate.committed", "live.halted", "live.resumed", "live.action",
       "heartbeat", "done",

--- a/frontend/src/hooks/useSSE.ts
+++ b/frontend/src/hooks/useSSE.ts
@@ -81,6 +81,7 @@ export function useSSE(config?: SSEConfig) {
     // Only subscribe to event types the backend actually emits
     const knownTypes = [
       "text_delta", "thinking_done", "tool_call", "tool_result", "compact",
+      "tool_heartbeat", "llm_usage",
       "attempt.created", "attempt.started", "attempt.completed", "attempt.failed",
       "message.received", "session.created",
       "goal.created", "goal.evidence", "goal.updated",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -79,3 +79,10 @@
   ::-webkit-scrollbar-thumb { background: hsl(var(--border)); border-radius: 3px; }
   ::-webkit-scrollbar-thumb:hover { background: hsl(var(--muted-foreground)); }
 }
+
+/* Streaming pulse-slide animation for the "running" bar */
+@keyframes pulse-slide {
+  0%   { transform: translateX(-100%); }
+  50%  { transform: translateX(200%); }
+  100% { transform: translateX(-100%); }
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -123,6 +123,8 @@ export const api = {
   swarmSseUrl: (id: string) => withAuthQuery(`${BASE}/swarm/runs/${id}/events`),
   cancelSwarmRun: (id: string) =>
     request<{ status: string }>(`/swarm/runs/${id}/cancel`, { method: "POST" }),
+  retrySwarmRun: (id: string) =>
+    request<{ id: string; status: string; preset_name: string }>(`/swarm/runs/${id}/retry`, { method: "POST" }),
   getLLMSettings: () => request<LLMSettings>("/settings/llm"),
   updateLLMSettings: (settings: UpdateLLMSettingsRequest) =>
     request<LLMSettings>("/settings/llm", {

--- a/frontend/src/pages/Agent.tsx
+++ b/frontend/src/pages/Agent.tsx
@@ -454,6 +454,20 @@ export function Agent() {
 
       compact: () => { touch(); },
 
+      "attempt.created": () => {
+        touch();
+        // Backend has created a new attempt — ensure streaming state is active
+        // even if we connected mid-stream (SSE replay / page reload).
+        if (act().status !== "streaming") act().setStatus("streaming");
+      },
+
+      "attempt.started": () => {
+        touch();
+        // Backend has begun executing the attempt. Re-affirm streaming state
+        // so the UI shows a working indicator for reconnects and fresh loads.
+        if (act().status !== "streaming") act().setStatus("streaming");
+      },
+
       "attempt.completed": async (d) => {
         touch();
         const s = act();
@@ -1052,7 +1066,7 @@ export function Agent() {
               <AgentAvatar />
               <div className="flex-1 min-w-0 flex items-center gap-2 text-xs text-muted-foreground pt-1">
                 <Loader2 className="h-3 w-3 animate-spin text-primary shrink-0" />
-                <span>Thinking…</span>
+                <span>Agent is working…</span>
               </div>
             </div>
           )}
@@ -1072,6 +1086,16 @@ export function Agent() {
                   <ToolProgressIndicator toolCalls={toolCalls} />
                 )}
               </div>
+            </div>
+          )}
+
+          {/* Persistent streaming pulse bar — always visible while agent is working */}
+          {status === "streaming" && (
+            <div className="flex items-center gap-2 px-1 pt-1">
+              <div className="h-0.5 flex-1 rounded-full bg-primary/20 overflow-hidden">
+                <div className="h-full w-1/3 bg-primary rounded-full animate-[pulse-slide_2s_ease-in-out_infinite]" />
+              </div>
+              <span className="text-[10px] text-muted-foreground shrink-0 tabular-nums">running</span>
             </div>
           )}
 

--- a/frontend/src/pages/Agent.tsx
+++ b/frontend/src/pages/Agent.tsx
@@ -421,6 +421,8 @@ export function Agent() {
 
       tool_heartbeat: (d) => {
         touch();
+        // Keep streaming state alive during long-running tools (swarm, backtest)
+        if (act().status !== "streaming") act().setStatus("streaming");
         const toolName = String(d.tool || "");
         if (!toolName) return;
         act().updateToolCall(toolName, {

--- a/frontend/src/stores/agent.ts
+++ b/frontend/src/stores/agent.ts
@@ -10,6 +10,10 @@ interface AgentState {
   status: "idle" | "streaming" | "error";
   streamingText: string;
 
+  /** The session currently streaming on the backend. Survives switchSession
+   *  so the sidebar spinner persists when the user navigates away. */
+  streamingSessionId: string | null;
+
   toolCalls: ToolCallEntry[];
 
   sseStatus: "disconnected" | "connected" | "reconnecting";
@@ -46,6 +50,7 @@ export const useAgentStore = create<AgentState>((set) => ({
   sessionId: null,
   status: "idle",
   streamingText: "",
+  streamingSessionId: null,
   toolCalls: [],
   sseStatus: "disconnected",
   sseRetryAttempt: 0,
@@ -57,7 +62,16 @@ export const useAgentStore = create<AgentState>((set) => ({
   appendDelta: (delta) =>
     set((s) => ({ streamingText: s.streamingText + delta })),
 
-  setStatus: (status) => set({ status }),
+  setStatus: (status) =>
+    set((s) => {
+      const patch: Partial<AgentState> = { status };
+      if (status === "streaming" && s.sessionId) {
+        patch.streamingSessionId = s.sessionId;
+      } else if (status !== "streaming" && s.streamingSessionId === s.sessionId) {
+        patch.streamingSessionId = null;
+      }
+      return patch;
+    }),
   setSessionId: (sessionId) => set({ sessionId }),
   loadHistory: (msgs) => set({ messages: msgs }),
 
@@ -85,14 +99,17 @@ export const useAgentStore = create<AgentState>((set) => ({
 
   switchSession: (sid, msgs) => {
     _id = 0;
-    set({
+    set((s) => ({
       sessionId: sid,
       messages: msgs || [],
       status: "idle",
       streamingText: "",
       toolCalls: [],
       sessionLoading: !msgs,
-    });
+      // Preserve streamingSessionId so the sidebar spinner stays visible
+      // when switching away from a running session.
+      streamingSessionId: s.streamingSessionId,
+    }));
   },
 
   setSessionLoading: (sessionLoading) => set({ sessionLoading }),
@@ -102,6 +119,7 @@ export const useAgentStore = create<AgentState>((set) => ({
     set({
       messages: [], status: "idle", streamingText: "",
       sessionId: null, toolCalls: [], sessionLoading: false,
+      streamingSessionId: null,
     });
   },
 }));


### PR DESCRIPTION
## Problem

1. **Session running indicator unreliable** — spinner flickers, disappears on session switch, sometimes shows no indication at all when a session is actively processing.
2. **SSE missing event types** — `tool_heartbeat` and `llm_usage` not in `knownTypes`, causing frontend to silently drop events during long-running tasks.
3. **Swarm hallucinates data** — Workers skip tool calls and generate plausible-sounding but fake financial data from training memory (e.g., reported 67.97 vs real 69.86 for 赣锋锂业).

## Changes

### Session status indicator
- Added `streamingSessionId` to agent store, independent of active session
- Sidebar spinner shows for running sessions regardless of which session is active
- `switchSession` preserves `status: "streaming"` when switching back to a running session (EventBus replay buffer caps at 500 events, so key state events like `attempt.created` may be dropped for long runs)
- `tool_heartbeat` / `tool_progress` handlers auto-recreate missing ToolCallEntry after session switch

### SSE event types
- Added `tool_heartbeat` and `llm_usage` to `useSSE.ts` knownTypes

### Swarm internal progress
- `SwarmTool.execute()` polling loop calls `emit_progress()` with task completion count, running agent names, and progress message
- Frontend `ToolProgressIndicator` now shows swarm progress (e.g., "report_editor · 3/4 tasks completed") instead of generic "Step 1 · run_swarm"

### LLM timeout & retry
- Default timeout increased from 120s to 300s for complex analysis tasks
- Added `POST /swarm/runs/{id}/retry` API endpoint

### Swarm data enforcement
- Worker execution rules restructured into 4 phases with Phase 2 **Data Acquisition (MANDATORY)** before any analysis
- Explicit data source guidance per market (tushare/akshare → A-shares, yfinance → HK/US, ccxt → crypto)
- `fundamental_research_team.yaml`: Added `⚠️ CRITICAL: Real Data Required` warnings to all 3 analyst agents
- Added `tushare` and `yfinance` skills to each analyst agent so `load_skill` descriptions are in-prompt

## Testing
- Verified session spinner persists across session switches
- Verified ToolProgressIndicator restores after switch via tool_heartbeat recreation
- Verified swarm progress display with `emit_progress()` in SwarmTool polling loop
- TypeScript compiles clean (`npx tsc --noEmit`)