### PR TITLE
test: cover assistant-prefill handoff paths

### DIFF
--- a/agent/tests/test_agent_loop_no_assistant_prefill.py
+++ b/agent/tests/test_agent_loop_no_assistant_prefill.py
@@ -12,7 +12,11 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+import pytest
+
+import src.agent.loop as loop_mod
 from src.agent.loop import AgentLoop
+from src.agent.trace import TraceWriter
 
 
 class _StubLLM:
@@ -20,8 +24,8 @@ class _StubLLM:
 
     def __init__(self) -> None:
         self.model_name = "claude-opus-4-8-20250219"
-
-    _call_count = 0
+        self.call_count = 0
+        self.seen_messages: list[list[dict[str, Any]]] = []
 
     class _Response:
         content: str = "Here is the analysis of AAPL stock."
@@ -40,9 +44,11 @@ class _StubLLM:
         tools: Any = None,
         on_text_chunk: Any = None,
         on_reasoning_chunk: Any = None,
+        should_cancel: Any = None,
     ) -> Any:
         messages = [m for m in messages]
-        _StubLLM._call_count += 1
+        self.call_count += 1
+        self.seen_messages.append(messages)
 
         for msg in reversed(messages):
             if msg.get("role") in ("user", "system", "tool"):
@@ -50,7 +56,7 @@ class _StubLLM:
             if msg.get("role") == "assistant":
                 raise AssertionError(
                     f"Messages should not end with assistant role "
-                    f"(call #{_StubLLM._call_count}): {msg}"
+                    f"(call #{self.call_count}): {msg}"
                 )
 
         return self._Response()
@@ -79,11 +85,62 @@ def _build_agent(llm: Any, max_iter: int = 3, tmp_run_dir: Path | None = None) -
 
 def test_agent_run_messages_never_end_with_assistant(tmp_path: Path) -> None:
     """A simple run() should never send a trailing assistant message to the LLM."""
+    llm = _StubLLM()
     agent = _build_agent(
-        _StubLLM(),
+        llm,
         max_iter=5,
         tmp_run_dir=tmp_path / "run",
     )
     result = agent.run("Analyze AAPL stock for 2024")
     assert result["status"] == "success"
-    assert _StubLLM._call_count >= 1
+    assert llm.call_count >= 1
+
+
+def test_background_notifications_are_reintroduced_as_user_messages(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Background notifications used to append a trailing assistant ack."""
+
+    class _BackgroundManager:
+        def drain_notifications(self) -> list[dict[str, str]]:
+            return [
+                {
+                    "task_id": "abc123",
+                    "status": "completed",
+                    "result": "finished",
+                }
+            ]
+
+    llm = _StubLLM()
+    monkeypatch.setattr(loop_mod, "get_background_manager", lambda: _BackgroundManager())
+    agent = _build_agent(llm, max_iter=1, tmp_run_dir=tmp_path / "run")
+
+    result = agent.run("Check background work")
+
+    assert result["status"] == "success"
+    first_call_messages = llm.seen_messages[0]
+    assert first_call_messages[-1]["role"] == "user"
+    assert "<background-results>" in first_call_messages[-1]["content"]
+
+
+def test_auto_compact_handoff_summary_is_reintroduced_as_user_message(
+    tmp_path: Path,
+) -> None:
+    """Auto-compact used to append a trailing assistant handoff ack."""
+    llm = _StubLLM()
+    agent = _build_agent(llm, max_iter=1, tmp_run_dir=tmp_path / "run")
+    trace = TraceWriter(tmp_path / "trace")
+    messages = [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": "earlier context"},
+        {"role": "user", "content": "large recent context " + ("x" * 100_000)},
+    ]
+
+    try:
+        agent._auto_compact(messages, tmp_path / "run", trace, iteration=1)
+    finally:
+        trace.close()
+
+    assert messages[-1]["role"] == "user"
+    assert "Continue from the summary above" in messages[-1]["content"]


### PR DESCRIPTION
## Summary

Follow-up to #248. Strengthen the assistant-prefill regression coverage by directly exercising the two AgentLoop handoff paths that used to append assistant-role acknowledgements.

## Changes

- Record messages seen by the stub LLM instead of relying on a class-level counter.
- Add a direct regression for background notification injection, asserting the injected handoff is a user message.
- Add a direct regression for `_auto_compact()` reconstruction, asserting the summary handoff is a user message.
- Accept the current `stream_chat(..., should_cancel=...)` call shape in the test stub.

## Validation

- `python -m pytest agent/tests/test_agent_loop_no_assistant_prefill.py -q`
- `python -m pytest agent/tests/test_agent_loop_no_assistant_prefill.py agent/tests/test_provider_diagnostics.py agent/tests/test_kimi_reasoning_content.py -q`
- `python -m ruff check agent/tests/test_agent_loop_no_assistant_prefill.py`
- `python -m compileall -q agent/tests/test_agent_loop_no_assistant_prefill.py`
- `git diff --check`
