### PR TITLE
docs: clarify OpenClaw MCP research-only smoke test

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,6 +706,12 @@ skills:
     command: vibe-trading-mcp
 ```
 
+For a first research-only smoke test, confirm tool discovery and run a market
+data or backtest request before selecting a trading connector profile. Core
+research tools can run without broker credentials; connector-backed `trading_*`
+tools should be used only after you intentionally select and check a connector
+profile. `run_swarm` requires an LLM key.
+
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

- add a short OpenClaw research-only smoke test note to the MCP Plugin section
- clarify that users should verify tool discovery and try market-data/backtest
  requests before selecting a trading connector profile
- mention that connector-backed `trading_*` tools require intentional connector
  selection, and `run_swarm` requires an LLM key

## Context

Refs #164.

## Testing

- Documentation-only change; not run.
