### PR TITLE
fix(run-card): write strict JSON for non-finite metrics

### DIFF
--- a/agent/backtest/run_card.py
+++ b/agent/backtest/run_card.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping, Sequence
@@ -70,10 +71,19 @@ def write_run_card(
     if "validation" in metrics:
         card["validation"] = metrics["validation"]
 
+    card = _json_safe(card)
     json_path = run_dir / "run_card.json"
     md_path = run_dir / "run_card.md"
     json_path.write_text(
-        json.dumps(card, ensure_ascii=False, indent=2, sort_keys=True, default=str) + "\n",
+        json.dumps(
+            card,
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+            default=str,
+            allow_nan=False,
+        )
+        + "\n",
         encoding="utf-8",
     )
     md_path.write_text(_render_markdown(card), encoding="utf-8")
@@ -113,6 +123,16 @@ def _scalar_metrics(metrics: Mapping[str, Any]) -> dict[str, Any]:
         for key, value in metrics.items()
         if key != "validation" and _is_scalar(value)
     }
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    return value
 
 
 def _is_scalar(value: Any) -> bool:

--- a/agent/tests/test_run_card_strict_json.py
+++ b/agent/tests/test_run_card_strict_json.py
@@ -1,0 +1,47 @@
+"""Regression tests for strict run card JSON output."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from backtest.run_card import write_run_card
+
+
+def test_run_card_replaces_non_finite_metrics_with_null(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+
+    card = write_run_card(
+        run_dir,
+        {"codes": ["AAPL"], "source": "yfinance"},
+        {
+            "sharpe": float("nan"),
+            "sortino": float("inf"),
+            "max_drawdown": float("-inf"),
+            "total_return": 0.12,
+            "validation": {
+                "consistency": float("nan"),
+                "windows": [1.0, float("inf"), {"tail_risk": float("-inf")}],
+            },
+        },
+    )
+
+    raw_json = (run_dir / "run_card.json").read_text(encoding="utf-8")
+    markdown = (run_dir / "run_card.md").read_text(encoding="utf-8")
+
+    for token in ("NaN", "Infinity", "-Infinity"):
+        assert token not in raw_json
+        assert token not in markdown
+
+    loaded = json.loads(raw_json)
+    assert loaded == card
+    assert loaded["metrics"] == {
+        "max_drawdown": None,
+        "sharpe": None,
+        "sortino": None,
+        "total_return": 0.12,
+    }
+    assert loaded["validation"] == {
+        "consistency": None,
+        "windows": [1.0, None, {"tail_risk": None}],
+    }


### PR DESCRIPTION
﻿## Summary

Make backtest run-card JSON strict when metrics contain non-finite floating-point values.

## Why

Python's default `json.dumps` can emit `NaN`, `Infinity`, and `-Infinity`, which are not valid JSON tokens for strict parsers. Backtest metrics can naturally produce non-finite values for degenerate or insufficient-return windows, so run-card artifacts should normalize those values before writing `run_card.json` and the Markdown companion.

## What Changed

- Normalize non-finite float values to `null` before serializing the run card.
- Write `run_card.json` with `allow_nan=False` so future regressions fail fast.
- Add a regression test covering scalar metrics and nested validation payloads.

## Validation

- `python -m pytest agent/tests/test_run_card.py agent/tests/test_run_card_strict_json.py -q`
- `python -m py_compile agent/backtest/run_card.py agent/tests/test_run_card_strict_json.py`
- `git diff --check origin/main...HEAD`

## Risk Notes

This keeps the change scoped to run-card artifact serialization. Finite metric values are preserved, while only non-finite values are represented as `null` in JSON/Markdown output.
