### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/agent/.env.example
+++ b/agent/.env.example
@@ -59,7 +59,7 @@ OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 
 # --- MiniMax ---
 # LANGCHAIN_PROVIDER=minimax
-# LANGCHAIN_MODEL_NAME=MiniMax-M2.7          # or MiniMax-M2.7-highspeed (faster)
+# LANGCHAIN_MODEL_NAME=MiniMax-M3              # or MiniMax-M2.7 / MiniMax-M2.7-highspeed
 # MINIMAX_API_KEY=xxx
 # MINIMAX_BASE_URL=https://api.minimax.io/v1
 # Note: MiniMax requires temperature > 0. Set LANGCHAIN_TEMPERATURE=1.0 (default when using MiniMax)

--- a/agent/cli/_legacy.py
+++ b/agent/cli/_legacy.py
@@ -4166,7 +4166,7 @@ _PROVIDER_CHOICES: list[dict[str, str | None]] = [
         "key_env": "MINIMAX_API_KEY",
         "base_env": "MINIMAX_BASE_URL",
         "base_url": "https://api.minimax.io/v1",
-        "model": "MiniMax-M2.7",
+        "model": "MiniMax-M3",
         "key_prefix": None,
         "key_placeholder": "api-key...",
     },

--- a/agent/src/providers/llm_providers.json
+++ b/agent/src/providers/llm_providers.json
@@ -96,7 +96,7 @@
     "label": "MiniMax",
     "api_key_env": "MINIMAX_API_KEY",
     "base_url_env": "MINIMAX_BASE_URL",
-    "default_model": "MiniMax-M2.7",
+    "default_model": "MiniMax-M3",
     "default_base_url": "https://api.minimax.io/v1",
     "api_key_required": true
   },

--- a/agent/tests/test_llm.py
+++ b/agent/tests/test_llm.py
@@ -156,7 +156,7 @@ class TestMinimaxTemperature:
             "LANGCHAIN_PROVIDER": "minimax",
             "MINIMAX_API_KEY": "minimax-key",
             "MINIMAX_BASE_URL": "https://api.minimax.io/v1",
-            "LANGCHAIN_MODEL_NAME": "MiniMax-M2.7",
+            "LANGCHAIN_MODEL_NAME": "MiniMax-M3",
             "LANGCHAIN_TEMPERATURE": "0.0",
         }
         with patch.dict(os.environ, env, clear=True):
@@ -181,7 +181,7 @@ class TestMinimaxTemperature:
             "LANGCHAIN_PROVIDER": "minimax",
             "MINIMAX_API_KEY": "minimax-key",
             "MINIMAX_BASE_URL": "https://api.minimax.io/v1",
-            "LANGCHAIN_MODEL_NAME": "MiniMax-M2.7",
+            "LANGCHAIN_MODEL_NAME": "MiniMax-M3",
             "LANGCHAIN_TEMPERATURE": "0.7",
         }
         with patch.dict(os.environ, env, clear=True):

--- a/agent/tests/test_llm_provider_defaults.py
+++ b/agent/tests/test_llm_provider_defaults.py
@@ -19,7 +19,7 @@ EXPECTED_PROVIDER_DEFAULTS = {
     "qwen": "qwen-plus-latest",
     "zhipu": "glm-5.1",
     "moonshot": "kimi-k2.6",
-    "minimax": "MiniMax-M2.7",
+    "minimax": "MiniMax-M3",
     "mimo": "MiMo-72B-A27B",
     "zai": "glm-5.1",
 }


### PR DESCRIPTION
## Summary
Upgrade the `minimax` provider's default model to the new flagship `MiniMax-M3`, while keeping `MiniMax-M2.7` (and `-highspeed`) available for users who want to pin to the previous generation.

## Changes
- `agent/src/providers/llm_providers.json` — bump `default_model` to `MiniMax-M3`
- `agent/cli/_legacy.py` — update the `_PROVIDER_CHOICES` entry suggested by `vibe-trading init`
- `agent/.env.example` — switch the example `LANGCHAIN_MODEL_NAME` to `MiniMax-M3` and mention `M2.7` / `M2.7-highspeed` as alternates
- `agent/tests/test_llm_provider_defaults.py` — update the registry/CLI default assertion to `MiniMax-M3`
- `agent/tests/test_llm.py` — refresh the temperature-clamping fixtures to exercise the new default

## Why
MiniMax released `MiniMax-M3` as the new flagship. It uses the same OpenAI-compatible endpoint and the same temperature constraint (`> 0`), so the existing `minimax` provider path needs no code change — only the default model ID. `M2.7` is preserved because some workloads have explicitly pinned to it.

## Testing
- `pytest agent/tests/test_llm_provider_defaults.py` — 3 passed
- `pytest agent/tests/test_llm.py` — 17 passed (incl. `TestMinimaxTemperature` cases)