### PR TITLE
fix(ui): reliable session running indicator + swarm retry + version (#156, supersedes #159)

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,7 +675,7 @@ Settings reads are side-effect free: `GET /settings/llm` and `GET /settings/data
 
 ## 🔌 MCP Plugin
 
-Vibe-Trading exposes 35 MCP tools for any MCP-compatible client. Runs as a stdio subprocess — no server setup needed. Core research tools work with zero API keys for HK/US/crypto; trading connector tools use the selected connector profile, and `run_swarm` needs an LLM key.
+Vibe-Trading exposes 36 MCP tools for any MCP-compatible client. Runs as a stdio subprocess — no server setup needed. Core research tools work with zero API keys for HK/US/crypto; trading connector tools use the selected connector profile, and `run_swarm` needs an LLM key.
 
 <details>
 <summary><b>Claude Desktop</b></summary>
@@ -943,7 +943,7 @@ Vibe-Trading/
 ├── agent/                          # Backend (Python)
 │   ├── cli/                        # CLI package — interactive TUI + subcommands
 │   ├── api_server.py               # FastAPI server — runs, sessions, upload, swarm, SSE
-│   ├── mcp_server.py               # MCP server — 35 tools for OpenClaw / Claude Desktop
+│   ├── mcp_server.py               # MCP server — 36 tools for OpenClaw / Claude Desktop
 │   │
 │   ├── src/
 │   │   ├── agent/                  # ReAct agent core

--- a/README_ar.md
+++ b/README_ar.md
@@ -774,7 +774,7 @@ Vibe-Trading/
 ├── agent/                          # Backend (Python)
 │   ├── cli/                        # CLI package — interactive TUI + subcommands
 │   ├── api_server.py               # FastAPI server — runs, sessions, upload, swarm, SSE
-│   ├── mcp_server.py               # MCP server — 35 tools for OpenClaw / Claude Desktop
+│   ├── mcp_server.py               # MCP server — 36 tools for OpenClaw / Claude Desktop
 │   │
 │   ├── src/
 │   │   ├── agent/                  # ReAct agent core

--- a/README_ja.md
+++ b/README_ja.md
@@ -671,7 +671,7 @@ Settings reads は side-effect free です。`GET /settings/llm` と `GET /setti
 
 ## 🔌 MCP Plugin
 
-Vibe-Trading は MCP-compatible client 向けに 35 MCP tools を公開します。stdio subprocess として動作し、server setup は不要です。Core research tools は HK/US/crypto で API key なしに動作し、trading connector tools は選択中の connector profile を使います。LLM key が必要なのは `run_swarm` のみです。
+Vibe-Trading は MCP-compatible client 向けに 36 MCP tools を公開します。stdio subprocess として動作し、server setup は不要です。Core research tools は HK/US/crypto で API key なしに動作し、trading connector tools は選択中の connector profile を使います。LLM key が必要なのは `run_swarm` のみです。
 
 <details>
 <summary><b>Claude Desktop</b></summary>
@@ -771,7 +771,7 @@ Vibe-Trading/
 ├── agent/                          # バックエンド (Python)
 │   ├── cli/                        # CLI パッケージ — インタラクティブ TUI + サブコマンド
 │   ├── api_server.py               # FastAPI サーバー — runs、sessions、upload、swarm、SSE
-│   ├── mcp_server.py               # MCP サーバー — OpenClaw / Claude Desktop 向け 35 tools
+│   ├── mcp_server.py               # MCP サーバー — OpenClaw / Claude Desktop 向け 36 tools
 │   │
 │   ├── src/
 │   │   ├── agent/                  # ReAct エージェントコア

--- a/README_ko.md
+++ b/README_ko.md
@@ -774,7 +774,7 @@ Vibe-Trading/
 ├── agent/                          # Backend (Python)
 │   ├── cli/                        # CLI package — interactive TUI + subcommands
 │   ├── api_server.py               # FastAPI server — runs, sessions, upload, swarm, SSE
-│   ├── mcp_server.py               # MCP server — 35 tools for OpenClaw / Claude Desktop
+│   ├── mcp_server.py               # MCP server — 36 tools for OpenClaw / Claude Desktop
 │   │
 │   ├── src/
 │   │   ├── agent/                  # ReAct agent core

--- a/README_zh.md
+++ b/README_zh.md
@@ -670,7 +670,7 @@ Settings 读取无副作用：`GET /settings/llm` 和 `GET /settings/data-source
 
 ## 🔌 MCP Plugin
 
-Vibe-Trading 为任何 MCP-compatible client 暴露 35 个 MCP tools。它作为 stdio subprocess 运行，无需 server setup。核心 research tools 对港股/美股/加密零 API key 可用；trading connector tools 使用当前选择的 connector profile；只有 `run_swarm` 需要 LLM key。
+Vibe-Trading 为任何 MCP-compatible client 暴露 36 个 MCP tools。它作为 stdio subprocess 运行，无需 server setup。核心 research tools 对港股/美股/加密零 API key 可用；trading connector tools 使用当前选择的 connector profile；只有 `run_swarm` 需要 LLM key。
 
 <details>
 <summary><b>Claude Desktop</b></summary>
@@ -770,7 +770,7 @@ Vibe-Trading/
 ├── agent/                          # 后端（Python）
 │   ├── cli/                        # CLI 包 —— 交互式 TUI + 子命令
 │   ├── api_server.py               # FastAPI server —— runs、sessions、upload、swarm、SSE
-│   ├── mcp_server.py               # MCP server —— 35 个工具，面向 OpenClaw / Claude Desktop
+│   ├── mcp_server.py               # MCP server —— 36 个工具，面向 OpenClaw / Claude Desktop
 │   │
 │   ├── src/
 │   │   ├── agent/                  # ReAct agent 内核

--- a/agent/api_server.py
+++ b/agent/api_server.py
@@ -2239,6 +2239,39 @@ async def cancel_swarm_run(run_id: str):
     return {"status": "cancelled"}
 
 
+@app.post("/swarm/runs/{run_id}/retry", dependencies=[Depends(require_auth)])
+async def retry_swarm_run(run_id: str, http_request: Request):
+    """Retry a failed, stale, or cancelled swarm run.
+
+    Creates a new run with the same preset and user_vars as the original.
+    """
+    _validate_path_param(run_id, "run_id")
+    runtime = _get_swarm_runtime()
+    loaded = runtime._store.load_run(run_id)
+    if not loaded:
+        raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
+
+    # Reconcile first so a stale "running" run whose host died gets demoted
+    # before we gate on status; only a genuinely active run blocks retry.
+    from src.swarm.models import RunStatus
+
+    reconciled = runtime._store.reconcile_run(loaded, write=True)
+    if reconciled.status == RunStatus.running:
+        raise HTTPException(status_code=409, detail="Cannot retry a running run. Cancel it first.")
+
+    try:
+        new_run = runtime.start_run(
+            reconciled.preset_name,
+            reconciled.user_vars or {},
+            include_shell_tools=_shell_tools_enabled_for_request(http_request),
+        )
+        return {"id": new_run.id, "status": new_run.status.value, "preset_name": new_run.preset_name}
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
 # ============================================================================
 # Live trading channel — consent commit + kill switch
 # ============================================================================

--- a/agent/cli/_version.py
+++ b/agent/cli/_version.py
@@ -1,16 +1,36 @@
 """Single source of truth for the CLI version string.
 
 Reads ``vibe-trading-ai``'s installed package metadata when available
-(``pip install -e .`` is enough). Falls back to the static constant
-below for un-installed checkouts (e.g. running straight from a clone
-with ``PYTHONPATH=agent``).
-
-Keep the fallback in sync with ``pyproject.toml`` ``[project] version``.
+(``pip install -e .`` is enough). For an un-installed checkout (e.g. running
+straight from a clone with ``PYTHONPATH=agent``) it falls back to reading the
+version straight out of ``pyproject.toml`` — so ``pyproject.toml`` is the one
+and only place the version is ever written. There is deliberately no hardcoded
+version constant to drift out of sync on release (issue #156).
 """
 
 from __future__ import annotations
 
 from typing import Final
+
+
+def _version_from_pyproject() -> str:
+    """Read ``[project] version`` from the repo's ``pyproject.toml``.
+
+    Returns:
+        The declared version, or ``"unknown"`` if the file cannot be located
+        or parsed (only reachable for an un-installed checkout whose tree has
+        been moved away from its ``pyproject.toml``).
+    """
+    import tomllib
+    from pathlib import Path
+
+    # agent/cli/_version.py -> parents[2] is the repo root holding pyproject.toml.
+    pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    try:
+        return tomllib.loads(pyproject.read_text(encoding="utf-8"))["project"]["version"]
+    except (OSError, KeyError, tomllib.TOMLDecodeError):
+        return "unknown"
+
 
 try:
     from importlib.metadata import PackageNotFoundError, version as _pkg_version
@@ -18,9 +38,9 @@ try:
     try:
         __version__: Final[str] = _pkg_version("vibe-trading-ai")
     except PackageNotFoundError:
-        __version__ = "0.1.8"
+        __version__ = _version_from_pyproject()
 except ImportError:  # pragma: no cover — importlib.metadata is stdlib on 3.8+
-    __version__ = "0.1.8"
+    __version__ = _version_from_pyproject()
 
 
 __all__ = ["__version__"]

--- a/agent/mcp_server.py
+++ b/agent/mcp_server.py
@@ -1285,6 +1285,60 @@ def reap_stale_runs() -> str:
     return json.dumps({"reaped": reaped}, ensure_ascii=False, indent=2)
 
 
+@mcp.tool
+def retry_run(run_id: str) -> str:
+    """Retry a failed, stale, or cancelled swarm run.
+
+    Re-launches a brand-new run with the same preset and variables as the
+    original; the original run is left untouched as a record. Use this after
+    spotting a ``failed`` or stale run via ``list_runs``. A still-``running``
+    run cannot be retried — cancel or reap it first.
+
+    Args:
+        run_id: ID of the run to retry (from ``list_runs`` / ``get_swarm_status``).
+
+    Returns:
+        JSON payload for the newly created run (``run_id`` / ``status`` /
+        ``preset`` …), or an ``error`` object if the run is missing or active.
+    """
+    from src.config import load_swarm_agent_config
+    from src.swarm.models import RunStatus
+    from src.swarm.runtime import SwarmRuntime
+
+    store = _get_swarm_store()
+    loaded = store.load_run(run_id)
+    if loaded is None:
+        return json.dumps({"status": "error", "error": f"Run {run_id} not found"}, ensure_ascii=False)
+
+    # Reconcile first so a zombie "running" run whose host died is demoted
+    # before we gate on status; only a genuinely active run blocks retry.
+    reconciled = store.reconcile_run(loaded, write=True)
+    if reconciled.status == RunStatus.running:
+        return json.dumps(
+            {"status": "error", "error": "Cannot retry a running run. Cancel or reap it first."},
+            ensure_ascii=False,
+        )
+
+    agent_config = load_swarm_agent_config()
+    runtime = SwarmRuntime(store=store, agent_config=agent_config)
+    try:
+        new_run = runtime.start_run(
+            reconciled.preset_name,
+            reconciled.user_vars or {},
+            include_shell_tools=_include_shell_tools,
+        )
+    except FileNotFoundError as exc:
+        return json.dumps({"status": "error", "error": str(exc)}, ensure_ascii=False)
+    except ValueError as exc:
+        return json.dumps({"status": "error", "error": f"DAG validation failed: {exc}"}, ensure_ascii=False)
+
+    return json.dumps(
+        _build_run_payload(store, new_run.id, new_run.preset_name, timed_out=False),
+        ensure_ascii=False,
+        indent=2,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Trade journal tool
 # ---------------------------------------------------------------------------

--- a/agent/tests/test_cli_version.py
+++ b/agent/tests/test_cli_version.py
@@ -1,0 +1,42 @@
+"""Regression tests for issue #156 — CLI version must track pyproject.toml.
+
+The shipped 0.1.8 wheel reported ``0.1.7`` because a hardcoded constant was
+not bumped on release. ``cli/_version.py`` now derives the version from package
+metadata, falling back to reading ``pyproject.toml`` directly, so there is no
+constant left to drift. These tests pin both invariants.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from cli import _version
+
+_PYPROJECT = Path(__file__).resolve().parents[2] / "pyproject.toml"
+
+
+def _declared_version() -> str:
+    return tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))["project"]["version"]
+
+
+def test_pyproject_fallback_matches_declared_version() -> None:
+    # The fallback is the single source of truth for an un-installed checkout;
+    # it must reproduce pyproject.toml exactly (never a stale hardcoded value).
+    assert _version._version_from_pyproject() == _declared_version()
+
+
+def test_exposed_version_is_resolved_not_unknown() -> None:
+    assert _version.__version__
+    assert _version.__version__ != "unknown"
+
+
+def test_no_hardcoded_version_constant_in_source() -> None:
+    # Guards against reintroducing a literal version string that can drift
+    # (the root cause of #156). The only version literal allowed is the
+    # "unknown" sentinel for a moved/un-installed tree.
+    import re
+
+    source = Path(_version.__file__).read_text(encoding="utf-8")
+    literals = re.findall(r"\"\d+\.\d+\.\d+\"", source)
+    assert not literals, f"hardcoded version literal(s) found in _version.py: {literals}"

--- a/agent/tests/test_mcp_regression.py
+++ b/agent/tests/test_mcp_regression.py
@@ -161,6 +161,7 @@ def test_mcp_server_exposes_well_known_tool_names() -> None:
         "read_file",
         "list_swarm_presets",
         "run_swarm",
+        "retry_run",
         "start_research_goal",
         "get_research_goal",
         "add_goal_evidence",

--- a/agent/tests/test_security_auth_api.py
+++ b/agent/tests/test_security_auth_api.py
@@ -305,6 +305,7 @@ def test_swarm_run_endpoints_reject_traversal_run_id() -> None:
         ("get", "/swarm/runs/foo.bar"),
         ("get", "/swarm/runs/foo.bar/events"),
         ("post", "/swarm/runs/foo.bar/cancel"),
+        ("post", "/swarm/runs/foo.bar/retry"),
     ):
         response = getattr(client, method)(path)
         assert response.status_code == 400, f"{method.upper()} {path} should be rejected"

--- a/agent/tests/test_swarm_retry.py
+++ b/agent/tests/test_swarm_retry.py
@@ -1,0 +1,85 @@
+"""Tests for the swarm-run retry path (MCP ``retry_run`` tool + HTTP endpoint).
+
+Retry re-launches a brand-new run with the same preset/variables as a prior
+``failed`` / ``cancelled`` / stale run, leaving the original untouched. A
+still-``running`` run must be refused so we never fork an active run.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import mcp_server
+import src.swarm.runtime as rt
+from src.swarm.models import RunStatus, SwarmAgentSpec, SwarmRun, SwarmTask, TaskStatus
+from src.swarm.store import SwarmStore
+from src.swarm.task_store import TaskStore
+
+
+def _make_run(run_id: str, status: RunStatus) -> SwarmRun:
+    agent = SwarmAgentSpec(id="analyst", role="Analyst", system_prompt="x", timeout_seconds=300)
+    task = SwarmTask(id="t1", agent_id="analyst", prompt_template="do x")
+    run = SwarmRun(
+        id=run_id,
+        preset_name="demo",
+        created_at=datetime.now(timezone.utc).isoformat(),
+        agents=[agent],
+        tasks=[task],
+        user_vars={"target": "AAPL.US"},
+    )
+    run.status = status
+    return run
+
+
+def test_retry_run_missing_returns_error(tmp_path, monkeypatch):
+    store = SwarmStore(base_dir=tmp_path)
+    monkeypatch.setattr(mcp_server, "_get_swarm_store", lambda: store)
+
+    payload = json.loads(mcp_server.retry_run("does-not-exist"))
+
+    assert payload["status"] == "error"
+    assert "not found" in payload["error"].lower()
+
+
+def test_retry_run_refuses_running_run(tmp_path, monkeypatch):
+    store = SwarmStore(base_dir=tmp_path)
+    run = _make_run("r-running", RunStatus.running)
+    store.create_run(run)
+    monkeypatch.setattr(mcp_server, "_get_swarm_store", lambda: store)
+
+    payload = json.loads(mcp_server.retry_run("r-running"))
+
+    assert payload["status"] == "error"
+    assert "running" in payload["error"].lower()
+
+
+def test_retry_run_relaunches_failed_run_with_same_preset(tmp_path, monkeypatch):
+    store = SwarmStore(base_dir=tmp_path)
+    original = _make_run("r-failed", RunStatus.failed)
+    store.create_run(original)
+    monkeypatch.setattr(mcp_server, "_get_swarm_store", lambda: store)
+
+    captured: dict[str, object] = {}
+
+    def fake_start_run(self, preset_name, variables, **kwargs):
+        captured["preset_name"] = preset_name
+        captured["variables"] = variables
+        new = _make_run("r-retry", RunStatus.running)
+        new.preset_name = preset_name
+        self._store.create_run(new)
+        TaskStore(self._store.run_dir(new.id)).save_task(
+            new.tasks[0].model_copy(update={"status": TaskStatus.in_progress})
+        )
+        return new
+
+    monkeypatch.setattr(rt.SwarmRuntime, "start_run", fake_start_run)
+
+    payload = json.loads(mcp_server.retry_run("r-failed"))
+
+    # Same preset + user_vars carried over from the original run.
+    assert captured["preset_name"] == "demo"
+    assert captured["variables"] == {"target": "AAPL.US"}
+    # A fresh run id is returned, not the original.
+    assert payload["run_id"] == "r-retry"
+    assert payload["status"] == "running"

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,6 +1,6 @@
 ﻿import { useEffect, useState } from "react";
 import { Link, Outlet, useLocation, useSearchParams } from "react-router-dom";
-import { BarChart3, Bot, Moon, Sun, Plus, Trash2, Pencil, MessageSquare, ChevronsLeft, ChevronsRight, Settings, Layers } from "lucide-react";
+import { BarChart3, Bot, Moon, Sun, Plus, Trash2, Pencil, MessageSquare, ChevronsLeft, ChevronsRight, Settings, Layers, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useDarkMode } from "@/hooks/useDarkMode";
 import { api, type SessionItem } from "@/lib/api";
@@ -29,6 +29,7 @@ export function Layout() {
   const [collapsed, setCollapsed] = useState(() => localStorage.getItem("qa-sidebar") === "collapsed");
 
   const activeSessionId = searchParams.get("session");
+  const streamingSessionId = useAgentStore(s => s.streamingSessionId);
 
   useEffect(() => {
     localStorage.setItem("qa-sidebar", collapsed ? "collapsed" : "expanded");
@@ -160,10 +161,14 @@ export function Layout() {
                         title={s.title || s.session_id}
                       >
                         <span className="flex items-center gap-1.5">
-                          <span className={cn(
-                            "h-1.5 w-1.5 rounded-full shrink-0",
-                            s.status === "failed" ? "bg-danger" : isActive ? "bg-warning" : "bg-success/60"
-                          )} />
+                          {streamingSessionId === s.session_id ? (
+                            <Loader2 className="h-3 w-3 shrink-0 animate-spin text-primary" />
+                          ) : (
+                            <span className={cn(
+                              "h-1.5 w-1.5 rounded-full shrink-0",
+                              isActive ? "bg-primary/70" : "bg-muted-foreground/40"
+                            )} />
+                          )}
                           {s.title || s.session_id.slice(0, 16)}
                         </span>
                       </Link>

--- a/frontend/src/hooks/useSSE.ts
+++ b/frontend/src/hooks/useSSE.ts
@@ -81,7 +81,9 @@ export function useSSE(config?: SSEConfig) {
     // Only subscribe to event types the backend actually emits
     const knownTypes = [
       "text_delta", "thinking_done", "tool_call", "tool_result", "compact",
-      "attempt.completed", "attempt.failed",
+      "tool_heartbeat", "llm_usage",
+      "attempt.created", "attempt.started", "attempt.completed", "attempt.failed",
+      "message.received", "session.created",
       "goal.created", "goal.evidence", "goal.updated",
       "mandate.proposal", "mandate.committed", "live.halted", "live.resumed", "live.action",
       "heartbeat", "done",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -79,3 +79,10 @@
   ::-webkit-scrollbar-thumb { background: hsl(var(--border)); border-radius: 3px; }
   ::-webkit-scrollbar-thumb:hover { background: hsl(var(--muted-foreground)); }
 }
+
+/* Streaming pulse-slide animation for the "running" bar */
+@keyframes pulse-slide {
+  0%   { transform: translateX(-100%); }
+  50%  { transform: translateX(200%); }
+  100% { transform: translateX(-100%); }
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -123,6 +123,8 @@ export const api = {
   swarmSseUrl: (id: string) => withAuthQuery(`${BASE}/swarm/runs/${id}/events`),
   cancelSwarmRun: (id: string) =>
     request<{ status: string }>(`/swarm/runs/${id}/cancel`, { method: "POST" }),
+  retrySwarmRun: (id: string) =>
+    request<{ id: string; status: string; preset_name: string }>(`/swarm/runs/${id}/retry`, { method: "POST" }),
   getLLMSettings: () => request<LLMSettings>("/settings/llm"),
   updateLLMSettings: (settings: UpdateLLMSettingsRequest) =>
     request<LLMSettings>("/settings/llm", {

--- a/frontend/src/pages/Agent.tsx
+++ b/frontend/src/pages/Agent.tsx
@@ -435,6 +435,8 @@ export function Agent() {
 
       tool_heartbeat: (d) => {
         touch();
+        // Keep streaming state alive during long-running tools (swarm, backtest)
+        if (act().status !== "streaming") act().setStatus("streaming");
         const toolName = String(d.tool || "");
         if (!toolName) return;
         act().updateToolCall(toolName, {
@@ -467,6 +469,20 @@ export function Agent() {
       },
 
       compact: () => { touch(); },
+
+      "attempt.created": () => {
+        touch();
+        // Backend has created a new attempt — ensure streaming state is active
+        // even if we connected mid-stream (SSE replay / page reload).
+        if (act().status !== "streaming") act().setStatus("streaming");
+      },
+
+      "attempt.started": () => {
+        touch();
+        // Backend has begun executing the attempt. Re-affirm streaming state
+        // so the UI shows a working indicator for reconnects and fresh loads.
+        if (act().status !== "streaming") act().setStatus("streaming");
+      },
 
       "attempt.completed": async (d) => {
         touch();
@@ -1081,7 +1097,7 @@ export function Agent() {
               <AgentAvatar />
               <div className="flex-1 min-w-0 flex items-center gap-2 text-xs text-muted-foreground pt-1">
                 <Loader2 className="h-3 w-3 animate-spin text-primary shrink-0" />
-                <span>Thinking…</span>
+                <span>Agent is working…</span>
               </div>
             </div>
           )}
@@ -1101,6 +1117,16 @@ export function Agent() {
                   <ToolProgressIndicator toolCalls={toolCalls} />
                 )}
               </div>
+            </div>
+          )}
+
+          {/* Persistent streaming pulse bar — always visible while agent is working */}
+          {status === "streaming" && (
+            <div className="flex items-center gap-2 px-1 pt-1">
+              <div className="h-0.5 flex-1 rounded-full bg-primary/20 overflow-hidden">
+                <div className="h-full w-1/3 bg-primary rounded-full animate-[pulse-slide_2s_ease-in-out_infinite]" />
+              </div>
+              <span className="text-[10px] text-muted-foreground shrink-0 tabular-nums">running</span>
             </div>
           )}
 

--- a/frontend/src/stores/agent.ts
+++ b/frontend/src/stores/agent.ts
@@ -10,6 +10,10 @@ interface AgentState {
   status: "idle" | "streaming" | "error";
   streamingText: string;
 
+  /** The session currently streaming on the backend. Survives switchSession
+   *  so the sidebar spinner persists when the user navigates away. */
+  streamingSessionId: string | null;
+
   toolCalls: ToolCallEntry[];
 
   sseStatus: "disconnected" | "connected" | "reconnecting";
@@ -46,6 +50,7 @@ export const useAgentStore = create<AgentState>((set) => ({
   sessionId: null,
   status: "idle",
   streamingText: "",
+  streamingSessionId: null,
   toolCalls: [],
   sseStatus: "disconnected",
   sseRetryAttempt: 0,
@@ -57,7 +62,16 @@ export const useAgentStore = create<AgentState>((set) => ({
   appendDelta: (delta) =>
     set((s) => ({ streamingText: s.streamingText + delta })),
 
-  setStatus: (status) => set({ status }),
+  setStatus: (status) =>
+    set((s) => {
+      const patch: Partial<AgentState> = { status };
+      if (status === "streaming" && s.sessionId) {
+        patch.streamingSessionId = s.sessionId;
+      } else if (status !== "streaming" && s.streamingSessionId === s.sessionId) {
+        patch.streamingSessionId = null;
+      }
+      return patch;
+    }),
   setSessionId: (sessionId) => set({ sessionId }),
   loadHistory: (msgs) => set({ messages: msgs }),
 
@@ -85,14 +99,17 @@ export const useAgentStore = create<AgentState>((set) => ({
 
   switchSession: (sid, msgs) => {
     _id = 0;
-    set({
+    set((s) => ({
       sessionId: sid,
       messages: msgs || [],
       status: "idle",
       streamingText: "",
       toolCalls: [],
       sessionLoading: !msgs,
-    });
+      // Preserve streamingSessionId so the sidebar spinner stays visible
+      // when switching away from a running session.
+      streamingSessionId: s.streamingSessionId,
+    }));
   },
 
   setSessionLoading: (sessionLoading) => set({ sessionLoading }),
@@ -102,6 +119,7 @@ export const useAgentStore = create<AgentState>((set) => ({
     set({
       messages: [], status: "idle", streamingText: "",
       sessionId: null, toolCalls: [], sessionLoading: false,
+      streamingSessionId: null,
     });
   },
 }));


### PR DESCRIPTION
Lands the **session running-status indicator** scoped out of #159, completes the **swarm-retry** capability into something actually usable, and fixes the **#156** version drift. Credit for the UI indicator and the swarm-retry origin goes to @ai7eam-dev (`Co-authored-by` on both commits).

## 1. Session running-status indicator (from #159, scoped)
The indicator flickered or vanished on reconnect / page reload / sidebar.
- `useSSE`: add `attempt.created/started`, `message.received`, `session.created`, `tool_heartbeat`, `llm_usage` to `knownTypes` so a mid-stream replay still surfaces the working state
- `stores/agent`: track `streamingSessionId`, preserved across `switchSession` so the sidebar spinner persists when navigating away from a running session
- `Agent.tsx`: handle `attempt.created/started` (re-affirm streaming on reconnect/reload), keep streaming alive on `tool_heartbeat`, persistent pulse bar, reword "Thinking…" → "Agent is working…"
- `Layout`: replace the dead-code `status === "failed"` dot with a spinning `Loader2` for the streaming session
- `index.css`: `pulse-slide` keyframe

> Dropped from #159 on purpose: the correlation fix (landed in #158), the SSE/LLM timeout change (landed in #157), and the `agent/src/providers/llm.py` default bump (protected module — needs separate discussion).

## 2. Swarm retry (HTTP + MCP)
#159 added a retry endpoint + an unused `api.ts` method but no usable trigger. Completed end-to-end:
- `api_server`: `POST /swarm/runs/{id}/retry` — reconciles a stale "running" run first, refuses a genuinely active run (409), else re-launches a new run with the original preset + `user_vars`
- `mcp_server`: `retry_run(run_id)` tool, so the `list_runs` → spot-failure → retry loop works from OpenClaw / Claude Desktop (the frontend has no swarm dashboard; MCP + HTTP are the real consumers)
- `api.ts`: `retrySwarmRun` client method (parity with `cancelSwarmRun`)

## 3. Version drift (#156)
The shipped 0.1.8 wheel reported `0.1.7` from a hardcoded constant. `cli/_version.py` now derives the version from package metadata, falling back to reading `pyproject.toml` directly — `pyproject.toml` is the single source of truth, no constant left to drift.

## Tests
- `test_swarm_retry.py` (new): missing-run / running-refused / happy-path relaunch
- `test_cli_version.py` (new): pyproject fallback matches declared version, resolved-not-unknown, guard against reintroducing a hardcoded version literal
- `test_mcp_regression.py`: lock `retry_run` as a well-known tool
- `test_security_auth_api.py`: traversal rejection for the new endpoint
- Full suite: **2884 passed, 43 skipped**; frontend `tsc --noEmit` clean + `vite build` passes

## Notes
- No protected-area changes (`src/agent/`, `src/session/`, `src/providers/` untouched)
- MCP tool count bumped 35 → 36 across the 5 READMEs. The ar/ko README **prose** still carries a stale 22-tool list — pre-existing localization debt, tracked separately, out of scope here.

Supersedes #159.