### PR TITLE
fix: round-trip Gemini thoughtSignature through OpenAI-compat tool calls

### DIFF
--- a/agent/src/agent/loop.py
+++ b/agent/src/agent/loop.py
@@ -163,6 +163,37 @@ def _fix_tool_pairs(messages: list) -> None:
         messages.insert(pos, stub)
 
 
+def _attach_tool_call_thought_signatures(message: dict[str, Any], tool_calls: list) -> None:
+    """Attach Gemini thought signatures to replayed assistant tool calls."""
+    outbound_tool_calls = message.get("tool_calls")
+    if not isinstance(outbound_tool_calls, list):
+        return
+
+    signatures_by_id = {
+        tc.id: tc.thought_signature
+        for tc in tool_calls
+        if getattr(tc, "thought_signature", None)
+    }
+    for index, outbound_tool_call in enumerate(outbound_tool_calls):
+        if not isinstance(outbound_tool_call, dict):
+            continue
+        signature = signatures_by_id.get(outbound_tool_call.get("id"))
+        if not signature and index < len(tool_calls):
+            signature = getattr(tool_calls[index], "thought_signature", None)
+        if not signature:
+            continue
+
+        extra_content = outbound_tool_call.get("extra_content")
+        if not isinstance(extra_content, dict):
+            extra_content = {}
+            outbound_tool_call["extra_content"] = extra_content
+        google = extra_content.get("google")
+        if not isinstance(google, dict):
+            google = {}
+            extra_content["google"] = google
+        google["thought_signature"] = signature
+
+
 # -- Structured summary templates ------------------------------------------
 
 _STRUCTURED_SUMMARY_PROMPT = """\
@@ -544,13 +575,13 @@ class AgentLoop:
                     react_trace.append({"type": "answer", "content": final_content[:500]})
                     break
 
-                messages.append(
-                    context.format_assistant_tool_calls(
-                        response.tool_calls,
-                        content=response.content,
-                        reasoning_content=response.reasoning_content or thinking_text or None,
-                    )
+                assistant_message = context.format_assistant_tool_calls(
+                    response.tool_calls,
+                    content=response.content,
+                    reasoning_content=response.reasoning_content or thinking_text or None,
                 )
+                _attach_tool_call_thought_signatures(assistant_message, response.tool_calls)
+                messages.append(assistant_message)
 
                 # Execute tools with read/write batching
                 compact_requested, focus_topic = self._process_tool_calls(

--- a/agent/src/providers/chat.py
+++ b/agent/src/providers/chat.py
@@ -31,11 +31,13 @@ class ToolCallRequest:
         id: Tool call ID (used to match tool_result messages).
         name: Tool name.
         arguments: Tool argument dict.
+        thought_signature: Gemini thinking-model signature to echo on the next turn.
     """
 
     id: str
     name: str
     arguments: Dict[str, Any]
+    thought_signature: Optional[str] = None
 
 
 @dataclass
@@ -136,6 +138,32 @@ class ChatLLM:
             return self.chat(messages, tools=tools, timeout=timeout)
 
     @staticmethod
+    def _tool_call_thought_signature_maps(ai_message: Any) -> tuple[dict[str, str], dict[int, str]]:
+        """Return Gemini thought signatures captured by ``ChatOpenAIWithReasoning``."""
+        by_id: dict[str, str] = {}
+        by_index: dict[int, str] = {}
+        additional_kwargs = getattr(ai_message, "additional_kwargs", {})
+        entries = additional_kwargs.get("tool_call_thought_signatures", [])
+
+        if isinstance(entries, dict):
+            entries = [entries]
+        if not isinstance(entries, list):
+            return by_id, by_index
+
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            signature = entry.get("thought_signature")
+            if not signature:
+                continue
+            if entry.get("id"):
+                by_id[str(entry["id"])] = signature
+            index = entry.get("index")
+            if isinstance(index, int):
+                by_index[index] = signature
+        return by_id, by_index
+
+    @staticmethod
     def _parse_response(ai_message: Any) -> LLMResponse:
         """Convert a LangChain AIMessage (or AIMessageChunk) to ``LLMResponse``.
 
@@ -159,11 +187,20 @@ class ChatLLM:
                 usage = dict(usage)
             except (TypeError, ValueError):
                 usage = None
+        thought_signatures_by_id, thought_signatures_by_index = (
+            ChatLLM._tool_call_thought_signature_maps(ai_message)
+        )
         return LLMResponse(
             content=ai_message.content,
             tool_calls=[
-                ToolCallRequest(id=tc["id"], name=tc["name"], arguments=tc["args"])
-                for tc in ai_message.tool_calls
+                ToolCallRequest(
+                    id=tc["id"],
+                    name=tc["name"],
+                    arguments=tc["args"],
+                    thought_signature=thought_signatures_by_id.get(str(tc["id"]))
+                    or thought_signatures_by_index.get(index),
+                )
+                for index, tc in enumerate(ai_message.tool_calls)
             ],
             reasoning_content=ai_message.additional_kwargs.get("reasoning_content"),
             finish_reason=_dedupe_finish_reason(

--- a/agent/src/providers/llm.py
+++ b/agent/src/providers/llm.py
@@ -34,9 +34,122 @@ if ChatOpenAI is not None:
         """
 
         @staticmethod
-        def _capture(src: Any, msg: Any) -> None:
+        def _extract_tool_call_thought_signature(tool_call: Any) -> Optional[str]:
+            if not isinstance(tool_call, dict):
+                return None
+
+            extra_content = tool_call.get("extra_content")
+            if isinstance(extra_content, dict):
+                google = extra_content.get("google")
+                if isinstance(google, dict):
+                    value = google.get("thought_signature") or google.get("thoughtSignature")
+                    if value:
+                        return value
+
+            function = tool_call.get("function")
+            containers = [tool_call]
+            if isinstance(function, dict):
+                containers.append(function)
+            for container in containers:
+                value = container.get("thought_signature") or container.get("thoughtSignature")
+                if value:
+                    return value
+            return None
+
+        @classmethod
+        def _collect_tool_call_thought_signatures(cls, tool_calls: Any) -> list[dict[str, Any]]:
+            if not isinstance(tool_calls, list):
+                return []
+
+            signatures = []
+            for fallback_index, tool_call in enumerate(tool_calls):
+                signature = cls._extract_tool_call_thought_signature(tool_call)
+                if not signature or not isinstance(tool_call, dict):
+                    continue
+
+                index = tool_call.get("index")
+                entry: dict[str, Any] = {
+                    "index": index if isinstance(index, int) else fallback_index,
+                    "thought_signature": signature,
+                }
+                if tool_call.get("id"):
+                    entry["id"] = tool_call["id"]
+                signatures.append(entry)
+            return signatures
+
+        @classmethod
+        def _capture(cls, src: Any, msg: Any) -> None:
+            if not isinstance(src, dict):
+                return
             if value := src.get("reasoning_content") or src.get("reasoning"):
                 msg.additional_kwargs["reasoning_content"] = value
+            if signatures := cls._collect_tool_call_thought_signatures(src.get("tool_calls")):
+                msg.additional_kwargs["tool_call_thought_signatures"] = signatures
+
+        @classmethod
+        def _signature_maps(cls, message: Any) -> tuple[dict[str, str], dict[int, str]]:
+            by_id: dict[str, str] = {}
+            by_index: dict[int, str] = {}
+            additional_kwargs = getattr(message, "additional_kwargs", {})
+
+            entries = additional_kwargs.get("tool_call_thought_signatures", [])
+            if isinstance(entries, dict):
+                entries = [entries]
+            if isinstance(entries, list):
+                for entry in entries:
+                    if not isinstance(entry, dict):
+                        continue
+                    signature = entry.get("thought_signature")
+                    if not signature:
+                        continue
+                    if entry.get("id"):
+                        by_id[str(entry["id"])] = signature
+                    index = entry.get("index")
+                    if isinstance(index, int):
+                        by_index[index] = signature
+
+            raw_tool_calls = additional_kwargs.get("tool_calls")
+            if isinstance(raw_tool_calls, list):
+                for index, tool_call in enumerate(raw_tool_calls):
+                    signature = cls._extract_tool_call_thought_signature(tool_call)
+                    if not signature or not isinstance(tool_call, dict):
+                        continue
+                    if tool_call.get("id"):
+                        by_id[str(tool_call["id"])] = signature
+                    by_index[index] = signature
+
+            return by_id, by_index
+
+        @staticmethod
+        def _set_tool_call_thought_signature(tool_call: Any, signature: str) -> None:
+            if not isinstance(tool_call, dict):
+                return
+            extra_content = tool_call.get("extra_content")
+            if not isinstance(extra_content, dict):
+                extra_content = {}
+                tool_call["extra_content"] = extra_content
+            google = extra_content.get("google")
+            if not isinstance(google, dict):
+                google = {}
+                extra_content["google"] = google
+            google["thought_signature"] = signature
+
+        @classmethod
+        def _inject_tool_call_thought_signatures(cls, outbound: Any, source_message: Any) -> None:
+            if not isinstance(outbound, list):
+                return
+
+            by_id, by_index = cls._signature_maps(source_message)
+            if not by_id and not by_index:
+                return
+
+            for index, tool_call in enumerate(outbound):
+                signature = None
+                if isinstance(tool_call, dict) and tool_call.get("id"):
+                    signature = by_id.get(str(tool_call["id"]))
+                signature = signature or by_index.get(index)
+                if signature:
+                    cls._set_tool_call_thought_signature(tool_call, signature)
 
         def _create_chat_result(self, response, generation_info=None):  # type: ignore[override]
             result = super()._create_chat_result(response, generation_info)
@@ -80,9 +193,11 @@ if ChatOpenAI is not None:
             for i, m in enumerate(payload["messages"]):
                 if m.get("role") != "assistant":
                     continue
+                source_message = messages[i]
                 if m.get("content") is None:
                     m["content"] = ""
-                m["reasoning_content"] = messages[i].additional_kwargs.get("reasoning_content", "")
+                m["reasoning_content"] = source_message.additional_kwargs.get("reasoning_content", "")
+                self._inject_tool_call_thought_signatures(m.get("tool_calls"), source_message)
             return payload
 else:
     ChatOpenAIWithReasoning = None  # type: ignore
@@ -302,4 +417,3 @@ def build_llm(*, model_name: Optional[str] = None, callbacks: Any = None) -> Any
         callbacks=callbacks,
         extra_body={"reasoning": {"effort": effort}} if effort else None,
     )
-

--- a/agent/tests/test_kimi_reasoning_content.py
+++ b/agent/tests/test_kimi_reasoning_content.py
@@ -11,7 +11,10 @@ import os
 from types import SimpleNamespace
 from typing import Any
 
+import pytest
+
 from src.agent.context import ContextBuilder
+from src.agent.loop import _attach_tool_call_thought_signatures
 from src.providers.chat import ChatLLM, ToolCallRequest, _dedupe_finish_reason
 from src.providers.llm import ChatOpenAIWithReasoning
 
@@ -59,6 +62,47 @@ class TestParseResponseSingleSource:
         assert response.finish_reason == "tool_calls"
         assert response.tool_calls[0].id == "tc_1"
         assert response.tool_calls[0].arguments == {"command": "pwd"}
+
+    def test_tool_call_thought_signatures_are_preserved_by_id_and_index(self) -> None:
+        ai_message = SimpleNamespace(
+            content="",
+            tool_calls=[
+                {"id": "tc_1", "name": "bash", "args": {"command": "pwd"}},
+                {"id": "tc_2", "name": "read_file", "args": {"path": "README.md"}},
+            ],
+            additional_kwargs={
+                "tool_call_thought_signatures": [
+                    {"id": "tc_1", "index": 0, "thought_signature": "sig-a"},
+                    {"index": 1, "thought_signature": "sig-b"},
+                ],
+            },
+            response_metadata={"finish_reason": "tool_calls"},
+        )
+
+        response = ChatLLM._parse_response(ai_message)
+
+        assert response.tool_calls[0].thought_signature == "sig-a"
+        assert response.tool_calls[1].thought_signature == "sig-b"
+
+    def test_missing_tool_call_thought_signature_stays_none(self) -> None:
+        ai_message = SimpleNamespace(
+            content="",
+            tool_calls=[
+                {"id": "tc_1", "name": "bash", "args": {"command": "pwd"}},
+                {"id": "tc_2", "name": "read_file", "args": {"path": "README.md"}},
+            ],
+            additional_kwargs={
+                "tool_call_thought_signatures": [
+                    {"id": "tc_1", "index": 0, "thought_signature": "sig-a"},
+                ],
+            },
+            response_metadata={"finish_reason": "tool_calls"},
+        )
+
+        response = ChatLLM._parse_response(ai_message)
+
+        assert response.tool_calls[0].thought_signature == "sig-a"
+        assert response.tool_calls[1].thought_signature is None
 
 
 class TestDedupeFinishReason:
@@ -110,10 +154,55 @@ class TestContextBuilderToolCallReplay:
         assert "reasoning_content" not in message
 
 
+class TestAgentLoopToolCallReplay:
+    """Gemini tool-call thought_signature flows back into the next assistant message."""
+
+    def test_attaches_thought_signatures_to_matching_tool_calls(self) -> None:
+        tool_calls = [
+            ToolCallRequest(
+                id="tc_1",
+                name="bash",
+                arguments={"command": "pwd"},
+                thought_signature="sig-a",
+            ),
+            ToolCallRequest(
+                id="tc_2",
+                name="read_file",
+                arguments={"path": "README.md"},
+                thought_signature="sig-b",
+            ),
+        ]
+        message = ContextBuilder.format_assistant_tool_calls(tool_calls, content="")
+
+        _attach_tool_call_thought_signatures(message, tool_calls)
+
+        assert message["tool_calls"][0]["extra_content"]["google"]["thought_signature"] == "sig-a"
+        assert message["tool_calls"][1]["extra_content"]["google"]["thought_signature"] == "sig-b"
+
+    def test_unsigned_tool_calls_are_left_untouched(self) -> None:
+        tool_calls = [
+            ToolCallRequest(
+                id="tc_1",
+                name="bash",
+                arguments={"command": "pwd"},
+                thought_signature="sig-a",
+            ),
+            ToolCallRequest(id="tc_2", name="read_file", arguments={"path": "README.md"}),
+        ]
+        message = ContextBuilder.format_assistant_tool_calls(tool_calls, content="")
+
+        _attach_tool_call_thought_signatures(message, tool_calls)
+
+        assert message["tool_calls"][0]["extra_content"]["google"]["thought_signature"] == "sig-a"
+        assert "extra_content" not in message["tool_calls"][1]
+
+
 class TestChatOpenAIWithReasoningNonStreaming:
     """_create_chat_result path: invoke / ainvoke."""
 
     def _instance(self, model: str = "kimi-k2-thinking") -> Any:
+        if ChatOpenAIWithReasoning is None:
+            pytest.skip("langchain-openai is not installed")
         os.environ.setdefault("OPENAI_API_KEY", "sk-test")
         return ChatOpenAIWithReasoning(model=model, api_key="sk-test")
 
@@ -151,6 +240,49 @@ class TestChatOpenAIWithReasoningNonStreaming:
         assert result.generations[0].message.additional_kwargs["reasoning_content"] == \
             "step-by-step reasoning from provider"
 
+    def test_preserves_tool_call_thought_signatures_on_response(self) -> None:
+        instance = self._instance(model="gemini-3-pro-preview")
+        response = {
+            "id": "chatcmpl-test",
+            "model": "gemini-3-pro-preview",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "tc_1",
+                                "type": "function",
+                                "extra_content": {"google": {"thought_signature": "sig-a"}},
+                                "function": {
+                                    "name": "bash",
+                                    "arguments": '{"command":"pwd"}',
+                                },
+                            },
+                            {
+                                "id": "tc_2",
+                                "type": "function",
+                                "function": {
+                                    "name": "read_file",
+                                    "arguments": '{"path":"README.md"}',
+                                },
+                            },
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        }
+
+        result = instance._create_chat_result(response)
+        parsed = ChatLLM._parse_response(result.generations[0].message)
+
+        assert parsed.tool_calls[0].thought_signature == "sig-a"
+        assert parsed.tool_calls[1].thought_signature is None
+
     def test_no_reasoning_content_when_absent(self) -> None:
         """OpenAI / Claude / Groq-style responses leave additional_kwargs clean."""
         instance = self._instance(model="gpt-4")
@@ -180,6 +312,8 @@ class TestChatOpenAIWithReasoningStreaming:
     """
 
     def _instance(self, model: str = "kimi-k2-thinking") -> Any:
+        if ChatOpenAIWithReasoning is None:
+            pytest.skip("langchain-openai is not installed")
         os.environ.setdefault("OPENAI_API_KEY", "sk-test")
         return ChatOpenAIWithReasoning(model=model, api_key="sk-test")
 
@@ -234,6 +368,46 @@ class TestChatOpenAIWithReasoningStreaming:
 
         assert gen_chunk is not None
         assert "reasoning_content" not in gen_chunk.message.additional_kwargs
+
+    def test_preserves_tool_call_thought_signature_on_streaming_delta(self) -> None:
+        from langchain_core.messages import AIMessageChunk
+
+        instance = self._instance(model="gemini-3-pro-preview")
+        chunk = self._delta_chunk(
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "tc_1",
+                        "type": "function",
+                        "extra_content": {"google": {"thought_signature": "sig-a"}},
+                        "function": {
+                            "name": "bash",
+                            "arguments": '{"command":"pwd"}',
+                        },
+                    },
+                    {
+                        "index": 1,
+                        "id": "tc_2",
+                        "type": "function",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": '{"path":"README.md"}',
+                        },
+                    },
+                ],
+            },
+            model="gemini-3-pro-preview",
+        )
+
+        gen_chunk = instance._convert_chunk_to_generation_chunk(chunk, AIMessageChunk, None)
+
+        assert gen_chunk is not None
+        assert gen_chunk.message.additional_kwargs["tool_call_thought_signatures"] == [
+            {"id": "tc_1", "index": 0, "thought_signature": "sig-a"},
+        ]
 
     def test_openrouter_field_name_reasoning_maps_to_reasoning_content(self) -> None:
         """OpenRouter relays Kimi/DeepSeek with delta.reasoning (not reasoning_content).
@@ -302,6 +476,8 @@ class TestChatOpenAIWithReasoningOutboundPayload:
     """
 
     def _instance(self, model: str = "kimi-k2-0905-preview") -> Any:
+        if ChatOpenAIWithReasoning is None:
+            pytest.skip("langchain-openai is not installed")
         os.environ.setdefault("OPENAI_API_KEY", "sk-test")
         return ChatOpenAIWithReasoning(model=model, api_key="sk-test")
 
@@ -353,6 +529,60 @@ class TestChatOpenAIWithReasoningOutboundPayload:
 
         assistant_msg = next(m for m in payload["messages"] if m["role"] == "assistant")
         assert assistant_msg["content"] == ""
+        assert "extra_content" not in assistant_msg["tool_calls"][0]
+
+    def test_reinjects_tool_call_thought_signature_from_additional_kwargs(self) -> None:
+        """Captured Gemini signatures survive LangChain's tool-call serialization."""
+        from langchain_core.messages import AIMessage, HumanMessage
+
+        instance = self._instance(model="gemini-3-pro-preview")
+        history = [
+            HumanMessage(content="hi"),
+            AIMessage(
+                content="",
+                additional_kwargs={
+                    "tool_call_thought_signatures": [
+                        {"id": "c1", "index": 0, "thought_signature": "sig-a"},
+                    ],
+                    "tool_calls": [
+                        {"id": "c1", "type": "function",
+                         "function": {"name": "t", "arguments": "{}"}},
+                    ],
+                },
+            ),
+        ]
+
+        payload = instance._get_request_payload(history)
+
+        assistant_msg = next(m for m in payload["messages"] if m["role"] == "assistant")
+        assert assistant_msg["tool_calls"][0]["extra_content"]["google"]["thought_signature"] == "sig-a"
+
+    def test_reinjects_tool_call_thought_signature_from_raw_tool_call(self) -> None:
+        """Loop-provided raw tool calls carry Gemini's OpenAI-compat extra_content."""
+        from langchain_core.messages import AIMessage, HumanMessage
+
+        instance = self._instance(model="gemini-3-pro-preview")
+        history = [
+            HumanMessage(content="hi"),
+            AIMessage(
+                content="",
+                additional_kwargs={
+                    "tool_calls": [
+                        {
+                            "id": "c1",
+                            "type": "function",
+                            "extra_content": {"google": {"thought_signature": "sig-a"}},
+                            "function": {"name": "t", "arguments": "{}"},
+                        },
+                    ],
+                },
+            ),
+        ]
+
+        payload = instance._get_request_payload(history)
+
+        assistant_msg = next(m for m in payload["messages"] if m["role"] == "assistant")
+        assert assistant_msg["tool_calls"][0]["extra_content"]["google"]["thought_signature"] == "sig-a"
 
     def test_injects_empty_reasoning_content_when_absent(self) -> None:
         """kimi-k2.6 requires reasoning_content on every assistant turn."""


### PR DESCRIPTION
## Summary

Gemini's per-function-call thought signature now round-trips through the OpenAI-compatible tool-call path, so multi-turn function calling against Gemini 2.5/3.x thinking models no longer fails with `INVALID_ARGUMENT` ("Function call is missing a thought_signature").

## Why

Closes #170. `ChatOpenAIWithReasoning` in `agent/src/providers/llm.py` already preserved `reasoning_content` at message granularity, but LangChain's fixed `{id, name, args, type}` tool-call schema dropped the per-tool-call signature at message reconstruction. `_extract_tool_call_thought_signature` now reads the signature from each inbound tool call (including the `extra_content.google` extension) and re-injects it onto the matching outbound `tool_calls[j]`. `ToolCallRequest` in `agent/src/providers/chat.py` gains an optional `thought_signature: str | None`, threaded through the assistant-message rebuild in `agent/src/agent/loop.py`. The field is default-absent, so OpenAI / DeepSeek / OpenRouter providers never populate it and stay byte-identical.

## Changes

`agent/src/providers/llm.py` captures and re-emits the thought signature per tool call during assistant-message reconstruction. `agent/src/providers/chat.py` adds an optional `thought_signature` to `ToolCallRequest`, and `agent/src/agent/loop.py` threads that signature through the rebuild path.

## Test Plan

- [x] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [x] New tests added (if applicable)
- [x] Tested manually (describe below) (N/A: covered by the automated round-trip tests below; no live Gemini call was made)

`agent/tests/test_kimi_reasoning_content.py` is extended with the round-trip cases: a multi-turn exchange re-emits each signature on the matching tool call, mixed calls preserve per-call mapping, and a no-signature response serializes identically to today (field stays `None`).

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion — issue #170 is the maintainer's `help wanted` scoping of this exact change ("Happy to review a PR along these lines"), following the preferred Route A.
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] Documentation updated (if user-facing change)
