### PR TITLE
chore: finish proposal_id hardening + document MCP initTimeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -967,6 +967,7 @@ No IBKR order-placement tool is registered.
 | `url` | string | required for `sse` / `streamableHttp` | Remote SSE / streamable HTTP endpoint URL. Not used for stdio servers. |
 | `headers` | object | `{}` | Extra HTTP headers for `sse` / `streamableHttp` servers only. |
 | `toolTimeout` | number | `30` | Per-tool call timeout in seconds |
+| `initTimeout` | number | unset (`max(toolTimeout, 30)`) | MCP initialize / OAuth authorization timeout in seconds. Use this for slow browser authorization without widening ordinary tool calls. |
 | `enabledTools` | array | `["*"]` | Tool allowlist. Use `["*"]` to expose all tools from the server |
 
 Config file location: `~/.vibe-trading/agent.json` (JSON or YAML).

--- a/agent/api_server.py
+++ b/agent/api_server.py
@@ -354,7 +354,7 @@ class CommitMandateRequest(BaseModel):
     """
 
     broker: str = Field(..., min_length=1, max_length=64)
-    proposal_id: str = Field(..., min_length=1, max_length=128)
+    proposal_id: str = Field(..., pattern=r"^mp_[0-9a-f]{32}$")
     selected_ordinal: int = Field(..., ge=1, le=10)
     adjustments: Optional[Dict[str, Any]] = None
     consent_ack: bool = Field(..., description="Explicit affirmative; must be true")
@@ -2528,7 +2528,7 @@ def _emit_live_event(session_id: Optional[str], event_type: str, data: Dict[str,
 # ``mandate.proposal`` frame. No protected touch.
 
 _PROPOSAL_TOOL_NAME = "propose_mandate_profiles"
-_PROPOSAL_ID_RE = re.compile(r'"proposal_id"\s*:\s*"(mp_[0-9a-zA-Z]+)"')
+_PROPOSAL_ID_RE = re.compile(r'"proposal_id"\s*:\s*"(mp_[0-9a-f]{32})"')
 
 
 def _load_full_proposal(proposal_id: str) -> Optional[Dict[str, Any]]:

--- a/agent/cli/_legacy.py
+++ b/agent/cli/_legacy.py
@@ -863,7 +863,7 @@ def _format_tool_result_preview(tool: str, status: str, preview: str) -> str:
 # protected ``loop.py``.
 
 _PROPOSAL_TOOL_NAME = "propose_mandate_profiles"
-_PROPOSAL_ID_RE = re.compile(r'"proposal_id"\s*:\s*"(mp_[0-9a-zA-Z]+)"')
+_PROPOSAL_ID_RE = re.compile(r'"proposal_id"\s*:\s*"(mp_[0-9a-f]{32})"')
 
 
 def _load_full_proposal(proposal_id: str) -> Optional[Dict[str, Any]]:

--- a/agent/src/config/loader.py
+++ b/agent/src/config/loader.py
@@ -319,6 +319,7 @@ def _default_mcp_server_payload(base: dict[str, Any]) -> dict[str, Any]:
         "url": "",
         "headers": {},
         "tool_timeout": base.get("tool_timeout", 30.0),
+        "init_timeout": base.get("init_timeout"),
         "enabled_tools": list(enabled_tools) if isinstance(enabled_tools, list) else ["*"],
     }
 

--- a/agent/tests/test_api_live_runtime.py
+++ b/agent/tests/test_api_live_runtime.py
@@ -261,7 +261,7 @@ def _seed_proposal(tmp_path: Path, proposal_id: str, broker: str = "robinhood") 
 
 def test_c1_relay_builds_mandate_proposal_frame(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path), raising=False)
-    proposal_id = "mp_01ABCdef"
+    proposal_id = "mp_" + "1" * 32
     _seed_proposal(tmp_path, proposal_id)
 
     event = SimpleNamespace(
@@ -306,7 +306,7 @@ def test_c1_relay_returns_none_when_proposal_missing(tmp_path: Path, monkeypatch
         data={
             "tool": "propose_mandate_profiles",
             "status": "ok",
-            "preview": json.dumps({"proposal_id": "mp_missing01"})[:200],
+            "preview": json.dumps({"proposal_id": "mp_" + "2" * 32})[:200],
         },
     )
     assert api_server._mandate_proposal_frame_from_tool_result(event) is None

--- a/agent/tests/test_cli_live.py
+++ b/agent/tests/test_cli_live.py
@@ -403,7 +403,7 @@ class TestNumericPick:
 
 def _proposal() -> Dict[str, Any]:
     return {
-        "proposal_id": "mp_test",
+        "proposal_id": "mp_" + "3" * 32,
         "session_id": "sess_1",
         "intent_normalized": "aggressive tech, ~$5000",
         "account": {"broker": "robinhood", "type": "cash"},
@@ -427,7 +427,7 @@ class TestProposalPickIntercept:
         commit.assert_called_once()
         # The commit binds the exact rendered proposal + the picked ordinal.
         called_proposal, called_ordinal = commit.call_args.args
-        assert called_proposal["proposal_id"] == "mp_test"
+        assert called_proposal["proposal_id"] == "mp_" + "3" * 32
         assert called_ordinal == 2
         # Successful commit clears the pending proposal.
         assert ctx.pending_proposal is None
@@ -487,7 +487,7 @@ class TestProposalPickIntercept:
         assert result["mandate_id"] == "m1"
         assert captured["url"].endswith("/mandate/commit")
         assert captured["body"]["selected_ordinal"] == 2
-        assert captured["body"]["proposal_id"] == "mp_test"
+        assert captured["body"]["proposal_id"] == "mp_" + "3" * 32
         assert captured["body"]["consent_ack"] is True
 
 
@@ -581,7 +581,7 @@ class TestProposalArmingRelay:
         directly). Drives the event THROUGH the real ``on_event`` relay and
         asserts the full proposal is reloaded from disk into the sink.
         """
-        proposal_id = "mp_armtest01"
+        proposal_id = "mp_" + "4" * 32
         _write_proposal_to_disk(live_root, proposal_id)
 
         captured: Dict[str, Any] = {}
@@ -616,7 +616,7 @@ class TestProposalArmingRelay:
         ``_handle_proposal_reply`` and routed to the commit endpoint, NOT the
         agent.
         """
-        proposal_id = "mp_e2e01"
+        proposal_id = "mp_" + "5" * 32
         _write_proposal_to_disk(live_root, proposal_id)
 
         # 1) Arm through the real relay.

--- a/agent/tests/test_mandate_commit_security.py
+++ b/agent/tests/test_mandate_commit_security.py
@@ -11,6 +11,8 @@ import pytest
 import src.live.paths as paths
 from src.live.mandate.commit import CommitError, commit_mandate, save_proposal
 
+pytestmark = pytest.mark.unit
+
 
 def _proposal(proposal_id: str) -> dict[str, object]:
     """Return a minimal valid proposal payload for commit_mandate."""


### PR DESCRIPTION
Finishes work the 2026-06-18 self-merged batch left half-applied (found while auditing that batch).

## What & why
- **proposal_id hardening (consistency fix).** #256 tightened `mandate/commit.py` to enforce the strict `^mp_[0-9a-f]{32}$` proposal-id format, but the relay/preview parsers in `api_server.py` and `cli/_legacy.py` were left on the loose `mp_[0-9a-zA-Z]+`. This aligns them so the relay and the commit gate agree on the format. (Not exploitable on its own — the loose regex already excludes path separators and `commit.py` backstops — but it was an inconsistent half-change.)
- **Document MCP `initTimeout`.** The key shipped in #263 (schema + `mcp.py` + CLI) but was undocumented; add the README config-table row and wire its base-default passthrough in `config/loader.py`.
- **Test marker.** Add the registered `pytest.mark.unit` marker to `test_mandate_commit_security.py` (used by 13 other test files; the merged copy was missing it).

## Test plan
- [x] `pytest tests/test_api_live_runtime.py tests/test_cli_live.py tests/test_mandate_commit_security.py tests/test_consent_commit.py tests/test_mcp_oauth_schema.py` → 125 passed
- [x] `git grep mp_\[0-9a-zA-Z\]\+` → no loose proposal-id regex remains anywhere