### PR TITLE
test(p0): add unit tests for background_tools, bash_tool, and tool_re…

### DIFF
--- a/agent/tests/test_background_tools.py
+++ b/agent/tests/test_background_tools.py
@@ -1,0 +1,278 @@
+"""Unit tests for src.tools.background_tools — BackgroundManager & Tool classes."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import threading
+
+import pytest
+
+from src.tools.background_tools import (
+    BackgroundManager,
+    BackgroundRunTool,
+    CheckBackgroundTool,
+)
+
+
+@pytest.fixture()
+def mgr() -> BackgroundManager:
+    """Create a fresh BackgroundManager instance per test."""
+    return BackgroundManager()
+
+
+def _make_completed_process(
+    stdout: str = "",
+    stderr: str = "",
+    returncode: int = 0,
+) -> subprocess.CompletedProcess:
+    """Helper to build a CompletedProcess mock result."""
+    return subprocess.CompletedProcess(args="fake", returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+# ─── Basic Functionality ─────────────────────────────────────────────────────────
+
+
+class TestRunBasic:
+    """Tests for BackgroundManager.run() basic behaviour."""
+
+    def test_run_returns_valid_json_with_task_id(self, mgr: BackgroundManager, monkeypatch: pytest.MonkeyPatch) -> None:
+        """run() returns valid JSON with task_id."""
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _make_completed_process())
+        result = json.loads(mgr.run("echo hi"))
+        assert "task_id" in result
+        assert result["status"] == "ok"
+        assert len(result["task_id"]) == 8
+
+    def test_run_task_initial_status_is_running(self, mgr: BackgroundManager, monkeypatch: pytest.MonkeyPatch) -> None:
+        """New task initial status is running."""
+        barrier = threading.Barrier(2, timeout=3)
+
+        def _blocking_run(*args, **kwargs):
+            barrier.wait()
+            return _make_completed_process()
+
+        monkeypatch.setattr(subprocess, "run", _blocking_run)
+        result = json.loads(mgr.run("sleep 1"))
+        task_id = result["task_id"]
+        # Check status before background thread executes
+        assert mgr.tasks[task_id]["status"] == "running"
+        barrier.wait()  # Release background thread
+
+    def test_execute_success_sets_completed(self, mgr: BackgroundManager, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Successful execution sets status to completed."""
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _make_completed_process(stdout="done"))
+        mgr.tasks["t1"] = {"status": "running", "result": None, "command": "echo done"}
+        mgr._execute("t1", "echo done")
+        assert mgr.tasks["t1"]["status"] == "completed"
+        assert mgr.tasks["t1"]["result"] == "done"
+
+    def test_execute_combines_stdout_stderr(self, mgr: BackgroundManager, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Output combines stdout and stderr."""
+        monkeypatch.setattr(
+            subprocess, "run", lambda *a, **kw: _make_completed_process(stdout="OUT\n", stderr="ERR\n")
+        )
+        mgr.tasks["t1"] = {"status": "running", "result": None, "command": "cmd"}
+        mgr._execute("t1", "cmd")
+        assert "OUT" in mgr.tasks["t1"]["result"]
+        assert "ERR" in mgr.tasks["t1"]["result"]
+
+
+# ─── Timeout and Exception Handling ───────────────────────────────────────────────
+
+
+class TestExceptionHandling:
+    """Tests for timeout and generic exception paths."""
+
+    def test_timeout_sets_status_timeout(self, mgr: BackgroundManager, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Subprocess timeout sets status to timeout."""
+        def _raise_timeout(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd="sleep 999", timeout=300)
+
+        monkeypatch.setattr(subprocess, "run", _raise_timeout)
+        mgr.tasks["t1"] = {"status": "running", "result": None, "command": "sleep 999"}
+        mgr._execute("t1", "sleep 999")
+        assert mgr.tasks["t1"]["status"] == "timeout"
+        assert "Timeout" in mgr.tasks["t1"]["result"]
+
+    def test_generic_exception_sets_status_error(self, mgr: BackgroundManager, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Generic exception sets status to error."""
+        def _raise_exc(*args, **kwargs):
+            raise OSError("Permission denied")
+
+        monkeypatch.setattr(subprocess, "run", _raise_exc)
+        mgr.tasks["t1"] = {"status": "running", "result": None, "command": "cmd"}
+        mgr._execute("t1", "cmd")
+        assert mgr.tasks["t1"]["status"] == "error"
+        assert "Permission denied" in mgr.tasks["t1"]["result"]
+
+    def test_empty_output_replaced_with_no_output(self, mgr: BackgroundManager, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Empty output is replaced with '(no output)'."""
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _make_completed_process(stdout="", stderr=""))
+        mgr.tasks["t1"] = {"status": "running", "result": None, "command": "cmd"}
+        mgr._execute("t1", "cmd")
+        assert mgr.tasks["t1"]["result"] == "(no output)"
+
+
+# ─── Output Truncation ────────────────────────────────────────────────────────────
+
+
+class TestOutputTruncation:
+    """Tests for output truncation at 50000 chars."""
+
+    def test_output_truncated_at_50000_chars(self, mgr: BackgroundManager, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Long output is truncated at 50000 chars."""
+        long_output = "x" * 60_000
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _make_completed_process(stdout=long_output))
+        mgr.tasks["t1"] = {"status": "running", "result": None, "command": "cmd"}
+        mgr._execute("t1", "cmd")
+        assert len(mgr.tasks["t1"]["result"]) == 50_000
+
+
+# ─── check() Behaviour ────────────────────────────────────────────────────────────
+
+
+class TestCheck:
+    """Tests for BackgroundManager.check() method."""
+
+    def test_check_unknown_task_returns_error(self, mgr: BackgroundManager) -> None:
+        """Querying unknown task returns error."""
+        result = json.loads(mgr.check("nonexistent"))
+        assert result["status"] == "error"
+        assert "Unknown task" in result["error"]
+
+    def test_check_specific_task_returns_status(self, mgr: BackgroundManager) -> None:
+        """Querying specific task returns full status."""
+        mgr.tasks["abc123"] = {"status": "completed", "result": "output", "command": "echo hello"}
+        result = json.loads(mgr.check("abc123"))
+        assert result["status"] == "completed"
+        assert result["command"] == "echo hello"
+        assert result["result"] == "output"
+
+    def test_check_all_lists_all_tasks(self, mgr: BackgroundManager) -> None:
+        """check() with no args lists all tasks."""
+        mgr.tasks["aaa"] = {"status": "running", "result": None, "command": "cmd1"}
+        mgr.tasks["bbb"] = {"status": "completed", "result": "ok", "command": "cmd2"}
+        output = mgr.check()
+        assert "aaa" in output
+        assert "bbb" in output
+        assert "[running]" in output
+        assert "[completed]" in output
+
+    def test_check_no_tasks_returns_message(self, mgr: BackgroundManager) -> None:
+        """Returns 'No background tasks.' when empty."""
+        assert mgr.check() == "No background tasks."
+
+
+# ─── Notification Queue ───────────────────────────────────────────────────────────
+
+
+class TestNotifications:
+    """Tests for notification queue behaviour."""
+
+    def test_notification_appended_on_completion(self, mgr: BackgroundManager, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Notification is appended on task completion."""
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _make_completed_process(stdout="ok"))
+        mgr.tasks["t1"] = {"status": "running", "result": None, "command": "echo ok"}
+        mgr._execute("t1", "echo ok")
+        assert len(mgr._notifications) == 1
+        assert mgr._notifications[0]["task_id"] == "t1"
+        assert mgr._notifications[0]["status"] == "completed"
+
+    def test_drain_notifications_returns_and_clears(self, mgr: BackgroundManager, monkeypatch: pytest.MonkeyPatch) -> None:
+        """drain returns notifications and clears queue."""
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _make_completed_process(stdout="x"))
+        mgr.tasks["t1"] = {"status": "running", "result": None, "command": "cmd"}
+        mgr._execute("t1", "cmd")
+        notifs = mgr.drain_notifications()
+        assert len(notifs) == 1
+        assert notifs[0]["task_id"] == "t1"
+        # Queue is now empty
+        assert mgr.drain_notifications() == []
+
+    def test_drain_empty_returns_empty_list(self, mgr: BackgroundManager) -> None:
+        """drain returns empty list when no notifications."""
+        assert mgr.drain_notifications() == []
+
+
+# ─── Concurrency Safety ───────────────────────────────────────────────────────────
+
+
+class TestConcurrency:
+    """Tests for thread safety — W-1 defect verification."""
+
+    def test_concurrent_run_and_check_no_crash(self, mgr: BackgroundManager, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Concurrent run + check does not crash."""
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _make_completed_process(stdout="ok"))
+        errors: list = []
+        barrier = threading.Barrier(10, timeout=3)
+
+        def _worker():
+            try:
+                barrier.wait()
+                result = json.loads(mgr.run("echo hi"))
+                mgr.check(result["task_id"])
+                mgr.check()
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=_worker) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=3)
+        assert errors == []
+
+    def test_concurrent_multiple_tasks_no_lost_notifications(
+        self, mgr: BackgroundManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Concurrent tasks do not lose notifications."""
+        call_count = 20
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _make_completed_process(stdout="done"))
+        barrier = threading.Barrier(call_count, timeout=3)
+
+        def _worker(tid: str):
+            mgr.tasks[tid] = {"status": "running", "result": None, "command": f"cmd-{tid}"}
+            barrier.wait()
+            mgr._execute(tid, f"cmd-{tid}")
+
+        threads = [threading.Thread(target=_worker, args=(f"task{i}",)) for i in range(call_count)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=3)
+
+        notifs = mgr.drain_notifications()
+        assert len(notifs) == call_count
+
+
+# ─── Tool Class Tests ─────────────────────────────────────────────────────────────
+
+
+class TestToolClasses:
+    """Tests for BackgroundRunTool and CheckBackgroundTool delegation."""
+
+    def test_background_run_tool_delegates_to_manager(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """BackgroundRunTool.execute delegates to manager."""
+        import src.tools.background_tools as bg_mod
+
+        fake_mgr = BackgroundManager()
+        monkeypatch.setattr(bg_mod, "_BG", fake_mgr)
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _make_completed_process(stdout="bg"))
+
+        tool = BackgroundRunTool()
+        result = json.loads(tool.execute(command="echo bg"))
+        assert result["status"] == "ok"
+        assert result["task_id"] in fake_mgr.tasks
+
+    def test_check_background_tool_delegates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """CheckBackgroundTool.execute delegates to manager."""
+        import src.tools.background_tools as bg_mod
+
+        fake_mgr = BackgroundManager()
+        fake_mgr.tasks["xyz"] = {"status": "completed", "result": "ok", "command": "ls"}
+        monkeypatch.setattr(bg_mod, "_BG", fake_mgr)
+
+        tool = CheckBackgroundTool()
+        result = json.loads(tool.execute(task_id="xyz"))
+        assert result["status"] == "completed"

--- a/agent/tests/test_bash_tool.py
+++ b/agent/tests/test_bash_tool.py
@@ -1,0 +1,193 @@
+"""Unit tests for src.tools.bash_tool.BashTool."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from src.tools.bash_tool import BashTool
+
+
+@pytest.fixture()
+def tool() -> BashTool:
+    """Create a BashTool instance for testing."""
+    return BashTool()
+
+
+def _make_completed_process(
+    stdout: str = "",
+    stderr: str = "",
+    returncode: int = 0,
+) -> subprocess.CompletedProcess:
+    """Helper to build a CompletedProcess mock result."""
+    return subprocess.CompletedProcess(
+        args="fake",
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+# ─── Normal Execution ───────────────────────────────────────────────────────────────
+
+
+class TestNormalExecution:
+    """Tests for normal command execution paths."""
+
+    def test_successful_command_returns_ok(self, tool: BashTool, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Successful command returns status=ok and exit_code=0."""
+        monkeypatch.setattr(
+            subprocess, "run", lambda *a, **kw: _make_completed_process(stdout="hello\n")
+        )
+        result = json.loads(tool.execute(command="echo hello"))
+        assert result["status"] == "ok"
+        assert result["exit_code"] == 0
+
+    def test_failed_command_returns_error_status(self, tool: BashTool, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Non-zero exit code returns status=error."""
+        monkeypatch.setattr(
+            subprocess, "run", lambda *a, **kw: _make_completed_process(returncode=1)
+        )
+        result = json.loads(tool.execute(command="false"))
+        assert result["status"] == "error"
+        assert result["exit_code"] == 1
+
+    def test_stdout_captured(self, tool: BashTool, monkeypatch: pytest.MonkeyPatch) -> None:
+        """stdout is captured correctly."""
+        monkeypatch.setattr(
+            subprocess, "run", lambda *a, **kw: _make_completed_process(stdout="output data")
+        )
+        result = json.loads(tool.execute(command="cmd"))
+        assert result["stdout"] == "output data"
+
+    def test_stderr_captured(self, tool: BashTool, monkeypatch: pytest.MonkeyPatch) -> None:
+        """stderr is captured correctly."""
+        monkeypatch.setattr(
+            subprocess, "run", lambda *a, **kw: _make_completed_process(stderr="warn msg", returncode=0)
+        )
+        result = json.loads(tool.execute(command="cmd"))
+        assert result["stderr"] == "warn msg"
+
+    def test_custom_cwd_passed(self, tool: BashTool) -> None:
+        """run_dir parameter is passed to subprocess as cwd."""
+        captured_kwargs: dict = {}
+
+        def _fake_run(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            return _make_completed_process()
+
+        with patch.object(subprocess, "run", side_effect=_fake_run):
+            tool.execute(command="ls", run_dir="/tmp/work")
+
+        assert captured_kwargs["cwd"] == "/tmp/work"
+
+
+# ─── Output Truncation ──────────────────────────────────────────────────────────────────
+
+
+class TestOutputTruncation:
+    """Tests for output truncation at _OUTPUT_LIMIT."""
+
+    def test_stdout_truncated_at_limit(self, tool: BashTool, monkeypatch: pytest.MonkeyPatch) -> None:
+        """stdout exceeding 50000 chars is truncated."""
+        long_output = "x" * 60_000
+        monkeypatch.setattr(
+            subprocess, "run", lambda *a, **kw: _make_completed_process(stdout=long_output)
+        )
+        result = json.loads(tool.execute(command="cmd"))
+        assert len(result["stdout"]) == 50_000
+
+    def test_stderr_truncated_at_limit(self, tool: BashTool, monkeypatch: pytest.MonkeyPatch) -> None:
+        """stderr exceeding 50000 chars is truncated."""
+        long_err = "e" * 60_000
+        monkeypatch.setattr(
+            subprocess, "run", lambda *a, **kw: _make_completed_process(stderr=long_err)
+        )
+        result = json.loads(tool.execute(command="cmd"))
+        assert len(result["stderr"]) == 50_000
+
+    def test_output_under_limit_not_truncated(self, tool: BashTool, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Output under limit is not truncated."""
+        output = "a" * 49_999
+        monkeypatch.setattr(
+            subprocess, "run", lambda *a, **kw: _make_completed_process(stdout=output)
+        )
+        result = json.loads(tool.execute(command="cmd"))
+        assert result["stdout"] == output
+        assert len(result["stdout"]) == 49_999
+
+
+# ─── Timeout Handling ──────────────────────────────────────────────────────────────────
+
+
+class TestTimeout:
+    """Tests for timeout handling."""
+
+    def test_timeout_returns_error_json(self, tool: BashTool, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Timeout returns correct error JSON."""
+        def _raise_timeout(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd="sleep 999", timeout=120)
+
+        monkeypatch.setattr(subprocess, "run", _raise_timeout)
+        result = json.loads(tool.execute(command="sleep 999"))
+        assert result["status"] == "error"
+        assert "error" in result
+
+    def test_timeout_message_includes_duration(self, tool: BashTool, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Timeout message includes 120s."""
+        def _raise_timeout(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd="sleep 999", timeout=120)
+
+        monkeypatch.setattr(subprocess, "run", _raise_timeout)
+        result = json.loads(tool.execute(command="sleep 999"))
+        assert "120s" in result["error"]
+
+
+# ─── Exception Handling ──────────────────────────────────────────────────────────────────
+
+
+class TestExceptionHandling:
+    """Tests for generic exception handling."""
+
+    def test_generic_exception_returns_error_json(self, tool: BashTool, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Generic exception returns error JSON."""
+        def _raise_exc(*args, **kwargs):
+            raise OSError("Permission denied")
+
+        monkeypatch.setattr(subprocess, "run", _raise_exc)
+        result = json.loads(tool.execute(command="cmd"))
+        assert result["status"] == "error"
+        assert "error" in result
+
+    def test_exception_message_preserved(self, tool: BashTool, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Exception message is preserved."""
+        msg = "Something went terribly wrong"
+
+        def _raise_exc(*args, **kwargs):
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr(subprocess, "run", _raise_exc)
+        result = json.loads(tool.execute(command="cmd"))
+        assert result["error"] == msg
+
+
+# ─── Tool Metadata ───────────────────────────────────────────────────────────────
+
+
+class TestToolMetadata:
+    """Tests for tool class-level attributes."""
+
+    def test_tool_name_is_bash(self, tool: BashTool) -> None:
+        """name attribute is bash."""
+        assert tool.name == "bash"
+
+    def test_tool_is_not_readonly(self, tool: BashTool) -> None:
+        """is_readonly is False."""
+        assert tool.is_readonly is False
+
+    def test_tool_is_repeatable(self, tool: BashTool) -> None:
+        """repeatable is True."""
+        assert tool.repeatable is True

--- a/agent/tests/test_tool_registry.py
+++ b/agent/tests/test_tool_registry.py
@@ -1,0 +1,225 @@
+"""Unit tests for BaseTool and ToolRegistry."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+import pytest
+
+from src.agent.tools import BaseTool, ToolRegistry
+
+
+# ---------------------------------------------------------------------------
+# Stub tools
+# ---------------------------------------------------------------------------
+
+
+class EchoTool(BaseTool):
+    """Simple tool that echoes its input as JSON."""
+
+    name = "echo"
+    description = "Echoes input back"
+    parameters = {
+        "type": "object",
+        "properties": {"message": {"type": "string"}},
+        "required": ["message"],
+    }
+
+    def execute(self, **kwargs: Any) -> str:
+        return json.dumps({"status": "ok", "echo": kwargs.get("message", "")})
+
+
+class FailingTool(BaseTool):
+    """Tool that always raises an exception."""
+
+    name = "fail"
+    description = "Always fails"
+
+    def execute(self, **kwargs: Any) -> str:
+        raise RuntimeError("something went wrong")
+
+
+class NoParamsTool(BaseTool):
+    """Tool with no parameters defined."""
+
+    name = "noop"
+    description = "Does nothing"
+    parameters: Dict[str, Any] = {}
+
+    def execute(self, **kwargs: Any) -> str:
+        return json.dumps({"status": "ok"})
+
+
+class AddTool(BaseTool):
+    """Tool that adds two numbers, used to verify kwargs passing."""
+
+    name = "add"
+    description = "Adds a and b"
+    parameters = {
+        "type": "object",
+        "properties": {"a": {"type": "number"}, "b": {"type": "number"}},
+        "required": ["a", "b"],
+    }
+
+    def execute(self, **kwargs: Any) -> str:
+        result = kwargs["a"] + kwargs["b"]
+        return json.dumps({"status": "ok", "result": result})
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def registry() -> ToolRegistry:
+    return ToolRegistry()
+
+
+@pytest.fixture
+def echo_tool() -> EchoTool:
+    return EchoTool()
+
+
+@pytest.fixture
+def failing_tool() -> FailingTool:
+    return FailingTool()
+
+
+# ---------------------------------------------------------------------------
+# BaseTool tests
+# ---------------------------------------------------------------------------
+
+
+class TestBaseTool:
+    def test_check_available_default_returns_true(self) -> None:
+        assert EchoTool.check_available() is True
+
+    def test_to_openai_schema_format(self, echo_tool: EchoTool) -> None:
+        schema = echo_tool.to_openai_schema()
+
+        assert schema["type"] == "function"
+        assert schema["function"]["name"] == "echo"
+        assert schema["function"]["description"] == "Echoes input back"
+        assert schema["function"]["parameters"] == echo_tool.parameters
+
+    def test_to_openai_schema_empty_params(self) -> None:
+        tool = NoParamsTool()
+        schema = tool.to_openai_schema()
+
+        expected_params = {"type": "object", "properties": {}, "required": []}
+        assert schema["function"]["parameters"] == expected_params
+
+
+# ---------------------------------------------------------------------------
+# ToolRegistry registration tests
+# ---------------------------------------------------------------------------
+
+
+class TestToolRegistryRegistration:
+    def test_register_adds_tool(self, registry: ToolRegistry, echo_tool: EchoTool) -> None:
+        registry.register(echo_tool)
+        assert registry.get("echo") is echo_tool
+
+    def test_register_duplicate_name_overwrites(self, registry: ToolRegistry) -> None:
+        tool_a = EchoTool()
+        tool_b = EchoTool()
+        registry.register(tool_a)
+        registry.register(tool_b)
+
+        assert registry.get("echo") is tool_b
+
+    def test_get_unregistered_returns_none(self, registry: ToolRegistry) -> None:
+        assert registry.get("nonexistent") is None
+
+    def test_len_reflects_registered_count(self, registry: ToolRegistry) -> None:
+        assert len(registry) == 0
+        registry.register(EchoTool())
+        assert len(registry) == 1
+        registry.register(AddTool())
+        assert len(registry) == 2
+
+    def test_contains_checks_registration(self, registry: ToolRegistry, echo_tool: EchoTool) -> None:
+        assert "echo" not in registry
+        registry.register(echo_tool)
+        assert "echo" in registry
+        assert "unknown" not in registry
+
+
+# ---------------------------------------------------------------------------
+# ToolRegistry execution tests
+# ---------------------------------------------------------------------------
+
+
+class TestToolRegistryExecution:
+    def test_execute_calls_tool_and_returns_result(self, registry: ToolRegistry, echo_tool: EchoTool) -> None:
+        registry.register(echo_tool)
+        result = registry.execute("echo", {"message": "hello"})
+        data = json.loads(result)
+
+        assert data["status"] == "ok"
+        assert data["echo"] == "hello"
+
+    def test_execute_unknown_tool_returns_error_json(self, registry: ToolRegistry) -> None:
+        result = registry.execute("ghost", {})
+        data = json.loads(result)
+
+        assert data["status"] == "error"
+        assert "ghost" in data["error"]
+
+    def test_execute_exception_returns_error_json(self, registry: ToolRegistry, failing_tool: FailingTool) -> None:
+        registry.register(failing_tool)
+        result = registry.execute("fail", {})
+        data = json.loads(result)
+
+        assert data["status"] == "error"
+        assert data["tool"] == "fail"
+
+    def test_execute_exception_preserves_message(self, registry: ToolRegistry, failing_tool: FailingTool) -> None:
+        registry.register(failing_tool)
+        result = registry.execute("fail", {})
+        data = json.loads(result)
+
+        assert data["error"] == "something went wrong"
+
+    def test_execute_passes_params_as_kwargs(self, registry: ToolRegistry) -> None:
+        registry.register(AddTool())
+        result = registry.execute("add", {"a": 3, "b": 7})
+        data = json.loads(result)
+
+        assert data["status"] == "ok"
+        assert data["result"] == 10
+
+
+# ---------------------------------------------------------------------------
+# get_definitions tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetDefinitions:
+    def test_get_definitions_returns_all_schemas(self, registry: ToolRegistry) -> None:
+        registry.register(EchoTool())
+        registry.register(AddTool())
+        defs = registry.get_definitions()
+
+        assert len(defs) == 2
+        names = {d["function"]["name"] for d in defs}
+        assert names == {"echo", "add"}
+
+    def test_get_definitions_empty_registry(self, registry: ToolRegistry) -> None:
+        assert registry.get_definitions() == []
+
+
+# ---------------------------------------------------------------------------
+# tool_names property tests
+# ---------------------------------------------------------------------------
+
+
+class TestToolNames:
+    def test_tool_names_returns_registered_names(self, registry: ToolRegistry) -> None:
+        registry.register(EchoTool())
+        registry.register(AddTool())
+
+        names = registry.tool_names
+        assert set(names) == {"echo", "add"}


### PR DESCRIPTION


## Summary

- test_background_tools.py: 19 cases covering concurrency, timeout, notifications
- test_bash_tool.py: 15 cases covering execution, truncation, timeout, exceptions
- test_tool_registry.py: 16 cases covering registration, execution, schema
- Add code review report (code-review-2026-06-21.md)
- Add P0 test coverage documentation (p0-test-coverage-2026-06-22.md)


## Why

Resolve some test coverage rate issues

## Changes

Add tests

## Test Plan

- [ ] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [ ] New tests added (if applicable)
- [ ] Tested manually (describe below)

## Checklist

- [ ] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [ ] No hardcoded values (API keys, file paths, magic numbers)
- [ ] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] Documentation updated (if user-facing change)
