### PR TITLE
feat: publish pre-built image to GHCR on release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,62 @@
+name: Publish Docker Image
+
+on:
+  release:
+    types: [published]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/vibe-trading
+          tags: |
+            # latest on every release
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+            # vX.Y.Z + vX.Y semver aliases on releases
+            type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
+            # edge tag on every push to main
+            type=raw,value=edge,enable=${{ github.event_name == 'push' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,10 @@ RUN npm run build
 # ============================================================================
 FROM python:3.11-slim AS runtime
 
+ARG VERSION=dev
 LABEL org.opencontainers.image.title="Vibe-Trading" \
     org.opencontainers.image.description="Natural-language finance research AI agent with backtesting" \
-    org.opencontainers.image.version="0.1.7" \
+    org.opencontainers.image.version="${VERSION}" \
     org.opencontainers.image.source="https://github.com/HKUDS/Vibe-Trading" \
     org.opencontainers.image.licenses="MIT"
 

--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ vibe-trading-mcp               # start MCP server (stdio)
 | **B. Local install** | Development, full CLI access | 5 min |
 | **C. MCP plugin** | Plug into your existing agent | 3 min |
 | **D. ClawHub** | One command, no cloning | 1 min |
+| **E. Pre-built image (GHCR)** | Home server / NAS, no Git needed | 2 min |
 
 ### Prerequisites
 
@@ -443,6 +444,36 @@ npx clawhub@latest install vibe-trading --force
 ```
 
 The skill + MCP config is downloaded into your agent's skills directory. See [ClawHub install](#-mcp-plugin) for details.
+
+### Path E: Pre-built image (no Git required)
+
+Pull the latest release image directly from the GitHub Container Registry — no repository clone, no local build. Ideal for home servers and Synology NAS.
+
+**1. Create a `.env` file** with your LLM provider credentials (see [Environment Variables](#-environment-variables) for all options):
+
+```bash
+# Minimal example — OpenRouter
+LANGCHAIN_PROVIDER=openrouter
+OPENROUTER_API_KEY=sk-or-...
+OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+LANGCHAIN_MODEL_NAME=deepseek/deepseek-v4-pro
+```
+
+**2. Download the production compose file:**
+
+```bash
+curl -O https://raw.githubusercontent.com/HKUDS/Vibe-Trading/main/docker-compose.prod.yml
+```
+
+**3. Start the container:**
+
+```bash
+docker compose -f docker-compose.prod.yml up -d
+```
+
+Open `http://localhost:8899`. The frontend is baked into the image and served at the same port — no separate build step required.
+
+> **Data persistence:** Run data (agent runs and sessions) is stored in named Docker volumes (`vibe-runs`, `vibe-sessions`) and survives container recreation.
 
 ---
 
@@ -1012,7 +1043,8 @@ Vibe-Trading/
 │       └── stores/                 #   Zustand state management
 │
 ├── Dockerfile                      # Multi-stage build
-├── docker-compose.yml              # One-command deploy
+├── docker-compose.yml              # One-command deploy (build from source)
+├── docker-compose.prod.yml         # Buildless deploy from GHCR pre-built image
 ├── pyproject.toml                  # Package config + CLI entrypoint
 ├── tools/                          # Repo-level CI helpers
 │   └── ci_grep_gates.sh            # rejects yaml.load / trademark / per-stock-data leaks

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,29 @@
+# Production compose for end-users — no build required.
+# Pull the pre-built image from GHCR and run with your own .env file.
+#
+# Usage:
+#   curl -O https://raw.githubusercontent.com/HKUDS/Vibe-Trading/main/docker-compose.prod.yml
+#   # Create .env with your LLM key (see agent/.env.example for all options)
+#   echo "LANGCHAIN_PROVIDER=openrouter" > .env
+#   echo "OPENROUTER_API_KEY=sk-..." >> .env
+#   echo "OPENROUTER_BASE_URL=https://openrouter.ai/api/v1" >> .env
+#   echo "LANGCHAIN_MODEL_NAME=deepseek/deepseek-v4-pro" >> .env
+#   docker compose -f docker-compose.prod.yml up -d
+
+services:
+  vibe-trading:
+    image: ghcr.io/hkuds/vibe-trading:latest
+    ports:
+      - "127.0.0.1:8899:8899"
+    env_file:
+      - .env
+    environment:
+      - VIBE_TRADING_TRUST_DOCKER_LOOPBACK=1
+    volumes:
+      - vibe-runs:/app/agent/runs
+      - vibe-sessions:/app/agent/sessions
+    restart: unless-stopped
+
+volumes:
+  vibe-runs:
+  vibe-sessions:


### PR DESCRIPTION
Enables end-users to deploy Vibe-Trading without cloning the repo or running a local build — pull a pre-built image directly from GHCR.

## Summary

- New CI workflow builds and pushes a multi-arch Docker image to GHCR on every release
- New `docker-compose.prod.yml` lets users spin up the full stack with zero `build:` blocks
- README documents the new no-clone deployment path (Path E)

## Why

End-users on home servers / NAS boxes had no way to consume the application without Git and a local build. The only missing pieces were a publish workflow and a registry-backed compose file.

closes #183

## Changes

- **`.github/workflows/docker-publish.yml`** — triggers on `release: published`; produces `latest`, `vX.Y.Z`, `vX.Y` tags (plus `edge` on `main` pushes). Multi-arch (`linux/amd64` + `linux/arm64`) via QEMU/Buildx. Pushes to `ghcr.io/hkuds/vibe-trading` using `GITHUB_TOKEN` — no extra secrets required.
- **`Dockerfile`** — replaced hard-coded `version="0.1.7"` label with `ARG VERSION=dev` so the workflow injects the release tag via `build-args`.
- **`docker-compose.prod.yml`** — image-only compose (no `build:`, no source mounts), named volumes for persistence, `restart: unless-stopped`.
- **`README.md`** — new "Path E: Pre-built image" section in Quick Start with step-by-step instructions and data-persistence note.

## Test Plan

- [x] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [x] New tests added (if applicable)
- [x] Tested manually (describe below)

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Documentation updated (if user-facing change)

## 🚀 Local Verification & Testing

I have successfully tested the generated Docker image from this branch on a local deployment environment (**Synology NAS** via **Docker Compose**). 

The container pulls correctly, boots up instantly without requiring local source code/compilation, and successfully connects to the LLM provider.

### Verified Deployment Configuration:
```yaml
services:
  vibe-trading:
    image: ghcr.io/kailuettmann/vibe-trading:latest
    ports:
      - 8899:8899
    environment:
      - VIBE_TRADING_TRUST_DOCKER_LOOPBACK=1
      - LANGCHAIN_PROVIDER=openrouter
      - LANGCHAIN_MODEL_NAME=deepseek/deepseek-v4-pro
      - OPENROUTER_API_KEY=sk-or...
      - LANGCHAIN_TEMPERATURE=0.0
    volumes:
      - /volume1/docker/vibe-trading/runs:/app/agent/runs:rw
      - /volume1/docker/vibe-trading/sessions:/app/agent/sessions:rw
    restart: unless-stopped