### PR TITLE
[security] fix(live): contain mandate proposal identifiers

### DIFF
--- a/agent/src/live/mandate/commit.py
+++ b/agent/src/live/mandate/commit.py
@@ -30,6 +30,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -46,6 +47,7 @@ DEFAULT_MANDATE_LIFETIME_DAYS = 30
 _MANDATE_FILENAME = "mandate.json"
 _PROPOSALS_DIRNAME = "proposals"
 _CONSENT_DIRNAME = "consent"
+_PROPOSAL_ID_RE = re.compile(r"^mp_[0-9a-f]{32}$")
 
 #: Maps every accepted alias of a clamped limit to its CANONICAL name. The
 #: proposal profile, the ceiling snapshot, and the clamp in
@@ -150,6 +152,19 @@ def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
     os.replace(tmp, path)
 
 
+def _proposal_path(broker: str, proposal_id: str) -> Path:
+    """Return the contained proposal path for a valid opaque proposal id."""
+    if not _PROPOSAL_ID_RE.fullmatch(proposal_id):
+        raise ValueError("proposal_id must be a bare mp_<32 hex> identifier")
+    base = _proposals_dir(broker).resolve()
+    path = (base / f"{proposal_id}.json").resolve()
+    try:
+        path.relative_to(base)
+    except ValueError as exc:  # pragma: no cover - regex is the primary guard
+        raise ValueError("proposal_id escapes the proposals directory") from exc
+    return path
+
+
 # ---------------------------------------------------------------------------
 # PROPOSE state — proposal persistence (read-only; grants no authority)
 # ---------------------------------------------------------------------------
@@ -179,13 +194,17 @@ def save_proposal(proposal: Mapping[str, Any]) -> None:
     broker = str((proposal.get("account") or {}).get("broker") or "").strip()
     if not broker:
         raise ValueError("proposal must carry account.broker")
-    path = _proposals_dir(broker) / f"{proposal_id}.json"
+    path = _proposal_path(broker, proposal_id)
     _atomic_write_json(path, dict(proposal))
 
 
 def _load_proposal(broker: str, proposal_id: str) -> dict[str, Any] | None:
     """Load a persisted proposal, or ``None`` when absent/unreadable."""
-    path = _proposals_dir(broker) / f"{proposal_id}.json"
+    try:
+        path = _proposal_path(broker, proposal_id)
+    except ValueError as exc:
+        logger.warning("proposal %s for %s is invalid: %s", proposal_id, broker, exc)
+        return None
     if not path.is_file():
         return None
     try:
@@ -199,8 +218,8 @@ def _load_proposal(broker: str, proposal_id: str) -> dict[str, Any] | None:
 def _invalidate_proposal(broker: str, proposal_id: str) -> None:
     """Delete a proposal so it can never be committed twice (idempotency)."""
     try:
-        (_proposals_dir(broker) / f"{proposal_id}.json").unlink()
-    except FileNotFoundError:
+        _proposal_path(broker, proposal_id).unlink()
+    except (FileNotFoundError, ValueError):
         pass
 
 

--- a/agent/tests/test_consent_commit.py
+++ b/agent/tests/test_consent_commit.py
@@ -252,7 +252,7 @@ def _save_handcrafted_proposal(
     Lets a test exercise commit-time validation against a profile the clamping
     proposer would never emit (e.g. one that breaches an alias-keyed ceiling).
     """
-    proposal_id = "mp_handcrafted_h9"
+    proposal_id = "mp_" + "9" * 32
     save_proposal(
         {
             "type": "mandate.proposal",

--- a/agent/tests/test_mandate_commit_security.py
+++ b/agent/tests/test_mandate_commit_security.py
@@ -1,0 +1,113 @@
+"""Security regressions for live mandate proposal commit boundaries."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+import src.live.paths as paths
+from src.live.mandate.commit import CommitError, commit_mandate, save_proposal
+
+
+def _proposal(proposal_id: str) -> dict[str, object]:
+    """Return a minimal valid proposal payload for commit_mandate."""
+    return {
+        "proposal_id": proposal_id,
+        "account": {"broker": "robinhood"},
+        "ceilings": {
+            "max_order_notional_usd": 100.0,
+            "max_total_exposure_usd": 500.0,
+            "max_trades_per_day": 2,
+            "leverage": "none",
+        },
+        "profiles": [
+            {
+                "ordinal": 1,
+                "account_funding_usd": 500.0,
+                "max_order_usd": 100.0,
+                "max_total_exposure_usd": 500.0,
+                "daily_trade_cap": 2,
+                "leverage": "none",
+                "instruments": ["equity"],
+                "asset_classes": ["us_equity"],
+                "exclude_symbols": ["GME"],
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def live_runtime(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point live-channel state at a temp runtime root."""
+    monkeypatch.setattr(paths, "get_runtime_root", lambda: tmp_path)
+    return tmp_path
+
+
+def test_commit_mandate_accepts_saved_bare_proposal_id(live_runtime: Path) -> None:
+    """The normal propose -> commit flow still works for opaque proposal ids."""
+    proposal_id = "mp_" + "a" * 32
+    save_proposal(_proposal(proposal_id))
+
+    result = commit_mandate(
+        proposal_id=proposal_id,
+        ordinal=1,
+        adjustments=None,
+        consent_ack=True,
+        broker="robinhood",
+        account_ref="acct-ok",
+    )
+
+    assert result["broker"] == "robinhood"
+    mandate_path = live_runtime / "live" / "robinhood" / "mandate.json"
+    assert mandate_path.is_file()
+    mandate = json.loads(mandate_path.read_text(encoding="utf-8"))
+    assert mandate["consent"]["account_ref"] == "acct-ok"
+
+
+def test_save_proposal_rejects_path_shaped_proposal_id(live_runtime: Path) -> None:
+    """Only generated mp_<hex> ids may be persisted as proposal records."""
+    with pytest.raises(ValueError, match="proposal_id"):
+        save_proposal(_proposal("../outside"))
+
+    assert not (live_runtime / "outside.json").exists()
+
+
+def test_commit_mandate_rejects_proposal_id_traversal_to_external_json(live_runtime: Path) -> None:
+    """A commit must not resolve proposal_id outside the broker proposals dir.
+
+    Before the fix, _load_proposal() joined ``proposal_id`` directly into
+    ``<live>/<broker>/proposals/{proposal_id}.json``. A path-shaped id could
+    escape that directory and load an attacker-controlled JSON file, then write
+    a live mandate from it.
+    """
+    from src.live.paths import broker_dir
+
+    proposals_dir = broker_dir("robinhood") / "proposals"
+    proposals_dir.mkdir(parents=True)
+
+    external = live_runtime / "uploads" / "crafted_proposal.json"
+    external.parent.mkdir(parents=True)
+    marker = "VIBE_TRAVERSAL_PROPOSAL_SHOULD_NOT_COMMIT"
+    payload = _proposal("mp_" + "b" * 32)
+    payload["profiles"][0]["exclude_symbols"] = [marker]  # type: ignore[index]
+    external.write_text(json.dumps(payload), encoding="utf-8")
+
+    # commit_mandate appends ".json", so omit the suffix from the relative path.
+    traversal_id = os.path.relpath(external.with_suffix(""), proposals_dir)
+    assert ".." in Path(traversal_id).parts
+
+    with pytest.raises(CommitError, match="not live"):
+        commit_mandate(
+            proposal_id=traversal_id,
+            ordinal=1,
+            adjustments=None,
+            consent_ack=True,
+            broker="robinhood",
+            account_ref="acct-traversal",
+        )
+
+    mandate_path = broker_dir("robinhood") / "mandate.json"
+    assert not mandate_path.exists()


### PR DESCRIPTION
## Summary
This PR hardens the live-mandate commit boundary so a `proposal_id` is always treated as an opaque generated identifier, not as a filesystem path fragment.

- Fixes a live-trading trust-boundary issue where path-shaped proposal IDs could escape the pending-proposals directory.
- Adds a shared proposal-path helper that validates the expected `mp_<32 hex>` identifier format and verifies resolved-path containment.
- Applies the same guard when saving, loading, and invalidating live-mandate proposals.
- Adds regression coverage for the normal propose-to-commit flow and for traversal-shaped proposal IDs.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Path-shaped live mandate `proposal_id` values could be resolved outside the broker proposals directory | An admitted API caller could cause `commit_mandate()` to read attacker-controlled JSON as a pending live-trading proposal, then write a committed live mandate from it | High / Critical business impact for live-trading deployments |

## Before this PR

- `commit_mandate()` loaded proposals by joining caller-controlled `proposal_id` into `live/<broker>/proposals/{proposal_id}.json`.
- `save_proposal()`, `_load_proposal()`, and `_invalidate_proposal()` each constructed the proposal filename directly.
- A path-shaped ID such as a relative traversal could resolve outside the broker proposals directory before the commit flow parsed the JSON.
- Existing tests covered mandate model loading, but not the proposal-ID storage boundary.

## After this PR

- Proposal IDs must match the generated opaque form: `mp_<32 lowercase hex characters>`.
- Proposal file paths are built through `_proposal_path()`, which resolves the final path and verifies it remains under the broker proposals directory.
- Invalid/path-shaped proposal IDs are rejected or treated as not-live proposals before any external JSON can be committed.
- New regression tests cover both accepted generated IDs and rejected traversal-shaped IDs.

## Why this matters

The live-trading mandate flow relies on a structural trust boundary: only proposals generated by the read-only proposal path should be eligible for user commit. The commit path is the code that turns a proposal into `mandate.json`, so it must not accept filesystem-shaped IDs that can point at arbitrary JSON elsewhere on disk.

Without this boundary, an admitted caller with access to the commit API could bypass the intended pending-proposal store and commit attacker-controlled limits/profile data as a live mandate.

## How this differs from related issue/PR

This is separate from the recent API and loopback hardening work:

- #241 addressed local shutdown authorization.
- #242 addressed rebound loopback `Host` handling.
- #243 addressed explicit opt-in for agent shell tools.
- #245 addressed authorization for settings writes.

This PR fixes a different layer: the live-mandate proposal storage boundary inside the commit state machine. The vulnerable behavior is not a shell-tool, settings-write, shutdown, or Host-header path; it is path resolution for `proposal_id` before a live mandate is written.

## Attack flow

```text
admitted API caller controls proposal_id
    -> POST /mandate/commit passes proposal_id into commit_mandate()
        -> _load_proposal() joins proposal_id into live/<broker>/proposals/{proposal_id}.json
            -> path-shaped ID can resolve to attacker-controlled JSON outside proposals/
                -> commit_mandate() writes live/<broker>/mandate.json from that JSON
```

## Affected code

| Issue | Files |
|-------|-------|
| Live mandate proposal ID path containment | `agent/src/live/mandate/commit.py`, `agent/tests/test_mandate_commit_security.py` |

## Root cause

Issue: live mandate proposal IDs were treated as path fragments.

- The generated proposal IDs are intended to be opaque IDs, but the read/write/delete helpers did not enforce that shape.
- The commit path loaded `proposal_id` by constructing a filename directly from user-controlled input.
- There was no resolved-path containment check under the broker proposals directory before parsing proposal JSON.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Path-shaped live mandate proposal IDs can escape the pending-proposals directory | 8.1 High | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:H` |

Rationale:

- The affected path is network/API reachable in deployments that expose the authenticated API surface.
- Exploitation requires an admitted caller for the live-mandate commit API, so this is not scored as unauthenticated CVSS access.
- Integrity impact is high because the issue can alter the committed live-trading mandate.
- Availability is scored high to reflect live-trading side effects and risk-control disruption from an attacker-controlled mandate profile.
- In live-trading deployments, the business impact can be Critical even though the conservative CVSS score is High.

## Safe reproduction steps

1. Prepare an attacker-controlled proposal-like JSON document outside `live/<broker>/proposals/`.
2. Ensure the normal broker proposals directory exists.
3. On vulnerable code, call `commit_mandate()` / `POST /mandate/commit` with a `proposal_id` that traverses from the proposals directory to that JSON file, omitting the `.json` suffix because the commit code appends it.
4. Observe that the vulnerable commit path reads the external JSON and writes `live/<broker>/mandate.json` from it.
5. On this branch, the same traversal-shaped `proposal_id` is rejected as not live and no mandate file is written.

## Expected vulnerable behavior

On vulnerable code, a path-shaped `proposal_id` could cause the commit path to read proposal JSON outside the pending-proposals directory. If that JSON contained a valid selected profile, the commit would proceed and persist a live mandate from content that did not come from the proposal store.

The regression test uses a safe marker in an external JSON file and asserts that no `mandate.json` is created after the traversal-shaped ID is supplied.

## Changes in this PR

- Adds `_PROPOSAL_ID_RE` for the expected generated proposal ID form.
- Adds `_proposal_path()` to centralize proposal path construction and containment checks.
- Updates `save_proposal()` to reject invalid proposal IDs before writing proposal records.
- Updates `_load_proposal()` to return `None` for invalid/path-shaped IDs so commit requests fail closed as not-live proposals.
- Updates `_invalidate_proposal()` to use the same path helper.
- Adds `agent/tests/test_mandate_commit_security.py` regression coverage.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Live mandate storage hardening | `agent/src/live/mandate/commit.py` | Validates proposal IDs and enforces resolved-path containment for proposal save/load/delete paths |
| Regression tests | `agent/tests/test_mandate_commit_security.py` | Covers normal commit behavior, invalid proposal IDs, and traversal-shaped IDs pointing at external JSON |

## Maintainer impact

- Normal generated proposal IDs from `propose_mandate_profiles` continue to work.
- Path-shaped, absolute, uppercase, malformed, or otherwise non-generated proposal IDs are rejected.
- The patch is limited to live mandate proposal persistence and commit handling.
- Frontend, broker adapters, uploads, and unrelated API routes are not changed.

## Fix rationale

`proposal_id` is an identifier, not a path. Enforcing that invariant at the proposal storage helper is narrower and more durable than trying to sanitize individual call sites independently.

The fix uses two layers:

1. strict identifier-shape validation for generated IDs; and
2. resolved-path containment under the broker proposals directory.

The regression tests lock both the expected success path and the security boundary so future refactors do not accidentally reintroduce direct path joins.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Focused live-mandate proposal security tests
- [x] Existing mandate model tests
- [x] Existing API auth and upload security tests

Executed with:

```bash
python3 -m pytest -q agent/tests/test_mandate_commit_security.py agent/tests/test_mandate_model.py agent/tests/test_security_auth_api.py agent/tests/test_upload_security.py
```

Result:

```text
69 passed, 2 warnings in 0.25s
```

## Disclosure notes

- This PR is intentionally bounded to proposal-ID containment in the live-mandate commit state machine.
- The finding assumes an admitted caller can reach the mandate commit API; it does not claim unauthenticated remote reachability.
- No production broker account or production trading endpoint was used for validation.
- No unrelated files are changed.
