### PR TITLE
fix: reject cross-site unsafe local API requests

### DIFF
--- a/agent/api_server.py
+++ b/agent/api_server.py
@@ -764,6 +764,9 @@ def _require_shutdown_authorization(
         )
 
 
+_SAFE_BROWSER_METHODS = {"GET", "HEAD", "OPTIONS"}
+
+
 def _validate_api_auth(
     *,
     request: Request,
@@ -772,6 +775,12 @@ def _validate_api_auth(
     allow_query: bool = False,
 ) -> None:
     """Validate configured auth, preserving loopback-only dev mode."""
+    # CORS protects response reads, not blind side effects. Reject unsafe
+    # browser-originated cross-site requests before honoring loopback dev-mode
+    # trust, otherwise a malicious page can drive local POST/PUT/DELETE routes.
+    if request.method.upper() not in _SAFE_BROWSER_METHODS:
+        _reject_cross_site_browser_request(request)
+
     # Loopback clients are always trusted, even when API_AUTH_KEY is set.
     # The key only gates non-local (LAN/remote) access.
     if _is_local_client(request):

--- a/agent/tests/test_upload_api.py
+++ b/agent/tests/test_upload_api.py
@@ -28,6 +28,47 @@ def _existing_uploads(uploads_dir: Path) -> list[Path]:
     return [p for p in uploads_dir.iterdir() if p.is_file()]
 
 
+def test_cross_site_browser_upload_is_rejected_even_from_loopback(
+    client: TestClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("API_AUTH_KEY", "secret")
+    monkeypatch.setattr(api_server, "_API_KEY", "secret")
+
+    response = client.post(
+        "/upload",
+        headers={
+            "Host": "127.0.0.1:8899",
+            "Origin": "https://evil.example",
+            "Sec-Fetch-Site": "cross-site",
+        },
+        files={"file": ("poc.txt", b"x" * 1024, "text/plain")},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Cross-site request denied"
+    assert _existing_uploads(tmp_path) == []
+
+
+def test_loopback_upload_without_browser_origin_still_allowed_when_key_configured(
+    client: TestClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("API_AUTH_KEY", "secret")
+    monkeypatch.setattr(api_server, "_API_KEY", "secret")
+
+    response = client.post(
+        "/upload",
+        headers={"Host": "127.0.0.1:8899"},
+        files={"file": ("note.txt", b"safe", "text/plain")},
+    )
+
+    assert response.status_code == 200
+    assert len(_existing_uploads(tmp_path)) == 1
+
+
 def test_upload_under_limit_succeeds(client: TestClient, tmp_path: Path) -> None:
     payload = b"x" * (2 * 1024)  # 2 KB, well under the 4 KB limit
     response = client.post(


### PR DESCRIPTION
## Summary

- Reject unsafe cross-site browser requests before applying loopback dev-mode auth trust.
- Add upload API regressions covering cross-site loopback rejection and the local non-browser upload control.

## Why

Loopback requests are trusted by the local API so CLI/local UI workflows can work in dev mode. However, browsers can also issue simple cross-origin requests to `127.0.0.1`; CORS prevents response reads but does not prevent side effects. This change makes unsafe browser-originated requests hit the existing cross-site guard before loopback auth bypass is honored.

## Changes

- Add `_SAFE_BROWSER_METHODS` and call `_reject_cross_site_browser_request()` from `_validate_api_auth()` for unsafe methods.
- Preserve existing safe-method behavior and local non-browser upload behavior.
- Add regression coverage for `POST /upload` with cross-site browser headers.

## Test Plan

- [x] Existing targeted tests pass: `python3 -m pytest -q agent/tests/test_upload_api.py agent/tests/test_security_auth_api.py agent/tests/test_settings_api.py`
- [x] New tests added (cross-site loopback upload rejection and local non-browser upload control)
- [x] Tested manually in Docker/container:
  - `docker run --rm -v "$PWD:/work" -w /work python:3.11-slim ... python -m pytest -q agent/tests/test_upload_api.py agent/tests/test_security_auth_api.py agent/tests/test_settings_api.py`
  - Result: `70 passed, 5 warnings in 0.54s`
  - Container proof after fix: cross-site upload returned `403` with no created files; local non-browser upload returned `200`.

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Documentation updated (not user-facing; regression tests added instead)
