### PR TITLE
fix: make harmonic backend optional

### DIFF
--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -30,7 +30,7 @@ joblib>=1.3.0
 
 # Signal Skills
 smartmoneyconcepts>=0.0.1
-pyharmonics>=1.5.0
+# optional: pip install "vibe-trading-ai[harmonic]" for the pyharmonics-backed harmonic pattern detector
 
 # Data Providers
 tushare>=1.2.89

--- a/agent/src/skills/harmonic/SKILL.md
+++ b/agent/src/skills/harmonic/SKILL.md
@@ -26,8 +26,11 @@ The Fibonacci geometry school uses precise ratio relationships to identify price
 ## Dependencies
 
 ```bash
-pip install pyharmonics pandas numpy requests
+pip install "vibe-trading-ai[harmonic]"
 ```
+
+`pyharmonics` is optional. If the extra is not installed, the example signal
+engine falls back to the bundled detector.
 
 ## Parameters
 

--- a/agent/tests/test_packaging_dependencies.py
+++ b/agent/tests/test_packaging_dependencies.py
@@ -1,0 +1,46 @@
+"""Packaging dependency regression tests."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _normalized_requirement_name(requirement: str) -> str:
+    name = requirement.split(";", 1)[0]
+    for marker in ("[", "<", ">", "="):
+        name = name.split(marker, 1)[0]
+    return name.strip().lower()
+
+
+def test_harmonic_backend_is_not_a_core_install_dependency() -> None:
+    """Keep optional harmonic plotting deps from breaking baseline installs."""
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text())
+
+    core_dependencies = {
+        _normalized_requirement_name(requirement)
+        for requirement in pyproject["project"]["dependencies"]
+    }
+    requirements_txt = {
+        _normalized_requirement_name(line)
+        for line in (ROOT / "agent" / "requirements.txt").read_text().splitlines()
+        if line and not line.startswith("#")
+    }
+
+    assert "pyharmonics" not in core_dependencies
+    assert "pyharmonics" not in requirements_txt
+
+
+def test_harmonic_backend_is_available_as_an_optional_extra() -> None:
+    """Users who need harmonic pattern detection can still opt in explicitly."""
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text())
+
+    harmonic_extra = {
+        _normalized_requirement_name(requirement)
+        for requirement in pyproject["project"]["optional-dependencies"]["harmonic"]
+    }
+
+    assert "pyharmonics" in harmonic_extra

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
     "scikit-learn>=1.3.0",
     "joblib>=1.3.0",
     "smartmoneyconcepts>=0.0.1",
-    "pyharmonics>=1.5.0",
     "tushare>=1.2.89",
     "requests>=2.31.0",
     "yfinance>=0.2.30",
@@ -103,6 +102,9 @@ ashare = [
     # HTTP CDN IP blocks that affect eastmoney-backed sources. The Tencent
     # A-share loader needs no extra dependency (stdlib HTTP only).
     "baostock>=0.8.8",
+]
+harmonic = [
+    "pyharmonics>=1.5.0",
 ]
 dev = [
     "pytest>=7.0",


### PR DESCRIPTION
## Summary

Fix Windows/Python baseline installs by moving the optional `pyharmonics` harmonic-pattern backend out of the core dependency set and into a dedicated `harmonic` extra.

## Root Cause

`vibe-trading-ai` depended on `pyharmonics>=1.5.0` unconditionally. `pyharmonics` depends on `ta`, which can be unavailable in some Windows/Python resolver environments, so a non-core harmonic-pattern backend could block `pip install vibe-trading-ai` entirely.

## Changes

- Remove `pyharmonics` from core `pyproject.toml` dependencies and `agent/requirements.txt`.
- Add `pyharmonics>=1.5.0` as `vibe-trading-ai[harmonic]`.
- Update the harmonic skill install instructions to use the extra and document the bundled fallback detector.
- Add a packaging regression test that keeps `pyharmonics` out of baseline installs while preserving the optional extra.

Fixes #249.

## Validation

- `python -m pytest agent/tests/test_packaging_dependencies.py -q`
- `python -m compileall -q agent/tests/test_packaging_dependencies.py`
- `python -m pip install --dry-run --ignore-installed --no-deps .`
- `git diff --check`
