### PR TITLE
Add backtest report library

### DIFF
--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,6 +1,6 @@
 ﻿import { useEffect, useState } from "react";
 import { Link, Outlet, useLocation, useSearchParams } from "react-router-dom";
-import { BarChart3, Bot, Moon, Sun, Plus, Trash2, Pencil, MessageSquare, ChevronsLeft, ChevronsRight, Settings, Layers, Loader2 } from "lucide-react";
+import { BarChart3, Bot, Moon, Sun, Plus, Trash2, Pencil, MessageSquare, ChevronsLeft, ChevronsRight, Settings, Layers, Loader2, FileText } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useDarkMode } from "@/hooks/useDarkMode";
 import { api, type SessionItem } from "@/lib/api";
@@ -13,6 +13,7 @@ const APP_VERSION = "v0.1.9";
 const NAV = [
   { to: "/", icon: BarChart3, label: "Home" },
   { to: "/agent", icon: Bot, label: "Agent" },
+  { to: "/reports", icon: FileText, label: "Reports" },
   { to: "/alpha-zoo", icon: Layers, label: "Alpha Zoo" },
   { to: "/settings", icon: Settings, label: "Settings" },
   { to: "/correlation", icon: BarChart3, label: "Correlation Matrix" },

--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -1,0 +1,236 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  AlertTriangle,
+  ArrowRight,
+  CheckCircle2,
+  FileText,
+  GitCompare,
+  Loader2,
+  RefreshCw,
+  Search,
+  XCircle,
+} from "lucide-react";
+import { api, type RunListItem } from "@/lib/api";
+import { formatMetricVal } from "@/lib/formatters";
+import { cn } from "@/lib/utils";
+
+const REPORT_SCAN_LIMIT = 100;
+
+export function Reports() {
+  const [runs, setRuns] = useState<RunListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [query, setQuery] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  async function loadReports(mode: "initial" | "refresh" = "refresh") {
+    if (mode === "initial") setLoading(true);
+    else setRefreshing(true);
+    setError(null);
+    try {
+      const list = await api.listRuns();
+      setRuns(Array.isArray(list) ? list.slice(0, REPORT_SCAN_LIMIT) : []);
+    } catch (err) {
+      setRuns([]);
+      setError(err instanceof Error ? err.message : "Unable to load reports.");
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }
+
+  useEffect(() => {
+    loadReports("initial");
+  }, []);
+
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return runs;
+    return runs.filter((run) => {
+      const haystack = [
+        run.run_id,
+        run.status,
+        run.prompt,
+        ...(run.codes || []),
+        run.start_date,
+        run.end_date,
+      ].filter(Boolean).join(" ").toLowerCase();
+      return haystack.includes(needle);
+    });
+  }, [runs, query]);
+
+  return (
+    <div className="min-h-screen p-6 lg:p-8">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6">
+        <section className="flex flex-col gap-4 border-b pb-6 lg:flex-row lg:items-end lg:justify-between">
+          <div className="space-y-3">
+            <div className="inline-flex items-center gap-2 rounded-md border px-2.5 py-1 text-xs font-medium text-muted-foreground">
+              <FileText className="h-3.5 w-3.5" />
+              Reports
+            </div>
+            <div>
+              <h1 className="text-3xl font-bold tracking-tight">Backtest Report Library</h1>
+              <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
+                Browse historical backtest reports, metrics, artifacts, and run details from one place.
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => loadReports("refresh")}
+            disabled={refreshing}
+            className="inline-flex items-center gap-2 rounded-md border px-4 py-2 text-sm font-medium transition hover:bg-muted disabled:opacity-50"
+          >
+            {refreshing ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+            Refresh
+          </button>
+        </section>
+
+        <section className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <label className="relative block md:w-96">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search run id, prompt, symbol, status..."
+              className="w-full rounded-md border bg-background py-2 pl-9 pr-3 text-sm outline-none transition focus:border-primary"
+            />
+          </label>
+          <div className="text-sm text-muted-foreground">
+            {filtered.length} of {runs.length} reports
+          </div>
+        </section>
+
+        {loading ? (
+          <div className="grid gap-3">
+            {[1, 2, 3, 4].map((item) => (
+              <div key={item} className="h-28 animate-pulse rounded-md border bg-muted/40" />
+            ))}
+          </div>
+        ) : null}
+
+        {!loading && error ? (
+          <section className="rounded-md border border-amber-500/30 bg-amber-500/5 p-5">
+            <div className="flex items-center gap-2 font-medium text-amber-700 dark:text-amber-300">
+              <AlertTriangle className="h-5 w-5" />
+              Report library unavailable
+            </div>
+            <p className="mt-2 text-sm text-muted-foreground">{error}</p>
+          </section>
+        ) : null}
+
+        {!loading && !error && filtered.length === 0 ? (
+          <section className="rounded-md border border-dashed p-8 text-center">
+            <FileText className="mx-auto h-8 w-8 text-muted-foreground" />
+            <h2 className="mt-3 font-medium">{runs.length === 0 ? "No reports yet" : "No matching reports"}</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {runs.length === 0 ? "Create a backtest from Agent, then return here to review it." : "Adjust your search query."}
+            </p>
+          </section>
+        ) : null}
+
+        {!loading && !error && filtered.length > 0 ? (
+          <section className="grid gap-3">
+            {filtered.map((run) => (
+              <ReportRow key={run.run_id} run={run} />
+            ))}
+          </section>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function ReportRow({ run }: { run: RunListItem }) {
+  return (
+    <article className="rounded-md border p-4 transition hover:border-primary/40 hover:bg-muted/30">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0 space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <StatusBadge status={run.status} />
+            <Link to={`/runs/${run.run_id}`} className="truncate font-mono text-sm font-medium hover:text-primary">
+              {run.run_id}
+            </Link>
+            <span className="text-xs text-muted-foreground">{formatRunDate(run.created_at)}</span>
+          </div>
+          <p className="line-clamp-2 text-sm text-muted-foreground">{run.prompt || "No prompt recorded."}</p>
+          <div className="flex flex-wrap gap-1.5">
+            {(run.codes || []).slice(0, 6).map((code) => (
+              <span key={code} className="rounded border px-2 py-0.5 font-mono text-xs text-muted-foreground">
+                {code}
+              </span>
+            ))}
+            {run.start_date || run.end_date ? (
+              <span className="rounded border px-2 py-0.5 text-xs text-muted-foreground">
+                {run.start_date || "?"} to {run.end_date || "?"}
+              </span>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-3 lg:items-end">
+          <div className="grid grid-cols-2 gap-2 text-right sm:flex sm:flex-wrap sm:justify-end">
+            <MetricPill label="Return" value={formatOptionalMetric("total_return", run.total_return)} />
+            <MetricPill label="Sharpe" value={formatOptionalMetric("sharpe", run.sharpe)} />
+          </div>
+          <div className="flex flex-wrap gap-2 lg:justify-end">
+            <Link
+              to={`/runs/${run.run_id}`}
+              className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition hover:opacity-90"
+            >
+              Full Report <ArrowRight className="h-3.5 w-3.5" />
+            </Link>
+            <Link
+              to="/compare"
+              className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs font-medium transition hover:bg-muted"
+            >
+              <GitCompare className="h-3.5 w-3.5" />
+              Compare
+            </Link>
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const normalized = status.toLowerCase();
+  const ok = ["success", "done", "completed", "complete"].includes(normalized);
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs font-medium",
+        ok ? "bg-success/10 text-success" : "bg-muted text-muted-foreground",
+      )}
+    >
+      {ok ? <CheckCircle2 className="h-3 w-3" /> : <XCircle className="h-3 w-3" />}
+      {status || "unknown"}
+    </span>
+  );
+}
+
+function MetricPill({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border px-3 py-1.5">
+      <div className="text-[11px] uppercase text-muted-foreground">{label}</div>
+      <div className="font-mono text-sm font-medium">{value}</div>
+    </div>
+  );
+}
+
+function formatOptionalMetric(key: string, value: number | undefined): string {
+  return Number.isFinite(value) ? formatMetricVal(key, value as number) : "-";
+}
+
+function formatRunDate(value: string): string {
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) return value || "unknown";
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+}

--- a/frontend/src/pages/__tests__/Reports.test.tsx
+++ b/frontend/src/pages/__tests__/Reports.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { Reports } from "../Reports";
+import type { RunListItem } from "@/lib/api";
+
+const apiMock = vi.hoisted(() => ({
+  listRuns: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: apiMock,
+}));
+
+function renderReports() {
+  return render(
+    <MemoryRouter>
+      <Reports />
+    </MemoryRouter>,
+  );
+}
+
+function makeRun(overrides: Partial<RunListItem> = {}): RunListItem {
+  return {
+    run_id: "run-1",
+    status: "success",
+    created_at: "2026-06-12T08:00:00Z",
+    prompt: "Backtest a momentum report",
+    total_return: 0.12,
+    sharpe: 1.2,
+    codes: ["AAPL.US"],
+    start_date: "2024-01-01",
+    end_date: "2024-06-30",
+    ...overrides,
+  };
+}
+
+describe("Reports page", () => {
+  beforeEach(() => {
+    apiMock.listRuns.mockReset();
+  });
+
+  it("lists historical reports and links to full report", async () => {
+    apiMock.listRuns.mockResolvedValue([makeRun()]);
+
+    renderReports();
+
+    expect(await screen.findByText("Backtest Report Library")).toBeInTheDocument();
+    expect(screen.getByText("run-1")).toBeInTheDocument();
+    expect(screen.getByText("AAPL.US")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Full Report/i })).toHaveAttribute("href", "/runs/run-1");
+    expect(apiMock.listRuns).toHaveBeenCalledWith();
+  });
+
+  it("filters reports by prompt and symbol", async () => {
+    apiMock.listRuns.mockResolvedValue([
+      makeRun({ run_id: "run-aapl", codes: ["AAPL.US"], prompt: "Apple momentum" }),
+      makeRun({ run_id: "run-nvda", codes: ["NVDA.US"], prompt: "Nvidia breakout" }),
+    ]);
+
+    renderReports();
+    expect(await screen.findByText("run-aapl")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText("Search run id, prompt, symbol, status..."), {
+      target: { value: "NVDA" },
+    });
+
+    expect(screen.queryByText("run-aapl")).not.toBeInTheDocument();
+    expect(screen.getByText("run-nvda")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -10,6 +10,9 @@ const RunDetail = lazy(() =>
 const Compare = lazy(() =>
   import("@/pages/Compare").then((m) => ({ default: m.Compare })),
 );
+const Reports = lazy(() =>
+  import("@/pages/Reports").then((m) => ({ default: m.Reports })),
+);
 const Settings = lazy(() =>
   import("@/pages/Settings").then((m) => ({ default: m.Settings })),
 );
@@ -42,6 +45,7 @@ export const router = createBrowserRouter([
     children: [
       { path: "/", element: wrap(Home) },
       { path: "/agent", element: wrap(Agent) },
+      { path: "/reports", element: wrap(Reports) },
       { path: "/settings", element: wrap(Settings) },
       { path: "/runs/:runId", element: wrap(RunDetail) },
       { path: "/compare", element: wrap(Compare) },


### PR DESCRIPTION
## Summary
- add a dedicated Backtest Report Library page at `/reports`
- add a sidebar Reports entry and router route
- show recent run rows with status, prompt, symbols, date range, return/sharpe, Full Report, and Compare links
- add search filtering for run id, prompt, symbol, and status

## Tests
- `npm run test:run -- src/pages/__tests__/Reports.test.tsx`
- `npm run build`
- `git diff --check`

## Notes
- This PR is independent from the Agent Usage Dashboard and Run Detail chart payload optimization PRs.
- It uses the existing `/runs` list contract and does not require `with_usage=true`.
- It does not include Moirix, MiniMax, or IBKR changes.
