### PR TITLE
[codex] Persist AgentLoop usage artifacts

### DIFF
--- a/agent/api_server.py
+++ b/agent/api_server.py
@@ -114,6 +114,7 @@ class RunResponse(BaseModel):
     metrics: Optional[BacktestMetrics] = Field(None, description="Backtest metrics")
     artifacts: List[Artifact] = Field(default_factory=list, description="Run artifacts")
     run_card: Optional[Dict[str, Any]] = Field(None, description="Trust Layer run card payload")
+    llm_usage: Optional[Dict[str, Any]] = Field(None, description="Persisted AgentLoop LLM usage summary")
 
     equity_curve: Optional[List[Dict[str, Any]]] = Field(None, description="Equity preview")
     trade_log: Optional[List[Dict[str, Any]]] = Field(None, description="Trade preview")
@@ -1114,6 +1115,9 @@ def _build_response_from_run_dir(run_dir: Path, elapsed: float, *, include_analy
             response.run_card = json.loads(run_card_path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
             pass
+
+    llm_usage_path = run_dir / "artifacts" / "llm_usage.json"
+    response.llm_usage = _load_json_file(llm_usage_path)
 
     trades_path = run_dir / "artifacts" / "trades.csv"
     if trades_path.exists():

--- a/agent/src/agent/loop.py
+++ b/agent/src/agent/loop.py
@@ -20,6 +20,7 @@ import os
 import queue
 import threading
 import time as _time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
@@ -49,6 +50,7 @@ REASONING_DELTA_MIN_INTERVAL_S = float(os.getenv("VT_REASONING_DELTA_MIN_INTERVA
 STREAM_RETRY_DELAY_S = float(os.getenv("VT_STREAM_RETRY_DELAY_S", "1.0"))
 TOOL_TIMEOUT_SECONDS = float(os.getenv("VIBE_TRADING_TOOL_TIMEOUT_SECONDS", "1800"))
 GOAL_MAX_CONTINUATIONS = int(os.getenv("VIBE_TRADING_GOAL_MAX_CONTINUATIONS", "3"))
+LLM_USAGE_ARTIFACT = Path("artifacts") / "llm_usage.json"
 
 # Layer 2: Context collapse thresholds
 COLLAPSE_THRESHOLD = int(TOKEN_THRESHOLD * 0.7)
@@ -98,6 +100,97 @@ def estimate_tokens(messages: list) -> int:
         Estimated token count.
     """
     return len(json.dumps(messages, default=str, ensure_ascii=False)) // 4
+
+
+def _coerce_usage_int(value: Any) -> int:
+    """Coerce provider token counts to non-negative ints."""
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _normalize_llm_usage(usage: Any) -> dict[str, int] | None:
+    """Normalize provider ``usage_metadata`` into the persisted schema."""
+    if usage is None:
+        return None
+    if not isinstance(usage, dict):
+        try:
+            usage = dict(usage)
+        except (TypeError, ValueError):
+            return None
+
+    input_tokens = _coerce_usage_int(usage.get("input_tokens"))
+    output_tokens = _coerce_usage_int(usage.get("output_tokens"))
+    total_tokens = _coerce_usage_int(usage.get("total_tokens"))
+    if total_tokens == 0 and (input_tokens or output_tokens):
+        total_tokens = input_tokens + output_tokens
+
+    if not (input_tokens or output_tokens or total_tokens):
+        return None
+
+    return {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": total_tokens,
+    }
+
+
+def _new_llm_usage_summary(llm: Any) -> dict[str, Any]:
+    """Create a run-scoped LLM usage accumulator without prompt content."""
+    model = getattr(llm, "model_name", None) or os.getenv("LANGCHAIN_MODEL_NAME") or None
+    provider = os.getenv("LANGCHAIN_PROVIDER") or None
+    return {
+        "schema_version": "0.1",
+        "provider": provider,
+        "model": model,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "total_tokens": 0,
+        "calls": 0,
+        "iterations": [],
+    }
+
+
+def _write_llm_usage_artifact(run_dir: Path, summary: dict[str, Any]) -> None:
+    """Persist LLM usage as a run artifact."""
+    path = run_dir / LLM_USAGE_ARTIFACT
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        **summary,
+        "updated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    tmp_path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    tmp_path.replace(path)
+
+
+def _record_llm_usage(
+    run_dir: Path,
+    summary: dict[str, Any],
+    usage: Any,
+    iteration: int,
+) -> dict[str, int] | None:
+    """Accumulate and persist one provider usage event."""
+    normalized = _normalize_llm_usage(usage)
+    if normalized is None:
+        return None
+
+    summary["input_tokens"] = int(summary.get("input_tokens") or 0) + normalized["input_tokens"]
+    summary["output_tokens"] = int(summary.get("output_tokens") or 0) + normalized["output_tokens"]
+    summary["total_tokens"] = int(summary.get("total_tokens") or 0) + normalized["total_tokens"]
+    summary["calls"] = int(summary.get("calls") or 0) + 1
+    summary.setdefault("iterations", []).append({"iter": iteration, **normalized})
+
+    try:
+        _write_llm_usage_artifact(run_dir, summary)
+    except OSError as exc:
+        logger.debug("LLM usage artifact write skipped: %s", exc)
+
+    return normalized
 
 
 def _microcompact(messages: list) -> None:
@@ -449,6 +542,7 @@ class AgentLoop:
         goal_continuations = 0
         goal_last_progress: tuple[int, int] | None = None
         wrap_up_at = max(1, int(self.max_iterations * 0.8))
+        llm_usage_summary = _new_llm_usage_summary(self.llm)
 
         try:
             while iteration < self.max_iterations:
@@ -576,19 +670,23 @@ class AgentLoop:
                         on_text_chunk=_on_text_chunk,
                         on_reasoning_chunk=_on_reasoning_chunk,
                     )
-                usage = getattr(response, "usage_metadata", None) or {}
-                if usage:
+                usage = getattr(response, "usage_metadata", None)
+                usage_delta = _record_llm_usage(
+                    run_dir,
+                    llm_usage_summary,
+                    usage,
+                    current_iter,
+                )
+                if usage_delta:
                     self._emit(
                         "llm_usage",
                         {
-                            "input_tokens": int(usage.get("input_tokens") or 0),
-                            "output_tokens": int(usage.get("output_tokens") or 0),
-                            "total_tokens": int(usage.get("total_tokens") or 0),
+                            **usage_delta,
                             "iter": current_iter,
                         },
                     )
                 if active_goal_id and session_id:
-                    token_delta = int(usage.get("total_tokens") or 0) if usage else 0
+                    token_delta = int(usage_delta.get("total_tokens") or 0) if usage_delta else 0
                     turn_delta = 0 if goal_turn_accounted else 1
                     if token_delta or turn_delta:
                         try:

--- a/agent/tests/test_agent_loop_terminal_state.py
+++ b/agent/tests/test_agent_loop_terminal_state.py
@@ -11,6 +11,7 @@ exits without hitting any real API.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any, Callable
 
@@ -23,11 +24,17 @@ from src.providers.chat import ProviderStreamError
 class _StubLLMResponse:
     """Minimal stand-in for ChatLLM's response object."""
 
-    def __init__(self) -> None:
-        self.content = ""
+    def __init__(
+        self,
+        *,
+        content: str = "",
+        usage_metadata: dict[str, int] | None = None,
+    ) -> None:
+        self.content = content
         self.tool_calls: list[Any] = []
         self.reasoning_content: str | None = None
         self.has_tool_calls = False
+        self.usage_metadata = usage_metadata
 
 
 class _StubLLMNoFinal:
@@ -75,6 +82,27 @@ class _StubLLMCancelMidStream:
 
     def chat(self, messages: list[dict[str, Any]], **_: Any) -> _StubLLMResponse:
         return _StubLLMResponse()
+
+
+class _StubLLMWithUsage:
+    """LLM stub that returns a final answer with provider usage metadata."""
+
+    model_name = "stub-model"
+
+    def stream_chat(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[Any] | None = None,
+        on_text_chunk: Callable[[str], None] | None = None,
+        on_reasoning_chunk: Callable[[str], None] | None = None,
+    ) -> _StubLLMResponse:
+        return _StubLLMResponse(
+            content="final answer",
+            usage_metadata={"input_tokens": 10, "output_tokens": 5},
+        )
+
+    def chat(self, messages: list[dict[str, Any]], **_: Any) -> _StubLLMResponse:
+        return _StubLLMResponse(content="final answer")
 
 
 def _build_agent(llm: Any, max_iter: int = 3, tmp_run_dir: Path | None = None) -> AgentLoop:
@@ -140,6 +168,30 @@ def test_session_service_renders_meaningful_error_from_result(tmp_path: Path) ->
     assert ui_error != "unknown"
     assert "empty_model_response" in ui_error
     assert "iteration 1" in ui_error
+
+
+def test_usage_metadata_is_persisted_to_run_artifact(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provider token usage should be available after the live SSE event is gone."""
+    monkeypatch.setenv("LANGCHAIN_PROVIDER", "pytest-provider")
+    monkeypatch.setenv("LANGCHAIN_MODEL_NAME", "env-model")
+    agent = _build_agent(_StubLLMWithUsage(), max_iter=2, tmp_run_dir=tmp_path / "run")
+
+    result = agent.run(user_message="anything")
+
+    assert result["status"] == "success"
+    usage_path = tmp_path / "run" / "artifacts" / "llm_usage.json"
+    payload = json.loads(usage_path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "0.1"
+    assert payload["provider"] == "pytest-provider"
+    assert payload["model"] == "stub-model"
+    assert payload["input_tokens"] == 10
+    assert payload["output_tokens"] == 5
+    assert payload["total_tokens"] == 15
+    assert payload["calls"] == 1
+    assert payload["iterations"] == [
+        {"iter": 1, "input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+    ]
+    assert payload["updated_at"].endswith("Z")
 
 
 class _StubLLMAlwaysToolCalls:

--- a/agent/tests/test_run_card.py
+++ b/agent/tests/test_run_card.py
@@ -130,6 +130,8 @@ def test_api_run_response_includes_run_card(tmp_path: Path) -> None:
 
     run_dir = tmp_path / "run_001"
     run_dir.mkdir()
+    artifacts_dir = run_dir / "artifacts"
+    artifacts_dir.mkdir()
     (run_dir / "state.json").write_text('{"status": "success"}\n', encoding="utf-8")
     run_card = {
         "schema_version": "0.1",
@@ -143,10 +145,22 @@ def test_api_run_response_includes_run_card(tmp_path: Path) -> None:
         "artifacts": [{"path": "artifacts/metrics.csv", "size_bytes": 42, "sha256": "feed"}],
     }
     (run_dir / "run_card.json").write_text(json.dumps(run_card), encoding="utf-8")
+    llm_usage = {
+        "schema_version": "0.1",
+        "provider": "openai",
+        "model": "gpt-test",
+        "input_tokens": 100,
+        "output_tokens": 25,
+        "total_tokens": 125,
+        "calls": 1,
+        "iterations": [{"iter": 1, "input_tokens": 100, "output_tokens": 25, "total_tokens": 125}],
+    }
+    (artifacts_dir / "llm_usage.json").write_text(json.dumps(llm_usage), encoding="utf-8")
 
     response = api_server._build_response_from_run_dir(run_dir, elapsed=0.0)
 
     assert response.run_card == run_card
+    assert response.llm_usage == llm_usage
 
 
 def test_runner_artifact_spec_surfaces_run_card_paths() -> None:

--- a/frontend/src/lib/__tests__/runReports.test.ts
+++ b/frontend/src/lib/__tests__/runReports.test.ts
@@ -23,6 +23,12 @@ describe("isReportWorthyRun", () => {
     ).toBe(true);
   });
 
+  it("returns true when llm_usage has keys", () => {
+    expect(
+      isReportWorthyRun(makeRunData({ llm_usage: { total_tokens: 1234 } })),
+    ).toBe(true);
+  });
+
   it("returns true when equity_curve is non-empty", () => {
     expect(
       isReportWorthyRun(makeRunData({ equity_curve: [{ time: "2024-01-01", equity: 10000 }] })),
@@ -74,6 +80,9 @@ describe("isReportWorthyRun", () => {
     ).toBe(true);
     expect(
       isReportWorthyRun(makeRunData({ artifacts: [{ name: "strategy.pine", path: "/tmp/s.pine" }] })),
+    ).toBe(true);
+    expect(
+      isReportWorthyRun(makeRunData({ artifacts: [{ name: "llm_usage.json", path: "/tmp/u.json" }] })),
     ).toBe(true);
   });
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -372,6 +372,7 @@ export interface RunData {
   metrics?: BacktestMetrics;
   artifacts?: ArtifactInfo[];
   run_card?: RunCard;
+  llm_usage?: LLMUsageSummary | null;
   validation?: ValidationData;
 
   price_series?: Record<string, PriceBar[]>;
@@ -380,6 +381,26 @@ export interface RunData {
   equity_curve?: EquityPoint[];
   trade_log?: Array<Record<string, string>>;
   run_logs?: Array<{ source?: string; line_number?: number; message?: string }>;
+}
+
+export interface LLMUsageIteration {
+  iter: number;
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+}
+
+export interface LLMUsageSummary {
+  schema_version?: string;
+  provider?: string | null;
+  model?: string | null;
+  input_tokens?: number;
+  output_tokens?: number;
+  total_tokens?: number;
+  calls?: number;
+  iterations?: LLMUsageIteration[];
+  updated_at?: string;
+  [key: string]: unknown;
 }
 
 export interface RunCard {

--- a/frontend/src/lib/runReports.ts
+++ b/frontend/src/lib/runReports.ts
@@ -10,17 +10,18 @@ function hasObjectKeys(value: unknown): boolean {
 
 export function isReportWorthyRun(run: Pick<
   RunData,
-  "metrics" | "run_card" | "equity_curve" | "trade_log" | "price_series" | "trade_markers" | "validation" | "artifacts"
+  "metrics" | "run_card" | "llm_usage" | "equity_curve" | "trade_log" | "price_series" | "trade_markers" | "validation" | "artifacts"
 > | null | undefined): boolean {
   if (!run) return false;
   if (hasObjectKeys(run.metrics)) return true;
   if (hasObjectKeys(run.run_card)) return true;
+  if (hasObjectKeys(run.llm_usage)) return true;
   if (hasItems(run.equity_curve)) return true;
   if (hasItems(run.trade_log)) return true;
   if (hasItems(run.trade_markers)) return true;
   if (hasObjectKeys(run.validation)) return true;
   if (run.price_series && Object.values(run.price_series).some(hasItems)) return true;
   return (run.artifacts || []).some((artifact) =>
-    /(?:metrics|equity|trades|positions|ohlcv|validation|strategy)\.(?:csv|json|pine|py)$/i.test(artifact.name),
+    /(?:metrics|equity|trades|positions|ohlcv|validation|strategy|llm_usage)\.(?:csv|json|pine|py)$/i.test(artifact.name),
   );
 }

--- a/frontend/src/pages/RunDetail.tsx
+++ b/frontend/src/pages/RunDetail.tsx
@@ -11,6 +11,7 @@ import {
   Download,
   FileCheck2,
   Fingerprint,
+  Gauge,
   List,
   ShieldCheck,
   XCircle,
@@ -133,6 +134,7 @@ export function RunDetail() {
         </div>
         {run.prompt && <p className="text-sm text-muted-foreground">{run.prompt}</p>}
         {run.metrics && <MetricsCard metrics={run.metrics as Record<string, number>} />}
+        {run.llm_usage && <LLMUsageCard usage={run.llm_usage} />}
 
         <div className="flex items-center gap-1">
           {TABS.filter(t => !t.hidden).map(({ id, label, icon: Icon }) => (
@@ -181,6 +183,27 @@ export function RunDetail() {
         </ErrorBoundary>
       </div>
     </div>
+  );
+}
+
+function LLMUsageCard({ usage }: { usage: NonNullable<RunData["llm_usage"]> }) {
+  const calls = typeof usage.calls === "number" ? usage.calls : usage.iterations?.length || 0;
+  const providerModel = [usage.provider, usage.model].filter(Boolean).join(" / ") || "Unknown provider";
+
+  return (
+    <section className="rounded-md border bg-card p-3">
+      <div className="mb-3 flex items-center gap-2 text-sm font-medium">
+        <Gauge className="h-4 w-4 text-muted-foreground" />
+        Agent Usage
+      </div>
+      <div className="grid gap-3 md:grid-cols-4">
+        <RunCardStat label="Input tokens" value={formatTokenCount(usage.input_tokens)} />
+        <RunCardStat label="Output tokens" value={formatTokenCount(usage.output_tokens)} />
+        <RunCardStat label="Total tokens" value={formatTokenCount(usage.total_tokens)} />
+        <RunCardStat label="LLM calls" value={String(calls)} />
+      </div>
+      <div className="mt-2 truncate text-xs text-muted-foreground">{providerModel}</div>
+    </section>
   );
 }
 
@@ -319,6 +342,11 @@ function formatBytes(value: number): string {
   if (value < 1024) return `${value} B`;
   if (value < 1024 * 1024) return `${(value / 1024).toFixed(1)} KB`;
   return `${(value / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatTokenCount(value: unknown): string {
+  const numeric = typeof value === "number" ? value : Number(value || 0);
+  return Number.isFinite(numeric) ? Math.round(numeric).toLocaleString() : "0";
 }
 
 function shortHash(value: string): string {


### PR DESCRIPTION
## Summary
- Persist provider-reported AgentLoop token usage to `artifacts/llm_usage.json` for each run.
- Expose the persisted usage payload from `/runs/{id}` as `llm_usage`.
- Show historical Agent Usage in Run Detail and treat usage-only runs as report-worthy.

## Why
The agent already emits live `llm_usage` SSE events and the CLI rail can accumulate usage during an active session, but the data disappears after the run. Persisting a compact artifact makes cost and usage auditing possible from historical run artifacts without recording prompts, responses, API keys, or hidden reasoning.

## Notes
- Uses provider `usage_metadata` only; no token estimation is persisted.
- Writes nothing when the provider omits usage metadata.
- This is a general AgentLoop observability change and does not include Moirix, MiniMax, IBKR, or authority-guard changes.

## Validation
- `pytest agent/tests/test_loop_helpers.py agent/tests/test_agent_loop_terminal_state.py agent/tests/test_run_card.py -q`
- `npm test -- --run src/lib/__tests__/runReports.test.ts`
- `npm run build`
- `git diff --cached --check`