### PR TITLE
[security] fix(api): reject rebound loopback hosts

### DIFF
--- a/agent/api_server.py
+++ b/agent/api_server.py
@@ -478,6 +478,16 @@ _DEFAULT_CORS_ORIGINS = [
     "http://127.0.0.1:8000",
 ]
 
+_DEFAULT_LOOPBACK_HOSTS = frozenset({
+    "localhost",
+    "127.0.0.1",
+    "::1",
+    "[::1]",
+    # Starlette/FastAPI TestClient default host; included so unit tests exercise
+    # the API without having to override Host on every request.
+    "testserver",
+})
+
 
 def _parse_cors_origins(raw: Optional[str]) -> List[str]:
     """Parse CORS origins and reject credentialed wildcard configuration.
@@ -504,6 +514,37 @@ def _parse_cors_origins(raw: Optional[str]) -> List[str]:
     return origins
 
 
+def _parse_extra_loopback_hosts(raw: Optional[str]) -> set[str]:
+    """Return additional trusted Host names for loopback API traffic."""
+    if raw is None or not raw.strip():
+        return set()
+    return {host.strip().lower().rstrip(".") for host in raw.split(",") if host.strip()}
+
+
+_EXTRA_LOOPBACK_HOSTS = _parse_extra_loopback_hosts(os.getenv("API_ALLOWED_HOSTS"))
+
+
+def _host_without_port(host: str) -> str:
+    """Normalize a Host header to a lowercase hostname without a port."""
+    value = host.strip().lower().rstrip(".")
+    if not value:
+        return ""
+    if value.startswith("["):
+        end = value.find("]")
+        if end != -1:
+            return value[: end + 1]
+        return value
+    if value.count(":") == 1:
+        return value.rsplit(":", 1)[0]
+    return value
+
+
+def _is_allowed_loopback_host(host: str) -> bool:
+    """Return whether ``host`` is allowed for loopback-trusted API requests."""
+    normalized = _host_without_port(host)
+    return normalized in _DEFAULT_LOOPBACK_HOSTS or normalized in _EXTRA_LOOPBACK_HOSTS
+
+
 # CORS: override with CORS_ORIGINS (comma-separated explicit origins)
 _CORS_ORIGINS = _parse_cors_origins(os.getenv("CORS_ORIGINS"))
 
@@ -514,6 +555,17 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+@app.middleware("http")
+async def _reject_untrusted_loopback_host(request: Request, call_next):
+    """Block DNS-rebinding Host headers before loopback auth bypasses run."""
+    if _is_local_client(request) and not _is_allowed_loopback_host(request.headers.get("host", "")):
+        return JSONResponse(
+            status_code=status.HTTP_403_FORBIDDEN,
+            content={"detail": "Untrusted local API host"},
+        )
+    return await call_next(request)
 
 
 # ----------------------------------------------------------------------------

--- a/agent/tests/test_security_auth_api.py
+++ b/agent/tests/test_security_auth_api.py
@@ -150,6 +150,109 @@ def test_loopback_bypasses_auth_even_when_api_key_configured(
     assert remote_bearer.status_code == 200
 
 
+def test_loopback_rejects_rebound_host_before_auth_bypass(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A loopback peer is not enough when Host is attacker-controlled."""
+    monkeypatch.setenv("API_AUTH_KEY", "secret")
+    monkeypatch.setattr(api_server, "_API_KEY", "secret")
+
+    response = _local_client().get(
+        "/runs",
+        headers={"Host": "attacker.example:8899", "Origin": "http://attacker.example:8899"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Untrusted local API host"
+
+
+def test_remote_untrusted_host_still_uses_bearer_auth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The Host gate only narrows loopback trust; remote clients still use API_AUTH_KEY."""
+    monkeypatch.setenv("API_AUTH_KEY", "secret")
+    monkeypatch.setattr(api_server, "_API_KEY", "secret")
+
+    response = _remote_client().get(
+        "/runs",
+        headers={"Host": "attacker.example:8899", "Origin": "http://attacker.example:8899"},
+    )
+
+    assert response.status_code == 401
+
+
+def test_rebound_host_cannot_start_live_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DNS-rebound loopback JSON requests must not reach live-runner control."""
+    monkeypatch.setenv("API_AUTH_KEY", "secret")
+    monkeypatch.setattr(api_server, "_API_KEY", "secret")
+    monkeypatch.setattr(api_server, "_active_mandate_state", lambda broker: SimpleNamespace(expired=False))
+
+    reached = {"factory": False}
+
+    class DummyRunner:
+        async def run_loop(self):
+            return None
+
+    def build_runner(broker: str) -> DummyRunner:
+        reached["factory"] = True
+        return DummyRunner()
+
+    monkeypatch.setattr(api_server, "_runner_factory", build_runner)
+    monkeypatch.setattr("src.trading.service.broker_supports_live_runner", lambda broker: True)
+    monkeypatch.setattr("src.live.halt.halt_flag_set", lambda broker=None: False)
+    api_server._runner_tasks.clear()
+
+    response = _local_client().post(
+        "/live/runner/start",
+        headers={
+            "Host": "attacker.example:8899",
+            "Origin": "http://attacker.example:8899",
+            "Content-Type": "application/json",
+        },
+        json={"broker": "robinhood", "session_id": "proof-session"},
+    )
+
+    assert response.status_code == 403
+    assert reached["factory"] is False
+    assert "robinhood" not in api_server._runner_tasks
+
+
+def test_allowed_loopback_host_can_start_live_runner_dev_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Allowed local hosts preserve the loopback dev-mode runner control path."""
+    monkeypatch.setattr(api_server, "_active_mandate_state", lambda broker: SimpleNamespace(expired=False))
+
+    reached = {"factory": False}
+
+    class DummyRunner:
+        async def run_loop(self):
+            return None
+
+    def build_runner(broker: str) -> DummyRunner:
+        reached["factory"] = True
+        return DummyRunner()
+
+    monkeypatch.setattr(api_server, "_runner_factory", build_runner)
+    monkeypatch.setattr("src.trading.service.broker_supports_live_runner", lambda broker: True)
+    monkeypatch.setattr("src.live.halt.halt_flag_set", lambda broker=None: False)
+    api_server._runner_tasks.clear()
+
+    response = _local_client().post(
+        "/live/runner/start",
+        headers={"Host": "127.0.0.1:8899", "Content-Type": "application/json"},
+        json={"broker": "robinhood", "session_id": "proof-session"},
+    )
+
+    assert response.status_code == 200
+    assert reached["factory"] is True
+    task = api_server._runner_tasks.pop("robinhood", None)
+    if task is not None and not task.done():
+        task.cancel()
+
+
 def test_configured_api_key_required_for_session_event_stream(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- Harden loopback API trust against DNS-rebinding Host headers.
- Require loopback-trusted requests to carry an expected local `Host` value before the loopback auth bypass is allowed.
- Add regression coverage proving attacker-controlled Host/Origin values cannot reach live-runner start, while normal loopback dev-mode runner control still works.

## Why

The API intentionally treats loopback clients as local/dev-mode callers before enforcing `API_AUTH_KEY`. That peer-IP shortcut is unsafe when a browser can be driven through DNS rebinding: an attacker-controlled hostname can resolve to `127.0.0.1` and then issue same-origin JSON requests with `Host: attacker.example:8899`.

A high-impact sink is `POST /live/runner/start`, which starts the persistent live runner when a committed mandate exists. The live runner is later wired to broker read/write tools, so the admission boundary for starting it should not depend only on peer IP.

This PR keeps the existing bearer-token behavior for remote/LAN clients and the normal loopback dev-mode path, but rejects loopback requests that present an unexpected Host header. Deployments that intentionally front the local API with another loopback hostname can opt in via `API_ALLOWED_HOSTS`.

Related context: this is distinct from #241. That PR hardens cross-site side effects on the bodyless shutdown endpoint. This PR addresses the DNS-rebinding/Host-header variant that can make JSON API calls same-origin under an attacker-controlled hostname.

## Changes

- Add default accepted loopback Host values:
  - `localhost`
  - `127.0.0.1`
  - `::1` / `[::1]`
  - `testserver` for FastAPI `TestClient`
- Add `API_ALLOWED_HOSTS` parsing for explicit extra loopback hostnames.
- Add middleware that rejects untrusted Host headers only when the peer is loopback-trusted.
- Add tests for:
  - loopback + attacker Host is rejected before auth bypass
  - remote + attacker Host still follows bearer-token auth
  - DNS-rebound Host cannot reach `/live/runner/start`
  - allowed loopback Host still reaches the dev-mode live-runner path

## Security issues covered

- DNS rebinding against local API trust.
- Loopback auth bypass caused by accepting attacker-controlled Host headers.
- Unauthorized live-runner control-plane admission through `/live/runner/start`.

## Before this PR

- A loopback peer address was enough to bypass `API_AUTH_KEY`.
- The API did not check whether `Host` was a local API authority.
- A DNS-rebound request could carry `Host: attacker.example:8899` and still reach authenticated local API routes as a loopback client.

## After this PR

- Loopback-trusted requests must also use an accepted local Host value.
- Rebound Host values are rejected with `403` before route handlers and live-runner factories are reached.
- Remote clients remain governed by the existing bearer-token auth path.

## Attack flow

1. Attacker serves a page from `http://attacker.example:8899`.
2. The hostname is rebound to `127.0.0.1`.
3. The browser sends a same-origin JSON request to the local API with `Host: attacker.example:8899` and no bearer token.
4. Before this PR, the API trusted the loopback peer IP and skipped `API_AUTH_KEY` validation.
5. The request could reach `POST /live/runner/start` and start the live runner when the account was already authorized/mandated.

## Affected code

- `agent/api_server.py`
  - loopback trust/auth boundary
  - new Host-header gate
  - live-runner route admission remains unchanged behind the stronger boundary
- `agent/tests/test_security_auth_api.py`
  - regression coverage for DNS-rebinding Host rejection and live-runner non-reachability

## Root cause

- Loopback peer IP was treated as sufficient proof of local user intent.
- CORS was present, but CORS does not defend DNS rebinding because the attacker hostname can become the browser's same origin after rebinding.
- No Host-header allowlist existed for loopback-trusted requests.

## CVSS assessment

- Score: 8.1 High
- Vector: `CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:H/A:H`
- Rationale: exploitation requires user interaction and DNS-rebinding timing, but a successful attack can reach privileged local control-plane actions without the configured API key. The demonstrated sink starts the live runner, which is connected to broker write operations once the user has already authorized and committed a mandate.

## Safe reproduction steps

The Docker proof used a monkeypatched runner/broker dependency so no broker was contacted and no trades could be placed. It compared a remote peer with a loopback peer carrying the same attacker-controlled Host/Origin.

Expected vulnerable behavior on the old code:

```text
[docker-proof:remote-control] status= 401
[docker-proof:remote-control] body= {"detail":"Invalid or missing API key"}
[docker-proof:remote-control] auth_header_sent= False
[docker-proof:remote-control] host= attacker.example:8899
[docker-proof:remote-control] origin= http://attacker.example:8899
[docker-proof:remote-control] runner_factory_called= False
[docker-proof:remote-control] runner_loop_entered= False
[docker-proof:dns-rebound-loopback] status= 200
[docker-proof:dns-rebound-loopback] body= {"broker":"robinhood","started":true,"already_running":false}
[docker-proof:dns-rebound-loopback] auth_header_sent= False
[docker-proof:dns-rebound-loopback] host= attacker.example:8899
[docker-proof:dns-rebound-loopback] origin= http://attacker.example:8899
[docker-proof:dns-rebound-loopback] runner_factory_called= True
[docker-proof:dns-rebound-loopback] runner_loop_entered= True
[docker-proof] remote_blocked_but_rebound_loopback_allowed= True
```

## Expected fixed behavior

- Loopback requests with `Host: attacker.example:8899` return `403`.
- The live-runner factory is not called.
- Normal loopback requests with `Host: 127.0.0.1:8899` continue to work in dev mode.
- Remote clients are still handled by `API_AUTH_KEY` bearer-token auth.

## Test Plan

- [x] Existing focused auth/security tests pass:

```bash
PYTHONPATH=agent python -m pytest agent/tests/test_security_auth_api.py -q
```

Result:

```text
44 passed, 2 warnings in 0.25s
```

- [x] New tests added for DNS-rebinding Host rejection and live-runner non-reachability.
- [x] Syntax/diff checks pass:

```bash
python -m py_compile agent/api_server.py agent/tests/test_security_auth_api.py
git diff --check
```

- [x] Docker validation passed:

```bash
docker run --rm -v "$PWD:/repo" -w /repo python:3.11-slim bash -lc '
apt-get update -qq >/dev/null && apt-get install -y -qq git >/dev/null
python -m pip install -q pytest fastapi httpx rich pydantic python-multipart sse-starlette pyyaml python-dotenv
PYTHONPATH=agent python -m pytest agent/tests/test_security_auth_api.py -q
python -m py_compile agent/api_server.py agent/tests/test_security_auth_api.py
git diff --check
'
```

Result:

```text
44 passed, 3 warnings in 0.24s
```

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Documentation updated (not user-facing; no docs update needed)
