### PR TITLE
fix(loaders): tolerate malformed crypto timeout env vars

### DIFF
--- a/agent/backtest/loaders/base.py
+++ b/agent/backtest/loaders/base.py
@@ -56,6 +56,38 @@ DEFAULT_BACKOFF: tuple[float, ...] = (0.5, 1.5, 4.0)
 DEFAULT_MAX_RETRIES = 3
 
 
+def positive_env_int(name: str, default: int) -> int:
+    """Read a positive integer env var, warning and falling back on invalid values."""
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning("invalid %s=%r, using default %s", name, raw, default)
+        return default
+    if value <= 0:
+        logger.warning("non-positive %s=%r, using default %s", name, raw, default)
+        return default
+    return value
+
+
+def positive_env_float(name: str, default: float) -> float:
+    """Read a positive float env var, warning and falling back on invalid values."""
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning("invalid %s=%r, using default %s", name, raw, default)
+        return default
+    if value <= 0:
+        logger.warning("non-positive %s=%r, using default %s", name, raw, default)
+        return default
+    return value
+
+
 def check_budget(deadline: float, label: str, budget_s: float | None = None) -> None:
     """Raise :class:`TimeoutError` if the monotonic clock has crossed ``deadline``.
 

--- a/agent/backtest/loaders/ccxt_loader.py
+++ b/agent/backtest/loaders/ccxt_loader.py
@@ -17,6 +17,8 @@ import pandas as pd
 from backtest.loaders.base import (
     cached_loader_fetch,
     check_budget,
+    positive_env_float,
+    positive_env_int,
     retry_with_budget,
     validate_date_range,
 )
@@ -34,8 +36,8 @@ _INTERVAL_MAP = {
 # minutes. Cap each HTTP call, bound transient retries, and enforce a hard
 # wall-clock budget so the fetch fails fast instead of hanging. Retry
 # scheduling is delegated to :mod:`backtest.loaders.base`.
-_CCXT_TIMEOUT_MS = int(os.getenv("CCXT_TIMEOUT_MS", "15000"))
-_CCXT_FETCH_BUDGET_S = float(os.getenv("CCXT_FETCH_BUDGET_S", "60"))
+_CCXT_TIMEOUT_MS = positive_env_int("CCXT_TIMEOUT_MS", 15_000)
+_CCXT_FETCH_BUDGET_S = positive_env_float("CCXT_FETCH_BUDGET_S", 60.0)
 
 
 def _first_proxy_env(*names: str) -> str:

--- a/agent/backtest/loaders/okx.py
+++ b/agent/backtest/loaders/okx.py
@@ -5,7 +5,6 @@ Supports 1m/5m/15m/30m/1H/4H/1D.
 Up to 300 bars per request; paginates with ``after`` for longer history.
 """
 
-import os
 import time
 from typing import Dict, List, Optional
 
@@ -15,6 +14,8 @@ import requests
 from backtest.loaders.base import (
     cached_loader_fetch,
     check_budget,
+    positive_env_float,
+    positive_env_int,
     retry_with_budget,
     validate_date_range,
 )
@@ -26,8 +27,8 @@ _MAX_PER_PAGE = 300
 # budget, so a transient blip dropped the whole symbol and a slow tier
 # could stall ~max_pages*timeout. Bound it like the ccxt loader; retry
 # scheduling is delegated to :mod:`backtest.loaders.base`.
-_OKX_TIMEOUT = int(os.getenv("OKX_TIMEOUT_S", "15"))
-_OKX_FETCH_BUDGET_S = float(os.getenv("OKX_FETCH_BUDGET_S", "60"))
+_OKX_TIMEOUT = positive_env_int("OKX_TIMEOUT_S", 15)
+_OKX_FETCH_BUDGET_S = positive_env_float("OKX_FETCH_BUDGET_S", 60.0)
 
 
 @register

--- a/agent/tests/test_ccxt_loader_bounded.py
+++ b/agent/tests/test_ccxt_loader_bounded.py
@@ -10,6 +10,8 @@ the happy path is unchanged (one call per page).
 
 from __future__ import annotations
 
+import importlib
+
 import pandas as pd
 import pytest
 
@@ -90,3 +92,34 @@ def test_wallclock_budget_enforced(monkeypatch):
 def test_get_exchange_sets_explicit_timeout():
     ex = DataLoader()._get_exchange()
     assert ex.timeout == cl._CCXT_TIMEOUT_MS
+
+
+def test_invalid_timeout_env_values_fall_back_on_reload(monkeypatch, caplog):
+    monkeypatch.setenv("CCXT_TIMEOUT_MS", "abc")
+    monkeypatch.setenv("CCXT_FETCH_BUDGET_S", "nope")
+    try:
+        with caplog.at_level("WARNING", logger="backtest.loaders.base"):
+            module = importlib.reload(cl)
+
+        assert module._CCXT_TIMEOUT_MS == 15_000
+        assert module._CCXT_FETCH_BUDGET_S == 60.0
+        assert "CCXT_TIMEOUT_MS" in caplog.text
+        assert "CCXT_FETCH_BUDGET_S" in caplog.text
+    finally:
+        monkeypatch.delenv("CCXT_TIMEOUT_MS", raising=False)
+        monkeypatch.delenv("CCXT_FETCH_BUDGET_S", raising=False)
+        importlib.reload(cl)
+
+
+def test_valid_timeout_env_values_are_honored_on_reload(monkeypatch):
+    monkeypatch.setenv("CCXT_TIMEOUT_MS", "1234")
+    monkeypatch.setenv("CCXT_FETCH_BUDGET_S", "2.5")
+    try:
+        module = importlib.reload(cl)
+
+        assert module._CCXT_TIMEOUT_MS == 1234
+        assert module._CCXT_FETCH_BUDGET_S == 2.5
+    finally:
+        monkeypatch.delenv("CCXT_TIMEOUT_MS", raising=False)
+        monkeypatch.delenv("CCXT_FETCH_BUDGET_S", raising=False)
+        importlib.reload(cl)

--- a/agent/tests/test_okx_loader_bounded.py
+++ b/agent/tests/test_okx_loader_bounded.py
@@ -10,6 +10,8 @@ the happy path still issues one request per page (no behavior change).
 
 from __future__ import annotations
 
+import importlib
+
 import pandas as pd
 import pytest
 import requests
@@ -92,3 +94,34 @@ def test_wallclock_budget_enforced(monkeypatch):
     monkeypatch.setattr(okx.requests, "get", _Seq([requests.ConnectionError("slow")]))
     with pytest.raises(TimeoutError):
         DataLoader()._fetch_candles("BTC-USDT", S, E, "1D", 20)
+
+
+def test_invalid_timeout_env_values_fall_back_on_reload(monkeypatch, caplog):
+    monkeypatch.setenv("OKX_TIMEOUT_S", "abc")
+    monkeypatch.setenv("OKX_FETCH_BUDGET_S", "nope")
+    try:
+        with caplog.at_level("WARNING", logger="backtest.loaders.base"):
+            module = importlib.reload(okx)
+
+        assert module._OKX_TIMEOUT == 15
+        assert module._OKX_FETCH_BUDGET_S == 60.0
+        assert "OKX_TIMEOUT_S" in caplog.text
+        assert "OKX_FETCH_BUDGET_S" in caplog.text
+    finally:
+        monkeypatch.delenv("OKX_TIMEOUT_S", raising=False)
+        monkeypatch.delenv("OKX_FETCH_BUDGET_S", raising=False)
+        importlib.reload(okx)
+
+
+def test_valid_timeout_env_values_are_honored_on_reload(monkeypatch):
+    monkeypatch.setenv("OKX_TIMEOUT_S", "7")
+    monkeypatch.setenv("OKX_FETCH_BUDGET_S", "2.5")
+    try:
+        module = importlib.reload(okx)
+
+        assert module._OKX_TIMEOUT == 7
+        assert module._OKX_FETCH_BUDGET_S == 2.5
+    finally:
+        monkeypatch.delenv("OKX_TIMEOUT_S", raising=False)
+        monkeypatch.delenv("OKX_FETCH_BUDGET_S", raising=False)
+        importlib.reload(okx)


### PR DESCRIPTION
## Summary

Make crypto loader timeout environment variables robust to malformed values.

## Why

Currently malformed values such as `CCXT_TIMEOUT_MS=abc` or `OKX_TIMEOUT_S=abc` can fail while importing the loader modules. That makes configuration mistakes harder to recover from and can prevent the app from starting.

## What changed

- Added shared positive numeric env helpers for loader configuration.
- Invalid, blank, or non-positive timeout/budget values now log a warning and fall back to existing defaults.
- Valid values are still honored for CCXT and OKX loaders.

## Tests

- `python -m pytest agent/tests/test_ccxt_loader_bounded.py agent/tests/test_okx_loader_bounded.py -q`
- `python -m pytest agent/tests/test_loader_retry_helpers.py -q` for the relevant retry helper tests
- `python -m py_compile agent/backtest/loaders/base.py agent/backtest/loaders/ccxt_loader.py agent/backtest/loaders/okx.py agent/tests/test_ccxt_loader_bounded.py agent/tests/test_okx_loader_bounded.py`
- `git diff --check`

## Risk notes

This keeps the existing default timeout and fetch budget values. The change only affects malformed or non-positive env values, which now degrade to defaults instead of failing at import time.
