### PR TITLE
[security] fix(api): require explicit auth for local shutdown

### DIFF
--- a/agent/api_server.py
+++ b/agent/api_server.py
@@ -17,6 +17,7 @@ import signal
 import time
 import csv
 import uuid
+import urllib.parse
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -642,6 +643,65 @@ def _auth_credential_from_header_or_query(
     if allow_query and query_api_key:
         return query_api_key
     return ""
+
+
+def _is_loopback_origin(origin: str) -> bool:
+    """Return whether a browser Origin header names a loopback web UI."""
+    try:
+        parsed = urllib.parse.urlsplit(origin)
+    except ValueError:
+        return False
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return False
+    host = parsed.hostname.rstrip(".").lower()
+    if host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def _reject_cross_site_browser_request(request: Request) -> None:
+    """Reject unsafe browser requests from non-loopback origins.
+
+    CORS protects response reads, not blind form/fetch side effects. Keep local
+    CLI/curl clients working while refusing browser-originated cross-site POSTs
+    to local control-plane actions such as shutdown.
+    """
+    sec_fetch_site = request.headers.get("sec-fetch-site", "").lower()
+    if sec_fetch_site == "cross-site":
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Cross-site request denied")
+
+    origin = request.headers.get("origin")
+    if origin and not _is_loopback_origin(origin):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Cross-site request denied")
+
+
+def _require_shutdown_authorization(
+    *,
+    request: Request,
+    cred: Optional[HTTPAuthorizationCredentials],
+) -> None:
+    """Authorize the local shutdown control-plane action.
+
+    Loopback peer IP alone is not enough for this browser-reachable, destructive
+    action. When API_AUTH_KEY is configured, require the Bearer token even for
+    loopback requests; otherwise preserve local dev-mode shutdown for direct
+    loopback clients while rejecting cross-site browser requests.
+    """
+    _reject_cross_site_browser_request(request)
+    api_key = _configured_api_key()
+    if api_key:
+        token = _auth_credential_from_header_or_query(cred, None, allow_query=False)
+        if not token or not hmac.compare_digest(token, api_key):
+            raise HTTPException(status_code=401, detail="Invalid or missing API key")
+        return
+    if not _is_local_client(request):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="API_AUTH_KEY is required for non-local API access",
+        )
 
 
 def _validate_api_auth(
@@ -1550,9 +1610,14 @@ def _terminate_current_process() -> None:
     os.kill(os.getpid(), signal.SIGTERM)
 
 
-@app.post("/system/shutdown", dependencies=[Depends(require_auth)])
-async def shutdown_local_api(background_tasks: BackgroundTasks, request: Request):
-    """Shut down the local API server when requested from loopback clients."""
+@app.post("/system/shutdown")
+async def shutdown_local_api(
+    background_tasks: BackgroundTasks,
+    request: Request,
+    cred: Optional[HTTPAuthorizationCredentials] = Security(_security),
+):
+    """Shut down the local API server after explicit local authorization."""
+    _require_shutdown_authorization(request=request, cred=cred)
     client_host = request.client.host if request.client else ""
     if client_host not in {"127.0.0.1", "::1", "localhost"}:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Local access only")

--- a/agent/tests/test_security_auth_api.py
+++ b/agent/tests/test_security_auth_api.py
@@ -215,6 +215,57 @@ def test_cors_origins_accept_explicit_remote_origins() -> None:
     assert origins == ["https://app.example.com", "https://admin.example.com"]
 
 
+def test_loopback_shutdown_requires_bearer_when_api_key_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Loopback alone must not authorize the browser-reachable shutdown action."""
+    called: list[bool] = []
+    monkeypatch.setenv("API_AUTH_KEY", "secret")
+    monkeypatch.setattr(api_server, "_API_KEY", "secret")
+    monkeypatch.setattr(api_server, "_terminate_current_process", lambda: called.append(True))
+
+    response = _local_client().post("/system/shutdown")
+
+    assert response.status_code == 401
+    assert called == []
+
+
+def test_loopback_shutdown_rejects_cross_site_browser_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CORS is not enough; unsafe cross-site browser POSTs must be rejected."""
+    called: list[bool] = []
+    monkeypatch.setenv("API_AUTH_KEY", "secret")
+    monkeypatch.setattr(api_server, "_API_KEY", "secret")
+    monkeypatch.setattr(api_server, "_terminate_current_process", lambda: called.append(True))
+
+    response = _local_client().post(
+        "/system/shutdown",
+        headers={"Origin": "https://attacker.example"},
+    )
+
+    assert response.status_code == 403
+    assert called == []
+
+
+def test_loopback_shutdown_accepts_valid_bearer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called: list[bool] = []
+    monkeypatch.setenv("API_AUTH_KEY", "secret")
+    monkeypatch.setattr(api_server, "_API_KEY", "secret")
+    monkeypatch.setattr(api_server, "_terminate_current_process", lambda: called.append(True))
+
+    response = _local_client().post(
+        "/system/shutdown",
+        headers={"Authorization": "Bearer secret", "Origin": "http://127.0.0.1:8899"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "shutting-down"
+    assert called == [True]
+
+
 # ============================================================================
 # Path-parameter validation (run_id / session_id)
 # ============================================================================


### PR DESCRIPTION
## Summary

This PR hardens the local shutdown control-plane boundary for the FastAPI server.

- Prevents loopback peer IP alone from authorizing `POST /system/shutdown` when `API_AUTH_KEY` is configured.
- Rejects browser-originated cross-site shutdown requests before scheduling the shutdown task.
- Preserves direct local shutdown when explicitly authorized, and keeps zero-config local dev behavior for non-browser direct loopback clients when no API key is configured.
- Adds regression coverage for unauthenticated loopback, cross-site browser, and valid bearer-token shutdown cases.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Cross-site loopback shutdown request | A remote website can make a victim browser send a blind POST to the local API and terminate the local control-plane process without knowing `API_AUTH_KEY`. | High |

## Before this PR

- `require_auth()` trusted loopback clients before checking `API_AUTH_KEY`.
- `POST /system/shutdown` was a bodyless state-changing endpoint protected by the same loopback trust rule.
- A browser could deliver a cross-site POST to `http://127.0.0.1:<port>/system/shutdown`; CORS would block reading the response, but not the side effect.
- There was no regression test proving that a configured API key is required for this local destructive action.

## After this PR

- Shutdown authorization is handled by a dedicated helper.
- When `API_AUTH_KEY` is configured, shutdown requires a matching `Authorization: Bearer <token>` header even from loopback.
- Cross-site browser shutdown requests are rejected using `Origin` / `Sec-Fetch-Site` signals.
- Local direct clients can still use the endpoint with explicit bearer auth when an API key is configured.
- Regression tests cover the denied and allowed paths.

## Why this matters

The API intentionally treats local developer workflows as trusted, but browser-delivered loopback requests are a different boundary. A remote page can cause the victim browser to send requests to `127.0.0.1`; if peer IP alone authorizes destructive actions, the remote page can trigger local side effects without reading responses or knowing the API key.

For Vibe-Trading, forced shutdown can interrupt the local web UI/API and any in-process control-plane work running in the same server process.

## Attack flow

```text
attacker-controlled web page
    -> victim browser sends blind POST to http://127.0.0.1:<port>/system/shutdown
        -> API treats loopback peer IP as trusted before checking API_AUTH_KEY
            -> shutdown task is scheduled
                -> local API process is terminated
```

## Affected code

| Issue | Files |
|-------|-------|
| Cross-site loopback shutdown request | `agent/api_server.py`, `agent/tests/test_security_auth_api.py` |

## Root cause

Issue: cross-site loopback shutdown request

- The generic API auth helper intentionally bypassed token checks for loopback clients.
- `/system/shutdown` reused that generic local trust boundary even though it is a destructive, browser-reachable local control-plane action.
- CORS was not a sufficient defense because it does not prevent blind form/fetch side effects.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Cross-site loopback shutdown request | 7.1 High | `CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:H` |

Rationale:

- The attack is network-delivered through a malicious web page and requires user interaction in the form of visiting that page.
- No API credentials are required for the vulnerable request.
- Impact is primarily availability, with limited integrity impact because a remote page can trigger a local control-plane action.

## Safe reproduction steps

1. Configure `API_AUTH_KEY` for the API process.
2. Send a loopback POST without an `Authorization` header and with a foreign browser origin:

   ```http
   POST /system/shutdown HTTP/1.1
   Host: 127.0.0.1:<port>
   Origin: https://attacker.example
   ```

3. On vulnerable code, the shutdown task is reached and the endpoint returns a successful shutdown response.
4. On this branch, the same request is rejected and the shutdown task is not scheduled.

## Expected vulnerable behavior

The pre-patch system accepted the loopback request without a bearer token and reached the shutdown sink. A safe Docker proof monkeypatched the shutdown function to avoid killing the proof process while confirming the sink was invoked.

```text
[docker-proof] terminate task reached (monkeypatched, process not killed)
[docker-proof] status= 200
[docker-proof] auth_header_sent= False
[docker-proof] terminate_called= True
```

After this patch, the same cross-site request is rejected before the sink:

```text
[docker-after-fix] status= 403
[docker-after-fix] body= {"detail":"Cross-site request denied"}
[docker-after-fix] auth_header_sent= False
[docker-after-fix] terminate_called= False
```

## Changes in this PR

- Adds `_is_loopback_origin()` to identify allowed local browser origins.
- Adds `_reject_cross_site_browser_request()` for unsafe browser-originated shutdown requests.
- Adds `_require_shutdown_authorization()` so shutdown has a stricter boundary than generic local API reads/writes.
- Updates `/system/shutdown` to require explicit shutdown authorization instead of using the generic loopback-bypass dependency.
- Adds tests for:
  - loopback shutdown denied without bearer when `API_AUTH_KEY` is configured
  - cross-site browser shutdown request denied
  - valid loopback bearer-token shutdown still accepted

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| API hardening | `agent/api_server.py` | Adds shutdown-specific authorization and cross-site browser request rejection. |
| Regression tests | `agent/tests/test_security_auth_api.py` | Covers denied unauthenticated/cross-site shutdown requests and valid bearer-token shutdown. |

## Maintainer impact

- Narrowly scoped to `/system/shutdown`.
- Does not change the broader loopback development model for ordinary API endpoints.
- Does not affect remote authenticated API access.
- Users with `API_AUTH_KEY` configured must provide the bearer token for shutdown, including from loopback clients.
- Direct local dev-mode shutdown without `API_AUTH_KEY` remains available for non-browser loopback clients.

## Fix rationale

Shutdown is a local destructive control-plane action, so it needs a stricter boundary than ordinary loopback API access. Requiring explicit bearer authorization when an API key is configured prevents browser loopback piggybacking from bypassing the configured key, while the `Origin` / `Sec-Fetch-Site` checks block the cross-site browser delivery path that CORS alone does not stop.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Docker focused regression tests
- [x] Python syntax compilation in Docker
- [x] Docker after-fix proof for the blocked cross-site shutdown request
- [x] Whitespace check

Executed with:

```bash
docker run --rm -v "$PWD:/repo" -w /repo python:3.11-slim bash -lc '
python -m pip install -q pytest fastapi httpx rich pydantic python-multipart sse-starlette pyyaml python-dotenv
PYTHONPATH=agent python -m pytest agent/tests/test_security_auth_api.py -q
python -m py_compile agent/api_server.py agent/tests/test_security_auth_api.py
'

git diff --check
```

Result:

```text
43 passed, 3 warnings in 0.23s
```

A direct host run of the same focused pytest command was not used for validation because the host Python environment was missing `httpx`; Docker validation above includes the required test dependencies.

## Disclosure notes

- This PR is bounded to the browser-to-loopback shutdown path.
- It does not claim a broader bypass of every local development endpoint.
- No production systems, real credentials, or external services were used in the proof.
- The shutdown sink was monkeypatched during proof to avoid terminating the proof process.
