### PR TITLE
test(search): cover ddgs retry fallback behavior

### DIFF
--- a/agent/tests/test_security_scanner.py
+++ b/agent/tests/test_security_scanner.py
@@ -95,6 +95,104 @@ def test_web_search_adds_security_warning_to_snippets(
     assert result["security_warnings"][0]["field"] == "results.0.snippet"
 
 
+def test_web_search_retries_configured_backends_after_transient_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeDDGS:
+        calls: list[str] = []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def text(self, query: str, max_results: int, backend: str):
+            self.calls.append(backend)
+            if len(self.calls) == 1:
+                raise RuntimeError("temporary rate limit")
+            return [
+                {
+                    "title": "Fallback result",
+                    "href": "https://example.com/fallback",
+                    "body": "fallback snippet",
+                }
+            ]
+
+    fake_module = types.SimpleNamespace(DDGS=FakeDDGS)
+    monkeypatch.setitem(sys.modules, "ddgs", fake_module)
+    monkeypatch.setattr(web_search_tool.time, "sleep", lambda seconds: None)
+    monkeypatch.setenv("VIBE_TRADING_SEARCH_BACKENDS", "google, bing")
+
+    result = json.loads(web_search_tool.WebSearchTool().execute(query="AAPL"))
+
+    assert result["status"] == "ok"
+    assert result["backends"] == "google, bing"
+    assert result["results"][0]["url"] == "https://example.com/fallback"
+    assert FakeDDGS.calls == ["google, bing", "google, bing"]
+
+
+def test_web_search_retries_without_backend_when_ddgs_rejects_backend_kw(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeDDGS:
+        calls: list[bool] = []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def text(self, query: str, max_results: int, **kwargs):
+            self.calls.append("backend" in kwargs)
+            if "backend" in kwargs:
+                raise TypeError("unexpected keyword argument 'backend'")
+            return [
+                {
+                    "title": "Legacy package result",
+                    "href": "https://example.com/legacy",
+                    "body": "legacy snippet",
+                }
+            ]
+
+    fake_module = types.SimpleNamespace(DDGS=FakeDDGS)
+    monkeypatch.setitem(sys.modules, "ddgs", fake_module)
+    monkeypatch.setenv("VIBE_TRADING_SEARCH_BACKENDS", "google, bing")
+
+    result = json.loads(web_search_tool.WebSearchTool().execute(query="AAPL"))
+
+    assert result["status"] == "ok"
+    assert result["backends"] == "duckduckgo"
+    assert result["results"][0]["url"] == "https://example.com/legacy"
+    assert FakeDDGS.calls == [True, False]
+
+
+def test_web_search_treats_no_results_as_empty_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeDDGS:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def text(self, query: str, max_results: int, backend: str):
+            raise RuntimeError("No results found.")
+
+    fake_module = types.SimpleNamespace(DDGS=FakeDDGS)
+    monkeypatch.setitem(sys.modules, "ddgs", fake_module)
+    monkeypatch.setenv("VIBE_TRADING_SEARCH_BACKENDS", "google")
+
+    result = json.loads(web_search_tool.WebSearchTool().execute(query="unlikely query"))
+
+    assert result["status"] == "ok"
+    assert result["backends"] == "google"
+    assert result["results"] == []
+    assert "No results" in result["note"]
+
+
 def test_read_document_adds_security_warning_to_text(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- add regression coverage for the current `web_search` ddgs multi-engine behavior
- cover transient retry with the configured backend list
- cover compatibility when ddgs/duckduckgo_search rejects the `backend` kwarg
- cover `No results found` as an empty successful response

## Validation
- `python -m pytest agent/tests/test_security_scanner.py -q`
- `python -m py_compile agent/src/tools/web_search_tool.py agent/tests/test_security_scanner.py`
- `git diff --check origin/main...HEAD`

## Notes
- Narrowed to tests after rebasing onto upstream `main`, which already includes the multi-engine implementation from #232.