### PR TITLE
fix(llm): preserve Gemini thought_signature through the AgentLoop dict path

### DIFF
--- a/agent/src/providers/llm.py
+++ b/agent/src/providers/llm.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, Optional
 from urllib.parse import urlsplit
@@ -85,6 +86,44 @@ if ChatOpenAI is not None:
                 msg.additional_kwargs["reasoning_content"] = value
             if signatures := cls._collect_tool_call_thought_signatures(src.get("tool_calls")):
                 msg.additional_kwargs["tool_call_thought_signatures"] = signatures
+
+        def _convert_input(self, input: Any) -> Any:  # type: ignore[override]
+            """Re-attach Gemini thought signatures dropped by dict->message conversion.
+
+            The AgentLoop replays history as OpenAI-format dicts, stamping the
+            signature into ``tool_calls[i].extra_content.google.thought_signature``
+            (loop.py ``_attach_tool_call_thought_signatures``). LangChain's
+            ``_convert_dict_to_message`` discards ``extra_content`` entirely, so by
+            the time ``_get_request_payload`` runs the signature is gone and Gemini
+            rejects the next turn with a ``missing thought_signature`` 400.
+
+            ``_convert_input`` is the single chokepoint both ``invoke`` and
+            ``stream`` call once at entry, while ``input`` is still raw dicts. Here
+            we lift the signatures back onto the converted ``AIMessage`` in the
+            same ``additional_kwargs["tool_call_thought_signatures"]`` shape the
+            in-memory (#176) path produces, so the existing ``_signature_maps`` /
+            ``_inject_tool_call_thought_signatures`` machinery handles both paths
+            identically. The ``isinstance(raw, dict)`` guard makes it a no-op when
+            re-invoked on already-converted ``BaseMessage`` objects (idempotent).
+            """
+            prompt_value = super()._convert_input(input)
+            if isinstance(input, Sequence) and not isinstance(input, (str, bytes)):
+                messages = prompt_value.to_messages()
+                if len(messages) == len(input):
+                    for raw, msg in zip(input, messages):
+                        if (
+                            isinstance(raw, dict)
+                            and getattr(msg, "type", None) == "ai"
+                            and not getattr(msg, "additional_kwargs", {}).get(
+                                "tool_call_thought_signatures"
+                            )
+                        ):
+                            sigs = self._collect_tool_call_thought_signatures(
+                                raw.get("tool_calls")
+                            )
+                            if sigs:
+                                msg.additional_kwargs["tool_call_thought_signatures"] = sigs
+            return prompt_value
 
         @classmethod
         def _signature_maps(cls, message: Any) -> tuple[dict[str, str], dict[int, str]]:

--- a/agent/tests/test_kimi_reasoning_content.py
+++ b/agent/tests/test_kimi_reasoning_content.py
@@ -584,6 +584,75 @@ class TestChatOpenAIWithReasoningOutboundPayload:
         assistant_msg = next(m for m in payload["messages"] if m["role"] == "assistant")
         assert assistant_msg["tool_calls"][0]["extra_content"]["google"]["thought_signature"] == "sig-a"
 
+    def _payload_via_runtime(self, instance: Any, dict_history: list) -> dict:
+        """Mirror ``invoke``: convert the raw OpenAI-format input first (where
+        ``_convert_input`` re-attaches signatures), then build the request payload
+        from the converted messages — exactly the runtime order."""
+        converted = instance._convert_input(dict_history).to_messages()
+        return instance._get_request_payload(converted)
+
+    def test_reattaches_thought_signature_from_raw_dict_input(self) -> None:
+        """Regression: the AgentLoop replays history as OpenAI-format dicts (not
+        AIMessage objects). LangChain's ``_convert_dict_to_message`` discards the
+        ``extra_content`` Gemini signature, so the #176 in-memory machinery alone
+        leaves the outbound payload unsigned and Gemini 400s on the next turn.
+        ``_convert_input`` must lift the signature back onto the converted message.
+        """
+        from src.agent.context import ContextBuilder
+        from src.agent.loop import _attach_tool_call_thought_signatures
+        from src.providers.chat import ToolCallRequest
+
+        instance = self._instance(model="gemini-3-pro-preview")
+        tool_calls = [
+            ToolCallRequest(id="c1", name="load_skill",
+                            arguments={"name": "momentum"}, thought_signature="sig-a"),
+        ]
+        assistant = ContextBuilder.format_assistant_tool_calls(tool_calls)
+        _attach_tool_call_thought_signatures(assistant, tool_calls)
+        history = [
+            {"role": "user", "content": "load momentum"},
+            assistant,
+            {"role": "tool", "tool_call_id": "c1", "content": "loaded"},
+        ]
+
+        payload = self._payload_via_runtime(instance, history)
+
+        assistant_msg = next(m for m in payload["messages"] if m["role"] == "assistant")
+        assert assistant_msg["tool_calls"][0]["extra_content"]["google"]["thought_signature"] == "sig-a"
+
+    def test_parallel_dict_input_keeps_first_signature_only(self) -> None:
+        """Gemini signs only the first of N parallel calls. The natural state
+        (first signed, rest genuinely absent) must round-trip unchanged through
+        the dict path — Gemini accepts the single signature for the whole block,
+        so we must neither drop the first nor fabricate the others.
+        """
+        from src.agent.context import ContextBuilder
+        from src.agent.loop import _attach_tool_call_thought_signatures
+        from src.providers.chat import ToolCallRequest
+
+        instance = self._instance(model="gemini-3-pro-preview")
+        tool_calls = [
+            ToolCallRequest(id="c1", name="load_skill", arguments={"name": "a"}, thought_signature="sig-a"),
+            ToolCallRequest(id="c2", name="load_skill", arguments={"name": "b"}, thought_signature=None),
+            ToolCallRequest(id="c3", name="load_skill", arguments={"name": "c"}, thought_signature=None),
+        ]
+        assistant = ContextBuilder.format_assistant_tool_calls(tool_calls)
+        _attach_tool_call_thought_signatures(assistant, tool_calls)
+        history = [
+            {"role": "user", "content": "load a, b, c"},
+            assistant,
+            {"role": "tool", "tool_call_id": "c1", "content": "ok"},
+            {"role": "tool", "tool_call_id": "c2", "content": "ok"},
+            {"role": "tool", "tool_call_id": "c3", "content": "ok"},
+        ]
+
+        payload = self._payload_via_runtime(instance, history)
+
+        tcs = next(m for m in payload["messages"] if m["role"] == "assistant")["tool_calls"]
+        assert tcs[0]["extra_content"]["google"]["thought_signature"] == "sig-a"
+        assert "extra_content" not in tcs[1]
+        assert "extra_content" not in tcs[2]
+
     def test_injects_empty_reasoning_content_when_absent(self) -> None:
         """kimi-k2.6 requires reasoning_content on every assistant turn."""
         from langchain_core.messages import AIMessage, HumanMessage


### PR DESCRIPTION
## Problem

Configuring a Gemini 3.x model (e.g. `gemini-3.5-flash`) breaks multi-turn tool calling:

> 400 - Function call is missing a thought_signature in functionCall parts ... `default_api:load_skill`, position 2

#176 added the thought_signature round-trip, but it only works when history is held as in-memory LangChain `AIMessage` objects — the path its unit tests exercise. The real `AgentLoop` replays history as OpenAI-format **dicts**, stamping the signature into `tool_calls[i].extra_content.google.thought_signature` (`loop.py:_attach_tool_call_thought_signatures`).

## Root cause

LangChain's `_convert_dict_to_message` discards `extra_content` during the early `_convert_input` step of `invoke()`/`stream()` — *before* `_get_request_payload` re-injects. So `_signature_maps` reads an empty `additional_kwargs` and the outbound payload goes out **unsigned** → Gemini 400 on the next tool-using turn. This affects every tool-using loop turn on gemini-3.x, not just parallel calls. (Parallel isn't special: Gemini signs only the first of N parallel calls and that one signature covers the block — the bug was that even the first never reached the wire.) Verified by diffing the outbound wire payload: the in-memory path carries `extra_content`, the dict path does not.

## Fix

Override `ChatOpenAIWithReasoning._convert_input` — the single chokepoint both `invoke` and `stream` call while `input` is still raw dicts — to re-attach the dict's signatures into `additional_kwargs["tool_call_thought_signatures"]` (the exact shape the in-memory path produces). The existing `_signature_maps`/`_inject_tool_call_thought_signatures` machinery then handles both paths uniformly. Idempotent via an `isinstance(raw, dict)` guard (no-op on already-converted `BaseMessage`s). No parallel-specific code needed.

## Tests

- Two regression tests in `TestChatOpenAIWithReasoningOutboundPayload` driving the real dict path (the gap #176's tests missed): confirmed **red** without the fix (`KeyError: 'extra_content'`), **green** with it.
- Full suite: **3072 passed, 2 skipped**.
- Verified end-to-end on a live server: a real session loaded `load_skill` ×2 and ran a backtest on `gemini-3.5-flash`, completing with no 400.
