### PR TITLE
fix(loaders): include requested yfinance end date

### DIFF
--- a/agent/backtest/loaders/yfinance_loader.py
+++ b/agent/backtest/loaders/yfinance_loader.py
@@ -68,6 +68,11 @@ def _to_yfinance_interval(interval: str) -> str:
     return _INTERVAL_MAP.get(normalized, normalized.lower())
 
 
+def _to_yfinance_exclusive_end(end_date: str) -> str:
+    """Convert the project-inclusive end date to yfinance's exclusive end."""
+    return (pd.Timestamp(end_date).normalize() + pd.Timedelta(days=1)).strftime("%Y-%m-%d")
+
+
 def _download_history(
     tickers: Union[List[str], str],
     start_date: str,
@@ -240,6 +245,7 @@ class DataLoader:
 
         requested_interval = str(interval or "1D").strip()
         yf_interval = _to_yfinance_interval(requested_interval)
+        yf_end_date = _to_yfinance_exclusive_end(end_date)
 
         symbol_groups: Dict[str, List[str]] = defaultdict(list)
         for code in codes:
@@ -270,7 +276,7 @@ class DataLoader:
             return results
 
         try:
-            bulk_data = _download_history(pending, start_date, end_date, yf_interval)
+            bulk_data = _download_history(pending, start_date, yf_end_date, yf_interval)
         except Exception as exc:
             print(f"[WARN] yfinance bulk download failed for {pending}: {exc}")
             bulk_data = pd.DataFrame()
@@ -279,7 +285,7 @@ class DataLoader:
             try:
                 symbol_frame = _extract_symbol_frame(bulk_data, symbol, len(pending))
                 if symbol_frame.empty:
-                    symbol_frame = _download_history(symbol, start_date, end_date, yf_interval)
+                    symbol_frame = _download_history(symbol, start_date, yf_end_date, yf_interval)
 
                 normalized = _normalize_frame(symbol_frame, requested_interval)
                 if normalized.empty:

--- a/agent/tests/test_yfinance_crypto.py
+++ b/agent/tests/test_yfinance_crypto.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pandas as pd
 import pytest
 
 from backtest.loaders.yfinance_loader import DataLoader, _to_yfinance_symbol
@@ -60,3 +61,80 @@ class TestDataLoaderCryptoMarket:
         """yfinance should be available if the package is installed."""
         loader = DataLoader()
         assert loader.is_available() is True
+
+
+def _download_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "Open": [1.0, 2.0],
+            "High": [1.5, 2.5],
+            "Low": [0.5, 1.5],
+            "Close": [1.2, 2.2],
+            "Volume": [100, 200],
+        },
+        index=pd.DatetimeIndex(["2025-01-02", "2025-01-03"], name="Date"),
+    )
+
+
+def test_fetch_passes_inclusive_end_date_to_yfinance_as_exclusive_end(monkeypatch: pytest.MonkeyPatch) -> None:
+    import backtest.loaders.yfinance_loader as yfl
+
+    monkeypatch.delenv("VIBE_TRADING_DATA_CACHE", raising=False)
+    calls = []
+
+    def fake_download(tickers, start_date, end_date, interval):
+        calls.append((tickers, start_date, end_date, interval))
+        return _download_frame()
+
+    monkeypatch.setattr(yfl, "_download_history", fake_download)
+
+    result = yfl.DataLoader().fetch(["AAPL.US"], "2025-01-01", "2025-01-03")
+
+    assert "AAPL.US" in result
+    assert calls == [(["AAPL"], "2025-01-01", "2025-01-04", "1d")]
+
+
+def test_fallback_single_symbol_download_uses_inclusive_end_date(monkeypatch: pytest.MonkeyPatch) -> None:
+    import backtest.loaders.yfinance_loader as yfl
+
+    monkeypatch.delenv("VIBE_TRADING_DATA_CACHE", raising=False)
+    calls = []
+
+    def fake_download(tickers, start_date, end_date, interval):
+        calls.append((tickers, start_date, end_date, interval))
+        if isinstance(tickers, list):
+            return pd.DataFrame()
+        return _download_frame()
+
+    monkeypatch.setattr(yfl, "_download_history", fake_download)
+
+    result = yfl.DataLoader().fetch(["AAPL.US"], "2025-01-01", "2025-01-03")
+
+    assert "AAPL.US" in result
+    assert calls == [
+        (["AAPL"], "2025-01-01", "2025-01-04", "1d"),
+        ("AAPL", "2025-01-01", "2025-01-04", "1d"),
+    ]
+
+
+def test_yfinance_cache_lookup_keeps_requested_end_date(monkeypatch: pytest.MonkeyPatch) -> None:
+    import backtest.loaders.yfinance_loader as yfl
+
+    cache_calls = []
+
+    def fake_cache_get(**kwargs):
+        cache_calls.append(kwargs)
+        return _download_frame()
+
+    def fail_download(*_args, **_kwargs):
+        raise AssertionError("cache hit should skip yfinance download")
+
+    monkeypatch.setattr(yfl, "loader_cache_get", fake_cache_get)
+    monkeypatch.setattr(yfl, "_download_history", fail_download)
+
+    result = yfl.DataLoader().fetch(["AAPL.US"], "2025-01-01", "2025-01-03")
+
+    assert "AAPL.US" in result
+    assert cache_calls[0]["symbol"] == "AAPL"
+    assert cache_calls[0]["start_date"] == "2025-01-01"
+    assert cache_calls[0]["end_date"] == "2025-01-03"


### PR DESCRIPTION
## Summary

Include the requested `end_date` when loading daily yfinance data.

## Why

The project-facing loader API accepts a `start_date` / `end_date` range that is expected to include the requested end date. yfinance's `download(end=...)` parameter is exclusive, so passing the requested `end_date` directly can omit the final trading day.

## What changed

- Adjust yfinance provider calls to pass `end_date + 1 day`.
- Preserve cache lookups and writes using the original requested date range.
- Apply the same boundary adjustment to the fallback single-symbol download path.

## Tests

- `python -m pytest agent/tests/test_yfinance_crypto.py -q`
- `python -m py_compile agent/backtest/loaders/yfinance_loader.py agent/tests/test_yfinance_crypto.py`
- `git diff --check`

## Risk notes

This only changes the yfinance provider call boundary. Cache keys remain based on the user-requested range, and the tests monkeypatch the download path without making network calls.
