### PR TITLE
[security] fix(api): require explicit opt-in for agent shell tools

### DIFF
--- a/agent/api_server.py
+++ b/agent/api_server.py
@@ -733,8 +733,8 @@ def _shell_tools_enabled_for_request(request: Request) -> bool:
     # Shell-capable tools execute commands on the host as the API process user.
     # Do not infer that privilege from peer IP alone: browser DNS rebinding can
     # make attacker-controlled pages appear as loopback clients. Operators who
-    # intentionally want API-started swarm workers to receive shell tools must
-    # opt in explicitly.
+    # intentionally want API-started agents or swarm workers to receive shell
+    # tools must opt in explicitly.
     return _env_shell_tools_enabled()
 
 

--- a/agent/api_server.py
+++ b/agent/api_server.py
@@ -730,7 +730,12 @@ def _env_shell_tools_enabled() -> bool:
 
 def _shell_tools_enabled_for_request(request: Request) -> bool:
     """Return whether this API request may expose shell tools to the agent."""
-    return _is_local_client(request) or _env_shell_tools_enabled()
+    # Shell-capable tools execute commands on the host as the API process user.
+    # Do not infer that privilege from peer IP alone: browser DNS rebinding can
+    # make attacker-controlled pages appear as loopback clients. Operators who
+    # intentionally want API-started swarm workers to receive shell tools must
+    # opt in explicitly.
+    return _env_shell_tools_enabled()
 
 
 async def require_local_or_auth(

--- a/agent/tests/test_security_auth_api.py
+++ b/agent/tests/test_security_auth_api.py
@@ -172,10 +172,10 @@ def test_session_event_stream_accepts_query_token_for_browser_eventsource(
     assert response.status_code in {404, 501}
 
 
-def test_shell_tools_allowed_for_loopback_api_request() -> None:
+def test_shell_tools_disabled_for_loopback_api_request_by_default() -> None:
     request = SimpleNamespace(client=SimpleNamespace(host="127.0.0.1"))
 
-    assert api_server._shell_tools_enabled_for_request(request)
+    assert not api_server._shell_tools_enabled_for_request(request)
 
 
 def test_shell_tools_disabled_for_remote_api_request_by_default() -> None:
@@ -184,13 +184,49 @@ def test_shell_tools_disabled_for_remote_api_request_by_default() -> None:
     assert not api_server._shell_tools_enabled_for_request(request)
 
 
-def test_shell_tools_remote_api_request_accepts_explicit_opt_in(
+def test_shell_tools_api_request_accepts_explicit_opt_in(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    request = SimpleNamespace(client=SimpleNamespace(host="203.0.113.10"))
+    request = SimpleNamespace(client=SimpleNamespace(host="127.0.0.1"))
     monkeypatch.setenv("VIBE_TRADING_ENABLE_SHELL_TOOLS", "1")
 
     assert api_server._shell_tools_enabled_for_request(request)
+
+
+def test_dns_rebound_swarm_run_does_not_enable_shell_tools_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeRuntime:
+        def start_run(self, preset_name: str, user_vars: dict, include_shell_tools: bool = False):
+            captured["preset_name"] = preset_name
+            captured["user_vars"] = user_vars
+            captured["include_shell_tools"] = include_shell_tools
+            return SimpleNamespace(
+                id="swarm-test-no-shell",
+                status=SimpleNamespace(value="running"),
+                preset_name=preset_name,
+            )
+
+    monkeypatch.setattr(api_server, "_get_swarm_runtime", lambda: FakeRuntime())
+    monkeypatch.setenv("API_AUTH_KEY", "secret")
+    monkeypatch.setattr(api_server, "_API_KEY", "secret")
+
+    response = _local_client().post(
+        "/swarm/runs",
+        headers={
+            "Host": "attacker.example:8899",
+            "Origin": "http://attacker.example:8899",
+        },
+        json={
+            "preset_name": "technical_analysis_panel",
+            "user_vars": {"target": "NVDA", "timeframe": "1d"},
+        },
+    )
+
+    assert response.status_code == 200
+    assert captured["include_shell_tools"] is False
 
 
 def test_default_cors_origins_are_loopback_only() -> None:

--- a/agent/tests/test_security_auth_api.py
+++ b/agent/tests/test_security_auth_api.py
@@ -229,6 +229,37 @@ def test_dns_rebound_swarm_run_does_not_enable_shell_tools_by_default(
     assert captured["include_shell_tools"] is False
 
 
+def test_dns_rebound_session_message_does_not_enable_shell_tools_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeSessionService:
+        async def send_message(self, session_id: str, content: str, include_shell_tools: bool = False):
+            captured["session_id"] = session_id
+            captured["content"] = content
+            captured["include_shell_tools"] = include_shell_tools
+            return {"message_id": "msg-test", "attempt_id": "attempt-test"}
+
+    monkeypatch.setattr(api_server, "_get_session_service", lambda: FakeSessionService())
+    monkeypatch.setenv("API_AUTH_KEY", "secret")
+    monkeypatch.setattr(api_server, "_API_KEY", "secret")
+
+    response = _local_client().post(
+        "/sessions/abcdef012345/messages",
+        headers={
+            "Host": "attacker.example:8899",
+            "Origin": "http://attacker.example:8899",
+        },
+        json={"content": "SESSION_DNS_REBIND_PROOF_PAYLOAD"},
+    )
+
+    assert response.status_code == 200
+    assert captured["session_id"] == "abcdef012345"
+    assert captured["content"] == "SESSION_DNS_REBIND_PROOF_PAYLOAD"
+    assert captured["include_shell_tools"] is False
+
+
 def test_default_cors_origins_are_loopback_only() -> None:
     origins = api_server._parse_cors_origins(None)
 


### PR DESCRIPTION
## Summary

This PR hardens the API-started agent boundary so shell-capable tools are not enabled solely because a request appears to come from loopback.

- Requires explicit operator opt-in via `VIBE_TRADING_ENABLE_SHELL_TOOLS` before API-created SWARM workers or session AgentLoop attempts can receive `bash` / background shell tools.
- Adds regression coverage for DNS-rebinding-shaped requests to both `/swarm/runs` and `/sessions/{session_id}/messages`, proving shell tools are not enabled by default.
- Preserves remote/LAN API-key behavior and the existing explicit shell-tool opt-in for trusted deployments.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Loopback peer IP automatically enabled shell tools for API-started SWARM workers and session AgentLoop attempts | A browser-to-localhost/DNS-rebinding path could combine loopback trust with agent routes that expose shell-capable tools, turning an unauthenticated local API request into a command-execution-capable workflow | Critical |

## Before this PR

- `_shell_tools_enabled_for_request()` returned true for any loopback client.
- `/swarm/runs` passed that value into `runtime.start_run(..., include_shell_tools=...)`.
- `/sessions/{session_id}/messages` passed that value into `svc.send_message(..., include_shell_tools=...)`.
- Built-in SWARM presets and the normal AgentLoop registry can expose shell-capable tools such as `bash` when shell tools are enabled.
- If a request reached the local API as a loopback peer, shell tools could be exposed without an explicit operator opt-in.

## After this PR

- API-started agents only receive shell tools when `VIBE_TRADING_ENABLE_SHELL_TOOLS` is explicitly enabled.
- Loopback peer IP remains insufficient to grant host shell capability.
- Regression tests cover loopback requests with attacker-controlled `Host` / `Origin` and verify `include_shell_tools=False` for both SWARM and session message flows.

## Explicit operator choice

Secure default:

```text
VIBE_TRADING_ENABLE_SHELL_TOOLS unset or false
```

Behavior:

- API-created SWARM workers do not receive shell-capable tools, even for loopback clients.
- Session AgentLoop attempts started through the API do not receive shell-capable tools, even for loopback clients.
- Research workflows can still start; shell-capable tools are filtered out.

Explicit trusted opt-in:

```text
VIBE_TRADING_ENABLE_SHELL_TOOLS=1
```

Behavior:

- Operators who intentionally trust their deployment can still expose shell tools to API-started agents.

## Why this matters

Shell-capable agent tools execute commands on the host as the API process user. Browser-origin requests can reach local services through localhost and DNS-rebinding patterns, so peer IP alone is not a reliable expression of operator intent.

A safer boundary is an explicit server-side operator opt-in for shell-capable tools.

## How this differs from related PRs

- #242 hardens Host-header validation for the live-runner DNS-rebinding path.
- This PR hardens shell-tool exposure itself. It prevents loopback status from granting `bash` / background shell capability to API-started SWARM workers or session AgentLoop attempts.
- The fixes are complementary: Host validation blocks rebound admission paths, while this PR makes the dangerous shell-tool capability require explicit operator opt-in even when a request is local.

## Attack flow

```text
1. API_AUTH_KEY is configured.
2. Attacker hosts a web page at attacker.example:8899.
3. Browser resolves attacker.example to the attacker first, then rebinding points it at 127.0.0.1.
4. Browser sends same-origin JSON requests with Host/Origin attacker.example:8899 but loopback peer IP.
5. The local API treats the request as loopback.
6. The request reaches `/swarm/runs` or `/sessions/{session_id}/messages` without an Authorization header.
7. The route starts an agent workflow with `include_shell_tools=True` because the peer is loopback.
8. The agent runtime can receive shell-capable tools such as `bash`.
```

## Affected code

| Area | File | Notes |
|------|------|-------|
| Shell-tool policy | `agent/api_server.py` | `_shell_tools_enabled_for_request()` inferred shell capability from loopback peer IP |
| Session agent route | `agent/api_server.py` | `/sessions/{session_id}/messages` passed the request-derived shell-tool flag into `SessionService.send_message()` |
| SWARM route | `agent/api_server.py` | `/swarm/runs` passed the request-derived shell-tool flag into SWARM runtime creation |
| Regression tests | `agent/tests/test_security_auth_api.py` | Covers default-deny shell tools, explicit opt-in, SWARM DNS-rebinding shape, and session DNS-rebinding shape |

## Root cause

- Loopback peer IP was treated as sufficient intent to expose host shell tools.
- Browser-to-localhost and DNS-rebinding threat models can make attacker-triggered requests appear as loopback.
- Shell/process tools are a host capability and should require explicit server-side operator configuration, not request-locality inference.

## CVSS assessment

- Issue: DNS-rebinding-triggered API agent shell-tool exposure
- Suggested severity: Critical
- Suggested CVSS v3.1: 9.6
- Suggested vector: `CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H`

Rationale: a remote attacker needs a victim to visit an attacker-controlled page, but no API key or Vibe-Trading credentials are required. The resulting workflow can expose host command-execution-capable tools in the local API process context.

## Safe reproduction steps

Before the fix, a Docker proof using the real FastAPI app, real routes, real session/SWARM services, and a deterministic fake LLM showed:

```text
[docker-proof:remote-control] create_status= 401
[docker-proof:remote-control] marker_exists= False
[docker-proof:dns-rebound-loopback] message_status= 200
[docker-proof:dns-rebound-loopback] marker_exists= True
[docker-proof:dns-rebound-loopback] marker_content= proof
[docker-proof] remote_blocked_but_rebound_session_rce_allowed= True
```

After this PR, the same session proof no longer exposes `bash`, so the marker is not created:

```text
[docker-proof:remote-control] create_status= 401
[docker-proof:remote-control] marker_exists= False
[docker-proof:dns-rebound-loopback] create_status= 201
[docker-proof:dns-rebound-loopback] message_status= 200
[docker-proof:dns-rebound-loopback] fake_llm_calls= 1
[docker-proof:dns-rebound-loopback] marker_exists= False
[docker-proof] remote_blocked_but_rebound_session_rce_allowed= False
```

## Expected vulnerable behavior

On vulnerable code, a rebound loopback request can cause an API-started agent workflow to receive shell tools without `VIBE_TRADING_ENABLE_SHELL_TOOLS` being set.

## Changes in this PR

- Changes `_shell_tools_enabled_for_request()` to rely only on `VIBE_TRADING_ENABLE_SHELL_TOOLS`.
- Keeps explicit operator opt-in behavior intact.
- Adds/updates tests proving:
  - loopback requests do not enable shell tools by default
  - remote requests do not enable shell tools by default
  - explicit opt-in enables shell tools
  - DNS-rebinding-shaped `/swarm/runs` requests get `include_shell_tools=False`
  - DNS-rebinding-shaped `/sessions/{session_id}/messages` requests get `include_shell_tools=False`

## Files changed

| File | Change |
|------|--------|
| `agent/api_server.py` | Removes loopback peer IP as an automatic shell-tool grant |
| `agent/tests/test_security_auth_api.py` | Adds regression coverage for the shell-tool policy and DNS-rebinding-shaped SWARM/session requests |

## Maintainer impact

- Secure-by-default deployments no longer expose host shell tools through API-started agents based only on loopback locality.
- Operators who intentionally need shell tools can enable `VIBE_TRADING_ENABLE_SHELL_TOOLS=1`.
- Existing API auth behavior is otherwise unchanged.

## Fix rationale

Host shell tools are a high-impact local capability. They should be gated by explicit server-side configuration so that browser-origin request tricks cannot turn request locality into host command execution capability.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation
- [ ] Refactor

## Test plan

Local validation:

```bash
PYTHONPATH=agent python -m pytest agent/tests/test_security_auth_api.py -q
python -m py_compile agent/api_server.py agent/tests/test_security_auth_api.py
git diff --check
```

Result:

```text
42 passed, 2 warnings in 0.25s
```

Docker validation:

```bash
docker run --rm -v "$PWD:/repo" -w /repo python:3.11-slim bash -lc '
apt-get update -qq && apt-get install -y -qq git >/dev/null &&
python -m pip install -q pytest fastapi httpx rich pydantic python-multipart sse-starlette pyyaml python-dotenv fastmcp &&
PYTHONPATH=agent python -m pytest agent/tests/test_security_auth_api.py -q &&
python -m py_compile agent/api_server.py agent/tests/test_security_auth_api.py
'
```

Result:

```text
42 passed, 3 warnings in 0.22s
```

After-fix Docker proof for the session route:

```text
[docker-proof:dns-rebound-loopback] marker_exists= False
[docker-proof] remote_blocked_but_rebound_session_rce_allowed= False
```

## Disclosure notes

This PR is intentionally bounded to shell-tool exposure for API-started agent workflows. It does not claim to replace Host-header/DNS-rebinding admission hardening; it complements that boundary by requiring explicit operator opt-in before shell-capable tools are exposed to agents started through the API.
