### PR TITLE
[security] fix(memory): validate persistent memory types

### DIFF
--- a/agent/src/memory/persistent.py
+++ b/agent/src/memory/persistent.py
@@ -288,6 +288,10 @@ class PersistentMemory:
         if not stripped_name:
             raise ValueError("memory name must not be empty or whitespace-only")
 
+        if memory_type not in MEMORY_TYPES:
+            allowed = ", ".join(MEMORY_TYPES)
+            raise ValueError(f"memory_type must be one of: {allowed}")
+
         # Preserve non-Latin script characters in the slug — collapsing
         # them all to ``_`` caused two same-length non-Latin names to share a
         # filename and silently overwrite each other (PR #95 + #104).

--- a/agent/src/tools/remember_tool.py
+++ b/agent/src/tools/remember_tool.py
@@ -86,7 +86,10 @@ class RememberTool(BaseTool):
         if not title or not content:
             return json.dumps({"status": "error", "error": "title and content required"})
         memory_type = kwargs.get("memory_type", "project")
-        path = self._memory.add(title, content, memory_type, description=title)
+        try:
+            path = self._memory.add(title, content, memory_type, description=title)
+        except ValueError as exc:
+            return json.dumps({"status": "error", "error": str(exc)})
         return json.dumps({"status": "ok", "message": f"Saved: {title}", "path": str(path)})
 
     def _recall(self, kwargs: dict) -> str:

--- a/agent/tests/test_remember_tool_security.py
+++ b/agent/tests/test_remember_tool_security.py
@@ -1,0 +1,40 @@
+"""Security regressions for RememberTool persistent memory writes."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.memory.persistent import PersistentMemory
+from src.tools.remember_tool import RememberTool
+
+
+def test_remember_rejects_memory_type_path_traversal(tmp_path: Path) -> None:
+    """memory_type must not be able to escape the memory directory."""
+    memory_dir = tmp_path / "memory"
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    tool = RememberTool(PersistentMemory(memory_dir=memory_dir))
+
+    result = json.loads(tool.execute(
+        action="save",
+        title="Traversal Proof",
+        content="SAFE_MARKER",
+        memory_type="../outside/proof",
+    ))
+
+    assert result["status"] == "error"
+    assert "memory_type" in result["error"]
+    assert not (outside_dir / "proof_traversal_proof.md").exists()
+
+
+def test_persistent_memory_rejects_unknown_memory_type(tmp_path: Path) -> None:
+    """The storage layer enforces the documented memory type enum itself."""
+    memory = PersistentMemory(memory_dir=tmp_path / "memory")
+
+    try:
+        memory.add("bad type", "content", "../../outside/proof")
+    except ValueError as exc:
+        assert "memory_type" in str(exc)
+    else:  # pragma: no cover - makes the assertion message clearer on vulnerable code
+        raise AssertionError("PersistentMemory.add() accepted an invalid memory_type")


### PR DESCRIPTION
## Summary

This PR hardens the persistent-memory file boundary by validating the caller-provided memory category before it is used in an on-disk filename.

- Fixes a `memory_type` path traversal in `PersistentMemory.add()`.
- Keeps the existing documented categories: `user`, `feedback`, `project`, and `reference`.
- Adds regression coverage through the real `RememberTool` wrapper and the storage layer.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| `memory_type` path traversal in persistent memory writes | A tool/MCP/agent caller could write controlled Markdown outside the intended memory directory by passing a path-shaped `memory_type`. | Medium |

## Before this PR

- `RememberTool._save()` accepted a caller-provided `memory_type` value and passed it directly to `PersistentMemory.add()`.
- `PersistentMemory.add()` sanitized the title-derived slug, but used `memory_type` directly in `filename = f"{memory_type}_{slug}.md"`.
- A path-shaped category such as `../outside/proof` could escape the configured memory root if the target directory already existed.
- Regression tests covered title/slug hardening, but not containment of the `memory_type` prefix.

## After this PR

- `PersistentMemory.add()` now enforces the documented `MEMORY_TYPES` allowlist before constructing the filename.
- `RememberTool._save()` converts storage validation failures into a normal JSON error response instead of surfacing an internal exception.
- New tests verify that traversal-shaped and unknown memory types are rejected and do not write outside the memory directory.

## Why this matters

Persistent memory is intended to be scoped to the Vibe-Trading memory directory. The tool schema already documents `memory_type` as an enum, but runtime callers should not be able to rely on schema-only validation for a filesystem boundary. Enforcing the category allowlist in the storage layer keeps the invariant true even for direct Python callers, MCP/tool adapters, or future wrappers that bypass JSON-schema validation.

## How this differs from related issue/PR

This is related to the memory hardening work in #112, but covers a different input and failure mode.

- #112 hardened memory body/title behavior: control bytes, write/read truncation, empty names, and colliding slug cases.
- This PR hardens the category prefix used in the filename before the sanitized title slug is appended.
- Both are storage-layer invariants, but the unsafe input here is `memory_type`, not the memory title or body.

## Attack flow

```text
admitted tool/MCP/agent caller controls memory_type
    -> RememberTool._save(..., memory_type="../outside/proof")
        -> PersistentMemory.add() uses memory_type in a filename prefix
            -> path resolves outside the configured memory directory
                -> controlled Markdown/frontmatter file is created or clobbered outside the memory root
```

## Affected code

| Issue | Files |
|-------|-------|
| `memory_type` path traversal | `agent/src/memory/persistent.py`, `agent/src/tools/remember_tool.py`, `agent/tests/test_remember_tool_security.py` |

## Root cause

`memory_type` path traversal:
- The storage layer treated `memory_type` as trusted because the tool schema declared an enum.
- `ToolRegistry.execute()` and direct Python callers dispatch arguments to tool implementations without enforcing that schema at the storage boundary.
- The filename construction used a sanitized slug only for the title, leaving the category prefix able to contain path separators.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| `memory_type` path traversal | 6.5 Medium | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:N` |

Rationale:
- The rating assumes an already-admitted tool/MCP/agent caller can invoke the `remember` tool with crafted arguments.
- The impact is bounded to writable filesystem locations reachable through traversal from the memory directory, with controlled Markdown/frontmatter content and a `.md` suffix.
- This PR does not claim unauthenticated reachability or code execution.

## Safe reproduction steps

1. Configure a temporary memory root with a sibling `outside/` directory.
2. Invoke the real `RememberTool` with:

   ```python
   RememberTool(PersistentMemory(memory_dir=memory_dir)).execute(
       action="save",
       title="Traversal Proof",
       content="SAFE_MARKER",
       memory_type="../outside/proof",
   )
   ```

3. On vulnerable code, the call returns success and creates `outside/proof_traversal_proof.md` outside the memory directory.
4. With this PR, the call returns a JSON error and the outside file is not created.

## Expected vulnerable behavior

On vulnerable code, the safe proof observed:

```text
status= ok
contained=NO
exists= True
content_has_marker= True
outside_files= ['memory/MEMORY.md', 'outside/proof_traversal_proof.md']
```

## Changes in this PR

- Add a storage-layer allowlist check for `memory_type` in `PersistentMemory.add()`.
- Return a structured JSON error from `RememberTool._save()` when storage validation rejects an invalid category.
- Add regression tests for traversal-shaped memory types and unknown categories.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Storage validation | `agent/src/memory/persistent.py` | Enforces `MEMORY_TYPES` before filename construction. |
| Tool error handling | `agent/src/tools/remember_tool.py` | Converts storage `ValueError` into a normal JSON error response. |
| Regression tests | `agent/tests/test_remember_tool_security.py` | Covers real-wrapper traversal rejection and storage-layer enum enforcement. |

## Maintainer impact

- Narrow backend-only change.
- Existing valid memory categories keep working unchanged.
- Invalid categories now fail closed before any file path is constructed.
- No frontend, live trading, broker, provider, or API settings behavior is changed.

## Fix rationale

The storage layer is the right boundary because it is the last component before filesystem writes. Tool schemas are useful for model/tool UX, but the file-writing layer should enforce its own enum before joining caller-controlled values into paths.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Verified the new tests fail on vulnerable code before the fix.
- [x] Focused local regression tests pass.
- [x] Containerized focused regression tests pass.
- [x] Ruff check on touched files passes in container.
- [x] `git diff --check` passes.
- [ ] Full repository test suite was not run; this PR is limited to persistent-memory storage/tool behavior.

Executed with:

```bash
python3 -m pytest -q agent/tests/test_remember_tool_security.py
python3 -m pytest -q agent/tests/test_remember_tool_security.py agent/tests/test_persistent_memory.py
docker run --rm -v "$PWD":/work -w /work python:3.11-slim bash -lc 'python -m pip install -q -e ".[dev]" && python -m pytest -q agent/tests/test_remember_tool_security.py agent/tests/test_persistent_memory.py'
docker run --rm -v "$PWD":/work -w /work python:3.11-slim bash -lc 'python -m pip install -q ruff && ruff check agent/src/memory/persistent.py agent/src/tools/remember_tool.py agent/tests/test_remember_tool_security.py'
git diff --check
```

A broader local shard including MCP/API auth tests was attempted but the local Python environment lacked optional test dependencies such as `fastmcp` and `httpx`, so it did not reach project assertions.

## Disclosure notes

- This PR is intentionally bounded to the persistent-memory filename containment issue.
- It does not claim unauthenticated reachability, live-trading impact, credential exposure, or code execution.
- No real credentials, broker state, live trading flows, or external services were used in validation.
- No unrelated files were changed.
