### PR TITLE
feat: first-class glm/zhipu provider alias + model-name inference

### DIFF
--- a/agent/src/providers/capabilities.py
+++ b/agent/src/providers/capabilities.py
@@ -70,6 +70,8 @@ _MOONSHOT_CAPABILITIES = ProviderCapabilities(
     default_headers={"User-Agent": _KIMI_USER_AGENT},
 )
 
+_ZHIPU_CAPABILITIES = ProviderCapabilities("zhipu", "ZHIPU_API_KEY", "ZHIPU_BASE_URL")
+
 _OPENAI_CODEX_CAPABILITIES = ProviderCapabilities("openai-codex", None, "OPENAI_CODEX_BASE_URL")
 
 
@@ -98,7 +100,8 @@ _PROVIDERS: dict[str, ProviderCapabilities] = {
     "groq": ProviderCapabilities("groq", "GROQ_API_KEY", "GROQ_BASE_URL"),
     "dashscope": ProviderCapabilities("dashscope", "DASHSCOPE_API_KEY", "DASHSCOPE_BASE_URL"),
     "qwen": ProviderCapabilities("qwen", "DASHSCOPE_API_KEY", "DASHSCOPE_BASE_URL"),
-    "zhipu": ProviderCapabilities("zhipu", "ZHIPU_API_KEY", "ZHIPU_BASE_URL"),
+    "zhipu": _ZHIPU_CAPABILITIES,
+    "glm": _ZHIPU_CAPABILITIES,
     "moonshot": _MOONSHOT_CAPABILITIES,
     "kimi": _MOONSHOT_CAPABILITIES,
     "minimax": ProviderCapabilities("minimax", "MINIMAX_API_KEY", "MINIMAX_BASE_URL"),
@@ -118,6 +121,8 @@ def _infer_from_model(model: str) -> str | None:
         return "gemini"
     if lowered.startswith("deepseek"):
         return "deepseek"
+    if lowered.startswith("glm"):
+        return "zhipu"
     if "kimi" in lowered or "moonshot" in lowered:
         return "moonshot"
     return None

--- a/agent/src/providers/llm_providers.json
+++ b/agent/src/providers/llm_providers.json
@@ -83,6 +83,15 @@
     "api_key_required": true
   },
   {
+    "name": "glm",
+    "label": "GLM (Zhipu)",
+    "api_key_env": "ZHIPU_API_KEY",
+    "base_url_env": "ZHIPU_BASE_URL",
+    "default_model": "glm-5.1",
+    "default_base_url": "https://open.bigmodel.cn/api/paas/v4",
+    "api_key_required": true
+  },
+  {
     "name": "moonshot",
     "label": "Moonshot / Kimi",
     "api_key_env": "MOONSHOT_API_KEY",

--- a/agent/tests/test_llm.py
+++ b/agent/tests/test_llm.py
@@ -7,7 +7,44 @@ from unittest.mock import patch
 
 import pytest
 
+from src.providers.capabilities import get_provider_capabilities, provider_env_names
 from src.providers.llm import _sync_provider_env, build_llm
+
+
+class TestProviderCapabilityAliases:
+    """Provider aliases and model-name inference."""
+
+    def test_glm_alias_uses_zhipu_capabilities(self) -> None:
+        glm_caps = get_provider_capabilities("glm")
+        zhipu_caps = get_provider_capabilities("zhipu")
+
+        assert (
+            glm_caps.name,
+            glm_caps.api_key_env,
+            glm_caps.base_url_env,
+        ) == (
+            zhipu_caps.name,
+            zhipu_caps.api_key_env,
+            zhipu_caps.base_url_env,
+        )
+
+    @pytest.mark.parametrize("model", ["glm-4.6", "glm-5.1"])
+    def test_glm_model_inference_uses_zhipu(self, model: str) -> None:
+        caps = get_provider_capabilities(provider=None, model=model)
+
+        assert caps.name == "zhipu"
+
+    def test_glm_provider_env_names_use_zhipu_env(self) -> None:
+        assert provider_env_names("glm") == ("ZHIPU_API_KEY", "ZHIPU_BASE_URL")
+
+    @pytest.mark.parametrize("model", ["", "something-unknown"])
+    def test_unknown_or_empty_model_without_provider_falls_back_to_openai(
+        self,
+        model: str,
+    ) -> None:
+        caps = get_provider_capabilities(provider=None, model=model)
+
+        assert caps.name == "openai"
 
 
 # ---------------------------------------------------------------------------
@@ -237,5 +274,4 @@ class TestReasoningEffortPassthrough:
             "LANGCHAIN_REASONING_EFFORT": "HIGH",
         })
         assert captured["extra_body"]["reasoning"]["effort"] == "high"
-
 

--- a/agent/tests/test_llm_provider_defaults.py
+++ b/agent/tests/test_llm_provider_defaults.py
@@ -18,6 +18,7 @@ EXPECTED_PROVIDER_DEFAULTS = {
     "dashscope": "qwen-plus-latest",
     "qwen": "qwen-plus-latest",
     "zhipu": "glm-5.1",
+    "glm": "glm-5.1",
     "moonshot": "kimi-k2.6",
     "minimax": "MiniMax-M3",
     "mimo": "MiMo-72B-A27B",


### PR DESCRIPTION
## Summary

This adds a first-class `glm` provider alias of the existing `zhipu` provider, plus model-name inference, so GLM / Zhipu coding-plan users no longer have to borrow the `openai` slot. When the model name starts with `glm`, the agent now resolves the Zhipu provider and its base URL automatically even if no explicit provider is configured.

## Why

This closes #237, where a user asked for first-class GLM / Zhipu support and you confirmed that a dedicated `glm` / `zhipu` alias, so people do not have to borrow the `openai` slot, would be a very welcome PR, pointing at the provider layer.

The problem today is silent and confusing. A `zhipu` provider already exists, but there is no `glm` alias and nothing that infers the provider from the model name. So a user who sets only their model to `glm-4.6` or `glm-5.1` falls through to the OpenAI capability record and gets pointed at the OpenAI base URL, with no error to explain why their GLM key is being ignored. Making `glm` a real alias and teaching the inference path about it removes that footgun and matches what the issue actually asked for.

## Changes

The change follows the existing `kimi` to `moonshot` alias precedent exactly. The Zhipu capability record is now shared between the canonical `zhipu` provider and the new `glm` alias, the model-name inference path maps any `glm`-prefixed model back to Zhipu, and the provider registry gains a `glm` entry that reuses the same Zhipu environment variables and default model so onboarding and diagnostics surface it. Tests cover the alias, both `glm-4.6` and `glm-5.1` inference, the environment-name resolution, and confirm that an unknown or empty model still falls back to OpenAI.

Two things are deliberately left out of scope. Coding-plan-specific request headers are not added here, because those need the exact 400 payload from the coding endpoint and a separate shape decision, the same situation as the Kimi For-Coding work in #204. The alias is also not added to the CLI status and choice maps, since the canonical `zhipu` already covers those displays, mirroring how `kimi` defers to `moonshot` there.

## Test Plan

- [x] New capability and inference tests pass (the `TestProviderCapabilityAliases` class plus the provider-defaults regression, 9 passing).
- [x] `ruff check` is clean on the changed files.

The `build_llm` tests that import the optional `langchain-openai` dependency were not run here because it is not installed in this environment; the same five errors are present on a pristine `main` checkout, so they are pre-existing and unrelated to this change.

## Checklist

- [x] No changes to protected areas without prior discussion; the provider-layer change is the one you invited in the issue.
- [x] No hardcoded values beyond the existing provider-registry conventions.
- [x] Code follows CONTRIBUTING.md, including the DCO sign-off on the commit and Google-style docstrings.
- [x] No README provider-list change is needed because GLM is an alias of the already-listed Zhipu provider.

Fixes #237
