### PR TITLE
[security] fix(mcp): contain swarm run identifiers

### DIFF
--- a/agent/mcp_server.py
+++ b/agent/mcp_server.py
@@ -1141,7 +1141,10 @@ def get_swarm_status(run_id: str) -> str:
         run_id: The run ID returned by run_swarm.
     """
     store = _get_swarm_store()
-    run = store.load_run(run_id)
+    try:
+        run = store.load_run(run_id)
+    except ValueError as exc:
+        return json.dumps({"status": "error", "error": str(exc)}, ensure_ascii=False)
     if run is None:
         return json.dumps({"status": "error", "error": f"Run {run_id} not found"}, ensure_ascii=False)
     reconciled = store.reconcile_run(run, write=True)
@@ -1165,7 +1168,10 @@ def get_run_result(run_id: str) -> str:
         run_id: The run ID returned by run_swarm.
     """
     store = _get_swarm_store()
-    run = store.load_run(run_id)
+    try:
+        run = store.load_run(run_id)
+    except ValueError as exc:
+        return json.dumps({"status": "error", "error": str(exc)}, ensure_ascii=False)
     if run is None:
         return json.dumps({"status": "error", "error": f"Run {run_id} not found"}, ensure_ascii=False)
     reconciled = store.reconcile_run(run, write=True)
@@ -1249,7 +1255,10 @@ def retry_run(run_id: str) -> str:
     from src.swarm.runtime import SwarmRuntime
 
     store = _get_swarm_store()
-    loaded = store.load_run(run_id)
+    try:
+        loaded = store.load_run(run_id)
+    except ValueError as exc:
+        return json.dumps({"status": "error", "error": str(exc)}, ensure_ascii=False)
     if loaded is None:
         return json.dumps({"status": "error", "error": f"Run {run_id} not found"}, ensure_ascii=False)
 

--- a/agent/src/swarm/store.py
+++ b/agent/src/swarm/store.py
@@ -136,8 +136,21 @@ class SwarmStore:
 
         Returns:
             Path to the run directory.
+
+        Raises:
+            ValueError: If run_id is empty, absolute, or path-shaped.
         """
-        return self.base_dir / run_id
+        candidate = Path(run_id)
+        if (
+            not run_id.strip()
+            or candidate.is_absolute()
+            or len(candidate.parts) != 1
+            or any(part in {"", ".", ".."} for part in candidate.parts)
+            or "/" in run_id
+            or "\\" in run_id
+        ):
+            raise ValueError(f"run_id {run_id!r} must be a bare run directory name")
+        return self.base_dir / candidate.name
 
     def create_run(self, run: SwarmRun) -> Path:
         """Create the directory structure for a new run and write initial state.
@@ -439,7 +452,7 @@ class SwarmStore:
 
     def _reap_stale(self, run: SwarmRun, *, now: datetime) -> SwarmRun:
         """Pure: mark non-terminal tasks failed; derive run status from tasks."""
-        from src.swarm.models import RunStatus, TaskStatus
+        from src.swarm.models import TaskStatus
 
         terminal_task = {TaskStatus.completed, TaskStatus.failed, TaskStatus.cancelled}
         last_event_at = _last_event_timestamp(self.run_dir(run.id) / "events.jsonl")

--- a/agent/tests/test_swarm_retry.py
+++ b/agent/tests/test_swarm_retry.py
@@ -42,6 +42,16 @@ def test_retry_run_missing_returns_error(tmp_path, monkeypatch):
     assert "not found" in payload["error"].lower()
 
 
+def test_retry_run_rejects_path_shaped_run_id(tmp_path, monkeypatch):
+    store = SwarmStore(base_dir=tmp_path)
+    monkeypatch.setattr(mcp_server, "_get_swarm_store", lambda: store)
+
+    payload = json.loads(mcp_server.retry_run("../outside/victim"))
+
+    assert payload["status"] == "error"
+    assert "run_id" in payload["error"]
+
+
 def test_retry_run_refuses_running_run(tmp_path, monkeypatch):
     store = SwarmStore(base_dir=tmp_path)
     run = _make_run("r-running", RunStatus.running)

--- a/agent/tests/test_swarm_status_hydration.py
+++ b/agent/tests/test_swarm_status_hydration.py
@@ -20,9 +20,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from datetime import datetime, timedelta, timezone
-from unittest.mock import patch
-
 import mcp_server
 import src.swarm.runtime as rt
 import src.swarm.store as store_mod
@@ -496,6 +495,35 @@ def test_get_swarm_status_auto_recovers_zombie(tmp_path, monkeypatch):
     assert payload["status"] == "failed", "zombie must auto-finalize on read"
     assert payload["tasks"][0]["status"] == "failed"
     assert store.load_run(run.id).status == RunStatus.failed
+
+
+def test_mcp_run_result_rejects_path_shaped_run_id_without_outside_write(tmp_path, monkeypatch):
+    """MCP result lookups must not treat run_id as a filesystem path.
+
+    HTTP swarm routes already reject traversal-shaped run ids; the MCP status
+    tools need the same invariant because reads can reconcile and write run
+    state back to disk.
+    """
+    base_dir = tmp_path / "runs"
+    outside_dir = tmp_path / "outside" / "victim"
+    base_dir.mkdir()
+    outside_dir.mkdir(parents=True)
+    traversal_id = os.path.relpath(outside_dir, base_dir)
+    store = SwarmStore(base_dir=base_dir)
+    run = _base_run(traversal_id)
+    run.status = RunStatus.running
+    run.tasks[0] = run.tasks[0].model_copy(
+        update={"status": TaskStatus.completed, "summary": "SAFE_MCP_SWARM_MARKER"}
+    )
+    (outside_dir / "run.json").write_text(run.model_dump_json(indent=2), encoding="utf-8")
+    monkeypatch.setattr(mcp_server, "_get_swarm_store", lambda: store)
+
+    payload = json.loads(mcp_server.get_run_result(traversal_id))
+
+    assert payload["status"] == "error"
+    assert "run_id" in payload["error"]
+    assert not (outside_dir / "tasks").exists()
+    assert not (outside_dir / "events.jsonl").exists()
 
 
 def test_run_swarm_emits_keepalive_every_poll(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

This PR hardens the MCP swarm run lookup boundary so caller-provided `run_id` values are treated as opaque run identifiers, not filesystem paths.

- Validates swarm run IDs at the storage boundary before any `run.json`, task, or event path is built.
- Returns structured MCP error payloads for path-shaped run IDs in status, result, and retry tools.
- Adds regression coverage proving a traversal-shaped MCP `run_id` does not reconcile or write state outside the swarm runs directory.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| MCP swarm `run_id` path traversal | An MCP caller could make swarm status/result/retry flows read a crafted `run.json` outside `.swarm/runs` and then persist reconciled swarm files outside the intended run store. | Medium |

## Before this PR

- `get_swarm_status(run_id)`, `get_run_result(run_id)`, and `retry_run(run_id)` accepted raw MCP `run_id` arguments.
- `SwarmStore.run_dir()` joined those values as `base_dir / run_id` without requiring a bare directory name.
- A path-shaped value such as `../outside/victim` could escape `.swarm/runs` if the target contained a parseable `run.json`.
- Because MCP status/result reads reconcile stale or terminal runs with `write=True`, a read-style operation could create or modify `tasks/*.json`, `events.jsonl`, and `run.json` outside the swarm store.

## After this PR

- `SwarmStore.run_dir()` now rejects empty, absolute, slash-containing, backslash-containing, or multi-part run IDs before constructing a path.
- MCP swarm status/result/retry tools convert invalid run IDs into JSON error payloads instead of raising uncaught exceptions or touching disk.
- Regression tests cover the MCP traversal path and verify no outside `tasks/` or `events.jsonl` artifacts are written.

## Why this matters

Swarm run state is intended to live under `.swarm/runs/{run_id}`. The MCP tools are a user-facing control surface for polling and retrying runs, so their `run_id` argument needs the same bare-ID containment invariant as HTTP route parameters.

Without that invariant, a caller with MCP access could cross from an identifier lookup into host filesystem path selection. The impact is bounded to writable locations that contain a parseable swarm `run.json`, but it still breaks the storage boundary and allows out-of-root swarm artifact writes.

## How this differs from related issue/PR

PR #160 added the MCP `retry_run(run_id)` path and HTTP retry coverage, including traversal rejection for the HTTP endpoint. This PR addresses the sibling MCP/storage boundary that remained: the MCP status, result, and retry tools still passed raw `run_id` strings into `SwarmStore`.

The fix is therefore not a duplicate of the HTTP route validation. It enforces the invariant at the storage boundary so every current and future swarm store caller receives the same protection.

## Attack flow

```text
MCP caller supplies path-shaped run_id
    -> MCP swarm status/result/retry tool
        -> SwarmStore.run_dir(base_dir / run_id)
            -> load outside run.json
                -> reconcile_run(..., write=True)
                    -> write tasks/events/run state outside .swarm/runs
```

## Affected code

| Issue | Files |
|-------|-------|
| MCP swarm `run_id` path traversal | `agent/mcp_server.py`, `agent/src/swarm/store.py`, `agent/tests/test_swarm_status_hydration.py`, `agent/tests/test_swarm_retry.py` |

## Root cause

MCP swarm `run_id` path traversal:
- The MCP tools treated a caller-provided run ID as if it were already a safe opaque identifier.
- The storage helper built paths directly from that value, so path validation depended on individual callers instead of the filesystem boundary.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| MCP swarm `run_id` path traversal | 5.4 Medium | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:L` |

Rationale:
- The attacker needs access to the configured MCP tool surface, so privileges are required.
- The issue can cause integrity and availability impact for writable swarm artifact paths outside the intended store.
- No direct confidentiality impact is claimed by this PR.

## Safe reproduction steps

1. Create a temporary swarm runs directory and a separate temporary `outside/victim` directory.
2. Write a parseable `outside/victim/run.json` whose `id` is the relative traversal from the runs directory to `outside/victim`.
3. Call the MCP wrapper `get_run_result(<relative traversal id>)`.
4. On vulnerable code, the call loads the outside run, reconciles it, and writes outside swarm artifacts such as `outside/victim/tasks/task-t1.json` and `outside/victim/events.jsonl`.
5. With this PR, the MCP call returns a structured error and the outside task/event artifacts are not created.

## Expected vulnerable behavior

A safe local proof on vulnerable code showed the MCP result path could leave the run store:

```text
mcp_status= completed
mcp_ready= True
outside_task_written= True
outside_events_written= True
contained= False
```

The new regression test locks the fixed behavior by asserting an error response and confirming the outside `tasks/` and `events.jsonl` paths remain absent.

## Changes in this PR

- Adds bare-run-id validation inside `SwarmStore.run_dir()`.
- Rejects path-shaped, absolute, empty, slash-containing, and backslash-containing run IDs before path construction.
- Handles invalid run IDs in MCP `get_swarm_status`, `get_run_result`, and `retry_run` as structured JSON errors.
- Adds MCP regression tests for traversal-shaped result and retry lookups.
- Removes pre-existing unused imports surfaced by the touched-file lint pass.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Swarm storage | `agent/src/swarm/store.py` | Enforces bare run IDs before joining paths. |
| MCP tools | `agent/mcp_server.py` | Converts invalid run IDs into JSON error responses for status/result/retry tools. |
| Tests | `agent/tests/test_swarm_status_hydration.py`, `agent/tests/test_swarm_retry.py` | Adds traversal regression coverage for MCP result and retry paths. |

## Maintainer impact

- The patch is intentionally narrow and limited to swarm run identifier handling.
- Normal generated run IDs and existing bare run directory names continue to work.
- HTTP, frontend, broker, mandate, and live-trading behavior are not changed.
- The storage-layer guard makes future swarm callers safer even if they forget to add boundary-specific validation.

## Fix rationale

Run IDs are identifiers, not paths. Enforcing that invariant inside `SwarmStore.run_dir()` keeps the filesystem boundary close to the path construction sink and avoids relying on every caller to remember the same validation rule.

The MCP tools still return user-readable JSON errors, preserving the existing tool response shape for missing or invalid runs while preventing any disk access for path-shaped input.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Confirmed the new regression tests fail on vulnerable code before the fix.
- [x] Ran focused swarm/path/auth regression tests locally.
- [x] Ran touched-file Python syntax checks.
- [x] Ran Ruff on touched files.
- [x] Ran focused MCP traversal regression tests in a Docker container.
- [x] Ran `git diff --check`.

Executed with:

- `python3 -m pytest -q agent/tests/test_swarm_status_hydration.py::test_mcp_run_result_rejects_path_shaped_run_id_without_outside_write agent/tests/test_swarm_retry.py::test_retry_run_rejects_path_shaped_run_id`
- `python3 -m pytest -q agent/tests/test_swarm_status_hydration.py agent/tests/test_swarm_retry.py agent/tests/test_path_safety.py agent/tests/test_security_auth_api.py`
- `python3 -m py_compile agent/mcp_server.py agent/src/swarm/store.py`
- `python3 -m ruff check agent/mcp_server.py agent/src/swarm/store.py agent/tests/test_swarm_status_hydration.py agent/tests/test_swarm_retry.py`
- `docker run --rm -v "$PWD":/work -w /work python:3.11-slim bash -lc 'python -m pip install -q pytest fastapi pydantic starlette fastmcp rich uvicorn && python -m pytest -q agent/tests/test_swarm_status_hydration.py::test_mcp_run_result_rejects_path_shaped_run_id_without_outside_write agent/tests/test_swarm_retry.py::test_retry_run_rejects_path_shaped_run_id'`
- `git diff --check`

Local focused suite result:

```text
103 passed, 2 warnings in 6.10s
```

Docker focused regression result:

```text
2 passed, 1 warning in 0.46s
```

## Disclosure notes

- This PR is bounded to MCP swarm run identifier containment.
- It does not claim unauthenticated reachability; the attacker must already be able to call the configured MCP swarm tools.
- It does not claim arbitrary file write without a parseable swarm `run.json` at the traversed target.
- No unrelated files were changed.
