### PR TITLE
fix(web): reconnect SSE when returning to a running session (#229 symptom 1)

### DIFF
--- a/frontend/src/pages/Agent.tsx
+++ b/frontend/src/pages/Agent.tsx
@@ -724,6 +724,21 @@ export function Agent() {
         loadSessionMessages(urlSessionId, gen);
       }
       setupSSE(urlSessionId);
+    } else if (urlSessionId && urlSessionId === curSid && sseSessionRef.current !== urlSessionId) {
+      // #229: returning to the SAME session after the page was unmounted (user
+      // navigated away and back). The store kept our messages, but the unmount
+      // cleanup tore down the SSE stream, so a running attempt stopped updating
+      // and the UI looked frozen until the safety timeout fired. Re-hydrate like
+      // a reload: reset the transient streaming view first (so replay=active
+      // rebuilds the in-flight turn from the backend ring buffer instead of
+      // duplicating deltas onto the preserved text), refresh committed history
+      // (covers an attempt that finished while we were away), then re-subscribe.
+      const gen = genRef.current + 1;
+      genRef.current = gen;
+      const seed = curMsgs.length > 0 ? curMsgs : getCachedSession(urlSessionId);
+      switchSession(urlSessionId, seed);
+      loadSessionMessages(urlSessionId, gen);
+      setupSSE(urlSessionId);
     } else if (!urlSessionId && curSid) {
       genRef.current += 1;
       doDisconnect();


### PR DESCRIPTION
## Summary

Fixes **symptom 1** of #229 — "切换页面经常就停止运作" (switching pages often makes the agent appear to stop working). Frontend-only.

## Why

The agent run executes server-side; the chat page only subscribes to progress via SSE. When the user navigates away, the page unmounts and its cleanup tears down the `EventSource`. The navigation effect in `Agent.tsx` only (re)subscribed when the URL session **differed** from the store session (`urlSessionId !== curSid`). Returning to the **same** session matched neither branch, so SSE was never reopened — in-flight `text_delta` / `tool_*` / `attempt.completed` events stopped arriving and the run looked frozen until the 90s safety timeout flipped the UI to idle (with a misleading "timed out").

The backend already buffers events per session in a ring buffer and replays them on connect (`GET /sessions/{id}/events?replay=active`), and `setupSSE` already requests `replay=active`. The only defect was the missing re-subscribe on same-session remount.

## Changes

`frontend/src/pages/Agent.tsx` — add the same-session remount branch to the navigation effect. It re-hydrates like a reload:

1. Reset the transient streaming view first (`switchSession`) so `replay=active` rebuilds the in-flight turn from the ring buffer instead of **duplicating** replayed deltas onto the preserved streaming text.
2. Refresh committed history (`loadSessionMessages`) — covers an attempt that finished while the user was away (replay only re-streams a *running* attempt).
3. Re-subscribe (`setupSSE`), which catches a still-running attempt back up automatically.

No backend change required.

## Scope

**Symptom 2** of #229 ("运行中点击停止无效") is cooperative-cancel granularity in the agent core (the cancel signal is only checked at iteration boundaries, not inside the LLM stream or tool execution). That's a separate, deeper change and is tracked on its own — this PR intentionally does **not** close #229.

## Test Plan

- [x] `tsc --noEmit` clean
- [x] `npm run build` passes
- [x] Existing `agent` store / `useSSE` / `Runtime` tests pass (42)
- [ ] Manual: start a long run → navigate to another page and back to the same session → progress resumes (no freeze, no duplicated text); and a run that finishes while away shows its final answer on return.

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`)
- [x] No hardcoded values
