### PR TITLE
fix(frontend): stop Alpha Zoo headline rendering the count twice

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -350,6 +350,7 @@
   "alphaZoo": {
     "title": "Alpha Zoo",
     "prebuiltAlpha": "{{count}} pre-built quant alphas across 4 zoos",
+    "prebuiltAlphaLoading": "Pre-built quant alphas across 4 zoos",
     "browseDesc": "Browse formula-driven cross-sectional signals from Qlib, the Kakushadze 101 set, GTJA 191, and the academic anomaly literature. Click any alpha to read its formula and source code, or run a bench to score the whole zoo on a universe and period.",
     "search": "Search",
     "searchPlaceholder": "Filter by id or nickname…",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -350,6 +350,7 @@
   "alphaZoo": {
     "title": "Alpha 动物园",
     "prebuiltAlpha": "{{count}} 个预构建量化 Alpha，覆盖 4 个动物园",
+    "prebuiltAlphaLoading": "预构建量化 Alpha，覆盖 4 个动物园",
     "browseDesc": "浏览来自 Qlib、Kakushadze 101 公式集、GTJA 191 以及学术异象文献的公式驱动截面信号。点击任意 Alpha 查看公式和源码，或运行基准测试在特定市场和时间段上评分整个动物园。",
     "search": "搜索",
     "searchPlaceholder": "按 ID 或昵称筛选…",

--- a/frontend/src/pages/AlphaZoo.tsx
+++ b/frontend/src/pages/AlphaZoo.tsx
@@ -215,7 +215,9 @@ function BrowseView() {
           <Layers className="h-3.5 w-3.5" aria-hidden="true" /> Alpha Zoo
         </div>
         <h1 className="text-2xl md:text-3xl font-bold tracking-tight">
-          {total > 0 ? total : 452} {i18n.t("alphaZoo.prebuiltAlpha", { count: total > 0 ? total : 452 })}
+          {loading
+            ? i18n.t("alphaZoo.prebuiltAlphaLoading")
+            : i18n.t("alphaZoo.prebuiltAlpha", { count: total })}
         </h1>
         <p className="text-sm text-muted-foreground max-w-2xl">
           Browse formula-driven cross-sectional signals from Qlib, the


### PR DESCRIPTION
## Summary

Fixes #286 — the Alpha Zoo page renders the alpha count twice in its headline (e.g. **"456 456 pre-built quant alphas across 4 zoos"**).

## Root cause

`frontend/src/pages/AlphaZoo.tsx:218` rendered a standalone `{total}` **and then** the translated `alphaZoo.prebuiltAlpha` string — which already interpolates `{{count}}`. So the number printed twice. The same line also carried a hardcoded, now-stale `452` fallback.

```tsx
// before
{total > 0 ? total : 452} {i18n.t("alphaZoo.prebuiltAlpha", { count: total > 0 ? total : 452 })}
```

## Fix

- Render **only** the translated string, with the live (filter-aware) `total` as the count.
- Drop the hardcoded `452` fallback; while alphas load, show a count-less loading variant gated on the existing `loading` flag (avoids a "0 pre-built…" flash).
- New `alphaZoo.prebuiltAlphaLoading` key added to **both** `en.json` and `zh-CN.json` (locale key sets stay in parity).

```tsx
// after
{loading
  ? i18n.t("alphaZoo.prebuiltAlphaLoading")
  : i18n.t("alphaZoo.prebuiltAlpha", { count: total })}
```

## Test Plan

- [x] `tsc --noEmit` — clean
- [x] `vitest run` — 22 files, 209 tests passed
- [x] Locale key parity verified (no en-only / zh-only keys)

Closes #286