### PR TITLE
fix(docker): reach host Ollama via host.docker.internal

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,9 @@ Open `http://localhost:8899`. Backend + frontend in one container.
 
 Docker publishes the backend on `127.0.0.1:8899` by default and runs the app as a non-root container user. If you intentionally expose the API beyond your own machine, set a strong `API_AUTH_KEY` and send `Authorization: Bearer <key>` from clients.
 
+> [!NOTE]
+> **Using Ollama with Docker:** the container reaches a host-side Ollama via `host.docker.internal`, not `localhost` (inside the container `localhost` is the container itself). `docker-compose.yml` defaults `OLLAMA_BASE_URL` to `http://host.docker.internal:11434`; export `OLLAMA_BASE_URL` (or set it in a top-level `.env`) to point elsewhere. This relies on the `host-gateway` mapping in `extra_hosts`, which requires **Docker Engine ≥ 20.10 / Compose v2** (provided automatically on Docker Desktop).
+
 ### Path B: Local install
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,13 @@ services:
     environment:
       - VIBE_TRADING_TRUST_DOCKER_LOOPBACK=1
       # Ollama runs on the host; from inside the container "localhost" is the
-      # container itself, so reach the host via host.docker.internal instead.
-      - OLLAMA_BASE_URL=http://host.docker.internal:11434
+      # container itself, so default to reaching the host via host.docker.internal.
+      # Override by exporting OLLAMA_BASE_URL (or setting it in a top-level .env)
+      # when Ollama runs elsewhere or on a different port.
+      - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-http://host.docker.internal:11434}
     extra_hosts:
       # Maps host.docker.internal -> host gateway (needed on Linux; harmless on Docker Desktop).
+      # Requires Docker Engine >= 20.10 / Compose v2 (host-gateway support).
       - "host.docker.internal:host-gateway"
     volumes:
       - vibe-runs:/app/agent/runs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,12 @@ services:
       - agent/.env
     environment:
       - VIBE_TRADING_TRUST_DOCKER_LOOPBACK=1
+      # Ollama runs on the host; from inside the container "localhost" is the
+      # container itself, so reach the host via host.docker.internal instead.
+      - OLLAMA_BASE_URL=http://host.docker.internal:11434
+    extra_hosts:
+      # Maps host.docker.internal -> host gateway (needed on Linux; harmless on Docker Desktop).
+      - "host.docker.internal:host-gateway"
     volumes:
       - vibe-runs:/app/agent/runs
       - vibe-sessions:/app/agent/sessions


### PR DESCRIPTION
## Problem

Running the stack with the default Ollama provider via `docker compose up` fails the LLM preflight check and every agent turn, even when Ollama is running on the host:

```
FAIL │ LLM (ollama) │ ConnectionError: HTTPConnectionPool(host='localhost', port=11434):
                     │ ... [Errno 111] Connection refused (agent cannot function)
...
AgentLoop error: Connection error.
openai.APIConnectionError: Connection error.
```

`agent/.env` ships with `OLLAMA_BASE_URL=http://localhost:11434`. Inside the container, `localhost` resolves to the container itself rather than the Docker host, so the agent can never reach a host-side Ollama.

## Fix

Override `OLLAMA_BASE_URL` to `http://host.docker.internal:11434` in the `vibe-trading` compose service. This:

- Leaves `agent/.env` correct for bare-metal runs (the override applies only in the container).
- Adds an `extra_hosts: host.docker.internal:host-gateway` mapping so the same compose file also works on Linux (it's provided automatically on Docker Desktop for Mac/Windows, where the mapping is harmless).

Applies via `docker compose up` with no rebuild needed.

## Testing

- `docker compose up` with host Ollama running: preflight `LLM (ollama)` flips from `FAIL` to `OK` and `AgentLoop` no longer raises `APIConnectionError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)