### PR TITLE
feat(autopilot): add goal-hypothesis bridge for Research Autopilot Phase 1

### DIFF
--- a/agent/src/tools/autopilot_tool.py
+++ b/agent/src/tools/autopilot_tool.py
@@ -1,14 +1,13 @@
-"""Research Autopilot Phase 1: goal-hypothesis bridge tool.
+"""Research Autopilot: goal-hypothesis bridge + backtest config generation.
 
-Connects the Hypothesis Registry to the Research Goal runtime so the agent
-can scaffold a full research workflow from a single ``run_research_autopilot``
-call instead of manually creating goals, recalling hypothesis IDs, and
-wiring criteria by hand.
+Phase 1: Connects the Hypothesis Registry to the Research Goal runtime.
+Phase 2: Auto-generates backtest config.json from hypothesis metadata.
 """
 
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
 from src.agent.tools import BaseTool
@@ -142,6 +141,149 @@ class RunResearchAutopilotTool(BaseTool):
                     "goal": snapshot,
                     "hypothesis": hypothesis_summary,
                     "next_step": "Continue the research workflow. Generate backtest code → execute → add_goal_evidence.",
+                }
+            )
+
+        except Exception as exc:
+            return _error(exc)
+
+
+_UNIVERSE_CODES: dict[str, list[str]] = {
+    "csi 300": ["000300.SH"],
+    "csi300": ["000300.SH"],
+    "csi 500": ["000905.SH"],
+    "csi500": ["000905.SH"],
+    "sse 50": ["000016.SH"],
+    "sse50": ["000016.SH"],
+    "szse comp": ["399001.SZ"],
+    "sse comp": ["000001.SH"],
+    "chiNext": ["399006.SZ"],
+    "s&p 500": ["SPY.US"],
+    "sp500": ["SPY.US"],
+    "nasdaq": ["QQQ.US"],
+    "dow jones": ["DIA.US"],
+    "hang seng": ["^HSI.HK"],
+    "nikkei": ["^N225.HK"],
+}
+
+
+def _lookup_codes(universe: str) -> list[str]:
+    key = universe.strip().lower().replace("-", " ").replace("_", " ")
+    return _UNIVERSE_CODES.get(key, [universe])
+
+
+class GenerateBacktestConfigTool(BaseTool):
+    """Generate backtest config.json from a research hypothesis.
+
+    Reads a hypothesis, derives config fields from its universe and
+    data_sources, and writes a ready-to-run config.json to a run directory.
+    The agent should then create signal_engine.py from the signal_definition
+    and call the backtest tool.
+    """
+
+    name = "generate_backtest_config"
+    description = (
+        "Generate a backtest config.json from a saved hypothesis. "
+        "Auto-populates codes from the hypothesis universe and source from "
+        "data_sources. Writes config.json to a run directory. You must still "
+        "create code/signal_engine.py from the signal_definition before calling "
+        "the backtest tool."
+    )
+    is_readonly = False
+    repeatable = True
+    parameters = {
+        "type": "object",
+        "properties": {
+            "hypothesis_id": {
+                "type": "string",
+                "description": "ID of a previously created research hypothesis",
+            },
+            "start_date": {
+                "type": "string",
+                "description": "Backtest start date (YYYY-MM-DD)",
+            },
+            "end_date": {
+                "type": "string",
+                "description": "Backtest end date (YYYY-MM-DD)",
+            },
+            "session_id": {
+                "type": "string",
+                "description": "Current session id (host-injected)",
+            },
+        },
+        "required": ["hypothesis_id", "start_date", "end_date"],
+    }
+
+    def execute(self, **kwargs: Any) -> str:
+        try:
+            hypothesis_id = str(kwargs.get("hypothesis_id", "")).strip()
+            if not hypothesis_id:
+                return json.dumps(
+                    {"status": "error", "error": "hypothesis_id is required"},
+                    ensure_ascii=False,
+                )
+
+            registry = HypothesisRegistry()
+            hypothesis = registry.get(hypothesis_id)
+            if hypothesis is None:
+                return json.dumps(
+                    {
+                        "status": "error",
+                        "error": f"Hypothesis not found: {hypothesis_id}",
+                        "hint": "Use search_hypotheses to list available hypotheses.",
+                    },
+                    ensure_ascii=False,
+                )
+
+            if not hypothesis.universe.strip():
+                return json.dumps(
+                    {
+                        "status": "error",
+                        "error": "Hypothesis has no universe set",
+                        "hint": "Use update_hypothesis to set a universe (e.g. 'CSI 300').",
+                    },
+                    ensure_ascii=False,
+                )
+
+            start_date = str(kwargs.get("start_date", "")).strip()
+            end_date = str(kwargs.get("end_date", "")).strip()
+
+            codes = _lookup_codes(hypothesis.universe)
+            source = (hypothesis.data_sources or ["auto"])[0]
+
+            config = {
+                "codes": codes,
+                "start_date": start_date,
+                "end_date": end_date,
+                "source": source,
+                "interval": "1D",
+            }
+
+            run_dir = Path.home() / ".vibe-trading" / "runs" / f"autopilot_{hypothesis_id[-8:]}"
+            run_dir.mkdir(parents=True, exist_ok=True)
+            (run_dir / "code").mkdir(parents=True, exist_ok=True)
+
+            config_path = run_dir / "config.json"
+            with open(config_path, "w", encoding="utf-8") as f:
+                json.dump(config, f, indent=2, ensure_ascii=False)
+
+            return _ok(
+                {
+                    "run_dir": str(run_dir),
+                    "config": config,
+                    "config_path": str(config_path),
+                    "hypothesis": {
+                        "hypothesis_id": hypothesis.hypothesis_id,
+                        "title": hypothesis.title,
+                        "signal_definition": hypothesis.signal_definition,
+                        "universe": hypothesis.universe,
+                        "data_sources": hypothesis.data_sources,
+                    },
+                    "next_step": (
+                        "Config written. Next: use write_file to create "
+                        "code/signal_engine.py from the signal_definition above, "
+                        "then call backtest(run_dir=...)."
+                    ),
                 }
             )
 

--- a/agent/src/tools/autopilot_tool.py
+++ b/agent/src/tools/autopilot_tool.py
@@ -1,0 +1,149 @@
+"""Research Autopilot Phase 1: goal-hypothesis bridge tool.
+
+Connects the Hypothesis Registry to the Research Goal runtime so the agent
+can scaffold a full research workflow from a single ``run_research_autopilot``
+call instead of manually creating goals, recalling hypothesis IDs, and
+wiring criteria by hand.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from src.agent.tools import BaseTool
+from src.hypotheses import HypothesisRegistry
+
+
+def _ok(payload: dict[str, Any]) -> str:
+    return json.dumps({"status": "ok", **payload}, ensure_ascii=False)
+
+
+def _error(exc: Exception) -> str:
+    return json.dumps({"status": "error", "error": str(exc)}, ensure_ascii=False)
+
+
+_AUTOPILOT_OBJECTIVE_TEMPLATE = """<hypothesis-id>{hypothesis_id}</hypothesis-id>
+<hypothesis-title>{title}</hypothesis-title>
+
+{thesis}
+
+---
+**Autopilot**: This goal was auto-scaffolded from a research hypothesis.
+Continue through the workflow: generate backtest code → execute → evaluate → record evidence."""
+
+
+class RunResearchAutopilotTool(BaseTool):
+    """Start a research workflow from a durable hypothesis.
+
+    Reads a hypothesis from the local registry, creates a research goal
+    with the hypothesis thesis as its objective, and returns the goal
+    snapshot so the agent can continue the backtest → evidence pipeline.
+    """
+
+    name = "run_research_autopilot"
+    description = (
+        "Start a research goal from a saved hypothesis. "
+        "Reads the hypothesis, creates a goal with the thesis as objective "
+        "and backtest-relevant criteria. Returns a goal snapshot you can "
+        "continue from with backtest/evidence tools."
+    )
+    is_readonly = False
+    repeatable = True
+    parameters = {
+        "type": "object",
+        "properties": {
+            "hypothesis_id": {
+                "type": "string",
+                "description": "ID of a previously created research hypothesis",
+            },
+            "session_id": {
+                "type": "string",
+                "description": "Current session id (host-injected)",
+            },
+        },
+        "required": ["hypothesis_id"],
+    }
+
+    def execute(self, **kwargs: Any) -> str:
+        try:
+            hypothesis_id = str(kwargs.get("hypothesis_id", "")).strip()
+            if not hypothesis_id:
+                return json.dumps(
+                    {"status": "error", "error": "hypothesis_id is required"},
+                    ensure_ascii=False,
+                )
+
+            registry = HypothesisRegistry()
+            hypothesis = registry.get(hypothesis_id)
+            if hypothesis is None:
+                return json.dumps(
+                    {
+                        "status": "error",
+                        "error": f"Hypothesis not found: {hypothesis_id}",
+                        "hint": "Use search_hypotheses to list available hypotheses.",
+                    },
+                    ensure_ascii=False,
+                )
+
+            session_id = str(kwargs.get("session_id", "")).strip()
+            if not session_id:
+                return json.dumps(
+                    {
+                        "status": "error",
+                        "error": "session_id is required",
+                        "hint": "Ask the host runtime for the current session id.",
+                    },
+                    ensure_ascii=False,
+                )
+
+            objective = _AUTOPILOT_OBJECTIVE_TEMPLATE.format(
+                hypothesis_id=hypothesis.hypothesis_id,
+                title=hypothesis.title,
+                thesis=hypothesis.thesis,
+            )
+
+            criteria = [
+                "Generate backtest code (signal_engine.py + config.json) from the signal definition",
+                "Execute a deterministic backtest with the configured data sources",
+                "Evaluate backtest metrics against the hypothesis thesis",
+                "Record evidence: link_backtest to hypothesis and add_goal_evidence",
+            ]
+
+            from src.goal import GoalStore
+
+            store = GoalStore()
+
+            goal = store.replace_goal(
+                session_id=session_id,
+                objective=objective,
+                criteria=criteria,
+                ui_summary=f"Research Autopilot: {hypothesis.title}",
+                source="autopilot",
+                protocol="thesis_review",
+            )
+
+            snapshot = store.get_goal_snapshot(goal.goal_id)
+
+            hypothesis_summary = {
+                "hypothesis_id": hypothesis.hypothesis_id,
+                "title": hypothesis.title,
+                "thesis": hypothesis.thesis[:300],
+                "status": hypothesis.status,
+                "universe": hypothesis.universe,
+                "signal_definition": hypothesis.signal_definition[:300],
+                "data_sources": hypothesis.data_sources,
+                "skills": hypothesis.skills,
+                "run_cards_count": len(hypothesis.run_cards),
+            }
+
+            return _ok(
+                {
+                    "goal": snapshot,
+                    "hypothesis": hypothesis_summary,
+                    "next_step": "Continue the research workflow. Generate backtest code → execute → add_goal_evidence.",
+                }
+            )
+
+        except Exception as exc:
+            return _error(exc)

--- a/agent/src/tools/autopilot_tool.py
+++ b/agent/src/tools/autopilot_tool.py
@@ -6,7 +6,9 @@ Phase 2: Auto-generates backtest config.json from hypothesis metadata.
 
 from __future__ import annotations
 
+import hashlib
 import json
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -20,6 +22,14 @@ def _ok(payload: dict[str, Any]) -> str:
 
 def _error(exc: Exception) -> str:
     return json.dumps({"status": "error", "error": str(exc)}, ensure_ascii=False)
+
+
+def _get_hypothesis(hypothesis_id: str):
+    """Return a hypothesis by id, or None when absent."""
+    for hypothesis in HypothesisRegistry().list():
+        if hypothesis.hypothesis_id == hypothesis_id:
+            return hypothesis
+    return None
 
 
 _AUTOPILOT_OBJECTIVE_TEMPLATE = """<hypothesis-id>{hypothesis_id}</hypothesis-id>
@@ -73,8 +83,7 @@ class RunResearchAutopilotTool(BaseTool):
                     ensure_ascii=False,
                 )
 
-            registry = HypothesisRegistry()
-            hypothesis = registry.get(hypothesis_id)
+            hypothesis = _get_hypothesis(hypothesis_id)
             if hypothesis is None:
                 return json.dumps(
                     {
@@ -157,7 +166,8 @@ _UNIVERSE_CODES: dict[str, list[str]] = {
     "sse50": ["000016.SH"],
     "szse comp": ["399001.SZ"],
     "sse comp": ["000001.SH"],
-    "chiNext": ["399006.SZ"],
+    "chinext": ["399006.SZ"],
+    "chi next": ["399006.SZ"],
     "s&p 500": ["SPY.US"],
     "sp500": ["SPY.US"],
     "nasdaq": ["QQQ.US"],
@@ -170,6 +180,26 @@ _UNIVERSE_CODES: dict[str, list[str]] = {
 def _lookup_codes(universe: str) -> list[str]:
     key = universe.strip().lower().replace("-", " ").replace("_", " ")
     return _UNIVERSE_CODES.get(key, [universe])
+
+
+def _validate_backtest_dates(start_date: str, end_date: str) -> None:
+    """Validate backtest dates before writing any run artifacts."""
+    try:
+        start = datetime.strptime(start_date, "%Y-%m-%d").date()
+    except ValueError as exc:
+        raise ValueError("start_date must be YYYY-MM-DD") from exc
+    try:
+        end = datetime.strptime(end_date, "%Y-%m-%d").date()
+    except ValueError as exc:
+        raise ValueError("end_date must be YYYY-MM-DD") from exc
+    if start > end:
+        raise ValueError("start_date must be on or before end_date")
+
+
+def _run_dir_for_hypothesis(hypothesis_id: str) -> Path:
+    """Return a path-contained run directory for any persisted hypothesis id."""
+    suffix = hashlib.sha256(hypothesis_id.encode("utf-8")).hexdigest()[:12]
+    return Path.home() / ".vibe-trading" / "runs" / f"autopilot_{suffix}"
 
 
 class GenerateBacktestConfigTool(BaseTool):
@@ -223,8 +253,7 @@ class GenerateBacktestConfigTool(BaseTool):
                     ensure_ascii=False,
                 )
 
-            registry = HypothesisRegistry()
-            hypothesis = registry.get(hypothesis_id)
+            hypothesis = _get_hypothesis(hypothesis_id)
             if hypothesis is None:
                 return json.dumps(
                     {
@@ -247,6 +276,7 @@ class GenerateBacktestConfigTool(BaseTool):
 
             start_date = str(kwargs.get("start_date", "")).strip()
             end_date = str(kwargs.get("end_date", "")).strip()
+            _validate_backtest_dates(start_date, end_date)
 
             codes = _lookup_codes(hypothesis.universe)
             source = (hypothesis.data_sources or ["auto"])[0]
@@ -259,7 +289,7 @@ class GenerateBacktestConfigTool(BaseTool):
                 "interval": "1D",
             }
 
-            run_dir = Path.home() / ".vibe-trading" / "runs" / f"autopilot_{hypothesis_id[-8:]}"
+            run_dir = _run_dir_for_hypothesis(hypothesis_id)
             run_dir.mkdir(parents=True, exist_ok=True)
             (run_dir / "code").mkdir(parents=True, exist_ok=True)
 

--- a/agent/tests/test_autopilot_tool.py
+++ b/agent/tests/test_autopilot_tool.py
@@ -1,0 +1,75 @@
+"""Tests for Research Autopilot bridge tools."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.hypotheses import HypothesisRegistry
+from src.tools.autopilot_tool import GenerateBacktestConfigTool, _lookup_codes
+
+
+def _seed_hypothesis(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, universe: str):
+    """Create a persisted hypothesis in an isolated registry."""
+    monkeypatch.setenv("VIBE_TRADING_HYPOTHESES_PATH", str(tmp_path / "hypotheses.json"))
+    return HypothesisRegistry().create(
+        title="Momentum in target universe",
+        thesis="A momentum signal should outperform over the test window.",
+        universe=universe,
+        signal_definition="Rank by trailing returns and buy the leaders.",
+        data_sources=["local"],
+    )
+
+
+def test_lookup_codes_matches_chinext_case_insensitively() -> None:
+    """Universe lookup should use the same normalized casing as input handling."""
+    assert _lookup_codes("chiNext") == ["399006.SZ"]
+    assert _lookup_codes("Chi-Next") == ["399006.SZ"]
+
+
+def test_generate_backtest_config_writes_safe_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The tool should write a config with mapped codes under the run root."""
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    hypothesis = _seed_hypothesis(tmp_path, monkeypatch, universe="chiNext")
+
+    payload = json.loads(
+        GenerateBacktestConfigTool().execute(
+            hypothesis_id=hypothesis.hypothesis_id,
+            start_date="2026-01-01",
+            end_date="2026-01-31",
+        )
+    )
+
+    assert payload["status"] == "ok"
+    assert payload["config"]["codes"] == ["399006.SZ"]
+    assert payload["config"]["source"] == "local"
+    run_dir = Path(payload["run_dir"])
+    assert run_dir.parent == tmp_path / ".vibe-trading" / "runs"
+    assert run_dir.name.startswith("autopilot_")
+    assert (run_dir / "code").is_dir()
+    config = json.loads((run_dir / "config.json").read_text(encoding="utf-8"))
+    assert config["start_date"] == "2026-01-01"
+
+
+def test_generate_backtest_config_rejects_invalid_date_before_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Invalid date ranges must fail before run artifacts are created."""
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    hypothesis = _seed_hypothesis(tmp_path, monkeypatch, universe="CSI 300")
+
+    payload = json.loads(
+        GenerateBacktestConfigTool().execute(
+            hypothesis_id=hypothesis.hypothesis_id,
+            start_date="2026-02-01",
+            end_date="2026-01-01",
+        )
+    )
+
+    assert payload["status"] == "error"
+    assert "start_date" in payload["error"]
+    assert not (tmp_path / ".vibe-trading" / "runs").exists()


### PR DESCRIPTION
## Summary

Research Autopilot Phase 1: a goal-hypothesis bridge tool that connects
the Hypothesis Registry to the Research Goal runtime.

## What it does

New `run_research_autopilot` agent tool:
1. Given a `hypothesis_id`, reads the hypothesis from the registry
2. Creates a research goal with the thesis as objective + backtest criteria
3. Returns goal snapshot + hypothesis context + next-step hints

The agent continues from there with existing tools (backtest, add_goal_evidence).

## Changes

- New: `agent/src/tools/autopilot_tool.py` (149 lines)
  - `RunResearchAutopilotTool` extends `BaseTool`
  - Auto-discovered by `BaseTool.__subclasses__()`, no manual registration

## Test Plan

- [x] `ruff check` — clean
- [x] `pytest agent/tests/ -k "hypothesis or goal" -q` — 71 passed
- [x] Full suite (excluding e2e) — 3231 passed, 1 skipped