### PR TITLE
fix(loaders): tolerate malformed RSSHub timeout env vars

### DIFF
--- a/agent/backtest/loaders/rsshub_events.py
+++ b/agent/backtest/loaders/rsshub_events.py
@@ -33,7 +33,7 @@ import pandas as pd
 from defusedxml import ElementTree as ET
 from defusedxml.common import DefusedXmlException
 
-from backtest.loaders.base import retry_with_budget
+from backtest.loaders.base import positive_env_float, retry_with_budget
 
 logger = logging.getLogger(__name__)
 
@@ -409,8 +409,8 @@ class RSSHubEventProvider:
         else:
             route = spec.route_template
         url = f"{self.base_url}{route}"
-        timeout = float(os.getenv(RSSHUB_TIMEOUT_ENV, DEFAULT_TIMEOUT_S))
-        budget = float(os.getenv(RSSHUB_BUDGET_ENV, DEFAULT_BUDGET_S))
+        timeout = positive_env_float(RSSHUB_TIMEOUT_ENV, DEFAULT_TIMEOUT_S)
+        budget = positive_env_float(RSSHUB_BUDGET_ENV, DEFAULT_BUDGET_S)
         client = self._client or self._default_client()
         deadline = time.monotonic() + budget
 

--- a/agent/tests/test_rsshub_events_provider.py
+++ b/agent/tests/test_rsshub_events_provider.py
@@ -7,6 +7,7 @@ import pytest
 
 from backtest.loaders.rsshub_events import (
     DEFAULT_FEEDS,
+    DEFAULT_TIMEOUT_S,
     EVENT_COLUMNS,
     EventProviderError,
     FeedSpec,
@@ -56,9 +57,11 @@ class _FakeClient:
     def __init__(self, payload: str) -> None:
         self.payload = payload
         self.calls: list[str] = []
+        self.timeouts: list[float | None] = []
 
     def get(self, url: str, timeout: float | None = None) -> _FakeResponse:
         self.calls.append(url)
+        self.timeouts.append(timeout)
         return _FakeResponse(self.payload)
 
 
@@ -228,6 +231,36 @@ def test_all_feeds_unreachable_raises(monkeypatch) -> None:
     )
     with pytest.raises(EventProviderError):
         provider.query_events(["AAA"], as_of="2024-01-31")
+
+
+def test_malformed_timeout_env_falls_back_to_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RSSHUB_TIMEOUT_S", "not-a-float")
+    client = _FakeClient(_RSS)
+    provider = RSSHubEventProvider(
+        "https://rsshub.local",
+        feeds=[FeedSpec("news", "/stock/news/{code}", "sentiment")],
+        client=client,
+    )
+
+    frame = provider.query_events(["AAA"], as_of="2024-01-31")
+
+    assert not frame.empty
+    assert client.timeouts == [DEFAULT_TIMEOUT_S]
+
+
+def test_malformed_budget_env_falls_back_to_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RSSHUB_FETCH_BUDGET_S", "not-a-float")
+    client = _FakeClient(_RSS)
+    provider = RSSHubEventProvider(
+        "https://rsshub.local",
+        feeds=[FeedSpec("news", "/stock/news/{code}", "sentiment")],
+        client=client,
+    )
+
+    frame = provider.query_events(["AAA"], as_of="2024-01-31")
+
+    assert not frame.empty
+    assert client.timeouts == [DEFAULT_TIMEOUT_S]
 
 
 def test_reachable_but_empty_feed_does_not_raise() -> None:


### PR DESCRIPTION
﻿## Summary

Make RSSHub event-provider timeout and fetch-budget environment variables robust to malformed values.

## Why

The crypto loaders already fall back cleanly when timeout env vars are blank, invalid, or non-positive. RSSHub event loading still parsed `RSSHUB_TIMEOUT_S` and `RSSHUB_FETCH_BUDGET_S` with direct `float(...)`, so a typo such as `RSSHUB_TIMEOUT_S=abc` could raise before the provider attempted a fetch.

## What Changed

- Reuse the shared positive float env helper for RSSHub timeout and budget settings.
- Add regression coverage for malformed RSSHub timeout and budget env values.
- Preserve existing defaults and fetch behavior when env vars are valid.

## Validation

- `python -m pytest agent/tests/test_rsshub_events_provider.py agent/tests/test_rsshub_events_lookahead.py -q`
- `python -m py_compile agent/backtest/loaders/rsshub_events.py agent/tests/test_rsshub_events_provider.py`
- `git diff --check`

## Risk Notes

This keeps the change scoped to RSSHub configuration parsing. Valid positive env values are still honored; malformed, blank, or non-positive values now fall back to existing defaults with the shared warning path.
