### PR TITLE
feat: add Dhan and Shoonya (Finvasia) Indian broker connectors

### DIFF
--- a/agent/src/trading/connectors/dhan/__init__.py
+++ b/agent/src/trading/connectors/dhan/__init__.py
@@ -1,0 +1,8 @@
+"""Dhan trading connector.
+
+Read-only and paper/live account access via the official ``dhanhq`` SDK.
+A ``broker_sdk`` transport for the Indian equity and F&O markets (NSE/BSE).
+
+Dhan provides free API access with a trading account. Paper trading uses the
+Dhan sandbox environment; live uses production endpoints.
+"""

--- a/agent/src/trading/connectors/dhan/classification.py
+++ b/agent/src/trading/connectors/dhan/classification.py
@@ -1,0 +1,32 @@
+"""Curated read/write classification for Dhan SDK operations.
+
+Keys are the connector's own operation names. Order-mutating SDK calls are
+pinned WRITE so the live gate never treats them as plain reads; anything
+unlisted and not a known read is treated as WRITE (fail-closed) by the gate.
+"""
+
+from __future__ import annotations
+
+from src.live.classification import ToolClass
+
+#: Dhan SDK operation read/write catalog.
+DHAN_TOOL_CLASS: dict[str, ToolClass] = {
+    # READ
+    "get_fund_limits": ToolClass.READ,
+    "get_holdings": ToolClass.READ,
+    "get_positions": ToolClass.READ,
+    "get_order_list": ToolClass.READ,
+    "get_order_by_id": ToolClass.READ,
+    "get_trade_book": ToolClass.READ,
+    "intraday_daily_candle_data": ToolClass.READ,
+    "historical_daily_candle_data": ToolClass.READ,
+    "ltp": ToolClass.READ,
+    "ohlc": ToolClass.READ,
+    "quote": ToolClass.READ,
+    "market_depth": ToolClass.READ,
+    # WRITE
+    "place_order": ToolClass.WRITE,
+    "modify_order": ToolClass.WRITE,
+    "cancel_order": ToolClass.WRITE,
+    "place_slice_order": ToolClass.WRITE,
+}

--- a/agent/src/trading/connectors/dhan/profiles.py
+++ b/agent/src/trading/connectors/dhan/profiles.py
@@ -1,0 +1,77 @@
+"""Built-in Dhan connector profiles.
+
+Dhan (https://dhan.co) is an Indian discount broker with free API access.
+Supports NSE/BSE equities, F&O (NIFTY/BANKNIFTY options), currency, and
+commodity segments.
+
+Paper trading is NOT natively supported by Dhan — the paper profile simulates
+trades locally using real market data from Dhan's API. The live profile
+connects directly to Dhan's production API for real order placement.
+"""
+
+from __future__ import annotations
+
+from src.trading.types import READ_CAPABILITIES, TradingProfile
+
+DHAN_PROFILES: tuple[TradingProfile, ...] = (
+    TradingProfile(
+        id="dhan-paper-sdk",
+        connector="dhan",
+        label="Dhan Paper · dhanhq (India)",
+        environment="paper",
+        transport="broker_sdk",
+        capabilities=READ_CAPABILITIES,
+        readonly=True,
+        config={"profile": "paper"},
+        notes=(
+            "Reads real-time Indian market data (NSE/BSE) via Dhan's free API. "
+            "Paper trades are simulated locally — Dhan does not provide a sandbox. "
+            "Supports equities, F&O (NIFTY/BANKNIFTY options), currency, commodity."
+        ),
+    ),
+    TradingProfile(
+        id="dhan-live-sdk-readonly",
+        connector="dhan",
+        label="Dhan Live · dhanhq Read-Only (India)",
+        environment="live",
+        transport="broker_sdk",
+        capabilities=READ_CAPABILITIES,
+        readonly=True,
+        config={"profile": "live-readonly"},
+        notes=(
+            "Reads a live Dhan account (account, positions, orders, quotes, "
+            "history). Order placement is not exposed in this profile."
+        ),
+    ),
+    TradingProfile(
+        id="dhan-paper-trade",
+        connector="dhan",
+        label="Dhan Paper · dhanhq Trade (India)",
+        environment="paper",
+        transport="broker_sdk",
+        capabilities=READ_CAPABILITIES + ("orders.place",),
+        readonly=False,
+        config={"profile": "paper"},
+        notes=(
+            "Paper trades on Indian markets using real Dhan market data. "
+            "Orders are simulated locally — no real money at risk. "
+            "Supports NSE equities and F&O (NIFTY/BANKNIFTY options)."
+        ),
+    ),
+    TradingProfile(
+        id="dhan-live-trade",
+        connector="dhan",
+        label="Dhan Live · dhanhq Trade (India)",
+        environment="live",
+        transport="broker_sdk",
+        capabilities=READ_CAPABILITIES + ("orders.place.requires_mandate",),
+        readonly=False,
+        config={"profile": "live"},
+        notes=(
+            "Reads and places orders on a live Dhan account (NSE/BSE). "
+            "F&O segment must be enabled on the Dhan account. "
+            "Placement on live funds requires an authorized mandate; "
+            "the caller enforces it. Brokerage: ₹20/order or plan-based."
+        ),
+    ),
+)

--- a/agent/src/trading/connectors/dhan/sdk.py
+++ b/agent/src/trading/connectors/dhan/sdk.py
@@ -1,0 +1,625 @@
+"""Read-only + order Dhan connector via the official ``dhanhq`` SDK.
+
+Wraps ``DhanHQ`` client for account, positions, orders, quotes, and historical
+data. Supports NSE/BSE equities and F&O (NIFTY/BANKNIFTY options).
+
+Paper-vs-live: Dhan has no sandbox environment. Paper mode uses the same API
+for market data reads but simulates orders locally. Live mode places real orders
+through Dhan's production API.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Mapping
+
+from src.config.paths import get_runtime_root
+
+CONFIG_FILENAME = "dhan.json"
+
+PROFILE_ENVIRONMENTS = {
+    "paper": "paper",
+    "live-readonly": "live",
+    "live": "live",
+}
+
+DHAN_API_URL = "https://api.dhan.co"
+
+
+class DhanDependencyError(RuntimeError):
+    """Raised when the optional ``dhanhq`` package is not installed."""
+
+
+class DhanConfigError(RuntimeError):
+    """Raised when the connector configuration is missing or invalid."""
+
+
+# ---------------------------------------------------------------------------
+# NSE instrument constants for F&O
+# ---------------------------------------------------------------------------
+
+#: NSE exchange segment codes used by Dhan API.
+class DhanSegment:
+    NSE_EQ = "NSE_EQ"
+    NSE_FNO = "NSE_FNO"
+    BSE_EQ = "BSE_EQ"
+    BSE_FNO = "BSE_FNO"
+    MCX_COMM = "MCX_COMM"
+    CUR = "CUR"
+
+
+#: Common NIFTY/BANKNIFTY security IDs (Dhan uses numeric security IDs).
+NIFTY_SECURITY_ID = "13"      # NIFTY 50 index
+BANKNIFTY_SECURITY_ID = "25"  # BANK NIFTY index
+
+
+@dataclass(frozen=True)
+class DhanConfig:
+    """Dhan connector connection settings.
+
+    Args:
+        client_id: Dhan client ID (visible on dhan.co dashboard).
+        access_token: Dhan API access token (generated from dhan.co).
+        profile: ``paper``, ``live-readonly`` or ``live``.
+        timeout: Network timeout in seconds.
+        readonly: Whether order placement is disabled.
+    """
+
+    client_id: str = ""
+    access_token: str = ""
+    profile: str = "paper"
+    timeout: float = 15.0
+    readonly: bool = True
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any] | None = None) -> "DhanConfig":
+        """Build a config from a JSON-like mapping."""
+        payload = dict(data or {})
+        profile = str(payload.get("profile") or "paper").strip().lower()
+        if profile not in PROFILE_ENVIRONMENTS:
+            raise DhanConfigError("profile must be 'paper', 'live-readonly' or 'live'")
+        return cls(
+            client_id=str(payload.get("client_id") or "").strip(),
+            access_token=str(payload.get("access_token") or "").strip(),
+            profile=profile,
+            timeout=float(payload.get("timeout") or 15.0),
+            readonly=bool(payload.get("readonly", True)),
+        )
+
+    def with_overrides(
+        self,
+        *,
+        client_id: str | None = None,
+        access_token: str | None = None,
+        profile: str | None = None,
+    ) -> "DhanConfig":
+        """Return a copy with CLI/tool overrides applied."""
+        payload = asdict(self)
+        if client_id is not None:
+            payload["client_id"] = client_id
+        if access_token is not None:
+            payload["access_token"] = access_token
+        if profile is not None:
+            payload["profile"] = profile
+        return DhanConfig.from_mapping(payload)
+
+    @property
+    def environment(self) -> str:
+        return PROFILE_ENVIRONMENTS.get(self.profile, "paper")
+
+    @property
+    def is_paper(self) -> bool:
+        return self.environment == "paper"
+
+
+_OVERRIDE_KEYS = ("client_id", "access_token", "profile")
+
+
+def build_config(
+    profile_config: Mapping[str, Any] | None = None,
+    overrides: Mapping[str, Any] | None = None,
+) -> "DhanConfig":
+    """Resolve config: saved file ← profile defaults ← CLI overrides."""
+    base = asdict(load_config())
+    for key, value in dict(profile_config or {}).items():
+        if value is not None:
+            base[key] = value
+    cfg = DhanConfig.from_mapping(base)
+    clean = {
+        k: v
+        for k, v in dict(overrides or {}).items()
+        if k in _OVERRIDE_KEYS and v not in (None, "")
+    }
+    return cfg.with_overrides(**clean) if clean else cfg
+
+
+def config_path() -> Path:
+    return get_runtime_root() / CONFIG_FILENAME
+
+
+def load_config() -> DhanConfig:
+    path = config_path()
+    if not path.exists():
+        return DhanConfig()
+    try:
+        return DhanConfig.from_mapping(json.loads(path.read_text(encoding="utf-8")))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        raise DhanConfigError(f"invalid Dhan config at {path}: {exc}") from exc
+
+
+def save_config(config: DhanConfig) -> Path:
+    path = config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(asdict(config), indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    try:
+        path.chmod(0o600)
+    except OSError:
+        pass
+    return path
+
+
+def dhan_available() -> bool:
+    try:
+        _require_dhan()
+        return True
+    except DhanDependencyError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Five read operations + order placement
+# ---------------------------------------------------------------------------
+
+
+def check_status(config: DhanConfig | None = None) -> dict[str, Any]:
+    """Check SDK readiness and config completeness."""
+    cfg = config or load_config()
+    report: dict[str, Any] = {
+        "status": "ok",
+        "config": _public_config(cfg),
+        "sdk": {"package": "dhanhq", "installed": dhan_available()},
+        "paper_guard": "simulated_locally",
+        "host": DHAN_API_URL,
+    }
+
+    missing = _missing_fields(cfg)
+    if missing:
+        report["status"] = "error"
+        report["error"] = f"Dhan connector not configured: missing {', '.join(missing)}."
+        return report
+
+    if not report["sdk"]["installed"]:
+        report["status"] = "error"
+        report["error"] = "Optional dependency missing: install with `pip install dhanhq`."
+        return report
+
+    try:
+        snapshot = get_account_snapshot(cfg)
+    except Exception as exc:
+        report["status"] = "error"
+        report["error"] = str(exc)
+        return report
+
+    report["account"] = {
+        "profile": cfg.profile,
+        "is_paper": cfg.is_paper,
+    }
+    return report
+
+
+def get_account_snapshot(config: DhanConfig | None = None) -> dict[str, Any]:
+    """Fetch fund limits (account summary) for the configured account."""
+    cfg = config or load_config()
+    client = _dhan_client(cfg)
+    funds = client.get_fund_limits()
+
+    return {
+        "status": "ok",
+        "profile": cfg.profile,
+        "is_paper": cfg.is_paper,
+        "host": DHAN_API_URL,
+        "account": {
+            "currency": "INR",
+            "available_margin": _safe_get(funds, "data", "availabelBalance"),
+            "used_margin": _safe_get(funds, "data", "utilizedAmount"),
+            "collateral": _safe_get(funds, "data", "collateralAmount"),
+        },
+    }
+
+
+def get_positions(config: DhanConfig | None = None) -> dict[str, Any]:
+    """Fetch current positions."""
+    cfg = config or load_config()
+    client = _dhan_client(cfg)
+    positions = client.get_positions()
+
+    rows = []
+    for item in _as_list(positions.get("data")):
+        rows.append({
+            "symbol": item.get("tradingSymbol", ""),
+            "security_id": item.get("securityId", ""),
+            "exchange_segment": item.get("exchangeSegment", ""),
+            "product_type": item.get("productType", ""),
+            "quantity": item.get("netQty", 0),
+            "average_cost": item.get("costPrice", 0),
+            "current_price": item.get("currentPrice", 0),
+            "unrealized_pnl": item.get("realizedProfit", 0),
+            "day_buy_qty": item.get("dayBuyQty", 0),
+            "day_sell_qty": item.get("daySellQty", 0),
+        })
+
+    return {
+        "status": "ok",
+        "profile": cfg.profile,
+        "is_paper": cfg.is_paper,
+        "positions": rows,
+    }
+
+
+def get_open_orders(
+    config: DhanConfig | None = None,
+    *,
+    include_executions: bool = False,
+) -> dict[str, Any]:
+    """Fetch open orders and optionally executed trades."""
+    cfg = config or load_config()
+    client = _dhan_client(cfg)
+    orders = client.get_order_list()
+
+    open_orders = []
+    executions = []
+    for item in _as_list(orders.get("data")):
+        order_dict = _order_to_dict(item)
+        status = str(item.get("orderStatus", "")).upper()
+        if status in ("PENDING", "TRANSIT", "OPEN"):
+            open_orders.append(order_dict)
+        elif include_executions and status in ("TRADED", "FILLED"):
+            executions.append(order_dict)
+
+    result: dict[str, Any] = {
+        "status": "ok",
+        "profile": cfg.profile,
+        "is_paper": cfg.is_paper,
+        "open_orders": open_orders,
+    }
+    if include_executions:
+        result["executions"] = executions
+    return result
+
+
+def get_quote(
+    symbol: str,
+    *,
+    config: DhanConfig | None = None,
+    security_id: str | None = None,
+    exchange_segment: str = "NSE_EQ",
+) -> dict[str, Any]:
+    """Fetch LTP + OHLC for a symbol.
+
+    Dhan requires numeric ``security_id`` + ``exchange_segment`` for quotes.
+    If ``security_id`` is not provided, attempt to use ``symbol`` as the ID.
+    """
+    cfg = config or load_config()
+    client = _dhan_client(cfg)
+
+    sec_id = str(security_id or symbol).strip()
+    segment = exchange_segment.strip().upper()
+
+    try:
+        ltp_data = client.ltp(security_id=sec_id, exchange_segment=segment)
+        ohlc_data = client.ohlc(security_id=sec_id, exchange_segment=segment)
+    except Exception as exc:
+        return {"status": "error", "error": str(exc), "symbol": symbol}
+
+    return {
+        "status": "ok",
+        "symbol": symbol,
+        "security_id": sec_id,
+        "exchange_segment": segment,
+        "quote": {
+            "ltp": _safe_get(ltp_data, "data", "lastPrice"),
+            "open": _safe_get(ohlc_data, "data", "open"),
+            "high": _safe_get(ohlc_data, "data", "high"),
+            "low": _safe_get(ohlc_data, "data", "low"),
+            "close": _safe_get(ohlc_data, "data", "close"),
+            "volume": _safe_get(ohlc_data, "data", "volume"),
+        },
+    }
+
+
+def get_historical_bars(
+    symbol: str,
+    *,
+    config: DhanConfig | None = None,
+    security_id: str | None = None,
+    exchange_segment: str = "NSE_EQ",
+    instrument_type: str = "EQUITY",
+    period: str = "1d",
+    limit: int = 90,
+) -> dict[str, Any]:
+    """Fetch historical OHLCV bars.
+
+    ``period`` tokens: ``1m``, ``5m``, ``15m``, ``30m`` → intraday candles.
+    ``1d`` → daily candles. Dhan's intraday data is limited to last 5 trading
+    days; daily goes back much further.
+    """
+    cfg = config or load_config()
+    client = _dhan_client(cfg)
+
+    sec_id = str(security_id or symbol).strip()
+    segment = exchange_segment.strip().upper()
+
+    from datetime import datetime, timedelta
+
+    to_date = datetime.now()
+    # Intraday: max 5 days back; daily: use limit
+    if period in ("1m", "5m", "15m", "30m"):
+        from_date = to_date - timedelta(days=5)
+    else:
+        from_date = to_date - timedelta(days=min(limit * 2, 365))
+
+    try:
+        if period in ("1m", "5m", "15m", "30m"):
+            interval_map = {"1m": "1", "5m": "5", "15m": "15", "30m": "30"}
+            data = client.intraday_daily_candle_data(
+                security_id=sec_id,
+                exchange_segment=segment,
+                instrument_type=instrument_type,
+            )
+        else:
+            data = client.historical_daily_candle_data(
+                security_id=sec_id,
+                exchange_segment=segment,
+                instrument_type=instrument_type,
+                from_date=from_date.strftime("%Y-%m-%d"),
+                to_date=to_date.strftime("%Y-%m-%d"),
+            )
+    except Exception as exc:
+        return {"status": "error", "error": str(exc), "symbol": symbol}
+
+    bars = []
+    for candle in _as_list(data.get("data", {}).get("candles")):
+        if len(candle) >= 6:
+            bars.append({
+                "time": candle[0],
+                "open": candle[1],
+                "high": candle[2],
+                "low": candle[3],
+                "close": candle[4],
+                "volume": candle[5],
+            })
+
+    return {
+        "status": "ok",
+        "symbol": symbol,
+        "security_id": sec_id,
+        "period": period,
+        "bars": bars[-limit:],
+    }
+
+
+def place_order(
+    config: DhanConfig | None = None,
+    *,
+    symbol: str,
+    side: str,
+    quantity: float | None = None,
+    notional: float | None = None,
+    order_type: str = "market",
+    limit_price: float | None = None,
+    time_in_force: str = "day",
+    security_id: str | None = None,
+    exchange_segment: str = "NSE_EQ",
+    product_type: str = "INTRADAY",
+) -> dict[str, Any]:
+    """Place an order on Dhan.
+
+    Paper mode returns a simulated fill. Live mode submits to Dhan's API.
+
+    Args:
+        symbol: Trading symbol or security ID.
+        side: ``buy`` or ``sell``.
+        quantity: Number of shares/lots.
+        order_type: ``market`` or ``limit``.
+        limit_price: Required for limit orders.
+        security_id: Dhan numeric security ID (required for real orders).
+        exchange_segment: NSE_EQ, NSE_FNO, BSE_EQ, etc.
+        product_type: INTRADAY, CNC (delivery), MARGIN.
+    """
+    cfg = config or load_config()
+
+    clean_symbol = str(symbol or "").strip().upper()
+    if not clean_symbol:
+        return {"status": "error", "error": "symbol is required"}
+
+    side_token = str(side or "").strip().upper()
+    if side_token not in ("BUY", "SELL"):
+        return {"status": "error", "error": "side must be 'buy' or 'sell'"}
+
+    type_token = str(order_type or "").strip().upper()
+    if type_token not in ("MARKET", "LIMIT"):
+        return {"status": "error", "error": "order_type must be 'market' or 'limit'"}
+
+    if quantity is None or float(quantity) <= 0:
+        return {"status": "error", "error": "quantity must be positive"}
+
+    qty = int(float(quantity))
+    sec_id = str(security_id or symbol).strip()
+
+    if type_token == "LIMIT" and limit_price is None:
+        return {"status": "error", "error": "limit order requires limit_price"}
+
+    price = float(limit_price) if limit_price is not None else 0
+
+    if cfg.is_paper:
+        # Paper mode: simulate locally
+        return {
+            "status": "ok",
+            "order_id": f"PAPER-{sec_id}-{side_token}-{qty}",
+            "symbol": clean_symbol,
+            "security_id": sec_id,
+            "side": side_token.lower(),
+            "profile": cfg.profile,
+            "is_paper": True,
+            "order_type": type_token.lower(),
+            "quantity": qty,
+            "limit_price": price if type_token == "LIMIT" else None,
+            "order_status": "simulated_fill",
+            "exchange_segment": exchange_segment,
+            "product_type": product_type,
+        }
+
+    # Live mode
+    try:
+        client = _dhan_client(cfg)
+        response = client.place_order(
+            security_id=sec_id,
+            exchange_segment=exchange_segment,
+            transaction_type=side_token,
+            quantity=qty,
+            order_type=type_token,
+            product_type=product_type,
+            price=price,
+        )
+    except DhanDependencyError as exc:
+        return {"status": "error", "error": str(exc)}
+    except Exception as exc:
+        return {"status": "error", "error": str(exc)}
+
+    order_id = _safe_get(response, "data", "orderId") or ""
+    return {
+        "status": "ok",
+        "order_id": str(order_id),
+        "symbol": clean_symbol,
+        "security_id": sec_id,
+        "side": side_token.lower(),
+        "profile": cfg.profile,
+        "is_paper": cfg.is_paper,
+        "order_type": type_token.lower(),
+        "quantity": qty,
+        "limit_price": price if type_token == "LIMIT" else None,
+        "order_status": _safe_get(response, "data", "orderStatus") or "submitted",
+        "exchange_segment": exchange_segment,
+        "product_type": product_type,
+    }
+
+
+def cancel_order(
+    config: DhanConfig | None = None,
+    order_id: str = "",
+    *,
+    symbol: str | None = None,
+) -> dict[str, Any]:
+    """Cancel an open order on Dhan."""
+    cfg = config or load_config()
+    clean_id = str(order_id or "").strip()
+    if not clean_id:
+        return {"status": "error", "error": "order_id is required"}
+
+    if cfg.is_paper:
+        return {
+            "status": "ok",
+            "order_id": clean_id,
+            "symbol": symbol,
+            "profile": cfg.profile,
+            "is_paper": True,
+            "cancelled": True,
+        }
+
+    try:
+        client = _dhan_client(cfg)
+        client.cancel_order(order_id=clean_id)
+    except Exception as exc:
+        return {"status": "error", "error": str(exc)}
+
+    return {
+        "status": "ok",
+        "order_id": clean_id,
+        "symbol": symbol.strip().upper() if isinstance(symbol, str) and symbol.strip() else None,
+        "profile": cfg.profile,
+        "is_paper": cfg.is_paper,
+        "cancelled": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# SDK plumbing
+# ---------------------------------------------------------------------------
+
+
+def _require_dhan() -> ModuleType:
+    try:
+        import dhanhq  # type: ignore
+    except ModuleNotFoundError as exc:
+        raise DhanDependencyError(
+            "dhanhq is not installed; run `pip install dhanhq`."
+        ) from exc
+    return dhanhq
+
+
+def _dhan_client(cfg: DhanConfig):
+    _require_dhan()
+    from dhanhq import dhanhq as DhanHQ  # type: ignore
+
+    if not cfg.client_id or not cfg.access_token:
+        raise DhanConfigError(
+            "Dhan connector not configured: set client_id and access_token "
+            "in ~/.vibe-trading/dhan.json or via environment."
+        )
+    return DhanHQ(cfg.client_id, cfg.access_token)
+
+
+def _missing_fields(cfg: DhanConfig) -> list[str]:
+    missing = []
+    if not cfg.client_id:
+        missing.append("client_id")
+    if not cfg.access_token:
+        missing.append("access_token")
+    return missing
+
+
+def _public_config(cfg: DhanConfig) -> dict[str, Any]:
+    data = asdict(cfg)
+    if data.get("access_token"):
+        data["access_token"] = data["access_token"][:8] + "***"
+    return data
+
+
+def _as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    return [value]
+
+
+def _safe_get(data: Any, *keys: str) -> Any:
+    """Safely traverse nested dicts."""
+    for key in keys:
+        if isinstance(data, Mapping):
+            data = data.get(key)
+        else:
+            return None
+    return data
+
+
+def _order_to_dict(item: Any) -> dict[str, Any]:
+    return {
+        "order_id": str(item.get("orderId", "")),
+        "symbol": item.get("tradingSymbol", ""),
+        "security_id": item.get("securityId", ""),
+        "side": item.get("transactionType", "").lower(),
+        "order_type": item.get("orderType", "").lower(),
+        "quantity": item.get("quantity", 0),
+        "filled_qty": item.get("filledQty", 0),
+        "price": item.get("price", 0),
+        "status": item.get("orderStatus", ""),
+        "exchange_segment": item.get("exchangeSegment", ""),
+        "product_type": item.get("productType", ""),
+    }

--- a/agent/src/trading/connectors/shoonya/__init__.py
+++ b/agent/src/trading/connectors/shoonya/__init__.py
@@ -1,0 +1,8 @@
+"""Shoonya (Finvasia) trading connector.
+
+Read-only and paper/live account access via the ``NorenRestApiPy`` SDK.
+A ``broker_sdk`` transport for the Indian equity and F&O markets (NSE/BSE).
+
+Shoonya offers ZERO brokerage and free API access — the cheapest Indian broker
+for algo trading. Supports NSE/BSE equities, F&O, currency, and commodity.
+"""

--- a/agent/src/trading/connectors/shoonya/classification.py
+++ b/agent/src/trading/connectors/shoonya/classification.py
@@ -1,0 +1,29 @@
+"""Curated read/write classification for Shoonya (Finvasia) SDK operations.
+
+Keys are the connector's own operation names. Order-mutating SDK calls are
+pinned WRITE so the live gate never treats them as plain reads; anything
+unlisted and not a known read is treated as WRITE (fail-closed) by the gate.
+"""
+
+from __future__ import annotations
+
+from src.live.classification import ToolClass
+
+#: Shoonya SDK operation read/write catalog.
+SHOONYA_TOOL_CLASS: dict[str, ToolClass] = {
+    # READ
+    "get_limits": ToolClass.READ,
+    "get_holdings": ToolClass.READ,
+    "get_positions": ToolClass.READ,
+    "get_order_book": ToolClass.READ,
+    "get_trade_book": ToolClass.READ,
+    "get_quotes": ToolClass.READ,
+    "get_time_price_series": ToolClass.READ,
+    "get_daily_price_series": ToolClass.READ,
+    "searchscrip": ToolClass.READ,
+    "get_security_info": ToolClass.READ,
+    # WRITE
+    "place_order": ToolClass.WRITE,
+    "modify_order": ToolClass.WRITE,
+    "cancel_order": ToolClass.WRITE,
+}

--- a/agent/src/trading/connectors/shoonya/profiles.py
+++ b/agent/src/trading/connectors/shoonya/profiles.py
@@ -1,0 +1,78 @@
+"""Built-in Shoonya (Finvasia) connector profiles.
+
+Shoonya (https://shoonya.com) by Finvasia offers ZERO brokerage on all
+segments — the cheapest Indian broker for algorithmic trading.
+
+Supports NSE/BSE equities, F&O (NIFTY/BANKNIFTY options), currency, and
+commodity. The API uses a TOTP-based login flow (vendor code + TOTP secret
+required alongside user/password).
+
+Paper trading is simulated locally — Shoonya has no sandbox.
+"""
+
+from __future__ import annotations
+
+from src.trading.types import READ_CAPABILITIES, TradingProfile
+
+SHOONYA_PROFILES: tuple[TradingProfile, ...] = (
+    TradingProfile(
+        id="shoonya-paper-sdk",
+        connector="shoonya",
+        label="Shoonya Paper · NorenApi (India, ₹0 brokerage)",
+        environment="paper",
+        transport="broker_sdk",
+        capabilities=READ_CAPABILITIES,
+        readonly=True,
+        config={"profile": "paper"},
+        notes=(
+            "Reads real-time Indian market data (NSE/BSE) via Shoonya's free API. "
+            "Paper trades are simulated locally. Zero brokerage on all segments. "
+            "Supports equities, F&O (NIFTY/BANKNIFTY options), currency, commodity."
+        ),
+    ),
+    TradingProfile(
+        id="shoonya-live-sdk-readonly",
+        connector="shoonya",
+        label="Shoonya Live · NorenApi Read-Only (India, ₹0 brokerage)",
+        environment="live",
+        transport="broker_sdk",
+        capabilities=READ_CAPABILITIES,
+        readonly=True,
+        config={"profile": "live-readonly"},
+        notes=(
+            "Reads a live Shoonya account (fund limits, positions, orders, "
+            "quotes, history). No order placement. Zero brokerage."
+        ),
+    ),
+    TradingProfile(
+        id="shoonya-paper-trade",
+        connector="shoonya",
+        label="Shoonya Paper · NorenApi Trade (India, ₹0 brokerage)",
+        environment="paper",
+        transport="broker_sdk",
+        capabilities=READ_CAPABILITIES + ("orders.place",),
+        readonly=False,
+        config={"profile": "paper"},
+        notes=(
+            "Paper trades on Indian markets using real Shoonya market data. "
+            "Orders are simulated locally — no real money at risk. "
+            "Zero brokerage. Supports NIFTY/BANKNIFTY options."
+        ),
+    ),
+    TradingProfile(
+        id="shoonya-live-trade",
+        connector="shoonya",
+        label="Shoonya Live · NorenApi Trade (India, ₹0 brokerage)",
+        environment="live",
+        transport="broker_sdk",
+        capabilities=READ_CAPABILITIES + ("orders.place.requires_mandate",),
+        readonly=False,
+        config={"profile": "live"},
+        notes=(
+            "Reads and places orders on a live Shoonya/Finvasia account. "
+            "ZERO brokerage on all segments (equities, F&O, currency, commodity). "
+            "Requires TOTP-based login (vendor code + TOTP secret). "
+            "Placement on live funds requires an authorized mandate."
+        ),
+    ),
+)

--- a/agent/src/trading/connectors/shoonya/sdk.py
+++ b/agent/src/trading/connectors/shoonya/sdk.py
@@ -1,0 +1,625 @@
+"""Read-only + order Shoonya (Finvasia) connector via ``NorenRestApiPy`` SDK.
+
+Wraps the Shoonya/NorenApi client for account, positions, orders, quotes, and
+historical data. Supports NSE/BSE equities and F&O (NIFTY/BANKNIFTY options).
+
+Zero brokerage on ALL segments — the cheapest Indian broker for algo trading.
+
+Authentication: Shoonya uses a TOTP-based login flow. The user must provide:
+- user_id: Shoonya login ID
+- password: Login password
+- vendor_code: API vendor code (from Shoonya dashboard)
+- api_secret: API secret key
+- totp_secret: TOTP secret for 2FA (base32 encoded)
+
+Paper-vs-live: Shoonya has no sandbox. Paper mode uses the same API for market
+data reads but simulates orders locally.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Mapping
+
+from src.config.paths import get_runtime_root
+
+CONFIG_FILENAME = "shoonya.json"
+
+PROFILE_ENVIRONMENTS = {
+    "paper": "paper",
+    "live-readonly": "live",
+    "live": "live",
+}
+
+SHOONYA_API_URL = "https://api.shoonya.com/NorenWClientTP"
+
+
+class ShoonyaDependencyError(RuntimeError):
+    """Raised when ``NorenRestApiPy`` is not installed."""
+
+
+class ShoonyaConfigError(RuntimeError):
+    """Raised when config is missing or invalid."""
+
+
+# ---------------------------------------------------------------------------
+# NSE exchange codes for Shoonya
+# ---------------------------------------------------------------------------
+
+class ShoonyaExchange:
+    NSE = "NSE"
+    NFO = "NFO"      # NSE F&O
+    BSE = "BSE"
+    BFO = "BFO"      # BSE F&O
+    CDS = "CDS"      # Currency
+    MCX = "MCX"      # Commodity
+
+
+@dataclass(frozen=True)
+class ShoonyaConfig:
+    """Shoonya connector connection settings."""
+
+    user_id: str = ""
+    password: str = ""
+    vendor_code: str = ""
+    api_secret: str = ""
+    totp_secret: str = ""
+    profile: str = "paper"
+    timeout: float = 15.0
+    readonly: bool = True
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any] | None = None) -> "ShoonyaConfig":
+        payload = dict(data or {})
+        profile = str(payload.get("profile") or "paper").strip().lower()
+        if profile not in PROFILE_ENVIRONMENTS:
+            raise ShoonyaConfigError("profile must be 'paper', 'live-readonly' or 'live'")
+        return cls(
+            user_id=str(payload.get("user_id") or "").strip(),
+            password=str(payload.get("password") or "").strip(),
+            vendor_code=str(payload.get("vendor_code") or "").strip(),
+            api_secret=str(payload.get("api_secret") or "").strip(),
+            totp_secret=str(payload.get("totp_secret") or "").strip(),
+            profile=profile,
+            timeout=float(payload.get("timeout") or 15.0),
+            readonly=bool(payload.get("readonly", True)),
+        )
+
+    def with_overrides(self, **kw: Any) -> "ShoonyaConfig":
+        payload = asdict(self)
+        for key in ("user_id", "password", "vendor_code", "api_secret", "totp_secret", "profile"):
+            if kw.get(key) is not None:
+                payload[key] = kw[key]
+        return ShoonyaConfig.from_mapping(payload)
+
+    @property
+    def environment(self) -> str:
+        return PROFILE_ENVIRONMENTS.get(self.profile, "paper")
+
+    @property
+    def is_paper(self) -> bool:
+        return self.environment == "paper"
+
+
+_OVERRIDE_KEYS = ("user_id", "password", "vendor_code", "api_secret", "totp_secret", "profile")
+
+
+def build_config(
+    profile_config: Mapping[str, Any] | None = None,
+    overrides: Mapping[str, Any] | None = None,
+) -> "ShoonyaConfig":
+    base = asdict(load_config())
+    for key, value in dict(profile_config or {}).items():
+        if value is not None:
+            base[key] = value
+    cfg = ShoonyaConfig.from_mapping(base)
+    clean = {
+        k: v for k, v in dict(overrides or {}).items()
+        if k in _OVERRIDE_KEYS and v not in (None, "")
+    }
+    return cfg.with_overrides(**clean) if clean else cfg
+
+
+def config_path() -> Path:
+    return get_runtime_root() / CONFIG_FILENAME
+
+
+def load_config() -> ShoonyaConfig:
+    path = config_path()
+    if not path.exists():
+        return ShoonyaConfig()
+    try:
+        return ShoonyaConfig.from_mapping(json.loads(path.read_text(encoding="utf-8")))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        raise ShoonyaConfigError(f"invalid Shoonya config at {path}: {exc}") from exc
+
+
+def save_config(config: ShoonyaConfig) -> Path:
+    path = config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(asdict(config), indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    try:
+        path.chmod(0o600)
+    except OSError:
+        pass
+    return path
+
+
+def shoonya_available() -> bool:
+    try:
+        _require_shoonya()
+        return True
+    except ShoonyaDependencyError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Five read operations + order placement
+# ---------------------------------------------------------------------------
+
+
+def check_status(config: ShoonyaConfig | None = None) -> dict[str, Any]:
+    cfg = config or load_config()
+    report: dict[str, Any] = {
+        "status": "ok",
+        "config": _public_config(cfg),
+        "sdk": {"package": "NorenRestApiPy", "installed": shoonya_available()},
+        "paper_guard": "simulated_locally",
+        "host": SHOONYA_API_URL,
+        "brokerage": "₹0 (zero) on all segments",
+    }
+
+    missing = _missing_fields(cfg)
+    if missing:
+        report["status"] = "error"
+        report["error"] = f"Shoonya connector not configured: missing {', '.join(missing)}."
+        return report
+
+    if not report["sdk"]["installed"]:
+        report["status"] = "error"
+        report["error"] = (
+            "Optional dependency missing: install with "
+            "`pip install NorenRestApiPy` or from "
+            "https://github.com/Shoonya-Dev/ShoonyaApi-py"
+        )
+        return report
+
+    return report
+
+
+def get_account_snapshot(config: ShoonyaConfig | None = None) -> dict[str, Any]:
+    cfg = config or load_config()
+    api = _login(cfg)
+    limits = api.get_limits()
+
+    if limits is None:
+        return {"status": "error", "error": "Failed to fetch fund limits"}
+
+    return {
+        "status": "ok",
+        "profile": cfg.profile,
+        "is_paper": cfg.is_paper,
+        "host": SHOONYA_API_URL,
+        "brokerage": "₹0",
+        "account": {
+            "currency": "INR",
+            "cash": limits.get("cash", "0"),
+            "margin_available": limits.get("marginavailable", "0"),
+            "margin_used": limits.get("marginused", "0"),
+            "collateral": limits.get("collateral", "0"),
+            "payin": limits.get("payin", "0"),
+        },
+    }
+
+
+def get_positions(config: ShoonyaConfig | None = None) -> dict[str, Any]:
+    cfg = config or load_config()
+    api = _login(cfg)
+    positions = api.get_positions()
+
+    rows = []
+    for item in _as_list(positions):
+        rows.append({
+            "symbol": item.get("tsym", ""),
+            "exchange": item.get("exch", ""),
+            "product_type": item.get("prd", ""),
+            "quantity": int(item.get("netqty", 0)),
+            "average_cost": float(item.get("netavgprc", 0)),
+            "ltp": float(item.get("lp", 0)),
+            "unrealized_pnl": float(item.get("urmtom", 0)),
+            "realized_pnl": float(item.get("rpnl", 0)),
+            "day_buy_qty": int(item.get("daybuyqty", 0)),
+            "day_sell_qty": int(item.get("daysellqty", 0)),
+        })
+
+    return {
+        "status": "ok",
+        "profile": cfg.profile,
+        "is_paper": cfg.is_paper,
+        "positions": rows,
+    }
+
+
+def get_open_orders(
+    config: ShoonyaConfig | None = None,
+    *,
+    include_executions: bool = False,
+) -> dict[str, Any]:
+    cfg = config or load_config()
+    api = _login(cfg)
+    orders = api.get_order_book()
+
+    open_orders = []
+    executions = []
+    for item in _as_list(orders):
+        order_dict = _order_to_dict(item)
+        status = str(item.get("status", "")).upper()
+        if status in ("PENDING", "OPEN", "TRIGGER_PENDING"):
+            open_orders.append(order_dict)
+        elif include_executions and status in ("COMPLETE", "FILLED"):
+            executions.append(order_dict)
+
+    result: dict[str, Any] = {
+        "status": "ok",
+        "profile": cfg.profile,
+        "is_paper": cfg.is_paper,
+        "open_orders": open_orders,
+    }
+    if include_executions:
+        result["executions"] = executions
+    return result
+
+
+def get_quote(
+    symbol: str,
+    *,
+    config: ShoonyaConfig | None = None,
+    exchange: str = "NSE",
+) -> dict[str, Any]:
+    """Fetch quote for a symbol.
+
+    Shoonya uses ``exchange:tradingsymbol`` format for quotes.
+    """
+    cfg = config or load_config()
+    api = _login(cfg)
+
+    clean = symbol.strip().upper()
+    try:
+        quote = api.get_quotes(exchange=exchange, token=clean)
+    except Exception as exc:
+        return {"status": "error", "error": str(exc), "symbol": clean}
+
+    if quote is None:
+        return {"status": "error", "error": "quote not found", "symbol": clean}
+
+    return {
+        "status": "ok",
+        "symbol": clean,
+        "exchange": exchange,
+        "quote": {
+            "ltp": float(quote.get("lp", 0)),
+            "open": float(quote.get("o", 0)),
+            "high": float(quote.get("h", 0)),
+            "low": float(quote.get("l", 0)),
+            "close": float(quote.get("c", 0)),
+            "volume": int(quote.get("v", 0)),
+            "bid": float(quote.get("bp1", 0)),
+            "ask": float(quote.get("sp1", 0)),
+        },
+    }
+
+
+def get_historical_bars(
+    symbol: str,
+    *,
+    config: ShoonyaConfig | None = None,
+    exchange: str = "NSE",
+    period: str = "1d",
+    limit: int = 90,
+) -> dict[str, Any]:
+    """Fetch historical OHLCV bars."""
+    cfg = config or load_config()
+    api = _login(cfg)
+
+    clean = symbol.strip().upper()
+    from datetime import datetime, timedelta
+
+    end = datetime.now()
+    if period in ("1m", "5m", "15m", "30m"):
+        start = end - timedelta(days=5)
+    else:
+        start = end - timedelta(days=min(limit * 2, 365))
+
+    interval_map = {"1m": "1", "5m": "5", "15m": "15", "30m": "30", "1h": "60", "1d": "D"}
+    interval = interval_map.get(period, "D")
+
+    try:
+        if interval == "D":
+            data = api.get_daily_price_series(
+                exchange=exchange,
+                tradingsymbol=clean,
+                startdate=start.timestamp(),
+                enddate=end.timestamp(),
+            )
+        else:
+            data = api.get_time_price_series(
+                exchange=exchange,
+                token=clean,
+                starttime=start.timestamp(),
+                endtime=end.timestamp(),
+                interval=interval,
+            )
+    except Exception as exc:
+        return {"status": "error", "error": str(exc), "symbol": clean}
+
+    bars = []
+    for item in _as_list(data):
+        bars.append({
+            "time": item.get("time", item.get("ssboe", "")),
+            "open": float(item.get("into", item.get("o", 0))),
+            "high": float(item.get("inth", item.get("h", 0))),
+            "low": float(item.get("intl", item.get("l", 0))),
+            "close": float(item.get("intc", item.get("c", 0))),
+            "volume": int(item.get("intv", item.get("v", 0))),
+        })
+
+    return {
+        "status": "ok",
+        "symbol": clean,
+        "exchange": exchange,
+        "period": period,
+        "bars": bars[-limit:],
+    }
+
+
+def place_order(
+    config: ShoonyaConfig | None = None,
+    *,
+    symbol: str,
+    side: str,
+    quantity: float | None = None,
+    notional: float | None = None,
+    order_type: str = "market",
+    limit_price: float | None = None,
+    time_in_force: str = "day",
+    exchange: str = "NSE",
+    product_type: str = "I",
+) -> dict[str, Any]:
+    """Place an order on Shoonya.
+
+    Args:
+        symbol: Trading symbol.
+        side: ``buy`` or ``sell``.
+        quantity: Number of shares/lots.
+        order_type: ``market`` or ``limit``.
+        exchange: NSE, NFO, BSE, BFO, MCX, CDS.
+        product_type: I (intraday), C (delivery/CNC), M (margin).
+    """
+    cfg = config or load_config()
+
+    clean_symbol = str(symbol or "").strip().upper()
+    if not clean_symbol:
+        return {"status": "error", "error": "symbol is required"}
+
+    side_token = str(side or "").strip().upper()
+    side_map = {"BUY": "B", "SELL": "S", "B": "B", "S": "S"}
+    if side_token not in side_map:
+        return {"status": "error", "error": "side must be 'buy' or 'sell'"}
+    buy_or_sell = side_map[side_token]
+
+    type_map = {"MARKET": "MKT", "LIMIT": "LMT", "MKT": "MKT", "LMT": "LMT"}
+    type_token = str(order_type or "").strip().upper()
+    if type_token not in type_map:
+        return {"status": "error", "error": "order_type must be 'market' or 'limit'"}
+    price_type = type_map[type_token]
+
+    if quantity is None or float(quantity) <= 0:
+        return {"status": "error", "error": "quantity must be positive"}
+
+    qty = int(float(quantity))
+    price = float(limit_price) if limit_price is not None else 0.0
+
+    if price_type == "LMT" and limit_price is None:
+        return {"status": "error", "error": "limit order requires limit_price"}
+
+    if cfg.is_paper:
+        return {
+            "status": "ok",
+            "order_id": f"PAPER-{clean_symbol}-{buy_or_sell}-{qty}",
+            "symbol": clean_symbol,
+            "side": side_token.lower(),
+            "profile": cfg.profile,
+            "is_paper": True,
+            "order_type": order_type.lower(),
+            "quantity": qty,
+            "limit_price": price if price_type == "LMT" else None,
+            "order_status": "simulated_fill",
+            "exchange": exchange,
+            "product_type": product_type,
+            "brokerage": "₹0",
+        }
+
+    try:
+        api = _login(cfg)
+        response = api.place_order(
+            buy_or_sell=buy_or_sell,
+            product_type=product_type,
+            exchange=exchange,
+            tradingsymbol=clean_symbol,
+            quantity=qty,
+            discloseqty=0,
+            price_type=price_type,
+            price=price,
+            trigger_price=None,
+            retention="DAY",
+        )
+    except ShoonyaDependencyError as exc:
+        return {"status": "error", "error": str(exc)}
+    except Exception as exc:
+        return {"status": "error", "error": str(exc)}
+
+    order_id = response.get("norenordno", "") if isinstance(response, dict) else ""
+    return {
+        "status": "ok",
+        "order_id": str(order_id),
+        "symbol": clean_symbol,
+        "side": side_token.lower(),
+        "profile": cfg.profile,
+        "is_paper": cfg.is_paper,
+        "order_type": order_type.lower(),
+        "quantity": qty,
+        "limit_price": price if price_type == "LMT" else None,
+        "order_status": "submitted",
+        "exchange": exchange,
+        "product_type": product_type,
+        "brokerage": "₹0",
+    }
+
+
+def cancel_order(
+    config: ShoonyaConfig | None = None,
+    order_id: str = "",
+    *,
+    symbol: str | None = None,
+) -> dict[str, Any]:
+    cfg = config or load_config()
+    clean_id = str(order_id or "").strip()
+    if not clean_id:
+        return {"status": "error", "error": "order_id is required"}
+
+    if cfg.is_paper:
+        return {
+            "status": "ok",
+            "order_id": clean_id,
+            "symbol": symbol,
+            "profile": cfg.profile,
+            "is_paper": True,
+            "cancelled": True,
+        }
+
+    try:
+        api = _login(cfg)
+        api.cancel_order(orderno=clean_id)
+    except Exception as exc:
+        return {"status": "error", "error": str(exc)}
+
+    return {
+        "status": "ok",
+        "order_id": clean_id,
+        "symbol": symbol.strip().upper() if isinstance(symbol, str) and symbol.strip() else None,
+        "profile": cfg.profile,
+        "is_paper": cfg.is_paper,
+        "cancelled": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# SDK plumbing
+# ---------------------------------------------------------------------------
+
+_cached_api = None
+
+
+def _require_shoonya() -> ModuleType:
+    try:
+        import NorenRestApiPy.NorenApi as NorenApi  # type: ignore
+    except ModuleNotFoundError as exc:
+        raise ShoonyaDependencyError(
+            "NorenRestApiPy is not installed; run "
+            "`pip install NorenRestApiPy` or install from "
+            "https://github.com/Shoonya-Dev/ShoonyaApi-py"
+        ) from exc
+    return NorenApi
+
+
+def _login(cfg: ShoonyaConfig):
+    """Login to Shoonya API with TOTP authentication."""
+    global _cached_api
+
+    if _cached_api is not None:
+        return _cached_api
+
+    missing = _missing_fields(cfg)
+    if missing:
+        raise ShoonyaConfigError(
+            f"Shoonya connector not configured: missing {', '.join(missing)}. "
+            "Set them in ~/.vibe-trading/shoonya.json"
+        )
+
+    NorenApi = _require_shoonya()
+
+    class ShoonyaApi(NorenApi.NorenApi):
+        def __init__(self):
+            super().__init__(
+                host=SHOONYA_API_URL,
+                websocket="wss://api.shoonya.com/NorenWSTP/",
+            )
+
+    api = ShoonyaApi()
+
+    # Generate TOTP
+    import pyotp
+    totp = pyotp.TOTP(cfg.totp_secret).now()
+
+    ret = api.login(
+        userid=cfg.user_id,
+        password=cfg.password,
+        twoFA=totp,
+        vendor_code=cfg.vendor_code,
+        api_secret=cfg.api_secret,
+        imei="vibe-trading",
+    )
+
+    if ret is None or ret.get("stat") != "Ok":
+        error_msg = ret.get("emsg", "Login failed") if ret else "Login returned None"
+        raise ShoonyaConfigError(f"Shoonya login failed: {error_msg}")
+
+    _cached_api = api
+    return api
+
+
+def _missing_fields(cfg: ShoonyaConfig) -> list[str]:
+    missing = []
+    for field in ("user_id", "password", "vendor_code", "api_secret", "totp_secret"):
+        if not getattr(cfg, field):
+            missing.append(field)
+    return missing
+
+
+def _public_config(cfg: ShoonyaConfig) -> dict[str, Any]:
+    data = asdict(cfg)
+    for secret in ("password", "api_secret", "totp_secret"):
+        if data.get(secret):
+            data[secret] = "***redacted***"
+    if data.get("user_id"):
+        data["user_id"] = data["user_id"][:2] + "***"
+    return data
+
+
+def _as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    return [value]
+
+
+def _order_to_dict(item: Any) -> dict[str, Any]:
+    return {
+        "order_id": str(item.get("norenordno", "")),
+        "symbol": item.get("tsym", ""),
+        "exchange": item.get("exch", ""),
+        "side": "buy" if item.get("trantype") == "B" else "sell",
+        "order_type": item.get("prctyp", "").lower(),
+        "quantity": int(item.get("qty", 0)),
+        "filled_qty": int(item.get("fillshares", 0)),
+        "price": float(item.get("prc", 0)),
+        "status": item.get("status", ""),
+        "product_type": item.get("prd", ""),
+    }

--- a/agent/src/trading/profiles.py
+++ b/agent/src/trading/profiles.py
@@ -8,11 +8,13 @@ from pathlib import Path
 from src.config.paths import get_runtime_root
 from src.trading.connectors.alpaca.profiles import ALPACA_PROFILES
 from src.trading.connectors.binance.profiles import BINANCE_PROFILES
+from src.trading.connectors.dhan.profiles import DHAN_PROFILES
 from src.trading.connectors.futu.profiles import FUTU_PROFILES
 from src.trading.connectors.ibkr.profiles import IBKR_PROFILES
 from src.trading.connectors.longbridge.profiles import LONGBRIDGE_PROFILES
 from src.trading.connectors.okx.profiles import OKX_PROFILES
 from src.trading.connectors.robinhood.profiles import ROBINHOOD_PROFILES
+from src.trading.connectors.shoonya.profiles import SHOONYA_PROFILES
 from src.trading.connectors.tiger.profiles import TIGER_PROFILES
 from src.trading.types import TradingProfile
 
@@ -28,6 +30,8 @@ BUILTIN_PROFILES: tuple[TradingProfile, ...] = (
     *OKX_PROFILES,
     *BINANCE_PROFILES,
     *FUTU_PROFILES,
+    *DHAN_PROFILES,
+    *SHOONYA_PROFILES,
 )
 
 

--- a/agent/src/trading/service.py
+++ b/agent/src/trading/service.py
@@ -20,6 +20,8 @@ _SDK_CONNECTOR_MODULES = {
     "okx": "src.trading.connectors.okx.sdk",
     "binance": "src.trading.connectors.binance.sdk",
     "futu": "src.trading.connectors.futu.sdk",
+    "dhan": "src.trading.connectors.dhan.sdk",
+    "shoonya": "src.trading.connectors.shoonya.sdk",
 }
 
 
@@ -202,6 +204,8 @@ _CONNECTOR_INSTRUMENT = {
     "tiger": ("equity", None),
     "longbridge": ("equity", None),
     "futu": ("equity", None),
+    "dhan": ("equity", "in_equity"),
+    "shoonya": ("equity", "in_equity"),
 }
 
 


### PR DESCRIPTION
## Summary

Adds two new `broker_sdk` connectors for the **Indian equity and F&O markets** (NSE/BSE), following the existing connector-first architecture.

## 🇮🇳 Dhan ([dhan.co](https://dhan.co))
- **Free API** access with trading account
- Supports NSE/BSE equities, **F&O (NIFTY/BANKNIFTY options)**, currency, commodity
- 4 profiles: `dhan-paper-sdk`, `dhan-live-sdk-readonly`, `dhan-paper-trade`, `dhan-live-trade`
- Full SDK wrapper: account, positions, orders, quotes, historical bars, place/cancel order
- Paper mode simulates locally (Dhan has no sandbox environment)
- Brokerage: ₹20/order or plan-based
- SDK: [`dhanhq`](https://pypi.org/project/dhanhq/)

## 🇮🇳 Shoonya / Finvasia ([shoonya.com](https://shoonya.com))
- **ZERO brokerage** on ALL segments — cheapest Indian broker for algo trading
- Free API access with trading account
- TOTP-based authentication flow (vendor code + TOTP secret + pyotp)
- Same 4 profiles and full SDK interface as Dhan
- Paper mode simulates locally
- SDK: [`NorenRestApiPy`](https://github.com/Shoonya-Dev/ShoonyaApi-py) + `pyotp`

## Integration
- Registered both connector profile sets in `profiles.py`
- Added `dhan` and `shoonya` to `_SDK_CONNECTOR_MODULES` in `service.py`
- Added `in_equity` asset class for Indian market mandate gating in `_CONNECTOR_INSTRUMENT`
- Both connectors follow the exact same pattern as existing connectors (Alpaca, Tiger, etc.)

## Files Changed
- **New:** `agent/src/trading/connectors/dhan/` (4 files)
- **New:** `agent/src/trading/connectors/shoonya/` (4 files)
- **Modified:** `agent/src/trading/profiles.py` (imports + registration)
- **Modified:** `agent/src/trading/service.py` (SDK map + asset class)

## Why Indian Brokers?
- India has one of the largest retail trading populations globally
- NIFTY/BANKNIFTY options are among the most traded derivatives worldwide
- No Indian broker was supported in Vibe-Trading until now
- Dhan and Shoonya both offer **free APIs** (unlike Zerodha Kite at ₹500/month)

## Dependencies
- `dhanhq` — official Dhan Python SDK (optional)
- `NorenRestApiPy` — official Shoonya/Finvasia SDK (optional)
- `pyotp` — TOTP generation for Shoonya auth (optional)

All dependencies are optional — connectors gracefully report missing SDKs.

## Testing
- All 8 new Python files pass `ast.parse()` syntax validation
- Profile registration verified (10 connector directories now)
- Follows existing patterns exactly — no new abstractions introduced

---

*First Indian market connectors for Vibe-Trading! 🇮🇳📈*