### PR TITLE
ci: bump first-party actions to Node 24 (checkout/setup-python/setup-node v6)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,9 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: pip
@@ -38,7 +38,7 @@ jobs:
         # the suite never silently switches state on env presence.
         run: pytest --ignore=agent/tests/e2e_backtest --ignore=agent/tests/test_e2e_harness_v2.py --cov=agent --cov-report=term-missing --cov-report=xml --tb=short -q
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: npm

--- a/.github/workflows/wiki-deploy.yml
+++ b/.github/workflows/wiki-deploy.yml
@@ -21,7 +21,7 @@ jobs:
       deployments: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Deploy wiki
         uses: cloudflare/wrangler-action@v3

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -18,13 +18,13 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
## Summary

Bumps the three GitHub first-party actions to their latest Node-24-native majors so CI stops running on the deprecated Node 20 runtime.

## Why

GitHub Actions surfaced this deprecation warning in CI logs:

> Node.js 20 actions are deprecated. … Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

`actions/checkout@v4`, `actions/setup-python@v5`, and `actions/setup-node@v4` all run on Node 20.

## Changes

Across `test.yml`, `wiki.yml`, and `wiki-deploy.yml`:

- `actions/checkout` v4 → **v6**
- `actions/setup-python` v5 → **v6**
- `actions/setup-node` v4 → **v6**

Inputs are unchanged — `node-version: "20"` is the frontend's JS runtime for `npm ci` / `vitest`, independent of the action runtime. The third-party `cloudflare/wrangler-action@v3` is out of scope (not a Node-20 first-party action).

## Test Plan

- [x] YAML validates (`yaml.safe_load` on all three workflows)
- [x] This PR touches `.github/workflows/**`, so `test.yml` and `wiki.yml` run on it and exercise the new action versions directly — green CI is the verification.
