### PR TITLE
fix(swarm): honor explicit preset names

### DIFF
--- a/agent/src/tools/swarm_tool.py
+++ b/agent/src/tools/swarm_tool.py
@@ -123,12 +123,12 @@ _PRESET_KEYWORDS: list[tuple[str, list[str], float]] = [
     (
         "derivatives_strategy_desk",
         [
-            r"\boption\b",
-            "call",
-            "put",
-            "Greeks",
+            r"\boptions?\b",
+            r"\bcall\s+options?\b",
+            r"\bput\s+options?\b",
+            r"\bGreeks?\b",
             r"implied\s+vol",
-            "IV",
+            r"\bIV\b",
             "期权",
             "衍生品",
         ],
@@ -374,6 +374,11 @@ def _match_preset(prompt: str) -> str:
     Returns:
         Best matching preset name.
     """
+    normalized_prompt = re.sub(r"[\s-]+", "_", prompt.strip().lower())
+    for preset_name, _, _ in _PRESET_KEYWORDS:
+        if re.search(rf"(?<![a-z0-9]){re.escape(preset_name)}(?![a-z0-9])", normalized_prompt):
+            return preset_name
+
     scores: dict[str, float] = {}
     for preset_name, keywords, boost in _PRESET_KEYWORDS:
         score = 0.0

--- a/agent/tests/test_swarm_tool_preset_matching.py
+++ b/agent/tests/test_swarm_tool_preset_matching.py
@@ -1,0 +1,26 @@
+"""Regression coverage for SwarmTool natural-language preset routing."""
+
+from __future__ import annotations
+
+import src.tools.swarm_tool as swarm_tool
+
+
+def test_explicit_preset_name_wins_over_keyword_scoring() -> None:
+    prompt = (
+        "[Swarm Team Mode] Use the investment_committee preset to evaluate "
+        "whether to go long or short on NVDA given current market conditions"
+    )
+
+    assert swarm_tool._match_preset(prompt) == "investment_committee"
+
+
+def test_plain_given_does_not_trigger_iv_derivatives_match() -> None:
+    prompt = "Evaluate whether to go long or short on NVDA given current market conditions"
+
+    assert swarm_tool._match_preset(prompt) != "derivatives_strategy_desk"
+
+
+def test_explicit_preset_name_accepts_spaces() -> None:
+    prompt = "Use the investment committee preset for NVDA"
+
+    assert swarm_tool._match_preset(prompt) == "investment_committee"


### PR DESCRIPTION
## Summary

- Honor explicit swarm preset names before falling back to keyword scoring.
- Tighten derivatives keyword matching so ordinary words like "given" no longer trigger the `IV` rule.
- Add regression coverage for the `investment_committee` prompt routing case.

## Why

The SwarmTool router currently treats the entire user prompt as natural language and scores keyword matches only. A prompt such as `Use the investment_committee preset ... given current market conditions` can miss `investment_committee` because of the underscore, while the bare `IV` derivatives keyword matches the `iv` inside `given`. That routes an explicitly requested investment committee run to `derivatives_strategy_desk`.

## Changes

- Normalize spaces and hyphens to underscores, then prefer an explicitly mentioned preset name before keyword scoring.
- Restrict derivatives English patterns to whole option-related phrases and whole-word `IV`.
- Add `agent/tests/test_swarm_tool_preset_matching.py` covering explicit underscore, explicit spaced preset name, and the `given` false-positive.

## Affected Areas

- `agent/src/tools/swarm_tool.py`
- `agent/tests/test_swarm_tool_preset_matching.py`

## Out of Scope

- No changes to preset YAML definitions.
- No changes to swarm runtime execution, tool permissions, broker/live trading, MCP server configuration, or frontend UI.

## Test Plan

- [ ] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
  - Ran in local `.venv` with the CI-style backend command:
    `./.venv/Scripts/python.exe -m pytest --ignore=agent/tests/e2e_backtest --ignore=agent/tests/test_e2e_harness_v2.py --tb=short -q`
  - Result: `3056 passed, 2 skipped, 8 failed, 9 errors`.
  - The remaining failures appear local/Windows-specific rather than caused by this PR:
    - `agent/tests/factors/test_registry.py`: symlink fixture fails with `WinError 1314` because this Windows session lacks symlink privilege/developer-mode elevation.
    - `agent/tests/test_oauth_token_cache.py`: `0700` directory mode assertions see `0o777` on Windows filesystem semantics.
    - `agent/tests/test_loader_retry_helpers.py`: opt-in loader cache tests observed local `Path.home()` / cache isolation differences on Windows.
  - `.venv` already had the project dependencies; `pip install -e ".[dev]"` reached package reinstall but could not replace `vibe-trading.exe` because another local process had it open. Test collection still proceeded with installed dependencies.
- [x] New tests added (if applicable)
  - `./.venv/Scripts/python.exe -m pytest agent/tests/test_swarm_tool_preset_matching.py` -> `3 passed`
- [x] Tested manually (describe below)
  - Verified the screenshot prompt now matches `investment_committee` via the new regression test.

## Risk Notes

- Live/broker risk: none. This only changes prompt-to-preset routing before a swarm run starts.
- MCP/network/secret risk: none. No credentials, external MCP configuration, or network behavior changed.
- Behavioral risk: low. Explicit preset names now take precedence; keyword fallback remains for prompts without a preset name.

## Rollback / Close Path

Revert this commit to restore the prior keyword-only routing behavior. The new regression test should be removed with the revert.

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Documentation updated (if user-facing change)
  - Not required: this is an internal routing bug fix with regression coverage.
