### PR TITLE
Add Taiwan market integration foundationFeature/taiwan market integration

### DIFF
--- a/agent/backtest/engines/_market_hooks.py
+++ b/agent/backtest/engines/_market_hooks.py
@@ -23,6 +23,9 @@ from backtest.models import Position
 # ── Symbol -> market classification (shared by runner.py + composite.py) ──
 
 _MARKET_PATTERNS = [
+    (re.compile(r"^TXO\w*\.TAIFEX$", re.I), "tw_options"),
+    (re.compile(r"^(TXF|MXF|TE|TF|GBF|XIF|MTX)\w*\.TAIFEX$", re.I), "tw_futures"),
+    (re.compile(r"^\d{4,6}\.(TW|TWO)$", re.I), "tw_stock"),
     (re.compile(r"^\d{6}\.(SZ|SH|BJ)$", re.I), "a_share"),
     (re.compile(r"^(51|15|56)\d{4}\.(SZ|SH)$", re.I), "a_share"),
     (re.compile(r"^[A-Z]+\.US$", re.I), "us_equity"),
@@ -51,14 +54,59 @@ _CHINA_EXCHANGES = {"CFFEX", "SHFE", "DCE", "ZCE", "INE", "GFEX"}
 # before lookup so callers can pass any case (``RB2410`` and ``rb2410``
 # both resolve correctly).
 _CN_FUTURES_PRODUCTS = {
-    "if", "ic", "ih", "im", "t", "tf", "ts", "tl",
-    "au", "ag", "cu", "al", "zn", "pb", "ni", "sn", "ss",
-    "rb", "hc", "i", "j", "jm",
-    "sc", "fu", "lu", "bu", "nr",
-    "c", "cs", "m", "y", "a", "p", "jd", "lh",
-    "cf", "sr", "ta", "ma", "ap", "rm", "oi",
-    "pp", "l", "v", "eg", "eb", "pf", "sa", "fg", "ur",
-    "si", "lc",
+    "if",
+    "ic",
+    "ih",
+    "im",
+    "t",
+    "tf",
+    "ts",
+    "tl",
+    "au",
+    "ag",
+    "cu",
+    "al",
+    "zn",
+    "pb",
+    "ni",
+    "sn",
+    "ss",
+    "rb",
+    "hc",
+    "i",
+    "j",
+    "jm",
+    "sc",
+    "fu",
+    "lu",
+    "bu",
+    "nr",
+    "c",
+    "cs",
+    "m",
+    "y",
+    "a",
+    "p",
+    "jd",
+    "lh",
+    "cf",
+    "sr",
+    "ta",
+    "ma",
+    "ap",
+    "rm",
+    "oi",
+    "pp",
+    "l",
+    "v",
+    "eg",
+    "eb",
+    "pf",
+    "sa",
+    "fg",
+    "ur",
+    "si",
+    "lc",
 }
 
 
@@ -109,6 +157,10 @@ def _is_china_futures(code: str) -> bool:
     return False
 
 
+def _is_taiwan_futures(symbol: str) -> bool:
+    return bool(re.match(r"^(TXF|MXF|TE|TF|GBF|XIF|MTX)\w*\.TAIFEX$", symbol, re.I))
+
+
 def _detect_submarket(codes: List[str]) -> str:
     """Detect US vs HK from symbol suffixes.
 
@@ -122,6 +174,7 @@ def _detect_submarket(codes: List[str]) -> str:
         if code.upper().endswith(".HK"):
             return "hk"
     return "us"
+
 
 # ── Crypto: OKX tiered maintenance margin table (simplified) ──
 
@@ -228,12 +281,22 @@ def check_crypto_liquidation(
 # ── Forex: swap tables ──
 
 _SWAP_LONG: dict[str, float] = {
-    "EUR/USD": -6.5, "GBP/USD": -3.0, "USD/JPY": 8.0, "USD/CHF": 4.0,
-    "AUD/USD": -2.0, "USD/CAD": 2.0, "NZD/USD": -1.5,
+    "EUR/USD": -6.5,
+    "GBP/USD": -3.0,
+    "USD/JPY": 8.0,
+    "USD/CHF": 4.0,
+    "AUD/USD": -2.0,
+    "USD/CAD": 2.0,
+    "NZD/USD": -1.5,
 }
 _SWAP_SHORT: dict[str, float] = {
-    "EUR/USD": 3.5, "GBP/USD": -1.0, "USD/JPY": -12.0, "USD/CHF": -8.0,
-    "AUD/USD": -1.0, "USD/CAD": -5.0, "NZD/USD": -2.0,
+    "EUR/USD": 3.5,
+    "GBP/USD": -1.0,
+    "USD/JPY": -12.0,
+    "USD/CHF": -8.0,
+    "AUD/USD": -1.0,
+    "USD/CAD": -5.0,
+    "NZD/USD": -2.0,
 }
 
 

--- a/agent/backtest/engines/composite.py
+++ b/agent/backtest/engines/composite.py
@@ -37,6 +37,9 @@ def _build_rule_engines(config: dict, codes: List[str]) -> Dict[str, BaseEngine]
         elif market == "hk_equity":
             from backtest.engines.global_equity import GlobalEquityEngine
             engines["hk_equity"] = GlobalEquityEngine(config, market="hk")
+        elif market == "tw_stock":
+            from backtest.engines.taiwan_stock import TaiwanStockEngine
+            engines["tw_stock"] = TaiwanStockEngine(config)
         elif market == "crypto":
             from backtest.engines.crypto import CryptoEngine
             engines["crypto"] = CryptoEngine(config)

--- a/agent/backtest/engines/taiwan_futures.py
+++ b/agent/backtest/engines/taiwan_futures.py
@@ -1,0 +1,129 @@
+"""Taiwan futures backtest engine."""
+
+from __future__ import annotations
+
+import re
+from typing import Final
+
+import pandas as pd
+
+from backtest.engines.futures_base import FuturesBaseEngine
+
+CONTRACTS: Final[dict[str, dict[str, float]]] = {
+    "TXF": {"multiplier": 200, "margin_rate": 0.12},
+    "MXF": {"multiplier": 50, "margin_rate": 0.12},
+    "TE": {"multiplier": 4000, "margin_rate": 0.10},
+    "TF": {"multiplier": 1000, "margin_rate": 0.10},
+    "GBF": {"multiplier": 200000, "margin_rate": 0.03},
+}
+DEFAULT_MARGIN_RATE: Final[float] = 0.10
+DEFAULT_MULTIPLIER: Final[float] = 1.0
+DEFAULT_COMMISSION_PER_CONTRACT: Final[float] = 50.0
+DEFAULT_PRICE_LIMIT: Final[float] = 0.10
+DEFAULT_SLIPPAGE: Final[float] = 0.0005
+
+
+def _extract_product(symbol: str) -> str:
+    """Extract the TAIFEX product code from a symbol."""
+    code = symbol.split(".")[0]
+    match = re.match(r"([A-Za-z]+)", code)
+    return match.group(1).upper() if match else code.upper()
+
+
+class TaiwanFuturesEngine(FuturesBaseEngine):
+    """TAIFEX futures engine with contract multipliers and margin rates."""
+
+    def __init__(self, config: dict):
+        leverage = config.get("leverage")
+        if leverage is None:
+            codes = config.get("codes", [])
+            if codes:
+                leverage = 1.0 / self.get_margin_rate(codes[0])
+            else:
+                leverage = 1.0 / DEFAULT_MARGIN_RATE
+        config = {**config, "leverage": leverage}
+        super().__init__(config)
+        self.slippage_rate: float = config.get("slippage", DEFAULT_SLIPPAGE)
+        self.commission_per_contract: float = config.get(
+            "commission_per_contract",
+            DEFAULT_COMMISSION_PER_CONTRACT,
+        )
+        self.price_limit: float = config.get("price_limit", DEFAULT_PRICE_LIMIT)
+
+    def can_execute(self, symbol: str, direction: int, bar: pd.Series) -> bool:
+        """Allow T+0 Taiwan futures trading unless daily limits block it."""
+        pct_chg = _calc_pct_change(bar)
+        if pct_chg is None:
+            return True
+        if direction == 1 and pct_chg >= self.price_limit:
+            return False
+        if direction == -1 and pct_chg <= -self.price_limit:
+            return False
+        if direction == 0:
+            position = self.positions.get(symbol)
+            if position is not None:
+                if position.direction == 1 and pct_chg <= -self.price_limit:
+                    return False
+                if position.direction == -1 and pct_chg >= self.price_limit:
+                    return False
+        return True
+
+    def round_size(self, raw_size: float, price: float) -> float:
+        """Round down to whole futures contracts."""
+        return max(int(raw_size), 0)
+
+    def calc_commission(self, size: float, price: float, _direction: int, is_open: bool) -> float:
+        """Return fixed per-contract commission using the active symbol."""
+        return self.calc_commission_for_symbol(self._active_symbol, size, price, is_open)
+
+    def calc_commission_for_symbol(
+        self,
+        symbol: str,
+        size: float,
+        price: float,
+        is_open: bool,
+    ) -> float:
+        """Return fixed one-side commission for a Taiwan futures symbol."""
+        del symbol
+        del price
+        del is_open
+        return size * self.commission_per_contract
+
+    def apply_slippage(self, price: float, direction: int) -> float:
+        """Apply proportional Taiwan futures slippage."""
+        return price * (1 + direction * self.slippage_rate)
+
+    def get_contract_multiplier(self, symbol: str) -> float:
+        """Return the configured multiplier for a Taiwan futures product."""
+        product = _extract_product(symbol)
+        contract = CONTRACTS.get(product)
+        if contract is None:
+            return DEFAULT_MULTIPLIER
+        return contract["multiplier"]
+
+    def get_margin_rate(self, symbol: str) -> float:
+        """Return the configured margin rate for a Taiwan futures product."""
+        product = _extract_product(symbol)
+        contract = CONTRACTS.get(product)
+        if contract is None:
+            return DEFAULT_MARGIN_RATE
+        return contract["margin_rate"]
+
+
+def _calc_pct_change(bar: pd.Series) -> float | None:
+    """Calculate fractional price change from futures bar data."""
+    settle = bar.get("settle")
+    pre_settle = bar.get("pre_settle")
+    if settle is not None and pre_settle is not None and pre_settle > 0:
+        return (float(settle) - float(pre_settle)) / float(pre_settle)
+
+    close = bar.get("close")
+    pre_close = bar.get("pre_close")
+    if close is not None and pre_close is not None and pre_close > 0:
+        return (float(close) - float(pre_close)) / float(pre_close)
+
+    if "pct_chg" in bar.index:
+        pct_chg = bar["pct_chg"]
+        if pd.notna(pct_chg):
+            return float(pct_chg) / 100.0
+    return None

--- a/agent/backtest/engines/taiwan_stock.py
+++ b/agent/backtest/engines/taiwan_stock.py
@@ -1,0 +1,79 @@
+"""Taiwan stock backtest engine.
+
+Market rules:
+  - T+0: same-day sell is allowed
+  - Price limits: ±10%
+  - Minimum lot: 1,000 shares (one board lot)
+  - Commission: 0.1425% bilateral, NT$20 minimum
+  - Transaction tax: 0.3% sell-side only
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+import pandas as pd
+
+from backtest.engines.base import BaseEngine
+
+
+COMMISSION_RATE: Final[float] = 0.001425
+COMMISSION_MIN: Final[float] = 20.0
+TRANSACTION_TAX: Final[float] = 0.003
+LOT_SIZE: Final[int] = 1000
+PRICE_LIMIT: Final[float] = 0.10
+
+
+class TaiwanStockEngine(BaseEngine):
+    """Taiwan stock market engine for TWSE/TPEX symbols."""
+
+    def __init__(self, config: dict):
+        config = {**config, "leverage": 1.0}
+        super().__init__(config)
+        self.commission_rate: float = config.get("commission_rate", COMMISSION_RATE)
+        self.commission_min: float = config.get("commission_min", COMMISSION_MIN)
+        self.transaction_tax: float = config.get("transaction_tax", TRANSACTION_TAX)
+        self.lot_size: int = config.get("lot_size", LOT_SIZE)
+        self.price_limit: float = config.get("price_limit", PRICE_LIMIT)
+        self.slippage_rate: float = config.get("slippage", 0.001)
+
+    def can_execute(self, symbol: str, direction: int, bar: pd.Series) -> bool:
+        """Allow T+0 Taiwan stock trades unless price limits block them."""
+        pct_chg = _calc_pct_change(bar)
+        if pct_chg is None:
+            return True
+        if direction == 1 and pct_chg >= self.price_limit:
+            return False
+        if direction == 0 and pct_chg <= -self.price_limit:
+            return False
+        return True
+
+    def round_size(self, raw_size: float, price: float) -> float:
+        """Round down to Taiwan board lots."""
+        return max(int(raw_size / self.lot_size) * self.lot_size, 0)
+
+    def calc_commission(self, size: float, price: float, _direction: int, is_open: bool) -> float:
+        """Calculate broker commission plus sell-side transaction tax."""
+        notional = size * price
+        fee = max(notional * self.commission_rate, self.commission_min)
+        if not is_open:
+            fee += notional * self.transaction_tax
+        return fee
+
+    def apply_slippage(self, price: float, direction: int) -> float:
+        """Apply proportional Taiwan stock slippage."""
+        return price * (1 + direction * self.slippage_rate)
+
+
+def _calc_pct_change(bar: pd.Series) -> float | None:
+    """Calculate fractional price change from a Taiwan stock OHLC bar."""
+    if "pct_chg" in bar.index:
+        pct_chg = bar["pct_chg"]
+        if pd.notna(pct_chg):
+            return float(pct_chg) / 100.0
+
+    close = bar.get("close")
+    pre_close = bar.get("pre_close")
+    if close is not None and pre_close is not None and pre_close > 0:
+        return (float(close) - float(pre_close)) / float(pre_close)
+    return None

--- a/agent/backtest/loaders/finmind_loader.py
+++ b/agent/backtest/loaders/finmind_loader.py
@@ -1,0 +1,20 @@
+"""FinMind loader skeleton for Taiwan markets."""
+
+from __future__ import annotations
+
+import os
+
+from backtest.loaders.registry import register
+
+
+@register
+class DataLoader:
+    name = "finmind"
+    markets = {"tw_stock", "tw_futures", "tw_options"}
+    requires_auth = True
+
+    def is_available(self) -> bool:
+        return bool(os.getenv("FINMIND_TOKEN"))
+
+    def fetch(self, codes, start_date, end_date, interval="1D"):
+        raise NotImplementedError

--- a/agent/backtest/loaders/registry.py
+++ b/agent/backtest/loaders/registry.py
@@ -72,6 +72,7 @@ def _ensure_registered() -> None:
         "backtest.loaders.okx",
         "backtest.loaders.yfinance_loader",
         "backtest.loaders.finmind_loader",
+        "backtest.loaders.shioaji_loader",
         "backtest.loaders.akshare_loader",
         "backtest.loaders.baostock_loader",
         "backtest.loaders.tencent_loader",

--- a/agent/backtest/loaders/registry.py
+++ b/agent/backtest/loaders/registry.py
@@ -40,6 +40,8 @@ VALID_SOURCES: set[str] = {
     "mootdx",
     "ccxt",
     "futu",
+    "finmind",
+    "shioaji",
     "auto",
 }
 
@@ -69,6 +71,7 @@ def _ensure_registered() -> None:
         "backtest.loaders.tushare",
         "backtest.loaders.okx",
         "backtest.loaders.yfinance_loader",
+        "backtest.loaders.finmind_loader",
         "backtest.loaders.akshare_loader",
         "backtest.loaders.baostock_loader",
         "backtest.loaders.tencent_loader",
@@ -94,6 +97,9 @@ FALLBACK_CHAINS: dict[str, list[str]] = {
     "hk_equity": ["yfinance", "futu", "akshare"],
     "crypto":    ["okx", "ccxt", "yfinance"],
     "futures":   ["tushare", "akshare"],
+    "tw_stock": ["shioaji", "finmind", "yfinance"],
+    "tw_futures": ["shioaji", "finmind"],
+    "tw_options": ["shioaji", "finmind"],
     "fund":      ["tushare", "akshare"],
     "macro":     ["akshare", "tushare"],
     "forex":     ["akshare", "yfinance"],

--- a/agent/backtest/loaders/shioaji_loader.py
+++ b/agent/backtest/loaders/shioaji_loader.py
@@ -1,0 +1,50 @@
+"""Shioaji loader skeleton for Taiwan markets."""
+
+from __future__ import annotations
+
+import os
+from typing import Final
+
+from backtest.loaders.registry import register
+
+_API_KEY_ENV: Final[str] = "SHIOAJI_API_KEY"
+_SECRET_KEY_ENV: Final[str] = "SHIOAJI_SECRET_KEY"
+
+
+@register
+class DataLoader:
+    """Shioaji-backed Taiwan market loader skeleton.
+
+    Importing this module must stay safe without credentials or the shioaji SDK
+    installed. Authentication and network activity are intentionally deferred.
+    """
+
+    name = "shioaji"
+    markets = {"tw_stock", "tw_futures", "tw_options"}
+    requires_auth = True
+
+    def __init__(self) -> None:
+        self._api = None
+
+    def is_available(self) -> bool:
+        """Return True only when credentials exist and API object creation succeeds."""
+        if not os.getenv(_API_KEY_ENV) or not os.getenv(_SECRET_KEY_ENV):
+            return False
+        try:
+            self._ensure_api()
+        except Exception:
+            return False
+        return True
+
+    def fetch(self, codes, start_date, end_date, interval="1D"):
+        """Placeholder fetch implementation for future task work."""
+        self._ensure_api()
+        raise NotImplementedError
+
+    def _ensure_api(self):
+        """Lazily construct a Shioaji API object without logging in."""
+        if self._api is None:
+            import shioaji as sj  # noqa: PLC0415
+
+            self._api = sj.Shioaji()
+        return self._api

--- a/agent/backtest/runner.py
+++ b/agent/backtest/runner.py
@@ -302,6 +302,9 @@ _MARKET_TO_SOURCE = {
     "hk_equity": "yfinance",
     "crypto": "okx",
     "futures": "tushare",
+    "tw_stock": "shioaji",
+    "tw_futures": "shioaji",
+    "tw_options": "shioaji",
     "fund": "tushare",
     "macro": "akshare",
     "forex": "akshare",
@@ -565,6 +568,14 @@ def _create_market_engine(source: str, config: dict, codes: List[str]):
     if "forex" in markets:
         from backtest.engines.forex import ForexEngine
         return ForexEngine(config)
+
+    if "tw_futures" in markets:
+        from backtest.engines.taiwan_futures import TaiwanFuturesEngine
+        return TaiwanFuturesEngine(config)
+
+    if "tw_stock" in markets:
+        from backtest.engines.taiwan_stock import TaiwanStockEngine
+        return TaiwanStockEngine(config)
 
     # Original routing (Wave 1)
     if source in ("okx", "ccxt"):

--- a/agent/tests/test_composite_taiwan_stock.py
+++ b/agent/tests/test_composite_taiwan_stock.py
@@ -1,0 +1,14 @@
+"""Tests for Task 5 Taiwan stock CompositeEngine routing."""
+
+from __future__ import annotations
+
+from backtest.engines.composite import CompositeEngine
+from backtest.engines.taiwan_stock import TaiwanStockEngine
+from backtest.runner import _create_market_engine
+
+
+def test_composite_engine_builds_taiwan_stock_rules() -> None:
+    engine = _create_market_engine("auto", {"initial_cash": 100_000}, ["000001.SZ", "2330.TW"])
+
+    assert isinstance(engine, CompositeEngine)
+    assert isinstance(engine._rule_engines["tw_stock"], TaiwanStockEngine)

--- a/agent/tests/test_engine_robustness.py
+++ b/agent/tests/test_engine_robustness.py
@@ -368,6 +368,16 @@ class TestBacktestConfigSchema:
             )
             assert c.source == src
 
+    def test_finmind_and_shioaji_sources_accepted(self) -> None:
+        for src in ("finmind", "shioaji"):
+            c = BacktestConfigSchema(
+                codes=["2330.TW"],
+                start_date="2025-01-01",
+                end_date="2025-06-01",
+                source=src,
+            )
+            assert c.source == src
+
     def test_valid_sources_covers_all_registered_loaders(self) -> None:
         """Every registered loader name must be an accepted config source, so a
         new loader can never be silently rejected by the config schema."""

--- a/agent/tests/test_market_detection.py
+++ b/agent/tests/test_market_detection.py
@@ -9,11 +9,17 @@ bare product-code form must resolve identically.
 
 from __future__ import annotations
 
+import sys
+from types import ModuleType
+
 import pytest
 
 from backtest.engines._market_hooks import _is_china_futures, _is_taiwan_futures
+from backtest.metrics import calc_bars_per_year
 from backtest.runner import (
+    _create_market_engine,
     _detect_market,
+    _detect_primary_source,
     _detect_source,
     _group_codes_by_market,
     _group_codes_by_source,
@@ -102,11 +108,46 @@ class TestDetectSource:
             ("0700.HK", "yfinance"),
             ("BTC-USDT", "okx"),
             ("IF2406.CFFEX", "tushare"),
+            ("2330.TW", "shioaji"),
+            ("TXF.TAIFEX", "shioaji"),
+            ("TXO.TAIFEX", "shioaji"),
             ("EUR/USD", "akshare"),
         ],
     )
     def test_source_mapping(self, code: str, expected_source: str) -> None:
         assert _detect_source(code) == expected_source
+
+
+class TestTaiwanRunnerRouting:
+    def test_detect_primary_source_uses_shioaji_for_taiwan_auto(self) -> None:
+        assert _detect_primary_source(["2330.TW"], "auto") == "shioaji"
+        assert calc_bars_per_year("1D", _detect_primary_source(["2330.TW"], "auto")) == 252
+
+    def test_create_market_engine_routes_tw_stock(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        module = ModuleType("backtest.engines.taiwan_stock")
+
+        class TaiwanStockEngine:
+            def __init__(self, config):
+                self.config = config
+
+        module.TaiwanStockEngine = TaiwanStockEngine
+        monkeypatch.setitem(sys.modules, "backtest.engines.taiwan_stock", module)
+
+        engine = _create_market_engine("shioaji", {"initial_cash": 100_000}, ["2330.TW"])
+        assert isinstance(engine, TaiwanStockEngine)
+
+    def test_create_market_engine_routes_tw_futures(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        module = ModuleType("backtest.engines.taiwan_futures")
+
+        class TaiwanFuturesEngine:
+            def __init__(self, config):
+                self.config = config
+
+        module.TaiwanFuturesEngine = TaiwanFuturesEngine
+        monkeypatch.setitem(sys.modules, "backtest.engines.taiwan_futures", module)
+
+        engine = _create_market_engine("shioaji", {"initial_cash": 100_000}, ["TXF.TAIFEX"])
+        assert isinstance(engine, TaiwanFuturesEngine)
 
 
 # ---------------------------------------------------------------------------

--- a/agent/tests/test_market_detection.py
+++ b/agent/tests/test_market_detection.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import pytest
 
-from backtest.engines._market_hooks import _is_china_futures
+from backtest.engines._market_hooks import _is_china_futures, _is_taiwan_futures
 from backtest.runner import (
     _detect_market,
     _detect_source,
@@ -55,11 +55,16 @@ class TestDetectMarket:
             ("ETH-USDT", "crypto"),
             ("BTC/USDT", "crypto"),
             # Futures
+            ("TXF.TAIFEX", "tw_futures"),
+            ("TXO.TAIFEX", "tw_options"),
             ("IF2406.CFFEX", "futures"),
             ("AU2412.SHFE", "futures"),
             ("C2409.DCE", "futures"),
             ("CF2409.ZCE", "futures"),
             ("SC2406.INE", "futures"),
+            # Taiwan stock
+            ("2330.TW", "tw_stock"),
+            ("6488.TWO", "tw_stock"),
             # Forex
             ("EUR/USD", "forex"),
             ("USD/JPY", "forex"),
@@ -73,6 +78,8 @@ class TestDetectMarket:
         assert _detect_market("000001.sz") == "a_share"
         assert _detect_market("aapl.us") == "us_equity"
         assert _detect_market("btc-usdt") == "crypto"
+        assert _detect_market("txf.taifex") == "tw_futures"
+        assert _detect_market("2330.tw") == "tw_stock"
 
     def test_unknown_defaults_to_a_share(self) -> None:
         assert _detect_market("UNKNOWN") == "a_share"
@@ -213,6 +220,17 @@ class TestIsChinaFutures:
         assert _is_china_futures("M2412") is True
 
 
+class TestIsTaiwanFutures:
+    def test_taifex_contract_suffix(self) -> None:
+        assert _is_taiwan_futures("TXF.TAIFEX") is True
+
+    def test_taifex_option_not_futures(self) -> None:
+        assert _is_taiwan_futures("TXO.TAIFEX") is False
+
+    def test_non_taifex_symbol_not_futures(self) -> None:
+        assert _is_taiwan_futures("IF2406.CFFEX") is False
+
+
 # ---------------------------------------------------------------------------
 # _detect_market — task-required exhaustive assertions
 # ---------------------------------------------------------------------------
@@ -229,3 +247,12 @@ class TestDetectMarketRequired:
 
     def test_crypto_hyphen_form(self) -> None:
         assert _detect_market("BTC-USDT") == "crypto"
+
+    def test_taiwan_stock(self) -> None:
+        assert _detect_market("2330.TW") == "tw_stock"
+
+    def test_taiwan_futures(self) -> None:
+        assert _detect_market("TXF.TAIFEX") == "tw_futures"
+
+    def test_taiwan_options(self) -> None:
+        assert _detect_market("TXO.TAIFEX") == "tw_options"

--- a/agent/tests/test_registry.py
+++ b/agent/tests/test_registry.py
@@ -117,7 +117,19 @@ class TestProtocol:
 
 class TestFallbackChains:
     def test_all_expected_markets_present(self) -> None:
-        expected = {"a_share", "us_equity", "hk_equity", "crypto", "futures", "fund", "macro", "forex"}
+        expected = {
+            "a_share",
+            "us_equity",
+            "hk_equity",
+            "crypto",
+            "futures",
+            "tw_stock",
+            "tw_futures",
+            "tw_options",
+            "fund",
+            "macro",
+            "forex",
+        }
         assert expected == set(FALLBACK_CHAINS.keys())
 
     def test_chains_are_non_empty(self) -> None:
@@ -131,6 +143,11 @@ class TestFallbackChains:
         assert FALLBACK_CHAINS["crypto"][:2] == ["okx", "ccxt"]
         assert FALLBACK_CHAINS["crypto"][-1] == "yfinance"
 
+    def test_taiwan_market_chains(self) -> None:
+        assert FALLBACK_CHAINS["tw_stock"] == ["shioaji", "finmind", "yfinance"]
+        assert FALLBACK_CHAINS["tw_futures"] == ["shioaji", "finmind"]
+        assert FALLBACK_CHAINS["tw_options"] == ["shioaji", "finmind"]
+
 
 # ---------------------------------------------------------------------------
 # resolve_loader
@@ -138,6 +155,27 @@ class TestFallbackChains:
 
 
 class TestResolveLoader:
+    def test_taiwan_markets_fall_back_to_finmind(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from backtest.loaders import registry as reg
+        from backtest.loaders.finmind_loader import DataLoader as FinMindLoader
+
+        monkeypatch.setenv("FINMIND_TOKEN", "test-token")
+        monkeypatch.setattr(reg, "_ensure_registered", lambda: None)
+
+        with patch.dict(LOADER_REGISTRY, {"finmind": FinMindLoader}, clear=True):
+            with patch.dict(
+                FALLBACK_CHAINS,
+                {
+                    "tw_stock": ["shioaji", "finmind", "yfinance"],
+                    "tw_futures": ["shioaji", "finmind"],
+                    "tw_options": ["shioaji", "finmind"],
+                },
+                clear=False,
+            ):
+                assert resolve_loader("tw_stock").name == "finmind"
+                assert resolve_loader("tw_futures").name == "finmind"
+                assert resolve_loader("tw_options").name == "finmind"
+
     def test_returns_first_available(self) -> None:
         with patch.dict(LOADER_REGISTRY, {
             "fake_unavailable": _FakeUnavailableLoader,

--- a/agent/tests/test_shioaji_loader.py
+++ b/agent/tests/test_shioaji_loader.py
@@ -1,0 +1,75 @@
+"""Tests for the Task 7 shioaji loader skeleton."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from backtest.loaders.registry import FALLBACK_CHAINS, LOADER_REGISTRY, resolve_loader
+
+
+def _reload_module():
+    module = importlib.import_module("backtest.loaders.shioaji_loader")
+    return importlib.reload(module)
+
+
+def test_import_without_credentials_does_not_crash(monkeypatch) -> None:
+    monkeypatch.delenv("SHIOAJI_API_KEY", raising=False)
+    monkeypatch.delenv("SHIOAJI_SECRET_KEY", raising=False)
+
+    module = _reload_module()
+
+    assert module.DataLoader().is_available() is False
+
+
+def test_is_available_false_when_key_missing(monkeypatch) -> None:
+    monkeypatch.delenv("SHIOAJI_API_KEY", raising=False)
+    monkeypatch.setenv("SHIOAJI_SECRET_KEY", "secret")
+
+    module = _reload_module()
+
+    assert module.DataLoader().is_available() is False
+
+
+def test_is_available_false_when_secret_missing(monkeypatch) -> None:
+    monkeypatch.setenv("SHIOAJI_API_KEY", "key")
+    monkeypatch.delenv("SHIOAJI_SECRET_KEY", raising=False)
+
+    module = _reload_module()
+
+    assert module.DataLoader().is_available() is False
+
+
+def test_is_available_true_with_stubbed_sdk_and_credentials(monkeypatch) -> None:
+    class FakeShioaji:
+        def __init__(self) -> None:
+            self.created = True
+
+    monkeypatch.setenv("SHIOAJI_API_KEY", "key")
+    monkeypatch.setenv("SHIOAJI_SECRET_KEY", "secret")
+    monkeypatch.setitem(sys.modules, "shioaji", SimpleNamespace(Shioaji=FakeShioaji))
+
+    module = _reload_module()
+    loader = module.DataLoader()
+
+    assert loader.is_available() is True
+
+
+def test_resolve_loader_can_pick_shioaji_without_real_account(monkeypatch) -> None:
+    class FakeShioaji:
+        def __init__(self) -> None:
+            self.created = True
+
+    monkeypatch.setenv("SHIOAJI_API_KEY", "key")
+    monkeypatch.setenv("SHIOAJI_SECRET_KEY", "secret")
+    monkeypatch.setitem(sys.modules, "shioaji", SimpleNamespace(Shioaji=FakeShioaji))
+
+    from backtest.loaders import registry as reg
+
+    monkeypatch.setattr(reg, "_registered", False)
+    sys.modules.pop("backtest.loaders.shioaji_loader", None)
+    with patch.dict(LOADER_REGISTRY, {}, clear=True):
+        with patch.dict(FALLBACK_CHAINS, {"tw_stock": ["shioaji", "finmind"]}, clear=False):
+            assert resolve_loader("tw_stock").name == "shioaji"

--- a/agent/tests/test_taiwan_futures_engine.py
+++ b/agent/tests/test_taiwan_futures_engine.py
@@ -1,0 +1,98 @@
+"""Tests for TaiwanFuturesEngine market rules."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from backtest.runner import _create_market_engine
+
+
+def _make_bar(
+    close: float = 22000.0,
+    pre_close: float | None = None,
+    settle: float | None = None,
+    pre_settle: float | None = None,
+) -> pd.Series:
+    data: dict[str, float] = {"close": close, "open": close}
+    if pre_close is not None:
+        data["pre_close"] = pre_close
+    if settle is not None:
+        data["settle"] = settle
+    if pre_settle is not None:
+        data["pre_settle"] = pre_settle
+    return pd.Series(data)
+
+
+def _make_engine(**overrides):
+    from backtest.engines.taiwan_futures import TaiwanFuturesEngine
+
+    config = {"initial_cash": 1_000_000, "codes": ["TXF.TAIFEX"]}
+    config.update(overrides)
+    return TaiwanFuturesEngine(config)
+
+
+class TestTaiwanFuturesExecutionRules:
+    def test_long_and_short_allowed(self) -> None:
+        engine = _make_engine()
+
+        assert engine.can_execute("TXF.TAIFEX", 1, _make_bar()) is True
+        assert engine.can_execute("TXF.TAIFEX", -1, _make_bar()) is True
+
+    def test_limit_up_blocks_long(self) -> None:
+        engine = _make_engine()
+
+        assert engine.can_execute("TXF.TAIFEX", 1, _make_bar(close=24200.0, pre_close=22000.0)) is False
+
+
+class TestTaiwanFuturesRoundSize:
+    def test_rounds_down_to_integer_contracts(self) -> None:
+        engine = _make_engine()
+
+        assert engine.round_size(2.8, 22000.0) == 2
+        assert engine.round_size(0.9, 22000.0) == 0
+
+
+class TestTaiwanFuturesContractSpecs:
+    @pytest.mark.parametrize(
+        ("symbol", "expected_multiplier", "expected_margin_rate"),
+        [
+            ("TXF.TAIFEX", 200, 0.12),
+            ("MXF.TAIFEX", 50, 0.12),
+            ("TE.TAIFEX", 4000, 0.10),
+            ("TF.TAIFEX", 1000, 0.10),
+            ("GBF.TAIFEX", 200000, 0.03),
+        ],
+    )
+    def test_multiplier_and_margin_rate(
+        self,
+        symbol: str,
+        expected_multiplier: int,
+        expected_margin_rate: float,
+    ) -> None:
+        engine = _make_engine()
+
+        assert engine.get_contract_multiplier(symbol) == expected_multiplier
+        assert engine.get_margin_rate(symbol) == expected_margin_rate
+
+    def test_txf_leverage_derived_from_margin_rate(self) -> None:
+        engine = _make_engine(codes=["TXF.TAIFEX"])
+
+        assert engine.default_leverage == pytest.approx(1 / 0.12)
+
+
+class TestTaiwanFuturesCommission:
+    def test_default_commission_per_contract(self) -> None:
+        engine = _make_engine()
+        engine._active_symbol = "TXF.TAIFEX"
+
+        assert engine.calc_commission(2, 22000.0, 1, is_open=True) == pytest.approx(100.0)
+
+
+class TestTaiwanFuturesRunnerInstantiation:
+    def test_runner_creates_taiwan_futures_engine(self) -> None:
+        from backtest.engines.taiwan_futures import TaiwanFuturesEngine
+
+        engine = _create_market_engine("shioaji", {"initial_cash": 100_000}, ["TXF.TAIFEX"])
+
+        assert isinstance(engine, TaiwanFuturesEngine)

--- a/agent/tests/test_taiwan_options_pipeline.py
+++ b/agent/tests/test_taiwan_options_pipeline.py
@@ -1,0 +1,178 @@
+"""Tests for Task 9 Taiwan options pipeline on existing engine="options" flow."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from backtest.engines import options_portfolio
+
+
+def _txf_bars() -> pd.DataFrame:
+    dates = pd.bdate_range("2025-01-01", periods=4)
+    return pd.DataFrame(
+        {
+            "open": [22000.0, 22100.0, 22200.0, 22300.0],
+            "high": [22100.0, 22200.0, 22300.0, 22400.0],
+            "low": [21900.0, 22000.0, 22100.0, 22200.0],
+            "close": [22050.0, 22150.0, 22250.0, 22350.0],
+            "volume": [1000, 1100, 1200, 1300],
+        },
+        index=dates,
+    )
+
+
+class _FakeLoader:
+    name = "finmind"
+
+    def __init__(self, bars: pd.DataFrame) -> None:
+        self._bars = bars
+
+    def fetch(self, codes, start_date, end_date):
+        del start_date
+        del end_date
+        return {code: self._bars.copy() for code in codes}
+
+
+class _OpenCloseSignalEngine:
+    def generate(self, data_map):
+        del data_map
+        return [
+            {
+                "date": "2025-01-01",
+                "action": "open",
+                "underlying": "TXF.TAIFEX",
+                "legs": [{"type": "call", "strike": 22100.0, "expiry": "2025-03-19", "qty": 1}],
+            },
+            {
+                "date": "2025-01-03",
+                "action": "close",
+                "underlying": "TXF.TAIFEX",
+                "legs": [{"type": "call", "strike": 22100.0, "expiry": "2025-03-19", "qty": 1}],
+            },
+        ]
+
+
+class _OpenOnlySignalEngine:
+    def generate(self, data_map):
+        del data_map
+        return [
+            {
+                "date": "2025-01-01",
+                "action": "open",
+                "underlying": "TXF.TAIFEX",
+                "legs": [{"type": "call", "strike": 22000.0, "expiry": "2025-03-19", "qty": 1}],
+            },
+        ]
+
+
+def _run_taiwan_options_backtest(tmp_path: Path, options_config: dict, engine) -> dict:
+    return options_portfolio.run_options_backtest(
+        {
+            "codes": ["TXF.TAIFEX"],
+            "start_date": "2025-01-01",
+            "end_date": "2025-01-06",
+            "source": "finmind",
+            "engine": "options",
+            "initial_cash": 100_000,
+            "options_config": options_config,
+        },
+        _FakeLoader(_txf_bars()),
+        engine,
+        tmp_path,
+    )
+
+
+def test_txf_underlying_and_txo_style_legs_write_expected_artifacts(tmp_path: Path) -> None:
+    metrics = _run_taiwan_options_backtest(
+        tmp_path,
+        {
+            "contract_multiplier": 50,
+            "exercise_style": "european",
+            "risk_free_rate": 0.01,
+        },
+        _OpenCloseSignalEngine(),
+    )
+
+    artifacts = tmp_path / "artifacts"
+    trades = pd.read_csv(artifacts / "trades.csv")
+    run_card = json.loads((tmp_path / "run_card.json").read_text(encoding="utf-8"))
+
+    assert metrics["trade_count"] == 2
+    assert list(trades["code"]) == ["TXF.TAIFEX", "TXF.TAIFEX"]
+    assert list(trades["option_type"]) == ["call", "call"]
+    assert list(trades["side"]) == ["buy", "close"]
+    assert trades["strike"].tolist() == [22100.0, 22100.0]
+    assert {path.name for path in artifacts.iterdir()} >= {
+        "equity.csv",
+        "trades.csv",
+        "greeks.csv",
+        "metrics.csv",
+        "ohlcv_TXF.TAIFEX.csv",
+    }
+    assert run_card["backtest"]["engine"] == "options"
+    assert run_card["data_sources"] == ["finmind"]
+
+
+def test_contract_multiplier_50_changes_trade_pnl_scale(tmp_path: Path, monkeypatch) -> None:
+    def fake_bs_price(spot, strike, T, r, sigma, option_type="call") -> float:
+        del strike
+        del T
+        del r
+        del sigma
+        del option_type
+        return spot / 1000.0
+
+    monkeypatch.setattr(options_portfolio, "bs_price", fake_bs_price)
+
+    run_one = tmp_path / "multiplier_1"
+    run_fifty = tmp_path / "multiplier_50"
+    _run_taiwan_options_backtest(
+        run_one,
+        {"contract_multiplier": 1, "exercise_style": "european", "risk_free_rate": 0.01},
+        _OpenCloseSignalEngine(),
+    )
+    _run_taiwan_options_backtest(
+        run_fifty,
+        {"contract_multiplier": 50, "exercise_style": "european", "risk_free_rate": 0.01},
+        _OpenCloseSignalEngine(),
+    )
+
+    pnl_one = pd.read_csv(run_one / "artifacts" / "trades.csv").query("side == 'close'")["pnl"].iloc[0]
+    pnl_fifty = pd.read_csv(run_fifty / "artifacts" / "trades.csv").query("side == 'close'")["pnl"].iloc[0]
+
+    assert pnl_fifty == pnl_one * 50
+
+
+def test_exercise_style_european_prevents_american_early_exercise(tmp_path: Path, monkeypatch) -> None:
+    def fake_bs_price(spot, strike, T, r, sigma, option_type="call") -> float:
+        del spot
+        del strike
+        del T
+        del r
+        del sigma
+        del option_type
+        return 1.0
+
+    monkeypatch.setattr(options_portfolio, "bs_price", fake_bs_price)
+
+    european_dir = tmp_path / "european"
+    american_dir = tmp_path / "american"
+    _run_taiwan_options_backtest(
+        european_dir,
+        {"contract_multiplier": 50, "exercise_style": "european", "risk_free_rate": 0.01},
+        _OpenOnlySignalEngine(),
+    )
+    _run_taiwan_options_backtest(
+        american_dir,
+        {"contract_multiplier": 50, "exercise_style": "american", "risk_free_rate": 0.01},
+        _OpenOnlySignalEngine(),
+    )
+
+    european_trades = pd.read_csv(european_dir / "artifacts" / "trades.csv")
+    american_trades = pd.read_csv(american_dir / "artifacts" / "trades.csv")
+
+    assert "early_exercise" not in set(european_trades["side"])
+    assert "early_exercise" in set(american_trades["side"])

--- a/agent/tests/test_taiwan_stock_engine.py
+++ b/agent/tests/test_taiwan_stock_engine.py
@@ -1,0 +1,93 @@
+"""Tests for TaiwanStockEngine market rules."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from backtest.engines.taiwan_stock import TaiwanStockEngine
+from backtest.runner import _create_market_engine
+
+
+def _make_bar(close: float = 100.0, pre_close: float | None = None) -> pd.Series:
+    """Build a minimal Taiwan stock OHLC bar."""
+    data: dict[str, float] = {"close": close, "open": close}
+    if pre_close is not None:
+        data["pre_close"] = pre_close
+    return pd.Series(data)
+
+
+def _make_engine(**overrides) -> TaiwanStockEngine:
+    config = {"initial_cash": 1_000_000}
+    config.update(overrides)
+    return TaiwanStockEngine(config)
+
+
+class TestTaiwanStockExecutionRules:
+    def test_same_day_sell_has_no_t_plus_one_block(self) -> None:
+        engine = _make_engine()
+
+        assert engine.can_execute("2330.TW", 0, _make_bar()) is True
+
+    def test_limit_up_blocks_buy(self) -> None:
+        engine = _make_engine()
+
+        assert engine.can_execute("2330.TW", 1, _make_bar(close=110.0, pre_close=100.0)) is False
+
+    def test_limit_down_blocks_sell(self) -> None:
+        engine = _make_engine()
+
+        assert engine.can_execute("2330.TW", 0, _make_bar(close=90.0, pre_close=100.0)) is False
+
+
+class TestTaiwanStockRoundSize:
+    def test_rounds_down_to_board_lots(self) -> None:
+        engine = _make_engine()
+
+        assert engine.round_size(2500.0, 100.0) == 2000
+        assert engine.round_size(999.0, 100.0) == 0
+
+    def test_negative_size_clamps_to_zero(self) -> None:
+        engine = _make_engine()
+
+        assert engine.round_size(-1000.0, 100.0) == 0
+
+
+class TestTaiwanStockCommission:
+    def test_buy_uses_minimum_broker_commission(self) -> None:
+        engine = _make_engine()
+
+        assert engine.calc_commission(1000.0, 10.0, 1, is_open=True) == pytest.approx(20.0)
+
+    def test_sell_adds_transaction_tax(self) -> None:
+        engine = _make_engine()
+        notional = 1000.0 * 100.0
+
+        buy_fee = engine.calc_commission(1000.0, 100.0, 1, is_open=True)
+        sell_fee = engine.calc_commission(1000.0, 100.0, 1, is_open=False)
+
+        assert sell_fee - buy_fee == pytest.approx(notional * 0.003)
+
+    def test_leverage_is_forced_to_one(self) -> None:
+        engine = _make_engine(leverage=3.0)
+
+        assert engine.default_leverage == 1.0
+
+
+class TestTaiwanStockSlippage:
+    def test_buy_slippage_increases_price(self) -> None:
+        engine = _make_engine(slippage=0.001)
+
+        assert engine.apply_slippage(100.0, 1) == pytest.approx(100.1)
+
+    def test_sell_slippage_decreases_price(self) -> None:
+        engine = _make_engine(slippage=0.001)
+
+        assert engine.apply_slippage(100.0, -1) == pytest.approx(99.9)
+
+
+class TestTaiwanStockRunnerInstantiation:
+    def test_runner_creates_taiwan_stock_engine(self) -> None:
+        engine = _create_market_engine("shioaji", {"initial_cash": 100_000}, ["2330.TW"])
+
+        assert isinstance(engine, TaiwanStockEngine)


### PR DESCRIPTION
## Summary

This PR adds the Taiwan market integration foundation for Vibe-Trading.

Included work:
- Taiwan market detection for TW/TWO equities and TAIFEX futures/options symbols.
- FinMind and Shioaji loader skeleton registration.
- Safe Shioaji loader behavior when credentials are missing.
- Taiwan stock MVP engine.
- Taiwan futures engine foundation.
- Taiwan stock CompositeEngine routing.
- Taiwan options compatibility verification through the existing `engine="options"` pipeline.
- Focused tests for detection, registry, loaders, engines, composite routing, and options pipeline.

## Verification

Focused Taiwan market regression suite:

| Test | Result |
|---|---:|
| `test_market_detection.py` | 69 passed |
| `test_registry.py` | 18 passed |
| `test_taiwan_stock_engine.py` | 11 passed |
| `test_composite_taiwan_stock.py` | 1 passed |
| `test_shioaji_loader.py` | 5 passed |
| `test_taiwan_futures_engine.py` | 11 passed |
| `test_taiwan_options_pipeline.py` | 3 passed |
| `test_run_card.py -k options` | 1 passed |

Total: **119 passed, 0 failed** across 8 focused suites.

## Known limitations / follow-ups

- FinMind and Shioaji loaders are still skeletons; real historical data fetching is future work.
- Taiwan options support is currently pipeline compatibility verification, not real TXO option-chain integration.
- `tw_futures` is not yet integrated into `CompositeEngine`.
- A recurring `RequestsDependencyWarning` appears due to the local environment's `requests` / `urllib3` / `charset-normalizer` version mismatch. This is not specific to the Taiwan market integration and did not affect test results.

## Reviewer focus areas

- Market detection ordering for Taiwan symbols.
- Loader registry and fallback chain behavior.
- Taiwan stock and futures engine assumptions.
- Ensuring `tw_options` continues to use the existing `engine="options"` pipeline rather than `_create_market_engine()`.