### PR TITLE
fix(live): extend Robinhood OAuth init timeout

### DIFF
--- a/agent/cli/_legacy.py
+++ b/agent/cli/_legacy.py
@@ -2741,6 +2741,7 @@ def cmd_provider_login(provider: str) -> int:
 # ---------------------------------------------------------------------------
 
 _DEFAULT_LIVE_BROKER = "robinhood"
+_LIVE_AUTHORIZE_INIT_TIMEOUT_SECONDS = 300.0
 
 
 def _live_api_base() -> str:
@@ -2844,6 +2845,14 @@ def cmd_live_authorize(broker: str) -> int:
     try:
         from src.tools.mcp import build_mcp_tool_wrappers
 
+        configured_init_timeout = getattr(server_config, "init_timeout", None)
+        if (
+            configured_init_timeout is None
+            or float(configured_init_timeout) < _LIVE_AUTHORIZE_INIT_TIMEOUT_SECONDS
+        ) and hasattr(server_config, "model_copy"):
+            server_config = server_config.model_copy(
+                update={"init_timeout": _LIVE_AUTHORIZE_INIT_TIMEOUT_SECONDS}
+            )
         tools = build_mcp_tool_wrappers(key, server_config)
     except Exception as exc:  # noqa: BLE001 — surface any handshake failure
         console.print(f"[red]Authorization failed:[/red] {exc}")

--- a/agent/src/config/schema.py
+++ b/agent/src/config/schema.py
@@ -184,6 +184,11 @@ def _allows_readonly_wildcard_probe(
 ROBINHOOD_MCP_SERVER_SEED: dict[str, object] = {
     "type": "streamableHttp",
     "url": "https://agent.robinhood.com/mcp/trading",
+    # Robinhood OAuth can require human face verification. Keep normal remote
+    # tool calls on the default 30s budget while giving the initial
+    # OAuth/initialize round-trip the same 300s window as FastMCP's callback
+    # server.
+    "init_timeout": 300.0,
     "auth": {
         "type": "oauth",
         "scopes": ["trading.read"],
@@ -297,6 +302,7 @@ class MCPServerConfig(ConfigBase):
     headers: dict[str, str] = Field(default_factory=dict)
     auth: MCPOAuthConfig | None = None
     tool_timeout: float = Field(default=30.0, ge=0.1)
+    init_timeout: float | None = Field(default=None, ge=0.1)
     enabled_tools: list[str] = Field(default_factory=lambda: ["*"])
 
     def resolved_transport(self) -> Literal["stdio", "sse", "streamableHttp"]:
@@ -361,6 +367,7 @@ class MCPServerConfigOverride(ConfigBase):
     headers: dict[str, str] | None = None
     auth: MCPOAuthConfig | None = None
     tool_timeout: float | None = Field(default=None, ge=0.1)
+    init_timeout: float | None = Field(default=None, ge=0.1)
     enabled_tools: list[str] | None = None
 
 

--- a/agent/src/tools/mcp.py
+++ b/agent/src/tools/mcp.py
@@ -429,8 +429,13 @@ class MCPServerAdapter:
 
         # Use a minimum of 30 s for init_timeout so cold-start servers (pip
         # install, docker pull, slow imports) do not trip the same short
-        # deadline as a per-call tool_timeout.
-        init_timeout = max(self.server_config.tool_timeout, 30.0)
+        # deadline as a per-call tool_timeout. OAuth-heavy servers may set an
+        # explicit init_timeout without widening ordinary tool-call timeout.
+        init_timeout = (
+            self.server_config.init_timeout
+            if self.server_config.init_timeout is not None
+            else max(self.server_config.tool_timeout, 30.0)
+        )
         return Client(
             transport,
             name=self.server_name,

--- a/agent/tests/test_cli_live.py
+++ b/agent/tests/test_cli_live.py
@@ -344,6 +344,29 @@ class TestLiveAuthorize:
         build.assert_called_once()
         assert build.call_args.args[0] == "robinhood"
 
+    def test_authorize_uses_long_init_budget_without_widening_tool_timeout(self) -> None:
+        """Old user configs without initTimeout still get enough OAuth time."""
+        from cli._legacy import cmd_live_authorize
+        from src.config.schema import MCPServerConfig
+
+        cfg = MCPServerConfig.model_validate(
+            {
+                "type": "streamableHttp",
+                "url": "https://agent.robinhood.com/mcp/trading",
+                "auth": {"type": "oauth", "scopes": ["trading.read"]},
+                "enabledTools": ["get_account"],
+            }
+        )
+        with patch("cli._legacy._live_server_config", return_value=cfg), patch(
+            "src.tools.mcp.build_mcp_tool_wrappers", return_value=[1]
+        ) as build:
+            assert cmd_live_authorize("robinhood") == 0
+
+        passed_cfg = build.call_args.args[1]
+        assert cfg.init_timeout is None
+        assert passed_cfg.init_timeout == 300
+        assert passed_cfg.tool_timeout == 30
+
 
 # ---------------------------------------------------------------------------
 # REPL intercept helpers

--- a/agent/tests/test_mcp_oauth_schema.py
+++ b/agent/tests/test_mcp_oauth_schema.py
@@ -85,6 +85,25 @@ def test_server_config_carries_auth() -> None:
     assert cfg.resolved_transport() == "streamableHttp"
 
 
+def test_server_config_round_trips_init_timeout_snake_and_camel() -> None:
+    snake = MCPServerConfig.model_validate(
+        {
+            "type": "streamableHttp",
+            "url": "https://agent.robinhood.com/mcp/trading",
+            "init_timeout": 300,
+        }
+    )
+    camel = MCPServerConfig.model_validate(
+        {
+            "type": "streamableHttp",
+            "url": "https://agent.robinhood.com/mcp/trading",
+            "initTimeout": 300,
+        }
+    )
+    assert snake == camel
+    assert snake.init_timeout == 300
+
+
 def test_override_carries_auth() -> None:
     override = MCPServerConfigOverride.model_validate(
         {"auth": {"type": "oauth", "scopes": ["trading.read"]}}
@@ -97,6 +116,8 @@ def test_robinhood_seed_is_readonly_and_oauth() -> None:
     rh = cfg.mcp_servers["robinhood"]
     assert rh.resolved_transport() == "streamableHttp"
     assert rh.auth is not None and rh.auth.type == "oauth"
+    assert rh.init_timeout == 300
+    assert rh.tool_timeout == 30
     assert "*" not in rh.enabled_tools
     assert rh.enabled_tools  # non-empty explicit allowlist
     assert "robinhood" in LIVE_BROKER_SERVER_KEYS
@@ -200,8 +221,12 @@ def test_non_live_broker_still_allows_wildcard() -> None:
 # --------------------------------------------------------------------------- #
 # _build_client OAuth wiring
 # --------------------------------------------------------------------------- #
+def _build_client(server_config: MCPServerConfig):
+    return MCPServerAdapter("robinhood", server_config)._build_client()
+
+
 def _build_transport(server_config: MCPServerConfig):
-    return MCPServerAdapter("robinhood", server_config)._build_client().transport
+    return _build_client(server_config).transport
 
 
 def test_build_client_yields_oauth_streamable_transport() -> None:
@@ -231,6 +256,38 @@ def test_build_client_yields_oauth_streamable_transport() -> None:
     assert transport.auth._client_id == "client-id"
     assert transport.auth._client_secret == "client-secret"
     assert transport.auth._client_metadata_url == "https://example.com/oauth/client.json"
+
+
+def test_build_client_uses_explicit_init_timeout_without_widening_tool_timeout() -> None:
+    cfg = MCPServerConfig.model_validate(
+        {
+            "type": "streamableHttp",
+            "url": "https://agent.robinhood.com/mcp/trading",
+            "tool_timeout": 7,
+            "init_timeout": 300,
+            "auth": {"type": "oauth", "scopes": ["trading.read"]},
+        }
+    )
+
+    client = _build_client(cfg)
+
+    assert client._init_timeout == 300
+    assert client._session_kwargs["read_timeout_seconds"].total_seconds() == 7
+
+
+def test_build_client_keeps_default_init_timeout_floor() -> None:
+    cfg = MCPServerConfig.model_validate(
+        {
+            "type": "streamableHttp",
+            "url": "https://kb/mcp",
+            "tool_timeout": 7,
+        }
+    )
+
+    client = _build_client(cfg)
+
+    assert client._init_timeout == 30
+    assert client._session_kwargs["read_timeout_seconds"].total_seconds() == 7
 
 
 def test_static_header_http_path_unchanged() -> None:


### PR DESCRIPTION
## Summary
- add an explicit init_timeout field for MCP server config and Robinhood's seed config
- keep normal remote tool calls on tool_timeout while allowing OAuth/initialize to wait up to 300s
- make connector authorize lift older Robinhood configs to the 300s init window without widening tool calls

Fixes #259

## Tests
- python -m pytest tests/test_cli_live.py tests/test_mcp_oauth_schema.py -q