### PR TITLE
[security] fix(api): require auth for settings writes

### DIFF
--- a/agent/api_server.py
+++ b/agent/api_server.py
@@ -753,6 +753,31 @@ async def require_local_or_auth(
         )
 
 
+async def require_settings_write_auth(
+    request: Request,
+    cred: Optional[HTTPAuthorizationCredentials] = Security(_security),
+) -> None:
+    """Require explicit authorization before changing credential-routing settings.
+
+    Settings writes can redirect stored provider credentials to a different
+    endpoint. When an API key is configured, loopback peer IP alone is not a
+    sufficient user-intent signal because a browser can reach local APIs after
+    DNS rebinding.
+    """
+    api_key = _configured_api_key()
+    if api_key:
+        token = _auth_credential_from_header_or_query(cred, None, allow_query=False)
+        if not token or not hmac.compare_digest(token, api_key):
+            raise HTTPException(status_code=401, detail="Invalid or missing API key")
+        return
+
+    if not _is_local_client(request):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Settings writes require API_AUTH_KEY or a local loopback client",
+        )
+
+
 # ============================================================================
 # Workflow Factory
 # ============================================================================
@@ -1408,7 +1433,7 @@ async def get_llm_settings():
     return _build_llm_settings_response()
 
 
-@app.put("/settings/llm", response_model=LLMSettingsResponse, dependencies=[Depends(require_local_or_auth)])
+@app.put("/settings/llm", response_model=LLMSettingsResponse, dependencies=[Depends(require_settings_write_auth)])
 async def update_llm_settings(payload: UpdateLLMSettingsRequest):
     """Persist project-local LLM settings and update the running process."""
     provider_name = payload.provider.strip().lower()
@@ -1479,7 +1504,7 @@ async def get_data_source_settings():
 @app.put(
     "/settings/data-sources",
     response_model=DataSourceSettingsResponse,
-    dependencies=[Depends(require_local_or_auth)],
+    dependencies=[Depends(require_settings_write_auth)],
 )
 async def update_data_source_settings(payload: UpdateDataSourceSettingsRequest):
     """Persist project-local data source credentials and update the running process."""

--- a/agent/tests/test_security_auth_api.py
+++ b/agent/tests/test_security_auth_api.py
@@ -130,7 +130,7 @@ def test_configured_api_key_accepts_bearer_for_sensitive_reads(
 def test_loopback_bypasses_auth_even_when_api_key_configured(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Loopback clients are always trusted — the API key only gates remote access."""
+    """Loopback clients remain trusted for non-settings reads."""
     monkeypatch.setenv("API_AUTH_KEY", "secret")
     monkeypatch.setattr(api_server, "_API_KEY", "secret")
 
@@ -148,6 +148,88 @@ def test_loopback_bypasses_auth_even_when_api_key_configured(
     # Remote with bearer: accepted
     remote_bearer = remote.get("/runs", headers={"Authorization": "Bearer secret"})
     assert remote_bearer.status_code == 200
+
+
+def _llm_settings_payload(base_url: str = "https://api.openai.com/v1") -> dict[str, object]:
+    return {
+        "provider": "openai",
+        "model_name": "gpt-4o-mini",
+        "base_url": base_url,
+        "temperature": 0,
+        "timeout_seconds": 120,
+        "max_retries": 2,
+    }
+
+
+def test_dns_rebound_loopback_cannot_write_llm_settings_without_bearer(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Configured API keys must gate credential-routing settings writes."""
+    monkeypatch.setenv("API_AUTH_KEY", "secret")
+    monkeypatch.setattr(api_server, "_API_KEY", "secret")
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "\n".join(
+            [
+                "LANGCHAIN_PROVIDER=openai",
+                "LANGCHAIN_MODEL_NAME=gpt-4o-mini",
+                "OPENAI_BASE_URL=https://api.openai.com/v1",
+                "OPENAI_API_KEY=sk-existing-test-key",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(api_server, "ENV_PATH", env_path)
+
+    response = _local_client().put(
+        "/settings/llm",
+        headers={"host": "attacker.example:8899", "origin": "http://attacker.example:8899"},
+        json=_llm_settings_payload("https://attacker.example/openai-compatible/v1"),
+    )
+
+    assert response.status_code == 401
+    saved = env_path.read_text(encoding="utf-8")
+    assert "https://attacker.example/openai-compatible/v1" not in saved
+    assert "OPENAI_BASE_URL=https://api.openai.com/v1" in saved
+    assert "OPENAI_API_KEY=sk-existing-test-key" in saved
+
+
+def test_authorized_client_can_write_llm_settings_when_api_key_configured(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("API_AUTH_KEY", "secret")
+    monkeypatch.setattr(api_server, "_API_KEY", "secret")
+    env_path = tmp_path / ".env"
+    env_path.write_text("", encoding="utf-8")
+    monkeypatch.setattr(api_server, "ENV_PATH", env_path)
+
+    response = _remote_client().put(
+        "/settings/llm",
+        headers={"Authorization": "Bearer secret"},
+        json=_llm_settings_payload("https://api.openai.com/v1"),
+    )
+
+    assert response.status_code == 200
+    assert "OPENAI_BASE_URL=https://api.openai.com/v1" in env_path.read_text(encoding="utf-8")
+
+
+def test_local_dev_can_write_llm_settings_when_api_key_unset(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    env_path = tmp_path / ".env"
+    monkeypatch.setattr(api_server, "ENV_PATH", env_path)
+
+    response = _local_client().put(
+        "/settings/llm",
+        json=_llm_settings_payload("https://api.openai.com/v1"),
+    )
+
+    assert response.status_code == 200
+    assert "OPENAI_BASE_URL=https://api.openai.com/v1" in env_path.read_text(encoding="utf-8")
 
 
 def test_configured_api_key_required_for_session_event_stream(


### PR DESCRIPTION
## Summary

This PR hardens credential-routing settings writes against DNS-rebinding requests to a local Vibe-Trading API.

- Requires an explicit bearer token for settings writes when `API_AUTH_KEY` is configured, even if the peer IP is loopback.
- Keeps local dev-mode settings writes available when no API key is configured.
- Adds regression coverage for a DNS-rebinding-shaped `/settings/llm` write that previously could persist an attacker-controlled provider base URL while preserving the existing provider key.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| DNS-rebound settings write can poison LLM provider endpoint | A browser-reachable local API request can persist an attacker-controlled model-provider base URL, potentially routing future provider calls and credentials to the attacker-controlled endpoint. | High |

## Before this PR

- `require_local_or_auth()` delegated to the general API auth helper when `API_AUTH_KEY` was configured.
- That general auth helper trusted loopback clients before checking the bearer token.
- A DNS-rebinding page could make the browser send a same-origin JSON request with an attacker-controlled `Host`/`Origin` while the peer appeared to be `127.0.0.1`.
- `PUT /settings/llm` could then update the persisted provider base URL without an `Authorization` header.

## After this PR

- Settings writes use a dedicated `require_settings_write_auth()` dependency.
- When `API_AUTH_KEY` is configured, settings writes must present the matching bearer token; loopback peer IP alone is not enough.
- When no API key is configured, local dev-mode writes still work for loopback clients and remote writes remain blocked.
- Regression tests cover the rebound-loopback denial, authorized settings writes, and dev-mode local writes.

## Why this matters

Provider base URL settings control where future LLM requests are sent. If an attacker can persist an attacker-controlled OpenAI-compatible endpoint while an existing provider key remains configured, later model calls may send credentialed traffic to the attacker-controlled endpoint.

CORS alone is not a complete defense for this boundary. With DNS rebinding, the attacker-controlled hostname can become the browser's same origin while resolving to `127.0.0.1`, so loopback peer-IP trust must not be treated as explicit authorization for credential-routing changes.

## How this differs from related issue/PR

This is the same browser-to-loopback trust-boundary family as prior DNS-rebinding hardening, but the sink is different:

- PR #242 focused on rebound access to live-runner control.
- PR #243 focused on shell-tool exposure for agent/SWARM execution paths.
- This PR focuses on settings writes that can redirect provider traffic and preserve existing credentials.

The fix is intentionally scoped to settings writes instead of changing the general loopback dev-mode behavior for all API reads and writes.

## Attack flow

```text
attacker-controlled page at attacker.example
    -> DNS rebinds attacker.example to 127.0.0.1
        -> sends same-origin PUT /settings/llm with no Authorization header
            -> loopback peer IP bypasses general API key auth
                -> attacker-controlled provider base URL is persisted
                    -> later provider traffic may use the victim's configured key against that endpoint
```

## Affected code

| Issue | Files |
|-------|-------|
| Settings writes trusted loopback peer IP before bearer auth | `agent/api_server.py`, `agent/tests/test_security_auth_api.py` |

## Root cause

Issue: DNS-rebound settings write can poison the LLM provider endpoint

- The general API auth helper intentionally preserves loopback dev-mode behavior.
- Settings writes are more sensitive than ordinary local reads because they change where stored provider credentials may be sent.
- The settings write routes reused the general loopback trust path, so `API_AUTH_KEY` did not require an explicit bearer token for loopback peers.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| DNS-rebound settings write can poison LLM provider endpoint | 8.0 High | `CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:H/I:H/A:N` |

Rationale:

- The attacker needs the victim to visit or interact with a malicious page and complete a DNS-rebinding timing condition.
- No API key or local account privilege is required by the attacker.
- Successful exploitation can persistently change credential-routing configuration and potentially expose future provider traffic/credentials to an attacker-controlled endpoint.

## Safe reproduction steps

1. Start from a configuration where `API_AUTH_KEY` is set and `agent/.env` contains an existing provider key and `OPENAI_BASE_URL=https://api.openai.com/v1`.
2. Send `PUT /settings/llm` without `Authorization` using:
   - `Host: attacker.example:8899`
   - `Origin: http://attacker.example:8899`
   - a loopback client peer such as `127.0.0.1`
   - JSON body setting `base_url` to an attacker-controlled OpenAI-compatible endpoint
3. On vulnerable code, the route returns success and persists the attacker-controlled base URL.
4. On this PR, the same request returns `401` and the original base URL remains unchanged.

## Expected vulnerable behavior

On vulnerable code, the remote-control request with a non-loopback peer was blocked, but the DNS-rebound loopback request was accepted and persisted the attacker-controlled provider base URL without an `Authorization` header.

## Changes in this PR

- Adds `require_settings_write_auth()` for settings mutation routes.
- Requires a valid bearer token for settings writes when `API_AUTH_KEY` is configured.
- Preserves loopback-only dev-mode settings writes when no API key is configured.
- Applies the write-specific guard to:
  - `PUT /settings/llm`
  - `PUT /settings/data-sources`
- Adds regression tests for rebound-loopback denial and intended authorized/local behavior.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| API auth boundary | `agent/api_server.py` | Added a settings-write-specific auth dependency and wired it to settings mutation routes. |
| Regression tests | `agent/tests/test_security_auth_api.py` | Added tests for DNS-rebound loopback settings write denial, authorized writes, and dev-mode local writes. |

## Maintainer impact

- Local development without `API_AUTH_KEY` continues to allow loopback settings writes.
- Deployments that configure `API_AUTH_KEY` now need to send the bearer token for settings writes even from localhost.
- Settings reads and unrelated API routes are not changed by this PR.
- Data-source settings writes receive the same protection because they also persist credential-related configuration.

## Fix rationale

Settings writes change credential-routing and credential-related state, so they need a stronger authorization boundary than generic local dev-mode reads. Requiring the configured bearer token when `API_AUTH_KEY` exists keeps the current deployment model intact while ensuring loopback peer IP alone is not treated as user intent after DNS rebinding.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Focused local security regression tests.
- [x] Docker/container validation of the focused security tests and syntax checks.
- [x] Docker/container after-fix proof for the DNS-rebound settings write.
- [x] Whitespace diff check.

Executed with:

```bash
PYTHONPATH=agent python -m pytest agent/tests/test_security_auth_api.py -q
```

```bash
docker run --rm -v "$PWD:/repo" -w /repo python:3.11-slim bash -lc '
python -m pip install -q pytest fastapi httpx rich pydantic python-multipart sse-starlette pyyaml python-dotenv &&
PYTHONPATH=agent python -m pytest agent/tests/test_security_auth_api.py -q &&
python -m py_compile agent/api_server.py agent/tests/test_security_auth_api.py &&
python .hermes_after_fix_settings_rebinding.py
'
```

```bash
git diff --check
```

Docker focused tests passed:

```text
43 passed, 3 warnings in 0.22s
```

After-fix Docker proof showed the rebound settings write is blocked:

```text
[docker-after-fix:dns-rebound-loopback] status= 401
[docker-after-fix:dns-rebound-loopback] attacker_base_persisted= False
[docker-after-fix:dns-rebound-loopback] original_base_preserved= True
[docker-after-fix] rebound_settings_poison_blocked= True
```

## Disclosure notes

This PR is intentionally bounded to settings writes that persist credential-routing configuration. It does not claim to remove all loopback dev-mode trust from the API, and it does not change unrelated session, run, or frontend behavior.