### PR TITLE
[stacked on #207] Add agent usage dashboard

### DIFF
--- a/agent/api_server.py
+++ b/agent/api_server.py
@@ -97,6 +97,10 @@ class RunInfo(BaseModel):
     codes: List[str] = Field(default_factory=list)
     start_date: Optional[str] = None
     end_date: Optional[str] = None
+    llm_usage: Optional[Dict[str, Any]] = Field(
+        None,
+        description="Optional persisted AgentLoop usage summary for dashboards",
+    )
 
 
 class RunResponse(BaseModel):
@@ -1247,7 +1251,10 @@ async def get_run_result(run_id: str):
 
 
 @app.get("/runs", response_model=List[RunInfo], dependencies=[Depends(require_auth)])
-async def list_runs(limit: int = 20):
+async def list_runs(
+    limit: int = 20,
+    with_usage: bool = Query(False, description="Include compact artifacts/llm_usage.json summaries"),
+):
     """List recent runs with summary fields."""
     limit = min(max(1, limit), 100)
     runs_dir = RUNS_DIR
@@ -1342,6 +1349,7 @@ async def list_runs(limit: int = 20):
             codes=run_context.get("codes") or [],
             start_date=run_context.get("start_date"),
             end_date=run_context.get("end_date"),
+            llm_usage=_load_json_file(d / "artifacts" / "llm_usage.json") if with_usage else None,
         ))
 
     return results

--- a/agent/api_server.py
+++ b/agent/api_server.py
@@ -114,6 +114,7 @@ class RunResponse(BaseModel):
     metrics: Optional[BacktestMetrics] = Field(None, description="Backtest metrics")
     artifacts: List[Artifact] = Field(default_factory=list, description="Run artifacts")
     run_card: Optional[Dict[str, Any]] = Field(None, description="Trust Layer run card payload")
+    llm_usage: Optional[Dict[str, Any]] = Field(None, description="Persisted AgentLoop LLM usage summary")
 
     equity_curve: Optional[List[Dict[str, Any]]] = Field(None, description="Equity preview")
     trade_log: Optional[List[Dict[str, Any]]] = Field(None, description="Trade preview")
@@ -1114,6 +1115,9 @@ def _build_response_from_run_dir(run_dir: Path, elapsed: float, *, include_analy
             response.run_card = json.loads(run_card_path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
             pass
+
+    llm_usage_path = run_dir / "artifacts" / "llm_usage.json"
+    response.llm_usage = _load_json_file(llm_usage_path)
 
     trades_path = run_dir / "artifacts" / "trades.csv"
     if trades_path.exists():

--- a/agent/src/agent/loop.py
+++ b/agent/src/agent/loop.py
@@ -20,6 +20,7 @@ import os
 import queue
 import threading
 import time as _time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
@@ -47,6 +48,7 @@ REASONING_DELTA_MIN_INTERVAL_S = float(os.getenv("VT_REASONING_DELTA_MIN_INTERVA
 STREAM_RETRY_DELAY_S = float(os.getenv("VT_STREAM_RETRY_DELAY_S", "1.0"))
 TOOL_TIMEOUT_SECONDS = float(os.getenv("VIBE_TRADING_TOOL_TIMEOUT_SECONDS", "1800"))
 GOAL_MAX_CONTINUATIONS = int(os.getenv("VIBE_TRADING_GOAL_MAX_CONTINUATIONS", "3"))
+LLM_USAGE_ARTIFACT = Path("artifacts") / "llm_usage.json"
 
 # Layer 2: Context collapse thresholds
 COLLAPSE_THRESHOLD = int(TOKEN_THRESHOLD * 0.7)
@@ -78,6 +80,97 @@ def estimate_tokens(messages: list) -> int:
         Estimated token count.
     """
     return len(json.dumps(messages, default=str, ensure_ascii=False)) // 4
+
+
+def _coerce_usage_int(value: Any) -> int:
+    """Coerce provider token counts to non-negative ints."""
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _normalize_llm_usage(usage: Any) -> dict[str, int] | None:
+    """Normalize provider ``usage_metadata`` into the persisted schema."""
+    if usage is None:
+        return None
+    if not isinstance(usage, dict):
+        try:
+            usage = dict(usage)
+        except (TypeError, ValueError):
+            return None
+
+    input_tokens = _coerce_usage_int(usage.get("input_tokens"))
+    output_tokens = _coerce_usage_int(usage.get("output_tokens"))
+    total_tokens = _coerce_usage_int(usage.get("total_tokens"))
+    if total_tokens == 0 and (input_tokens or output_tokens):
+        total_tokens = input_tokens + output_tokens
+
+    if not (input_tokens or output_tokens or total_tokens):
+        return None
+
+    return {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": total_tokens,
+    }
+
+
+def _new_llm_usage_summary(llm: Any) -> dict[str, Any]:
+    """Create a run-scoped LLM usage accumulator without prompt content."""
+    model = getattr(llm, "model_name", None) or os.getenv("LANGCHAIN_MODEL_NAME") or None
+    provider = os.getenv("LANGCHAIN_PROVIDER") or None
+    return {
+        "schema_version": "0.1",
+        "provider": provider,
+        "model": model,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "total_tokens": 0,
+        "calls": 0,
+        "iterations": [],
+    }
+
+
+def _write_llm_usage_artifact(run_dir: Path, summary: dict[str, Any]) -> None:
+    """Persist LLM usage as a run artifact."""
+    path = run_dir / LLM_USAGE_ARTIFACT
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        **summary,
+        "updated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    tmp_path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    tmp_path.replace(path)
+
+
+def _record_llm_usage(
+    run_dir: Path,
+    summary: dict[str, Any],
+    usage: Any,
+    iteration: int,
+) -> dict[str, int] | None:
+    """Accumulate and persist one provider usage event."""
+    normalized = _normalize_llm_usage(usage)
+    if normalized is None:
+        return None
+
+    summary["input_tokens"] = int(summary.get("input_tokens") or 0) + normalized["input_tokens"]
+    summary["output_tokens"] = int(summary.get("output_tokens") or 0) + normalized["output_tokens"]
+    summary["total_tokens"] = int(summary.get("total_tokens") or 0) + normalized["total_tokens"]
+    summary["calls"] = int(summary.get("calls") or 0) + 1
+    summary.setdefault("iterations", []).append({"iter": iteration, **normalized})
+
+    try:
+        _write_llm_usage_artifact(run_dir, summary)
+    except OSError as exc:
+        logger.debug("LLM usage artifact write skipped: %s", exc)
+
+    return normalized
 
 
 def _microcompact(messages: list) -> None:
@@ -410,6 +503,7 @@ class AgentLoop:
         goal_continuations = 0
         goal_last_progress: tuple[int, int] | None = None
         wrap_up_at = max(1, int(self.max_iterations * 0.8))
+        llm_usage_summary = _new_llm_usage_summary(self.llm)
 
         try:
             while iteration < self.max_iterations:
@@ -535,19 +629,23 @@ class AgentLoop:
                         on_text_chunk=_on_text_chunk,
                         on_reasoning_chunk=_on_reasoning_chunk,
                     )
-                usage = getattr(response, "usage_metadata", None) or {}
-                if usage:
+                usage = getattr(response, "usage_metadata", None)
+                usage_delta = _record_llm_usage(
+                    run_dir,
+                    llm_usage_summary,
+                    usage,
+                    iteration,
+                )
+                if usage_delta:
                     self._emit(
                         "llm_usage",
                         {
-                            "input_tokens": int(usage.get("input_tokens") or 0),
-                            "output_tokens": int(usage.get("output_tokens") or 0),
-                            "total_tokens": int(usage.get("total_tokens") or 0),
+                            **usage_delta,
                             "iter": iteration,
                         },
                     )
                 if active_goal_id and session_id:
-                    token_delta = int(usage.get("total_tokens") or 0) if usage else 0
+                    token_delta = int(usage_delta.get("total_tokens") or 0) if usage_delta else 0
                     turn_delta = 0 if goal_turn_accounted else 1
                     if token_delta or turn_delta:
                         try:

--- a/agent/tests/test_agent_loop_terminal_state.py
+++ b/agent/tests/test_agent_loop_terminal_state.py
@@ -11,6 +11,7 @@ exits without hitting any real API.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any, Callable
 
@@ -23,11 +24,17 @@ from src.providers.chat import ProviderStreamError
 class _StubLLMResponse:
     """Minimal stand-in for ChatLLM's response object."""
 
-    def __init__(self) -> None:
-        self.content = ""
+    def __init__(
+        self,
+        *,
+        content: str = "",
+        usage_metadata: dict[str, int] | None = None,
+    ) -> None:
+        self.content = content
         self.tool_calls: list[Any] = []
         self.reasoning_content: str | None = None
         self.has_tool_calls = False
+        self.usage_metadata = usage_metadata
 
 
 class _StubLLMNoFinal:
@@ -75,6 +82,27 @@ class _StubLLMCancelMidStream:
 
     def chat(self, messages: list[dict[str, Any]], **_: Any) -> _StubLLMResponse:
         return _StubLLMResponse()
+
+
+class _StubLLMWithUsage:
+    """LLM stub that returns a final answer with provider usage metadata."""
+
+    model_name = "stub-model"
+
+    def stream_chat(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[Any] | None = None,
+        on_text_chunk: Callable[[str], None] | None = None,
+        on_reasoning_chunk: Callable[[str], None] | None = None,
+    ) -> _StubLLMResponse:
+        return _StubLLMResponse(
+            content="final answer",
+            usage_metadata={"input_tokens": 10, "output_tokens": 5},
+        )
+
+    def chat(self, messages: list[dict[str, Any]], **_: Any) -> _StubLLMResponse:
+        return _StubLLMResponse(content="final answer")
 
 
 def _build_agent(llm: Any, max_iter: int = 3, tmp_run_dir: Path | None = None) -> AgentLoop:
@@ -140,6 +168,30 @@ def test_session_service_renders_meaningful_error_from_result(tmp_path: Path) ->
     assert ui_error != "unknown"
     assert "empty_model_response" in ui_error
     assert "iteration 1" in ui_error
+
+
+def test_usage_metadata_is_persisted_to_run_artifact(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provider token usage should be available after the live SSE event is gone."""
+    monkeypatch.setenv("LANGCHAIN_PROVIDER", "pytest-provider")
+    monkeypatch.setenv("LANGCHAIN_MODEL_NAME", "env-model")
+    agent = _build_agent(_StubLLMWithUsage(), max_iter=2, tmp_run_dir=tmp_path / "run")
+
+    result = agent.run(user_message="anything")
+
+    assert result["status"] == "success"
+    usage_path = tmp_path / "run" / "artifacts" / "llm_usage.json"
+    payload = json.loads(usage_path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "0.1"
+    assert payload["provider"] == "pytest-provider"
+    assert payload["model"] == "stub-model"
+    assert payload["input_tokens"] == 10
+    assert payload["output_tokens"] == 5
+    assert payload["total_tokens"] == 15
+    assert payload["calls"] == 1
+    assert payload["iterations"] == [
+        {"iter": 1, "input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+    ]
+    assert payload["updated_at"].endswith("Z")
 
 
 class _StubLLMAlwaysToolCalls:

--- a/agent/tests/test_run_card.py
+++ b/agent/tests/test_run_card.py
@@ -130,6 +130,8 @@ def test_api_run_response_includes_run_card(tmp_path: Path) -> None:
 
     run_dir = tmp_path / "run_001"
     run_dir.mkdir()
+    artifacts_dir = run_dir / "artifacts"
+    artifacts_dir.mkdir()
     (run_dir / "state.json").write_text('{"status": "success"}\n', encoding="utf-8")
     run_card = {
         "schema_version": "0.1",
@@ -143,10 +145,22 @@ def test_api_run_response_includes_run_card(tmp_path: Path) -> None:
         "artifacts": [{"path": "artifacts/metrics.csv", "size_bytes": 42, "sha256": "feed"}],
     }
     (run_dir / "run_card.json").write_text(json.dumps(run_card), encoding="utf-8")
+    llm_usage = {
+        "schema_version": "0.1",
+        "provider": "openai",
+        "model": "gpt-test",
+        "input_tokens": 100,
+        "output_tokens": 25,
+        "total_tokens": 125,
+        "calls": 1,
+        "iterations": [{"iter": 1, "input_tokens": 100, "output_tokens": 25, "total_tokens": 125}],
+    }
+    (artifacts_dir / "llm_usage.json").write_text(json.dumps(llm_usage), encoding="utf-8")
 
     response = api_server._build_response_from_run_dir(run_dir, elapsed=0.0)
 
     assert response.run_card == run_card
+    assert response.llm_usage == llm_usage
 
 
 def test_runner_artifact_spec_surfaces_run_card_paths() -> None:

--- a/agent/tests/test_run_card.py
+++ b/agent/tests/test_run_card.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 from pathlib import Path
@@ -161,6 +162,31 @@ def test_api_run_response_includes_run_card(tmp_path: Path) -> None:
 
     assert response.run_card == run_card
     assert response.llm_usage == llm_usage
+
+
+def test_api_list_runs_can_include_compact_llm_usage(tmp_path: Path, monkeypatch) -> None:
+    import api_server
+
+    monkeypatch.setattr(api_server, "RUNS_DIR", tmp_path)
+    run_dir = tmp_path / "20260612_120000_00_usage"
+    artifacts_dir = run_dir / "artifacts"
+    artifacts_dir.mkdir(parents=True)
+    (run_dir / "state.json").write_text('{"status": "success"}\n', encoding="utf-8")
+    llm_usage = {
+        "provider": "openai",
+        "model": "gpt-test",
+        "input_tokens": 100,
+        "output_tokens": 25,
+        "total_tokens": 125,
+        "calls": 1,
+    }
+    (artifacts_dir / "llm_usage.json").write_text(json.dumps(llm_usage), encoding="utf-8")
+
+    without_usage = asyncio.run(api_server.list_runs(limit=10, with_usage=False))
+    with_usage = asyncio.run(api_server.list_runs(limit=10, with_usage=True))
+
+    assert without_usage[0].llm_usage is None
+    assert with_usage[0].llm_usage == llm_usage
 
 
 def test_runner_artifact_spec_surfaces_run_card_paths() -> None:

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,6 +1,6 @@
 ﻿import { useEffect, useState } from "react";
 import { Link, Outlet, useLocation, useSearchParams } from "react-router-dom";
-import { BarChart3, Bot, Moon, Sun, Plus, Trash2, Pencil, MessageSquare, ChevronsLeft, ChevronsRight, Settings, Layers, Loader2 } from "lucide-react";
+import { BarChart3, Bot, Gauge, Moon, Sun, Plus, Trash2, Pencil, MessageSquare, ChevronsLeft, ChevronsRight, Settings, Layers, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useDarkMode } from "@/hooks/useDarkMode";
 import { api, type SessionItem } from "@/lib/api";
@@ -13,6 +13,7 @@ const APP_VERSION = "v0.1.9";
 const NAV = [
   { to: "/", icon: BarChart3, label: "Home" },
   { to: "/agent", icon: Bot, label: "Agent" },
+  { to: "/usage", icon: Gauge, label: "Usage" },
   { to: "/alpha-zoo", icon: Layers, label: "Alpha Zoo" },
   { to: "/settings", icon: Settings, label: "Settings" },
   { to: "/correlation", icon: BarChart3, label: "Correlation Matrix" },

--- a/frontend/src/lib/__tests__/runReports.test.ts
+++ b/frontend/src/lib/__tests__/runReports.test.ts
@@ -23,6 +23,12 @@ describe("isReportWorthyRun", () => {
     ).toBe(true);
   });
 
+  it("returns true when llm_usage has keys", () => {
+    expect(
+      isReportWorthyRun(makeRunData({ llm_usage: { total_tokens: 1234 } })),
+    ).toBe(true);
+  });
+
   it("returns true when equity_curve is non-empty", () => {
     expect(
       isReportWorthyRun(makeRunData({ equity_curve: [{ time: "2024-01-01", equity: 10000 }] })),
@@ -74,6 +80,9 @@ describe("isReportWorthyRun", () => {
     ).toBe(true);
     expect(
       isReportWorthyRun(makeRunData({ artifacts: [{ name: "strategy.pine", path: "/tmp/s.pine" }] })),
+    ).toBe(true);
+    expect(
+      isReportWorthyRun(makeRunData({ artifacts: [{ name: "llm_usage.json", path: "/tmp/u.json" }] })),
     ).toBe(true);
   });
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -73,7 +73,13 @@ function appendQueryParam(url: string, key: string, value: string): string {
 
 export const api = {
   uploadFile,
-  listRuns: () => request<RunListItem[]>("/runs"),
+  listRuns: (params: RunListParams = {}) => {
+    const q = new URLSearchParams();
+    if (params.limit !== undefined) q.set("limit", String(params.limit));
+    if (params.with_usage !== undefined) q.set("with_usage", params.with_usage ? "true" : "false");
+    const qs = q.toString();
+    return request<RunListItem[]>(`/runs${qs ? `?${qs}` : ""}`);
+  },
   getRun: (id: string) => request<RunData>(`/runs/${id}`),
   getRunCode: (id: string) => request<Record<string, string>>(`/runs/${id}/code`),
   getRunPine: (id: string) => request<PineScriptResult>(`/runs/${id}/pine`),
@@ -284,6 +290,12 @@ export interface RunListItem {
   codes?: string[];
   start_date?: string;
   end_date?: string;
+  llm_usage?: LLMUsageSummary | null;
+}
+
+export interface RunListParams {
+  limit?: number;
+  with_usage?: boolean;
 }
 
 export interface PriceBar {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -372,6 +372,7 @@ export interface RunData {
   metrics?: BacktestMetrics;
   artifacts?: ArtifactInfo[];
   run_card?: RunCard;
+  llm_usage?: LLMUsageSummary | null;
   validation?: ValidationData;
 
   price_series?: Record<string, PriceBar[]>;
@@ -380,6 +381,26 @@ export interface RunData {
   equity_curve?: EquityPoint[];
   trade_log?: Array<Record<string, string>>;
   run_logs?: Array<{ source?: string; line_number?: number; message?: string }>;
+}
+
+export interface LLMUsageIteration {
+  iter: number;
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+}
+
+export interface LLMUsageSummary {
+  schema_version?: string;
+  provider?: string | null;
+  model?: string | null;
+  input_tokens?: number;
+  output_tokens?: number;
+  total_tokens?: number;
+  calls?: number;
+  iterations?: LLMUsageIteration[];
+  updated_at?: string;
+  [key: string]: unknown;
 }
 
 export interface RunCard {

--- a/frontend/src/lib/runReports.ts
+++ b/frontend/src/lib/runReports.ts
@@ -10,17 +10,18 @@ function hasObjectKeys(value: unknown): boolean {
 
 export function isReportWorthyRun(run: Pick<
   RunData,
-  "metrics" | "run_card" | "equity_curve" | "trade_log" | "price_series" | "trade_markers" | "validation" | "artifacts"
+  "metrics" | "run_card" | "llm_usage" | "equity_curve" | "trade_log" | "price_series" | "trade_markers" | "validation" | "artifacts"
 > | null | undefined): boolean {
   if (!run) return false;
   if (hasObjectKeys(run.metrics)) return true;
   if (hasObjectKeys(run.run_card)) return true;
+  if (hasObjectKeys(run.llm_usage)) return true;
   if (hasItems(run.equity_curve)) return true;
   if (hasItems(run.trade_log)) return true;
   if (hasItems(run.trade_markers)) return true;
   if (hasObjectKeys(run.validation)) return true;
   if (run.price_series && Object.values(run.price_series).some(hasItems)) return true;
   return (run.artifacts || []).some((artifact) =>
-    /(?:metrics|equity|trades|positions|ohlcv|validation|strategy)\.(?:csv|json|pine|py)$/i.test(artifact.name),
+    /(?:metrics|equity|trades|positions|ohlcv|validation|strategy|llm_usage)\.(?:csv|json|pine|py)$/i.test(artifact.name),
   );
 }

--- a/frontend/src/pages/RunDetail.tsx
+++ b/frontend/src/pages/RunDetail.tsx
@@ -11,6 +11,7 @@ import {
   Download,
   FileCheck2,
   Fingerprint,
+  Gauge,
   List,
   ShieldCheck,
   XCircle,
@@ -133,6 +134,7 @@ export function RunDetail() {
         </div>
         {run.prompt && <p className="text-sm text-muted-foreground">{run.prompt}</p>}
         {run.metrics && <MetricsCard metrics={run.metrics as Record<string, number>} />}
+        {run.llm_usage && <LLMUsageCard usage={run.llm_usage} />}
 
         <div className="flex items-center gap-1">
           {TABS.filter(t => !t.hidden).map(({ id, label, icon: Icon }) => (
@@ -181,6 +183,27 @@ export function RunDetail() {
         </ErrorBoundary>
       </div>
     </div>
+  );
+}
+
+function LLMUsageCard({ usage }: { usage: NonNullable<RunData["llm_usage"]> }) {
+  const calls = typeof usage.calls === "number" ? usage.calls : usage.iterations?.length || 0;
+  const providerModel = [usage.provider, usage.model].filter(Boolean).join(" / ") || "Unknown provider";
+
+  return (
+    <section className="rounded-md border bg-card p-3">
+      <div className="mb-3 flex items-center gap-2 text-sm font-medium">
+        <Gauge className="h-4 w-4 text-muted-foreground" />
+        Agent Usage
+      </div>
+      <div className="grid gap-3 md:grid-cols-4">
+        <RunCardStat label="Input tokens" value={formatTokenCount(usage.input_tokens)} />
+        <RunCardStat label="Output tokens" value={formatTokenCount(usage.output_tokens)} />
+        <RunCardStat label="Total tokens" value={formatTokenCount(usage.total_tokens)} />
+        <RunCardStat label="LLM calls" value={String(calls)} />
+      </div>
+      <div className="mt-2 truncate text-xs text-muted-foreground">{providerModel}</div>
+    </section>
   );
 }
 
@@ -319,6 +342,11 @@ function formatBytes(value: number): string {
   if (value < 1024) return `${value} B`;
   if (value < 1024 * 1024) return `${(value / 1024).toFixed(1)} KB`;
   return `${(value / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatTokenCount(value: unknown): string {
+  const numeric = typeof value === "number" ? value : Number(value || 0);
+  return Number.isFinite(numeric) ? Math.round(numeric).toLocaleString() : "0";
 }
 
 function shortHash(value: string): string {

--- a/frontend/src/pages/Usage.tsx
+++ b/frontend/src/pages/Usage.tsx
@@ -1,0 +1,328 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  AlertTriangle,
+  BarChart3,
+  Bot,
+  Database,
+  Gauge,
+  Loader2,
+  RefreshCw,
+} from "lucide-react";
+import { api, type LLMUsageSummary, type RunData, type RunListItem } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+const USAGE_RUN_SCAN_LIMIT = 25;
+const HEAVY_RUN_LIMIT = 8;
+
+export function Usage() {
+  const [runs, setRuns] = useState<UsageRun[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function loadUsage(mode: "initial" | "refresh" = "refresh") {
+    if (mode === "initial") setLoading(true);
+    else setRefreshing(true);
+    setError(null);
+    try {
+      const list = await api.listRuns();
+      const recent = Array.isArray(list) ? list.slice(0, USAGE_RUN_SCAN_LIMIT) : [];
+      const details = await Promise.allSettled(
+        recent.map(async (run) => [run, await api.getRun(run.run_id)] as const),
+      );
+      const usageRuns = details.flatMap((result) => {
+        if (result.status !== "fulfilled") return [];
+        const [run, detail] = result.value;
+        const usage = toUsageRun(run, detail);
+        return usage ? [usage] : [];
+      });
+      setRuns(usageRuns);
+    } catch (err) {
+      setRuns([]);
+      setError(err instanceof Error ? err.message : "Unable to load agent usage.");
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }
+
+  useEffect(() => {
+    loadUsage("initial");
+  }, []);
+
+  const summary = useMemo(() => summarizeUsage(runs), [runs]);
+  const modelRows = useMemo(() => summarizeByModel(runs), [runs]);
+  const heavyRuns = useMemo(
+    () => [...runs].sort((a, b) => b.totalTokens - a.totalTokens).slice(0, HEAVY_RUN_LIMIT),
+    [runs],
+  );
+
+  return (
+    <div className="min-h-screen p-6 lg:p-8">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6">
+        <section className="flex flex-col gap-4 border-b pb-6 lg:flex-row lg:items-end lg:justify-between">
+          <div className="space-y-3">
+            <div className="inline-flex items-center gap-2 rounded-md border px-2.5 py-1 text-xs font-medium text-muted-foreground">
+              <Gauge className="h-3.5 w-3.5" />
+              Agent Usage
+            </div>
+            <div>
+              <h1 className="text-3xl font-bold tracking-tight">Agent Usage Dashboard</h1>
+              <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
+                Aggregates persisted <span className="font-mono">artifacts/llm_usage.json</span> from recent runs.
+                Token counts are shown as provider-reported usage; prices are intentionally not estimated.
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => loadUsage("refresh")}
+            disabled={refreshing}
+            className="inline-flex items-center gap-2 rounded-md border px-4 py-2 text-sm font-medium transition hover:bg-muted disabled:opacity-50"
+          >
+            {refreshing ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+            Refresh
+          </button>
+        </section>
+
+        {loading ? (
+          <div className="grid gap-3 md:grid-cols-4">
+            {[1, 2, 3, 4].map((item) => (
+              <div key={item} className="h-24 animate-pulse rounded-md border bg-muted/40" />
+            ))}
+          </div>
+        ) : null}
+
+        {!loading && error ? (
+          <section className="rounded-md border border-amber-500/30 bg-amber-500/5 p-5">
+            <div className="flex items-center gap-2 font-medium text-amber-700 dark:text-amber-300">
+              <AlertTriangle className="h-5 w-5" />
+              Usage dashboard unavailable
+            </div>
+            <p className="mt-2 text-sm text-muted-foreground">{error}</p>
+          </section>
+        ) : null}
+
+        {!loading && !error && runs.length === 0 ? (
+          <section className="rounded-md border border-dashed p-8 text-center">
+            <Bot className="mx-auto h-8 w-8 text-muted-foreground" />
+            <h2 className="mt-3 font-medium">No persisted usage found</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Recent runs do not have <span className="font-mono">llm_usage.json</span> artifacts yet.
+            </p>
+          </section>
+        ) : null}
+
+        {!loading && !error && runs.length > 0 ? (
+          <>
+            <section className="grid gap-3 md:grid-cols-4">
+              <SummaryTile label="Runs with usage" value={String(summary.runCount)} icon={Database} />
+              <SummaryTile label="LLM calls" value={formatNumber(summary.calls)} icon={Bot} />
+              <SummaryTile label="Input tokens" value={formatNumber(summary.inputTokens)} icon={BarChart3} />
+              <SummaryTile label="Output tokens" value={formatNumber(summary.outputTokens)} icon={BarChart3} />
+            </section>
+
+            <section className="grid gap-4 xl:grid-cols-[1fr_1.2fr]">
+              <div className="rounded-md border p-4">
+                <h2 className="font-semibold">Provider / Model</h2>
+                <div className="mt-4 space-y-3">
+                  {modelRows.map((row) => (
+                    <ModelUsageRow key={row.key} row={row} maxTokens={summary.totalTokens} />
+                  ))}
+                </div>
+              </div>
+
+              <div className="rounded-md border p-4">
+                <h2 className="font-semibold">Usage-Heavy Runs</h2>
+                <div className="mt-4 divide-y rounded-md border">
+                  {heavyRuns.map((run) => (
+                    <RunUsageRow key={run.runId} run={run} />
+                  ))}
+                </div>
+              </div>
+            </section>
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+interface UsageRun {
+  runId: string;
+  createdAt: string;
+  prompt?: string;
+  provider: string;
+  model: string;
+  calls: number;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+}
+
+interface UsageSummary {
+  runCount: number;
+  calls: number;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+}
+
+interface ModelUsageSummary extends UsageSummary {
+  key: string;
+  provider: string;
+  model: string;
+}
+
+function SummaryTile({ label, value, icon: Icon }: { label: string; value: string; icon: typeof Gauge }) {
+  return (
+    <div className="rounded-md border p-4">
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-xs font-medium uppercase text-muted-foreground">{label}</span>
+        <Icon className="h-4 w-4 text-muted-foreground" />
+      </div>
+      <div className="mt-3 text-2xl font-semibold">{value}</div>
+    </div>
+  );
+}
+
+function ModelUsageRow({ row, maxTokens }: { row: ModelUsageSummary; maxTokens: number }) {
+  const width = maxTokens > 0 ? Math.max(4, Math.min(100, (row.totalTokens / maxTokens) * 100)) : 0;
+  return (
+    <div>
+      <div className="flex items-center justify-between gap-3 text-sm">
+        <div className="min-w-0">
+          <div className="truncate font-medium">{row.provider}</div>
+          <div className="truncate font-mono text-xs text-muted-foreground">{row.model}</div>
+        </div>
+        <div className="text-right font-mono text-sm">{formatNumber(row.totalTokens)}</div>
+      </div>
+      <div className="mt-2 h-2 overflow-hidden rounded-sm bg-muted">
+        <div className="h-full bg-primary" style={{ width: `${width}%` }} />
+      </div>
+      <div className="mt-1 flex justify-between text-xs text-muted-foreground">
+        <span>{row.runCount} runs · {formatNumber(row.calls)} calls</span>
+        <span>{formatNumber(row.inputTokens)} in / {formatNumber(row.outputTokens)} out</span>
+      </div>
+    </div>
+  );
+}
+
+function RunUsageRow({ run }: { run: UsageRun }) {
+  return (
+    <Link to={`/runs/${run.runId}`} className="block p-3 transition hover:bg-muted/40">
+      <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <div className="min-w-0">
+          <div className="truncate font-mono text-sm font-medium">{run.runId}</div>
+          <div className="mt-1 truncate text-xs text-muted-foreground">{run.prompt || "No prompt recorded."}</div>
+        </div>
+        <div className="flex flex-wrap gap-2 text-xs md:justify-end">
+          <UsagePill label="total" value={formatNumber(run.totalTokens)} />
+          <UsagePill label="calls" value={formatNumber(run.calls)} />
+          <UsagePill label="created" value={formatRunDate(run.createdAt)} />
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+function UsagePill({ label, value }: { label: string; value: string }) {
+  return (
+    <span className={cn("rounded border px-2 py-1 font-mono", label === "total" && "border-primary/30 text-primary")}>
+      <span className="mr-1 text-muted-foreground">{label}</span>
+      {value}
+    </span>
+  );
+}
+
+function toUsageRun(run: RunListItem, detail: RunData): UsageRun | null {
+  const usage = detail.llm_usage;
+  if (!usage || !hasUsage(usage)) return null;
+  const inputTokens = toFiniteNumber(usage.input_tokens);
+  const outputTokens = toFiniteNumber(usage.output_tokens);
+  const totalTokens = toFiniteNumber(usage.total_tokens) || inputTokens + outputTokens;
+  return {
+    runId: run.run_id,
+    createdAt: run.created_at,
+    prompt: run.prompt || detail.prompt,
+    provider: stringOrUnknown(usage.provider),
+    model: stringOrUnknown(usage.model),
+    calls: toFiniteNumber(usage.calls) || countIterations(usage),
+    inputTokens,
+    outputTokens,
+    totalTokens,
+  };
+}
+
+function hasUsage(usage: LLMUsageSummary): boolean {
+  return Boolean(
+    toFiniteNumber(usage.input_tokens) ||
+    toFiniteNumber(usage.output_tokens) ||
+    toFiniteNumber(usage.total_tokens) ||
+    toFiniteNumber(usage.calls) ||
+    countIterations(usage),
+  );
+}
+
+function summarizeUsage(runs: UsageRun[]): UsageSummary {
+  return runs.reduce<UsageSummary>((acc, run) => ({
+    runCount: acc.runCount + 1,
+    calls: acc.calls + run.calls,
+    inputTokens: acc.inputTokens + run.inputTokens,
+    outputTokens: acc.outputTokens + run.outputTokens,
+    totalTokens: acc.totalTokens + run.totalTokens,
+  }), { runCount: 0, calls: 0, inputTokens: 0, outputTokens: 0, totalTokens: 0 });
+}
+
+function summarizeByModel(runs: UsageRun[]): ModelUsageSummary[] {
+  const rows = new Map<string, ModelUsageSummary>();
+  for (const run of runs) {
+    const key = `${run.provider}:::${run.model}`;
+    const current = rows.get(key) || {
+      key,
+      provider: run.provider,
+      model: run.model,
+      runCount: 0,
+      calls: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+    };
+    current.runCount += 1;
+    current.calls += run.calls;
+    current.inputTokens += run.inputTokens;
+    current.outputTokens += run.outputTokens;
+    current.totalTokens += run.totalTokens;
+    rows.set(key, current);
+  }
+  return Array.from(rows.values()).sort((a, b) => b.totalTokens - a.totalTokens);
+}
+
+function countIterations(usage: LLMUsageSummary): number {
+  return Array.isArray(usage.iterations) ? usage.iterations.length : 0;
+}
+
+function toFiniteNumber(value: unknown): number {
+  const numeric = typeof value === "number" ? value : Number(value || 0);
+  return Number.isFinite(numeric) ? Math.max(0, numeric) : 0;
+}
+
+function stringOrUnknown(value: unknown): string {
+  return typeof value === "string" && value.trim() ? value.trim() : "unknown";
+}
+
+function formatNumber(value: number): string {
+  return Math.round(value).toLocaleString();
+}
+
+function formatRunDate(value: string): string {
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) return value || "unknown";
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+}

--- a/frontend/src/pages/Usage.tsx
+++ b/frontend/src/pages/Usage.tsx
@@ -12,7 +12,7 @@ import {
 import { api, type LLMUsageSummary, type RunData, type RunListItem } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
-const USAGE_RUN_SCAN_LIMIT = 25;
+const USAGE_RUN_SCAN_LIMIT = 100;
 const HEAVY_RUN_LIMIT = 8;
 
 export function Usage() {
@@ -26,15 +26,15 @@ export function Usage() {
     else setRefreshing(true);
     setError(null);
     try {
-      const list = await api.listRuns();
+      const list = await api.listRuns({ limit: USAGE_RUN_SCAN_LIMIT, with_usage: true });
       const recent = Array.isArray(list) ? list.slice(0, USAGE_RUN_SCAN_LIMIT) : [];
       const details = await Promise.allSettled(
-        recent.map(async (run) => [run, await api.getRun(run.run_id)] as const),
+        recent.map(async (run) => [run, run.llm_usage ? null : await api.getRun(run.run_id)] as const),
       );
       const usageRuns = details.flatMap((result) => {
         if (result.status !== "fulfilled") return [];
         const [run, detail] = result.value;
-        const usage = toUsageRun(run, detail);
+        const usage = toUsageRun(run, detail || null);
         return usage ? [usage] : [];
       });
       setRuns(usageRuns);
@@ -236,8 +236,8 @@ function UsagePill({ label, value }: { label: string; value: string }) {
   );
 }
 
-function toUsageRun(run: RunListItem, detail: RunData): UsageRun | null {
-  const usage = detail.llm_usage;
+function toUsageRun(run: RunListItem, detail: RunData | null): UsageRun | null {
+  const usage = run.llm_usage || detail?.llm_usage;
   if (!usage || !hasUsage(usage)) return null;
   const inputTokens = toFiniteNumber(usage.input_tokens);
   const outputTokens = toFiniteNumber(usage.output_tokens);
@@ -245,7 +245,7 @@ function toUsageRun(run: RunListItem, detail: RunData): UsageRun | null {
   return {
     runId: run.run_id,
     createdAt: run.created_at,
-    prompt: run.prompt || detail.prompt,
+    prompt: run.prompt || detail?.prompt,
     provider: stringOrUnknown(usage.provider),
     model: stringOrUnknown(usage.model),
     calls: toFiniteNumber(usage.calls) || countIterations(usage),

--- a/frontend/src/pages/__tests__/Usage.test.tsx
+++ b/frontend/src/pages/__tests__/Usage.test.tsx
@@ -1,0 +1,117 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { Usage } from "../Usage";
+import type { RunData, RunListItem } from "@/lib/api";
+
+const apiMock = vi.hoisted(() => ({
+  listRuns: vi.fn(),
+  getRun: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: apiMock,
+}));
+
+function renderUsage() {
+  return render(
+    <MemoryRouter>
+      <Usage />
+    </MemoryRouter>,
+  );
+}
+
+function makeRun(overrides: Partial<RunListItem> = {}): RunListItem {
+  return {
+    run_id: "run-1",
+    status: "success",
+    created_at: "2026-06-12T08:00:00Z",
+    prompt: "Backtest a momentum strategy",
+    ...overrides,
+  };
+}
+
+function makeDetail(overrides: Partial<RunData> = {}): RunData {
+  return {
+    run_id: "run-1",
+    status: "success",
+    llm_usage: {
+      provider: "anthropic",
+      model: "claude-sonnet",
+      input_tokens: 1000,
+      output_tokens: 200,
+      total_tokens: 1200,
+      calls: 2,
+      iterations: [{ iter: 1, input_tokens: 1000, output_tokens: 200, total_tokens: 1200 }],
+    },
+    ...overrides,
+  };
+}
+
+describe("Usage dashboard", () => {
+  beforeEach(() => {
+    apiMock.listRuns.mockReset();
+    apiMock.getRun.mockReset();
+  });
+
+  it("aggregates persisted usage across recent runs", async () => {
+    apiMock.listRuns.mockResolvedValue([
+      makeRun(),
+      makeRun({ run_id: "run-2", prompt: "Use a different model" }),
+      makeRun({ run_id: "no-usage" }),
+    ]);
+    apiMock.getRun.mockImplementation((runId: string) => {
+      if (runId === "run-2") {
+        return Promise.resolve(makeDetail({
+          run_id: "run-2",
+          llm_usage: {
+            provider: "openai",
+            model: "gpt-4.1",
+            input_tokens: 250,
+            output_tokens: 50,
+            total_tokens: 300,
+            calls: 1,
+            iterations: [{ iter: 1, input_tokens: 250, output_tokens: 50, total_tokens: 300 }],
+          },
+        }));
+      }
+      if (runId === "no-usage") return Promise.resolve({ run_id: runId, status: "success" });
+      return Promise.resolve(makeDetail());
+    });
+
+    renderUsage();
+
+    expect(await screen.findByText("Agent Usage Dashboard")).toBeInTheDocument();
+    expect(screen.getByText("Runs with usage").closest(".rounded-md")).toHaveTextContent("2");
+    expect(screen.getByText("LLM calls").closest(".rounded-md")).toHaveTextContent("3");
+    expect(screen.getByText("Input tokens").closest(".rounded-md")).toHaveTextContent("1,250");
+    expect(screen.getByText("Output tokens").closest(".rounded-md")).toHaveTextContent("250");
+    expect(screen.getByText("anthropic")).toBeInTheDocument();
+    expect(screen.getByText("claude-sonnet")).toBeInTheDocument();
+    expect(screen.getByText("openai")).toBeInTheDocument();
+    expect(screen.getByText("gpt-4.1")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /run-1/ })).toHaveAttribute("href", "/runs/run-1");
+    expect(document.body.textContent || "").not.toContain("$");
+  });
+
+  it("shows an empty state when recent runs have no usage artifact", async () => {
+    apiMock.listRuns.mockResolvedValue([makeRun()]);
+    apiMock.getRun.mockResolvedValue({ run_id: "run-1", status: "success" });
+
+    renderUsage();
+
+    expect(await screen.findByText("No persisted usage found")).toBeInTheDocument();
+  });
+
+  it("refreshes by reading recent run usage again", async () => {
+    apiMock.listRuns.mockResolvedValue([makeRun()]);
+    apiMock.getRun.mockResolvedValue(makeDetail());
+
+    renderUsage();
+    await screen.findByText("run-1");
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+
+    await waitFor(() => expect(apiMock.listRuns).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(apiMock.getRun).toHaveBeenCalledTimes(2));
+  });
+});

--- a/frontend/src/pages/__tests__/Usage.test.tsx
+++ b/frontend/src/pages/__tests__/Usage.test.tsx
@@ -55,28 +55,23 @@ describe("Usage dashboard", () => {
 
   it("aggregates persisted usage across recent runs", async () => {
     apiMock.listRuns.mockResolvedValue([
-      makeRun(),
-      makeRun({ run_id: "run-2", prompt: "Use a different model" }),
+      makeRun({ llm_usage: makeDetail().llm_usage }),
+      makeRun({
+        run_id: "run-2",
+        prompt: "Use a different model",
+        llm_usage: {
+          provider: "openai",
+          model: "gpt-4.1",
+          input_tokens: 250,
+          output_tokens: 50,
+          total_tokens: 300,
+          calls: 1,
+          iterations: [{ iter: 1, input_tokens: 250, output_tokens: 50, total_tokens: 300 }],
+        },
+      }),
       makeRun({ run_id: "no-usage" }),
     ]);
-    apiMock.getRun.mockImplementation((runId: string) => {
-      if (runId === "run-2") {
-        return Promise.resolve(makeDetail({
-          run_id: "run-2",
-          llm_usage: {
-            provider: "openai",
-            model: "gpt-4.1",
-            input_tokens: 250,
-            output_tokens: 50,
-            total_tokens: 300,
-            calls: 1,
-            iterations: [{ iter: 1, input_tokens: 250, output_tokens: 50, total_tokens: 300 }],
-          },
-        }));
-      }
-      if (runId === "no-usage") return Promise.resolve({ run_id: runId, status: "success" });
-      return Promise.resolve(makeDetail());
-    });
+    apiMock.getRun.mockResolvedValue({ run_id: "no-usage", status: "success" });
 
     renderUsage();
 
@@ -91,6 +86,18 @@ describe("Usage dashboard", () => {
     expect(screen.getByText("gpt-4.1")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /run-1/ })).toHaveAttribute("href", "/runs/run-1");
     expect(document.body.textContent || "").not.toContain("$");
+    expect(apiMock.listRuns).toHaveBeenCalledWith({ limit: 100, with_usage: true });
+    expect(apiMock.getRun).toHaveBeenCalledTimes(1);
+    expect(apiMock.getRun).toHaveBeenCalledWith("no-usage");
+  });
+
+  it("uses compact /runs llm_usage without loading full run details", async () => {
+    apiMock.listRuns.mockResolvedValue([makeRun({ llm_usage: makeDetail().llm_usage })]);
+
+    renderUsage();
+
+    expect(await screen.findByText("run-1")).toBeInTheDocument();
+    expect(apiMock.getRun).not.toHaveBeenCalled();
   });
 
   it("shows an empty state when recent runs have no usage artifact", async () => {

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -13,6 +13,9 @@ const Compare = lazy(() =>
 const Settings = lazy(() =>
   import("@/pages/Settings").then((m) => ({ default: m.Settings })),
 );
+const Usage = lazy(() =>
+  import("@/pages/Usage").then((m) => ({ default: m.Usage })),
+);
 const Correlation = lazy(() =>
   import("@/pages/Correlation").then((m) => ({ default: m.Correlation })),
 );
@@ -42,6 +45,7 @@ export const router = createBrowserRouter([
     children: [
       { path: "/", element: wrap(Home) },
       { path: "/agent", element: wrap(Agent) },
+      { path: "/usage", element: wrap(Usage) },
       { path: "/settings", element: wrap(Settings) },
       { path: "/runs/:runId", element: wrap(RunDetail) },
       { path: "/compare", element: wrap(Compare) },


### PR DESCRIPTION
## Summary
- add a dedicated `/usage` page and sidebar entry for persisted AgentLoop usage
- aggregate recent run `llm_usage` artifacts by provider/model, calls, input tokens, output tokens, and total tokens
- list usage-heavy runs with links back to Run Detail

## Stack / Dependency
This PR is intentionally stacked on #207 (`codex/agent-usage-artifacts`) because it consumes the `llm_usage` artifact/API field introduced there. It is marked draft until #207 lands; after #207 merges, this PR should shrink to the dashboard-only diff.

## Scope
- upstream-friendly frontend only
- no price or cost estimation
- no Moirix, IBKR, MiniMax, broker, live runtime, order, or authority behavior

## Tests
- `npm run test:run -- src/pages/__tests__/Usage.test.tsx`
- `npm run build`
- `git diff --check`
- local browser smoke on `http://127.0.0.1:5910/usage` confirmed usage page, empty state, no price estimate, and no Moirix/IBKR/MiniMax text