### PR TITLE
fix(baostock): support baostock-native code format (sh.601398)

### DIFF
--- a/agent/backtest/loaders/baostock_loader.py
+++ b/agent/backtest/loaders/baostock_loader.py
@@ -21,7 +21,12 @@ logger = logging.getLogger(__name__)
 
 
 def _is_a_share(code: str) -> bool:
-    return code.upper().endswith((".SZ", ".SH"))
+    # Support both baostock native format (sh.601398) and tushare-style suffix (601398.SH)
+    code_lower = code.lower()
+    return (
+        code_lower.startswith(("sh.", "sz."))
+        or code.upper().endswith((".SZ", ".SH"))
+    )
 
 
 @register
@@ -101,16 +106,21 @@ class DataLoader:
         if not _is_a_share(code):
             return None
 
-        # BaoStock format: sh.601595 or sz.000001
-        parts = code.upper().split(".")
-        symbol = parts[0]
-        suffix = parts[1] if len(parts) > 1 else ""
-        if suffix == "SH":
-            bs_code = f"sh.{symbol}"
-        elif suffix == "SZ":
-            bs_code = f"sz.{symbol}"
+        # Support baostock native format (sh.601398 / sz.000001)
+        # and tushare-style suffix (601398.SH / 000001.SZ)
+        code_lower = code.lower()
+        if code_lower.startswith("sh.") or code_lower.startswith("sz."):
+            bs_code = code_lower
         else:
-            return None
+            parts = code.upper().split(".")
+            symbol = parts[0]
+            suffix = parts[1] if len(parts) > 1 else ""
+            if suffix == "SH":
+                bs_code = f"sh.{symbol}"
+            elif suffix == "SZ":
+                bs_code = f"sz.{symbol}"
+            else:
+                return None
 
         rs = bs.query_history_k_data_plus(
             bs_code,

--- a/agent/tests/test_baostock_loader.py
+++ b/agent/tests/test_baostock_loader.py
@@ -1,0 +1,108 @@
+"""Tests for baostock_loader: code format handling.
+
+Ensures both baostock native (sh.601398) and tushare-style (601398.SH) codes work.
+"""
+from backtest.loaders.baostock_loader import _is_a_share
+
+
+class TestIsAShareCodeFormat:
+    """Verify _is_a_share accepts both baostock native and tushare-style codes."""
+
+    def test_baostock_native_sh_format(self):
+        """sh.601398 is the baostock-native format and should be recognized."""
+        assert _is_a_share("sh.601398") is True
+        assert _is_a_share("sh.600036") is True
+
+    def test_baostock_native_sz_format(self):
+        """sz.000001 is the baostock-native format and should be recognized."""
+        assert _is_a_share("sz.000001") is True
+        assert _is_a_share("sz.002594") is True
+
+    def test_tushare_style_sh_suffix(self):
+        """600036.SH is the tushare-style format and should be recognized."""
+        assert _is_a_share("600036.SH") is True
+        assert _is_a_share("601398.SH") is True
+
+    def test_tushare_style_sz_suffix(self):
+        """000001.SZ is the tushare-style format and should be recognized."""
+        assert _is_a_share("000001.SZ") is True
+        assert _is_a_share("002594.SZ") is True
+
+    def test_case_insensitive(self):
+        """Code format detection should be case-insensitive."""
+        assert _is_a_share("SH.601398") is True
+        assert _is_a_share("sh.601398") is True
+        assert _is_a_share("601398.sh") is True
+        assert _is_a_share("601398.SH") is True
+
+    def test_rejects_non_a_share(self):
+        """Non-A-share codes should be rejected."""
+        assert _is_a_share("AAPL") is False
+        assert _is_a_share("BRK.B") is False
+        assert _is_a_share("BTC-USD") is False
+        assert _is_a_share("") is False
+        assert _is_a_share("just_random_text") is False
+
+    def test_rejects_hk_and_us_codes(self):
+        """Hong Kong (5-digit) and US stock codes should not match."""
+        assert _is_a_share("00700") is False
+        assert _is_a_share("AAPL") is False
+        assert _is_a_share("TSLA") is False
+
+
+class TestFetchOneCodeHandling:
+    """Verify _fetch_one handles both baostock native and tushare-style codes.
+
+    These tests are unit-level only — they don't make real network calls.
+    """
+
+    def test_baostock_native_passthrough(self):
+        """baostock native format (sh.601398) should pass through unchanged."""
+        from unittest.mock import MagicMock
+        from backtest.loaders.baostock_loader import DataLoader
+
+        loader = DataLoader()
+        bs_mock = MagicMock()
+        mock_rs = MagicMock()
+        mock_rs.error_code = "0"
+        mock_rs.error_msg = "success"
+        mock_rs.next.side_effect = [False]
+        bs_mock.query_history_k_data_plus.return_value = mock_rs
+
+        loader._fetch_one(bs_mock, "sh.601398", "2024-01-01", "2024-01-31")
+        call_args = bs_mock.query_history_k_data_plus.call_args
+        assert call_args[0][0] == "sh.601398"
+
+    def test_tushare_style_converted(self):
+        """tushare-style format (601398.SH) should be converted to sh.601398."""
+        from unittest.mock import MagicMock
+        from backtest.loaders.baostock_loader import DataLoader
+
+        loader = DataLoader()
+        bs_mock = MagicMock()
+        mock_rs = MagicMock()
+        mock_rs.error_code = "0"
+        mock_rs.error_msg = "success"
+        mock_rs.next.side_effect = [False]
+        bs_mock.query_history_k_data_plus.return_value = mock_rs
+
+        loader._fetch_one(bs_mock, "601398.SH", "2024-01-01", "2024-01-31")
+        call_args = bs_mock.query_history_k_data_plus.call_args
+        assert call_args[0][0] == "sh.601398"
+
+    def test_tushare_sz_style_converted(self):
+        """tushare-style SZ (000001.SZ) should be converted to sz.000001."""
+        from unittest.mock import MagicMock
+        from backtest.loaders.baostock_loader import DataLoader
+
+        loader = DataLoader()
+        bs_mock = MagicMock()
+        mock_rs = MagicMock()
+        mock_rs.error_code = "0"
+        mock_rs.error_msg = "success"
+        mock_rs.next.side_effect = [False]
+        bs_mock.query_history_k_data_plus.return_value = mock_rs
+
+        loader._fetch_one(bs_mock, "000001.SZ", "2024-01-01", "2024-01-31")
+        call_args = bs_mock.query_history_k_data_plus.call_args
+        assert call_args[0][0] == "sz.000001"


### PR DESCRIPTION
The baostock loader previously only accepted tushare-style codes (601398.SH, 000001.SZ) but rejected baostock-native codes (sh.601398, sz.000001) — which is the format baostock uses in its own documentation and examples.

This caused users passing sh.601398 to:
- Have _is_a_share() return False → _fetch_one() immediately returns None
- Have _fetch_one() split "sh.601398" as ["SH", "601398"] then walk the dead branch (suffix "601398" never matches "SH" or "SZ")

Fix:
- _is_a_share() now accepts both formats (case-insensitive)
- _fetch_one() detects baostock-native format first and passes it through unchanged, only converting tushare-style suffixes

Tests:
- New test file: agent/tests/test_baostock_loader.py
- 10 unit tests covering both code formats and conversion logic
- All 10 pass

Closes: #TBD

## Summary

<!-- What does this PR do? 1-3 bullet points. -->

-

## Why

<!-- What problem does it solve? Link related issues with "Closes #123". -->

## Changes

<!-- List key changes. For new skills/presets, describe what they cover. -->

-

## Test Plan

- [ ] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [ ] New tests added (if applicable)
- [ ] Tested manually (describe below)

## Checklist

- [ ] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [ ] No hardcoded values (API keys, file paths, magic numbers)
- [ ] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] Documentation updated (if user-facing change)
