### PR TITLE
Optimize Run Detail chart payloads

### DIFF
--- a/agent/api_server.py
+++ b/agent/api_server.py
@@ -126,6 +126,7 @@ class RunResponse(BaseModel):
     run_directory: str = Field(..., description="Run directory path")
     run_stage: Optional[str] = Field(None, description="UI-facing run stage")
     run_context: Optional[Dict[str, Any]] = Field(None, description="Normalized request context")
+    chart_symbols: List[str] = Field(default_factory=list, description="Symbols available for chart loading")
     price_series: Optional[Dict[str, List[Dict[str, Any]]]] = Field(None, description="Grouped OHLC series")
     indicator_series: Optional[Dict[str, Dict[str, List[Dict[str, Any]]]]] = Field(
         None,
@@ -1025,7 +1026,13 @@ def _load_csv_to_dict(path: Path, limit: Optional[int] = None) -> List[Dict[str,
 
 
 
-def _build_response_from_run_dir(run_dir: Path, elapsed: float, *, include_analysis: bool = False) -> RunResponse:
+def _build_response_from_run_dir(
+    run_dir: Path,
+    elapsed: float,
+    *,
+    include_analysis: bool = False,
+    chart_symbol: Optional[str] = None,
+) -> RunResponse:
     """Build a run response from a persisted run directory."""
     run_id = run_dir.name
 
@@ -1102,11 +1109,13 @@ def _build_response_from_run_dir(run_dir: Path, elapsed: float, *, include_analy
 
     equity_path = run_dir / "artifacts" / "equity.csv"
     if equity_path.exists():
-        response.artifacts_equity_csv = _load_csv_to_dict(equity_path)
+        equity_rows = _load_csv_to_dict(equity_path)
+    else:
+        equity_rows = []
 
     metrics_csv_path = run_dir / "artifacts" / "metrics.csv"
     if metrics_csv_path.exists():
-        response.artifacts_metrics_csv = _load_csv_to_dict(metrics_csv_path)
+        response.artifacts_metrics_csv = _load_csv_to_dict(metrics_csv_path, limit=200)
 
     run_card_path = run_dir / "run_card.json"
     if run_card_path.exists():
@@ -1117,7 +1126,9 @@ def _build_response_from_run_dir(run_dir: Path, elapsed: float, *, include_analy
 
     trades_path = run_dir / "artifacts" / "trades.csv"
     if trades_path.exists():
-        response.artifacts_trades_csv = _load_csv_to_dict(trades_path)
+        trade_rows = _load_csv_to_dict(trades_path)
+    else:
+        trade_rows = []
 
     validation_path = run_dir / "artifacts" / "validation.json"
     if validation_path.exists():
@@ -1126,9 +1137,9 @@ def _build_response_from_run_dir(run_dir: Path, elapsed: float, *, include_analy
         except (json.JSONDecodeError, OSError):
             pass
 
-    if response.artifacts_equity_csv:
+    if equity_rows:
         filtered_equity = []
-        for row in response.artifacts_equity_csv[:1000]:
+        for row in equity_rows[:1000]:
             filtered_row: Dict[str, Any] = {}
             if "timestamp" in row:
                 filtered_row["time"] = row["timestamp"]
@@ -1139,13 +1150,14 @@ def _build_response_from_run_dir(run_dir: Path, elapsed: float, *, include_analy
             filtered_equity.append(filtered_row)
         response.equity_curve = filtered_equity
 
-    if response.artifacts_trades_csv:
-        response.trade_log = response.artifacts_trades_csv[:500]
+    if trade_rows:
+        response.trade_log = trade_rows[:500]
 
     if include_analysis:
-        analysis = build_run_analysis(run_dir)
+        analysis = build_run_analysis(run_dir, symbols=[chart_symbol] if chart_symbol else None)
         response.run_stage = analysis.get("run_stage")
         response.run_context = analysis.get("run_context")
+        response.chart_symbols = analysis.get("chart_symbols") or []
         response.price_series = analysis.get("price_series")
         response.indicator_series = analysis.get("indicator_series")
         response.trade_markers = analysis.get("trade_markers")
@@ -1226,7 +1238,10 @@ async def get_run_pine(run_id: str):
 
 
 @app.get("/runs/{run_id}", response_model=RunResponse, dependencies=[Depends(require_auth)])
-async def get_run_result(run_id: str):
+async def get_run_result(
+    run_id: str,
+    chart_symbol: Optional[str] = Query(None, description="Return chart payloads only for this symbol"),
+):
     """Fetch full details for a historical run by ``run_id``."""
     _validate_path_param(run_id, "run_id")
     run_dir = RUNS_DIR / run_id
@@ -1237,7 +1252,12 @@ async def get_run_result(run_id: str):
             detail=f"Run {run_id} not found"
         )
 
-    response = _build_response_from_run_dir(run_dir, elapsed=0.0, include_analysis=True)
+    response = _build_response_from_run_dir(
+        run_dir,
+        elapsed=0.0,
+        include_analysis=True,
+        chart_symbol=chart_symbol,
+    )
 
     return response
 

--- a/agent/src/ui_services.py
+++ b/agent/src/ui_services.py
@@ -250,7 +250,7 @@ def collect_run_logs(run_dir: Path, line_limit: int = 200) -> List[Dict[str, Any
     return entries
 
 
-def build_trade_markers(trades: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+def build_trade_markers(trades: List[Dict[str, Any]], symbols: Optional[set[str]] = None) -> List[Dict[str, Any]]:
     """Normalize trade rows into frontend marker objects.
 
     Args:
@@ -261,13 +261,16 @@ def build_trade_markers(trades: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """
     markers: List[Dict[str, Any]] = []
     for row in trades:
+        code = str(row.get("code") or "")
+        if symbols is not None and code not in symbols:
+            continue
         side = str(row.get("side") or "").upper()
         timestamp = str(row.get("timestamp") or "")
         markers.append(
             {
                 "time": timestamp[:10],
                 "timestamp": timestamp,
-                "code": row.get("code"),
+                "code": code or row.get("code"),
                 "side": side,
                 "price": _safe_float(row.get("price")),
                 "qty": _safe_float(row.get("qty")),
@@ -443,7 +446,7 @@ def reconstruct_price_series(run_dir: Path) -> List[Dict[str, Any]]:
     return _flatten_data_map(data_map, start_date=start_date)
 
 
-def build_run_analysis(run_dir: Path) -> Dict[str, Any]:
+def build_run_analysis(run_dir: Path, symbols: Optional[List[str]] = None) -> Dict[str, Any]:
     """Build the analysis payload consumed by the run detail page.
 
     Args:
@@ -453,15 +456,22 @@ def build_run_analysis(run_dir: Path) -> Dict[str, Any]:
         A serializable dictionary of chart, trade, and log data.
     """
     price_rows = load_price_series(run_dir)
+    all_symbols = sorted({str(row.get("code") or "") for row in price_rows if row.get("code")})
+    requested_symbols = [symbol for symbol in (symbols or []) if symbol]
+    selected_symbols = requested_symbols or all_symbols[:1]
+    selected_symbol_set = set(selected_symbols)
+    if selected_symbol_set:
+        price_rows = [row for row in price_rows if str(row.get("code") or "") in selected_symbol_set]
     periods = infer_indicator_periods(run_dir)
     trades = load_csv_records(run_dir / "artifacts" / "trades.csv")
 
     return {
         "run_stage": infer_run_stage(run_dir),
         "run_context": load_run_context(run_dir),
+        "chart_symbols": all_symbols,
         "price_series": group_price_rows(price_rows),
         "indicator_series": build_indicator_series(price_rows, periods) if price_rows else {},
-        "trade_markers": build_trade_markers(trades),
+        "trade_markers": build_trade_markers(trades, selected_symbol_set if selected_symbol_set else None),
         "run_logs": collect_run_logs(run_dir),
     }
 

--- a/agent/tests/test_run_card.py
+++ b/agent/tests/test_run_card.py
@@ -125,6 +125,50 @@ def test_json_and_markdown_files_are_written(tmp_path: Path) -> None:
     assert "sample warning" in markdown
 
 
+def test_api_run_response_filters_chart_symbol_payload(tmp_path: Path) -> None:
+    import api_server
+
+    run_dir = tmp_path / "run_001"
+    artifacts_dir = run_dir / "artifacts"
+    artifacts_dir.mkdir(parents=True)
+    (run_dir / "state.json").write_text('{"status": "success"}\n', encoding="utf-8")
+    (artifacts_dir / "price_series.csv").write_text(
+        "\n".join(
+            [
+                "time,code,open,high,low,close,volume",
+                "2024-01-02,AAA,1,2,0.5,1.5,100",
+                "2024-01-02,BBB,3,4,2.5,3.5,200",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (artifacts_dir / "trades.csv").write_text(
+        "\n".join(
+            [
+                "timestamp,code,side,price,qty,reason",
+                "2024-01-02,AAA,BUY,1.5,10,alpha",
+                "2024-01-02,BBB,SELL,3.5,5,beta",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    default_response = api_server._build_response_from_run_dir(run_dir, elapsed=0.0, include_analysis=True)
+    filtered_response = api_server._build_response_from_run_dir(
+        run_dir,
+        elapsed=0.0,
+        include_analysis=True,
+        chart_symbol="BBB",
+    )
+
+    assert default_response.chart_symbols == ["AAA", "BBB"]
+    assert list(default_response.price_series or {}) == ["AAA"]
+    assert list(filtered_response.price_series or {}) == ["BBB"]
+    assert {marker["code"] for marker in filtered_response.trade_markers or []} == {"BBB"}
+    assert filtered_response.artifacts_trades_csv is None
+    assert filtered_response.artifacts_equity_csv is None
+
+
 def test_api_run_response_includes_run_card(tmp_path: Path) -> None:
     import api_server
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -74,7 +74,12 @@ function appendQueryParam(url: string, key: string, value: string): string {
 export const api = {
   uploadFile,
   listRuns: () => request<RunListItem[]>("/runs"),
-  getRun: (id: string) => request<RunData>(`/runs/${id}`),
+  getRun: (id: string, params: RunDetailParams = {}) => {
+    const q = new URLSearchParams();
+    if (params.chart_symbol) q.set("chart_symbol", params.chart_symbol);
+    const qs = q.toString();
+    return request<RunData>(`/runs/${id}${qs ? `?${qs}` : ""}`);
+  },
   getRunCode: (id: string) => request<Record<string, string>>(`/runs/${id}/code`),
   getRunPine: (id: string) => request<PineScriptResult>(`/runs/${id}/pine`),
   listSessions: () => request<SessionItem[]>("/sessions"),
@@ -286,6 +291,10 @@ export interface RunListItem {
   end_date?: string;
 }
 
+export interface RunDetailParams {
+  chart_symbol?: string;
+}
+
 export interface PriceBar {
   time: string;
   timestamp?: string;
@@ -368,6 +377,7 @@ export interface RunData {
   run_directory?: string;
   run_stage?: string;
   run_context?: Record<string, unknown>;
+  chart_symbols?: string[];
 
   metrics?: BacktestMetrics;
   artifacts?: ArtifactInfo[];

--- a/frontend/src/pages/RunDetail.tsx
+++ b/frontend/src/pages/RunDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { ReactNode } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import {
@@ -12,6 +12,7 @@ import {
   FileCheck2,
   Fingerprint,
   List,
+  Loader2,
   ShieldCheck,
   XCircle,
 } from "lucide-react";
@@ -29,6 +30,11 @@ import { ErrorBoundary } from "@/components/common/ErrorBoundary";
 const rehypePlugins = [rehypeHighlight];
 
 type Tab = "chart" | "trades" | "runCard" | "code" | "validation";
+type ChartPayload = Pick<RunData, "price_series" | "indicator_series" | "trade_markers">;
+type ChartCache = Record<string, ChartPayload>;
+type ChartLoadProgress = { done: number; total: number };
+
+const MULTI_CHART_PAGE_SIZE = 8;
 
 function downloadCsv(filename: string, csvContent: string) {
   const blob = new Blob(["\uFEFF" + csvContent], { type: "text/csv;charset=utf-8;" });
@@ -62,6 +68,33 @@ function buildMetricsCsv(metrics: BacktestMetrics): string {
   return [header, ...rows].join("\n");
 }
 
+function cacheFromRun(run: RunData | null, requestedSymbol?: string): ChartCache {
+  if (!run?.price_series) return {};
+  const cache: ChartCache = {};
+  const markerRows = run.trade_markers || [];
+  for (const [symbol, bars] of Object.entries(run.price_series)) {
+    cache[symbol] = {
+      price_series: { [symbol]: bars },
+      indicator_series: run.indicator_series?.[symbol] ? { [symbol]: run.indicator_series[symbol] } : {},
+      trade_markers: markerRows.filter((marker) => !marker.code || marker.code === symbol),
+    };
+  }
+  if (requestedSymbol && !cache[requestedSymbol]) {
+    cache[requestedSymbol] = { price_series: {}, indicator_series: {}, trade_markers: [] };
+  }
+  return cache;
+}
+
+function mergeChartCache(current: ChartCache, next: ChartCache): ChartCache {
+  return { ...current, ...next };
+}
+
+function yieldToBrowser(): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, 0);
+  });
+}
+
 export function RunDetail() {
   const { runId } = useParams<{ runId: string }>();
   const navigate = useNavigate();
@@ -69,6 +102,15 @@ export function RunDetail() {
   const [code, setCode] = useState<Record<string, string>>({});
   const [tab, setTab] = useState<Tab>("chart");
   const [loading, setLoading] = useState(true);
+  const [selectedSymbol, setSelectedSymbol] = useState("");
+  const [chartPickerSymbol, setChartPickerSymbol] = useState("");
+  const [selectedSymbols, setSelectedSymbols] = useState<string[]>([]);
+  const [chartCache, setChartCache] = useState<ChartCache>({});
+  const [chartLoadingSymbols, setChartLoadingSymbols] = useState<Record<string, boolean>>({});
+  const [bulkChartLoading, setBulkChartLoading] = useState(false);
+  const [bulkChartProgress, setBulkChartProgress] = useState<ChartLoadProgress>({ done: 0, total: 0 });
+  const chartCacheRef = useRef<ChartCache>({});
+  const cancelBulkChartLoadRef = useRef(false);
 
   const hasValidation = !!run?.validation;
   const hasRunCard = !!run?.run_card;
@@ -85,7 +127,17 @@ export function RunDetail() {
     Promise.all([
       api.getRun(runId).catch(() => null),
       api.getRunCode(runId).catch(() => ({})),
-    ]).then(([r, c]) => { setRun(r); setCode(c || {}); }).finally(() => setLoading(false));
+    ]).then(([r, c]) => {
+      setRun(r);
+      setCode(c || {});
+      const firstSymbol = r?.chart_symbols?.[0] || Object.keys(r?.price_series || {})[0] || "";
+      setSelectedSymbol(firstSymbol);
+      setChartPickerSymbol(firstSymbol);
+      setSelectedSymbols(firstSymbol ? [firstSymbol] : []);
+      const initialCache = cacheFromRun(r, firstSymbol);
+      chartCacheRef.current = initialCache;
+      setChartCache(initialCache);
+    }).finally(() => setLoading(false));
   }, [runId]);
 
   if (loading) {
@@ -114,6 +166,82 @@ export function RunDetail() {
   );
 
   const ok = run.status === "success";
+
+  async function loadChartSymbol(symbol: string) {
+    if (!runId || !symbol) return;
+    if (chartCacheRef.current[symbol]?.price_series?.[symbol]?.length) return;
+    setChartLoadingSymbols((prev) => ({ ...prev, [symbol]: true }));
+    try {
+      const nextRun = await api.getRun(runId, { chart_symbol: symbol });
+      const nextCache = cacheFromRun(nextRun, symbol);
+      const mergedCache = mergeChartCache(chartCacheRef.current, nextCache);
+      chartCacheRef.current = mergedCache;
+      setChartCache(mergedCache);
+      setRun((prev) => prev ? {
+        ...prev,
+        chart_symbols: nextRun.chart_symbols?.length ? nextRun.chart_symbols : prev.chart_symbols,
+        equity_curve: nextRun.equity_curve?.length ? nextRun.equity_curve : prev.equity_curve,
+      } : nextRun);
+    } finally {
+      setChartLoadingSymbols((prev) => {
+        const next = { ...prev };
+        delete next[symbol];
+        return next;
+      });
+    }
+  }
+
+  async function handleAddChartSymbol(symbol: string) {
+    if (!symbol) return;
+    setSelectedSymbol(symbol);
+    setChartPickerSymbol(symbol);
+    setSelectedSymbols((prev) => prev.includes(symbol) ? prev : [...prev, symbol]);
+    await loadChartSymbol(symbol);
+  }
+
+  async function handleCurrentChartOnly(symbol: string) {
+    if (!symbol) return;
+    setSelectedSymbol(symbol);
+    setChartPickerSymbol(symbol);
+    setSelectedSymbols([symbol]);
+    await loadChartSymbol(symbol);
+  }
+
+  function handleRemoveChartSymbol(symbol: string) {
+    const nextSymbols = selectedSymbols.filter((item) => item !== symbol);
+    setSelectedSymbols(nextSymbols);
+    if (selectedSymbol === symbol) {
+      const fallback = nextSymbols[0] || run?.chart_symbols?.[0] || "";
+      setSelectedSymbol(fallback);
+      setChartPickerSymbol(fallback);
+    }
+  }
+
+  async function handleLoadAllChartSymbols() {
+    const symbols = run?.chart_symbols || [];
+    if (symbols.length === 0 || bulkChartLoading) return;
+    cancelBulkChartLoadRef.current = false;
+    setBulkChartLoading(true);
+    setBulkChartProgress({ done: 0, total: symbols.length });
+    try {
+      for (let index = 0; index < symbols.length; index += 1) {
+        if (cancelBulkChartLoadRef.current) break;
+        const symbol = symbols[index];
+        setSelectedSymbol(symbol);
+        setChartPickerSymbol(symbol);
+        setSelectedSymbols((prev) => prev.includes(symbol) ? prev : [...prev, symbol]);
+        await loadChartSymbol(symbol);
+        setBulkChartProgress({ done: index + 1, total: symbols.length });
+        await yieldToBrowser();
+      }
+    } finally {
+      setBulkChartLoading(false);
+    }
+  }
+
+  function handleCancelLoadAllCharts() {
+    cancelBulkChartLoadRef.current = true;
+  }
 
   return (
     <div className="flex flex-col h-full">
@@ -173,7 +301,24 @@ export function RunDetail() {
 
       <div className="flex-1 overflow-auto">
         <ErrorBoundary>
-          {tab === "chart" && <ChartTab run={run} />}
+          {tab === "chart" && (
+            <ChartTab
+              run={run}
+              selectedSymbol={selectedSymbol}
+              chartPickerSymbol={chartPickerSymbol}
+              selectedSymbols={selectedSymbols}
+              chartCache={chartCache}
+              loadingSymbols={chartLoadingSymbols}
+              bulkLoading={bulkChartLoading}
+              bulkProgress={bulkChartProgress}
+              onPickSymbol={setChartPickerSymbol}
+              onAddSymbol={handleAddChartSymbol}
+              onCurrentOnly={handleCurrentChartOnly}
+              onRemoveSymbol={handleRemoveChartSymbol}
+              onLoadAll={handleLoadAllChartSymbols}
+              onCancelLoadAll={handleCancelLoadAllCharts}
+            />
+          )}
           {tab === "trades" && <TradesTab run={run} />}
           {tab === "validation" && run.validation && <ValidationPanel data={run.validation} />}
           {tab === "runCard" && run.run_card && <RunCardTab card={run.run_card} />}
@@ -325,11 +470,56 @@ function shortHash(value: string): string {
   return value.length > 16 ? `${value.slice(0, 12)}...${value.slice(-6)}` : value;
 }
 
-function ChartTab({ run }: { run: RunData }) {
-  const entries = run.price_series ? Object.entries(run.price_series) : [];
+function ChartTab({
+  run,
+  selectedSymbol,
+  chartPickerSymbol,
+  selectedSymbols,
+  chartCache,
+  loadingSymbols,
+  bulkLoading,
+  bulkProgress,
+  onPickSymbol,
+  onAddSymbol,
+  onCurrentOnly,
+  onRemoveSymbol,
+  onLoadAll,
+  onCancelLoadAll,
+}: {
+  run: RunData;
+  selectedSymbol: string;
+  chartPickerSymbol: string;
+  selectedSymbols: string[];
+  chartCache: ChartCache;
+  loadingSymbols: Record<string, boolean>;
+  bulkLoading: boolean;
+  bulkProgress: ChartLoadProgress;
+  onPickSymbol: (symbol: string) => void;
+  onAddSymbol: (symbol: string) => void;
+  onCurrentOnly: (symbol: string) => void;
+  onRemoveSymbol: (symbol: string) => void;
+  onLoadAll: () => void;
+  onCancelLoadAll: () => void;
+}) {
+  const [visibleChartCount, setVisibleChartCount] = useState(MULTI_CHART_PAGE_SIZE);
+  const chartSymbols = run.chart_symbols || [];
+  const activeSymbols = selectedSymbols.length ? selectedSymbols : selectedSymbol ? [selectedSymbol] : [];
+  const entries = activeSymbols.flatMap((symbol) => {
+    const payload = chartCache[symbol];
+    const bars = payload?.price_series?.[symbol];
+    return bars?.length ? [{ symbol, bars, payload }] : [];
+  });
+  const visibleEntries = entries.slice(0, visibleChartCount);
+  const loadingSelectedSymbols = activeSymbols.filter((symbol) => loadingSymbols[symbol] && !chartCache[symbol]?.price_series?.[symbol]?.length);
   const hasEquity = run.equity_curve && run.equity_curve.length > 0;
+  const progressPct = bulkProgress.total > 0 ? Math.round((bulkProgress.done / bulkProgress.total) * 100) : 0;
+  const pickerValue = chartPickerSymbol || selectedSymbol || chartSymbols[0] || "";
 
-  if (entries.length === 0 && !hasEquity) {
+  useEffect(() => {
+    setVisibleChartCount(selectedSymbols.length > 1 ? MULTI_CHART_PAGE_SIZE : 1);
+  }, [selectedSymbols.join("|")]);
+
+  if (entries.length === 0 && loadingSelectedSymbols.length === 0 && !hasEquity) {
     return (
       <div className="p-8 text-center text-muted-foreground space-y-2">
         <p className="text-sm">No chart data available</p>
@@ -340,12 +530,131 @@ function ChartTab({ run }: { run: RunData }) {
 
   return (
     <div className="p-4 space-y-4">
-      {entries.map(([sym, bars]) => (
-        <div key={sym}>
-          <h3 className="text-sm font-medium mb-1">{sym}</h3>
-          <CandlestickChart data={bars} markers={run.trade_markers?.filter(m => m.code === sym)} indicators={run.indicator_series?.[sym]} height={500} />
+      {chartSymbols.length > 1 && (
+        <div className="space-y-3 rounded-md border bg-card p-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <label className="text-xs font-medium uppercase text-muted-foreground">Chart symbols</label>
+            <select
+              value={pickerValue}
+              onChange={(event) => onPickSymbol(event.target.value)}
+              disabled={bulkLoading}
+              className="rounded-md border bg-background px-2 py-1 text-sm outline-none transition focus:border-primary disabled:opacity-60"
+            >
+              {chartSymbols.map((symbol) => (
+                <option key={symbol} value={symbol}>{symbol}</option>
+              ))}
+            </select>
+            <button
+              type="button"
+              onClick={() => onAddSymbol(pickerValue)}
+              disabled={!pickerValue || bulkLoading || !!loadingSymbols[pickerValue]}
+              className="rounded-md border px-2.5 py-1 text-xs font-medium transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Add
+            </button>
+            <button
+              type="button"
+              onClick={() => onCurrentOnly(pickerValue)}
+              disabled={!pickerValue || bulkLoading || !!loadingSymbols[pickerValue]}
+              className="rounded-md border px-2.5 py-1 text-xs font-medium transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Current only
+            </button>
+            <button
+              type="button"
+              onClick={onLoadAll}
+              disabled={bulkLoading || chartSymbols.length === 0}
+              className="rounded-md border px-2.5 py-1 text-xs font-medium transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Load all
+            </button>
+            {bulkLoading && (
+              <button
+                type="button"
+                onClick={onCancelLoadAll}
+                className="rounded-md border border-amber-500/30 px-2.5 py-1 text-xs font-medium text-amber-700 transition hover:bg-amber-500/10 dark:text-amber-300"
+              >
+                Cancel
+              </button>
+            )}
+            {loadingSymbols[pickerValue] && (
+              <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                Loading {pickerValue}
+              </span>
+            )}
+            <span className="ml-auto text-xs text-muted-foreground">
+              {activeSymbols.length} selected / {chartSymbols.length} available; charts load progressively.
+            </span>
+          </div>
+
+          {bulkProgress.total > 0 && (
+            <div className="space-y-1">
+              <div className="flex items-center justify-between text-xs text-muted-foreground">
+                <span>{bulkLoading ? "Loading charts" : "Chart load progress"}</span>
+                <span>{bulkProgress.done} / {bulkProgress.total} ({progressPct}%)</span>
+              </div>
+              <div className="h-2 overflow-hidden rounded-full bg-muted">
+                <div className="h-full bg-primary transition-[width]" style={{ width: `${progressPct}%` }} />
+              </div>
+            </div>
+          )}
+
+          {activeSymbols.length > 0 && (
+            <div className="flex flex-wrap gap-1.5">
+              {activeSymbols.slice(0, 48).map((symbol) => (
+                <button
+                  key={symbol}
+                  type="button"
+                  onClick={() => onRemoveSymbol(symbol)}
+                  className={cn(
+                    "inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs transition hover:bg-muted",
+                    symbol === selectedSymbol ? "border-primary/50 text-primary" : "text-muted-foreground"
+                  )}
+                  title={`Remove ${symbol}`}
+                >
+                  {loadingSymbols[symbol] && <Loader2 className="h-3 w-3 animate-spin" />}
+                  {symbol}
+                  <span aria-hidden="true">x</span>
+                </button>
+              ))}
+              {activeSymbols.length > 48 && (
+                <span className="rounded-md border px-2 py-1 text-xs text-muted-foreground">
+                  +{activeSymbols.length - 48} more selected
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+      {loadingSelectedSymbols.map((symbol) => (
+        <div key={`loading-${symbol}`} className="rounded-md border bg-card p-4 text-sm text-muted-foreground">
+          <span className="inline-flex items-center gap-2">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading {symbol}
+          </span>
         </div>
       ))}
+      {visibleEntries.map(({ symbol, bars, payload }) => (
+        <div key={symbol}>
+          <h3 className="text-sm font-medium mb-1">{symbol}</h3>
+          <CandlestickChart data={bars} markers={limitedMarkers(payload.trade_markers?.filter(m => !m.code || m.code === symbol))} indicators={payload.indicator_series?.[symbol]} height={500} />
+        </div>
+      ))}
+      {entries.length > visibleEntries.length && (
+        <div className="rounded-md border bg-card p-3 text-center">
+          <button
+            type="button"
+            onClick={() => setVisibleChartCount((count) => Math.min(entries.length, count + MULTI_CHART_PAGE_SIZE))}
+            className="rounded-md border px-3 py-1.5 text-sm font-medium transition hover:bg-muted"
+          >
+            Show {Math.min(MULTI_CHART_PAGE_SIZE, entries.length - visibleEntries.length)} more charts
+          </button>
+          <p className="mt-2 text-xs text-muted-foreground">
+            Showing {visibleEntries.length} of {entries.length} loaded charts to keep the page responsive.
+          </p>
+        </div>
+      )}
       {hasEquity && (
         <div>
           <h3 className="text-sm font-medium mb-1">Equity & Drawdown</h3>
@@ -354,6 +663,11 @@ function ChartTab({ run }: { run: RunData }) {
       )}
     </div>
   );
+}
+
+function limitedMarkers(markers: RunData["trade_markers"]): RunData["trade_markers"] {
+  if (!markers || markers.length <= 1000) return markers;
+  return markers.slice(-1000);
 }
 
 function TradesTab({ run }: { run: RunData }) {

--- a/frontend/src/pages/__tests__/RunDetail.test.tsx
+++ b/frontend/src/pages/__tests__/RunDetail.test.tsx
@@ -1,0 +1,86 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { RunDetail } from "../RunDetail";
+import type { RunData } from "@/lib/api";
+
+const apiMock = vi.hoisted(() => ({
+  getRun: vi.fn(),
+  getRunCode: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: apiMock,
+}));
+
+vi.mock("@/components/charts/CandlestickChart", () => ({
+  CandlestickChart: ({ data }: { data: Array<{ code?: string; time: string }> }) => (
+    <div data-testid={`chart-${data[0]?.code || data[0]?.time}`}>{data[0]?.code || data[0]?.time}</div>
+  ),
+}));
+
+vi.mock("@/components/charts/EquityChart", () => ({
+  EquityChart: () => <div data-testid="equity-chart" />,
+}));
+
+function renderRunDetail() {
+  return render(
+    <MemoryRouter initialEntries={["/runs/run-1"]}>
+      <Routes>
+        <Route path="/runs/:runId" element={<RunDetail />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function makeRun(symbol: string, overrides: Partial<RunData> = {}): RunData {
+  return {
+    run_id: "run-1",
+    status: "success",
+    chart_symbols: ["AAA", "BBB", "CCC"],
+    price_series: {
+      [symbol]: [
+        { time: "2024-01-02", code: symbol, open: 1, high: 2, low: 0.5, close: 1.5, volume: 100 },
+      ],
+    },
+    indicator_series: {},
+    trade_markers: [{ time: "2024-01-02", code: symbol, side: "BUY", price: 1.5 }],
+    equity_curve: [{ time: "2024-01-02", equity: 1000, drawdown: 0 }],
+    ...overrides,
+  };
+}
+
+describe("RunDetail chart loading", () => {
+  beforeEach(() => {
+    apiMock.getRun.mockReset();
+    apiMock.getRunCode.mockReset();
+    apiMock.getRunCode.mockResolvedValue({});
+    apiMock.getRun.mockImplementation((_runId: string, params?: { chart_symbol?: string }) => {
+      return Promise.resolve(makeRun(params?.chart_symbol || "AAA"));
+    });
+  });
+
+  it("loads an added chart symbol without replacing existing charts", async () => {
+    renderRunDetail();
+
+    expect(await screen.findByTestId("chart-AAA")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "BBB" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+
+    expect(await screen.findByTestId("chart-BBB")).toBeInTheDocument();
+    expect(screen.getByTestId("chart-AAA")).toBeInTheDocument();
+    expect(apiMock.getRun).toHaveBeenCalledWith("run-1", { chart_symbol: "BBB" });
+  });
+
+  it("progressively loads all symbols and reports progress", async () => {
+    renderRunDetail();
+
+    expect(await screen.findByTestId("chart-AAA")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Load all" }));
+
+    expect(await screen.findByTestId("chart-CCC")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText("3 / 3 (100%)")).toBeInTheDocument());
+    expect(apiMock.getRun).toHaveBeenCalledWith("run-1", { chart_symbol: "BBB" });
+    expect(apiMock.getRun).toHaveBeenCalledWith("run-1", { chart_symbol: "CCC" });
+  });
+});


### PR DESCRIPTION
## Summary
- add a `chart_symbol` query parameter for `GET /runs/{id}` so Run Detail can request one symbol's chart payload at a time
- return `chart_symbols` for symbol discovery while avoiding full equity/trades artifact CSV payloads in run detail responses
- update Run Detail with symbol selection, additive multi-select, progressive Load all, cancelable progress, and bounded chart rendering

## Tests
- `uv run --extra dev python -m pytest tests/test_run_card.py -q`
- `npm run test:run -- src/pages/__tests__/RunDetail.test.tsx`
- `npm run build`
- `git diff --check`

## Notes
- This PR is upstream-friendly and does not include Moirix, MiniMax, IBKR, Reports Library, or Agent Usage Dashboard changes.
