### PR TITLE
feat(shadow-account): add as-of price-context features (entry RSI, prior return)

### DIFF
--- a/agent/src/shadow_account/extractor.py
+++ b/agent/src/shadow_account/extractor.py
@@ -7,10 +7,11 @@ Pipeline:
     → LLM-light natural-language translation (template fallback if no LLM)
 
 Design constraints:
-    * No external price-data calls in v1. All features are derivable from
-      the journal itself (holding_days, pnl_pct, entry hour/weekday, market).
-      Price-dependent features (prior_N_return, rsi) are stubbed with None
-      and dropped from the feature matrix if unavailable.
+    * No *mandatory* external price-data calls. Journal-derived features
+      (holding_days, pnl_pct, entry hour/weekday, market) always work offline.
+      Price-context features (entry_rsi14, prior_5d_return) are read as-of the
+      buy date via the backtest loader registry and degrade to NaN — dropped
+      from the feature matrix — whenever price data is unavailable.
     * Must survive tiny samples: <5 profitable roundtrips → explicit error.
       <2 clusters → degrade to a single-cluster heuristic rule.
     * Rules are immutable ShadowRule objects — codegen's only input.
@@ -37,6 +38,23 @@ DEFAULT_MAX_RULES = 5
 DEFAULT_MIN_SUPPORT = 3
 _NUMERIC_FEATURES = ("holding_days", "pnl_pct", "entry_hour", "entry_weekday")
 _CATEGORICAL_FEATURES = ("market",)
+
+# Price-context features attached as-of buy_dt (NaN when price data unavailable).
+_PRICE_FEATURES = ("entry_rsi14", "prior_5d_return")
+_RSI_PERIOD = 14
+_PRIOR_RETURN_WINDOW = 5
+# Calendar buffer added before the earliest buy_dt so the RSI warmup has enough
+# trading bars even across weekends/holidays.
+_PRICE_LOOKBACK_DAYS = 40
+
+# Journal market label → backtest loader-registry market key. Labels with no
+# mapping (e.g. "other") skip the price fetch and degrade to NaN.
+_MARKET_KEY_MAP = {
+    "china_a": "a_share",
+    "us": "us_equity",
+    "hk": "hk_equity",
+    "crypto": "crypto",
+}
 
 
 # ---------------- Public API ----------------
@@ -126,6 +144,155 @@ def extract_shadow_profile(
 
 # ---------------- Feature engineering ----------------
 
+def _compute_rsi(close: pd.Series, period: int = _RSI_PERIOD) -> pd.Series:
+    """Causal Wilder-EWM RSI.
+
+    Mirrors the shape of ``compute_rsi`` in
+    ``agent/src/skills/technical-basic/example_signal_engine.py:13`` — that
+    module lives under a hyphenated (non-importable) skills directory, so the
+    formula is re-implemented here rather than imported. Causal by construction:
+    ``RSI[t]`` depends only on closes dated ``<= t``.
+
+    Args:
+        close: Close-price series indexed by date.
+        period: RSI lookback period.
+
+    Returns:
+        RSI series (0-100), NaN for the warmup window.
+    """
+    delta = close.diff()
+    gain = delta.clip(lower=0)
+    loss = (-delta).clip(lower=0)
+    avg_gain = gain.ewm(alpha=1 / period, min_periods=period).mean()
+    avg_loss = loss.ewm(alpha=1 / period, min_periods=period).mean()
+    rs = avg_gain / avg_loss
+    return 100 - 100 / (1 + rs)
+
+
+def _fetch_price_history(
+    symbol: str,
+    market: str,
+    *,
+    start: pd.Timestamp,
+    end: pd.Timestamp,
+) -> pd.DataFrame | None:
+    """Fetch daily OHLCV for one symbol via the backtest loader registry.
+
+    Uses the same access path as the backtest runner (``resolve_loader`` +
+    the loader ``fetch`` protocol). Any failure — unmapped market, no available
+    source, empty result, symbol absent from the returned map — degrades to
+    ``None`` so the caller can drop the price features rather than raise.
+
+    Args:
+        symbol: Journal symbol, passed to the loader as-is (no cross-market
+            normalization in v1).
+        market: Journal market label (e.g. ``"china_a"``).
+        start: Inclusive fetch start (already buffered for indicator warmup).
+        end: Inclusive fetch end — never later than the roundtrip's buy_dt, so
+            look-ahead is structurally impossible.
+
+    Returns:
+        A ``trade_date``-indexed OHLCV frame, or ``None`` when unavailable.
+    """
+    market_key = _MARKET_KEY_MAP.get(market)
+    if market_key is None:
+        return None
+    try:
+        from backtest.loaders.base import NoAvailableSourceError
+        from backtest.loaders.registry import resolve_loader
+
+        loader = resolve_loader(market_key)
+        data_map = loader.fetch(
+            [symbol],
+            start.strftime("%Y-%m-%d"),
+            end.strftime("%Y-%m-%d"),
+            interval="1D",
+        )
+    except NoAvailableSourceError as exc:
+        logger.debug("No price source for %s (%s): %s", symbol, market, exc)
+        return None
+    except Exception as exc:  # pragma: no cover — loader/network edge cases
+        logger.debug("Price fetch failed for %s (%s): %s", symbol, market, exc)
+        return None
+
+    frame = data_map.get(symbol)
+    if frame is None or frame.empty or "close" not in frame.columns:
+        return None
+    return frame
+
+
+def _as_of_index(frame: pd.DataFrame, buy_dt: pd.Timestamp) -> pd.DataFrame:
+    """Slice a price frame to bars dated on or before *buy_dt*.
+
+    The loader frame is indexed by a tz-naive ``DatetimeIndex`` at day
+    granularity; ``buy_dt`` carries a time-of-day and may be tz-aware. Normalize
+    to a tz-naive date before slicing, otherwise the ``.loc`` comparison raises.
+    """
+    as_of = pd.Timestamp(buy_dt)
+    if as_of.tzinfo is not None:
+        as_of = as_of.tz_localize(None)
+    as_of = as_of.normalize()
+    return frame.loc[:as_of]
+
+
+def _price_features_as_of(
+    frame: pd.DataFrame | None,
+    buy_dt: pd.Timestamp,
+) -> dict[str, float]:
+    """Compute price-context features as-of *buy_dt* from a price frame.
+
+    Every value is read from bars dated ``<= buy_dt`` only; bars in the
+    ``(buy_dt, sell_dt]`` exit window are never consulted. Insufficient history
+    leaves the affected feature as ``NaN``.
+    """
+    out: dict[str, float] = {name: float("nan") for name in _PRICE_FEATURES}
+    if frame is None:
+        return out
+
+    history = _as_of_index(frame, buy_dt)
+    close = history["close"].dropna()
+    if close.empty:
+        return out
+
+    if len(close) >= _RSI_PERIOD:
+        rsi = _compute_rsi(close).iloc[-1]
+        out["entry_rsi14"] = float(rsi) if pd.notna(rsi) else float("nan")
+
+    if len(close) >= _PRIOR_RETURN_WINDOW + 1:
+        ret = close.pct_change(_PRIOR_RETURN_WINDOW).iloc[-1]
+        out["prior_5d_return"] = float(ret) if pd.notna(ret) else float("nan")
+
+    return out
+
+
+def _attach_price_features(
+    rows: list[dict[str, Any]],
+) -> None:
+    """Attach price-context features in place, batching one fetch per symbol.
+
+    Groups roundtrips by symbol, fetches each symbol's price window once over
+    ``[min(buy_dt) - buffer, max(buy_dt)]``, then reads each roundtrip's
+    features as-of its own buy_dt. Mutates each row dict with the price-feature
+    keys (NaN when unavailable).
+    """
+    by_symbol: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        by_symbol.setdefault(row["symbol"], []).append(row)
+
+    for symbol, sym_rows in by_symbol.items():
+        market = sym_rows[0]["market"]
+        buy_dts = [pd.Timestamp(r["buy_dt"]) for r in sym_rows]
+        end = max(buy_dts)
+        start = min(buy_dts) - pd.Timedelta(days=_PRICE_LOOKBACK_DAYS)
+        if end.tzinfo is not None:
+            end = end.tz_localize(None)
+        if start.tzinfo is not None:
+            start = start.tz_localize(None)
+        frame = _fetch_price_history(symbol, market, start=start, end=end)
+        for row in sym_rows:
+            row.update(_price_features_as_of(frame, pd.Timestamp(row["buy_dt"])))
+
+
 def _compute_features(
     roundtrips: list[dict[str, Any]],
     trades_df: pd.DataFrame,
@@ -133,7 +300,8 @@ def _compute_features(
     """Compute a features row per profitable roundtrip.
 
     Columns: symbol, market, holding_days, pnl, pnl_pct, entry_hour,
-    entry_weekday, buy_dt, sell_dt.
+    entry_weekday, buy_dt, sell_dt, plus price-context features (entry_rsi14,
+    prior_5d_return) read as-of buy_dt — NaN when price data is unavailable.
     """
     market_by_symbol = (
         trades_df.drop_duplicates("symbol").set_index("symbol")["market"].to_dict()
@@ -153,10 +321,30 @@ def _compute_features(
             "buy_dt": buy_dt,
             "sell_dt": sell_dt,
         })
+    _attach_price_features(rows)
     return pd.DataFrame(rows)
 
 
 # ---------------- Cluster + decision-tree rule extraction ----------------
+
+def _promoted_numeric_features(
+    features_df: pd.DataFrame,
+    *,
+    min_support: int,
+) -> tuple[str, ...]:
+    """Return the numeric feature set used for clustering.
+
+    Always includes the journal-derived ``_NUMERIC_FEATURES``. A price feature
+    joins only when it is present (non-NaN) for at least ``min_support`` rows —
+    too-sparse price features are excluded so clustering behaves exactly as the
+    journal-only baseline when price data is largely unavailable.
+    """
+    promoted = list(_NUMERIC_FEATURES)
+    for name in _PRICE_FEATURES:
+        if name in features_df.columns and features_df[name].notna().sum() >= min_support:
+            promoted.append(name)
+    return tuple(promoted)
+
 
 def _extract_rules(
     features_df: pd.DataFrame,
@@ -169,7 +357,10 @@ def _extract_rules(
     if len(features_df) < min_support:
         return [_heuristic_single_rule(features_df, min_support, llm_translator)]
 
-    cluster_labels = _auto_cluster(features_df, max_k=min(max_rules, 5))
+    numeric_features = _promoted_numeric_features(features_df, min_support=min_support)
+    cluster_labels = _auto_cluster(
+        features_df, max_k=min(max_rules, 5), numeric_features=numeric_features,
+    )
     rules: list[ShadowRule] = []
     total_profitable = len(features_df)
     used_markets: set[str] = set()
@@ -199,17 +390,30 @@ def _extract_rules(
     return rules
 
 
-def _auto_cluster(features_df: pd.DataFrame, *, max_k: int) -> np.ndarray:
+def _auto_cluster(
+    features_df: pd.DataFrame,
+    *,
+    max_k: int,
+    numeric_features: tuple[str, ...] = _NUMERIC_FEATURES,
+) -> np.ndarray:
     """Pick a cluster count via simple silhouette heuristic (fallback k=2).
 
-    Uses only numeric features; scales by z-score to avoid holding_days
-    dominating pnl_pct.
+    Uses the supplied numeric features; scales by z-score to avoid any single
+    feature dominating. Promoted price features may carry NaNs for rows whose
+    price data was unavailable; those are median-imputed so the KMeans input is
+    complete and stays row-aligned with ``features_df`` (StandardScaler/KMeans
+    reject NaN). Imputation only affects *grouping* — ``_cluster_to_rule`` never
+    reads price features — so a neutral median cannot distort rule bounds.
     """
     from sklearn.cluster import KMeans
     from sklearn.preprocessing import StandardScaler
 
-    numeric = features_df[list(_NUMERIC_FEATURES)].astype(float).to_numpy()
-    if len(numeric) <= 2 or max_k < 2:
+    numeric_df = features_df[list(numeric_features)].astype(float)
+    numeric_df = numeric_df.fillna(numeric_df.median(numeric_only=True))
+    # A feature that is all-NaN stays NaN after median fill — drop such columns.
+    numeric_df = numeric_df.dropna(axis=1, how="all")
+    numeric = numeric_df.to_numpy()
+    if len(numeric) <= 2 or max_k < 2 or numeric.shape[1] == 0:
         return np.zeros(len(numeric), dtype=int)
     scaled = StandardScaler().fit_transform(numeric)
 

--- a/agent/tests/test_shadow_account.py
+++ b/agent/tests/test_shadow_account.py
@@ -38,6 +38,29 @@ from src.shadow_account.extractor import MIN_PROFITABLE_ROUNDTRIPS
 
 # ---------------- Helpers ----------------
 
+@pytest.fixture(autouse=True)
+def _offline_prices(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default every test to an offline price source.
+
+    `_compute_features` now reaches the loader registry for price-context
+    features. Without this, the suite could make real network calls in a
+    connected environment (auth-free loaders like stooq/yahoo). Forcing
+    `resolve_loader` to raise keeps the suite deterministic and network-free;
+    extraction degrades to NaN price features exactly as in production offline.
+    Tests that exercise the price path override this with a fixture loader.
+    """
+    from backtest.loaders.base import NoAvailableSourceError
+
+    def _no_source(market: str):
+        raise NoAvailableSourceError(f"offline test: no source for {market}")
+
+    # Patch at the source module: `_fetch_price_history` imports `resolve_loader`
+    # locally at call time, so the binding to override lives in the registry.
+    monkeypatch.setattr(
+        "backtest.loaders.registry.resolve_loader", _no_source,
+    )
+
+
 def _write_journal(path: Path, rows: list[dict]) -> Path:
     """Write a plain-utf8 Tonghuashun-style CSV the parser can ingest."""
     df = pd.DataFrame(rows)
@@ -595,3 +618,343 @@ def test_attribution_is_zero_without_journal(
     assert result.attribution.noise_trades_pnl == 0.0
     assert result.real_total_pnl == 0.0
     assert result.attribution.counterfactual_trades == ()
+
+
+# ---------------- Price-context features (as-of buy_dt) ----------------
+
+from src.shadow_account.extractor import (  # noqa: E402
+    _MARKET_KEY_MAP,
+    _attach_price_features,
+    _compute_rsi,
+    _price_features_as_of,
+    _promoted_numeric_features,
+)
+
+
+def _price_frame(dates: list[str], closes: list[float]) -> pd.DataFrame:
+    """Build a tz-naive trade_date-indexed OHLCV frame like a loader returns."""
+    idx = pd.to_datetime(dates)
+    return pd.DataFrame(
+        {
+            "open": closes,
+            "high": [c * 1.01 for c in closes],
+            "low": [c * 0.99 for c in closes],
+            "close": closes,
+            "volume": [1_000_000] * len(closes),
+        },
+        index=pd.DatetimeIndex(idx, name="trade_date"),
+    )
+
+
+class _FixtureLoader:
+    """Minimal loader returning a fixed frame for any requested symbol."""
+
+    def __init__(self, frame: pd.DataFrame) -> None:
+        self._frame = frame
+
+    def fetch(self, codes, start_date, end_date, *, interval="1D", fields=None):
+        # Mirror real loaders: only return bars within [start, end].
+        lo, hi = pd.Timestamp(start_date), pd.Timestamp(end_date)
+        sliced = self._frame.loc[lo:hi]
+        return {code: sliced.copy() for code in codes}
+
+
+@pytest.fixture
+def with_price_loader(monkeypatch: pytest.MonkeyPatch):
+    """Override the offline default with a fixture loader the test controls."""
+
+    def _install(frame: pd.DataFrame) -> None:
+        loader = _FixtureLoader(frame)
+        monkeypatch.setattr(
+            "backtest.loaders.registry.resolve_loader", lambda market: loader,
+        )
+
+    return _install
+
+
+@pytest.mark.unit
+def test_compute_rsi_is_causal_and_bounded() -> None:
+    rising = pd.Series(range(1, 40), dtype=float)
+    rsi = _compute_rsi(rising)
+    assert rsi.isna().sum() == 14  # warmup window
+    assert 99.0 <= float(rsi.iloc[-1]) <= 100.0  # monotonic up → RSI ~100
+    # Causality: truncating future bars does not change an earlier RSI value.
+    at_20_full = float(_compute_rsi(rising).iloc[20])
+    at_20_trunc = float(_compute_rsi(rising.iloc[:21]).iloc[-1])
+    assert at_20_full == pytest.approx(at_20_trunc)
+
+
+@pytest.mark.unit
+def test_price_features_as_of_reads_only_past_bars() -> None:
+    dates = [f"2026-02-{d:02d}" for d in range(1, 21)]
+    closes = [10.0 + 0.1 * i for i in range(20)]  # steadily rising
+    frame = _price_frame(dates, closes)
+    buy_dt = pd.Timestamp("2026-02-20 10:30:00")
+
+    feats = _price_features_as_of(frame, buy_dt)
+    assert not pd.isna(feats["entry_rsi14"])
+    # prior_5d_return over a +0.1/step ramp ending at 11.9 vs 5 steps back (11.4)
+    assert feats["prior_5d_return"] == pytest.approx((11.9 - 11.4) / 11.4, rel=1e-6)
+
+
+@pytest.mark.unit
+def test_price_features_no_lookahead_past_buy_dt() -> None:
+    """Appending bars dated after buy_dt must not change feature values."""
+    dates = [f"2026-02-{d:02d}" for d in range(1, 21)]
+    closes = [10.0 + 0.1 * i for i in range(20)]
+    buy_dt = pd.Timestamp("2026-02-20 10:30:00")
+
+    base = _price_features_as_of(_price_frame(dates, closes), buy_dt)
+
+    future_dates = dates + [f"2026-02-{d:02d}" for d in range(21, 26)]
+    future_closes = closes + [99.0, 1.0, 99.0, 1.0, 99.0]  # wild future moves
+    extended = _price_features_as_of(_price_frame(future_dates, future_closes), buy_dt)
+
+    assert extended["entry_rsi14"] == pytest.approx(base["entry_rsi14"])
+    assert extended["prior_5d_return"] == pytest.approx(base["prior_5d_return"])
+
+
+@pytest.mark.unit
+def test_price_features_tz_aware_buy_dt_does_not_raise() -> None:
+    dates = [f"2026-02-{d:02d}" for d in range(1, 21)]
+    closes = [10.0 + 0.1 * i for i in range(20)]
+    frame = _price_frame(dates, closes)
+
+    naive = _price_features_as_of(frame, pd.Timestamp("2026-02-20 10:30:00"))
+    aware = _price_features_as_of(
+        frame, pd.Timestamp("2026-02-20 10:30:00", tz="Asia/Shanghai"),
+    )
+    assert aware["entry_rsi14"] == pytest.approx(naive["entry_rsi14"])
+    assert aware["prior_5d_return"] == pytest.approx(naive["prior_5d_return"])
+
+
+@pytest.mark.unit
+def test_price_features_insufficient_history_is_nan() -> None:
+    frame = _price_frame(["2026-02-01", "2026-02-02", "2026-02-03"], [10.0, 10.1, 10.2])
+    feats = _price_features_as_of(frame, pd.Timestamp("2026-02-03"))
+    assert pd.isna(feats["entry_rsi14"])  # <14 closes
+    assert pd.isna(feats["prior_5d_return"])  # <6 closes
+
+
+@pytest.mark.unit
+def test_attach_price_features_unmapped_market_is_nan() -> None:
+    rows = [{"symbol": "X", "market": "other", "buy_dt": pd.Timestamp("2026-02-20")}]
+    _attach_price_features(rows)  # "other" has no registry mapping → no fetch
+    assert pd.isna(rows[0]["entry_rsi14"])
+    assert pd.isna(rows[0]["prior_5d_return"])
+
+
+@pytest.mark.unit
+def test_extract_with_price_features_promotes_into_clustering(
+    profitable_journal: Path, with_price_loader, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # 60 daily bars so RSI(14) + prior-5d are well-defined as-of every buy_dt.
+    dates = pd.bdate_range("2025-12-01", periods=60).strftime("%Y-%m-%d").tolist()
+    closes = [10.0 + 0.05 * i for i in range(60)]
+    with_price_loader(_price_frame(dates, closes))
+
+    # Capture what `_compute_features` produced and which numeric features the
+    # clusterer was actually handed — a rule count alone can't prove promotion.
+    import src.shadow_account.extractor as extractor
+
+    captured: dict[str, object] = {}
+    orig_features = extractor._compute_features
+    orig_cluster = extractor._auto_cluster
+
+    def spy_features(roundtrips, trades_df):
+        df = orig_features(roundtrips, trades_df)
+        captured["features_df"] = df
+        return df
+
+    def spy_cluster(features_df, *, max_k, numeric_features=extractor._NUMERIC_FEATURES):
+        captured["numeric_features"] = numeric_features
+        return orig_cluster(
+            features_df, max_k=max_k, numeric_features=numeric_features,
+        )
+
+    monkeypatch.setattr(extractor, "_compute_features", spy_features)
+    monkeypatch.setattr(extractor, "_auto_cluster", spy_cluster)
+
+    profile = extract_shadow_profile(profitable_journal, min_support=2)
+    assert isinstance(profile, ShadowProfile)
+    assert len(profile.rules) >= 1
+
+    # Price columns were actually attached and populated (not all-NaN)...
+    fdf = captured["features_df"]
+    assert "entry_rsi14" in fdf.columns and "prior_5d_return" in fdf.columns
+    assert fdf["entry_rsi14"].notna().any()
+    assert fdf["prior_5d_return"].notna().any()
+    # ...and both were promoted into the clustering feature set.
+    numeric = captured["numeric_features"]
+    assert "entry_rsi14" in numeric
+    assert "prior_5d_return" in numeric
+
+
+@pytest.mark.unit
+def test_sparse_price_features_fall_back_to_journal_only(
+    profitable_journal: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With prices offline (autouse), promotion is skipped and rules still form."""
+    import src.shadow_account.extractor as extractor
+
+    captured: dict[str, object] = {}
+    orig_cluster = extractor._auto_cluster
+
+    def spy_cluster(features_df, *, max_k, numeric_features=extractor._NUMERIC_FEATURES):
+        captured["numeric_features"] = numeric_features
+        return orig_cluster(
+            features_df, max_k=max_k, numeric_features=numeric_features,
+        )
+
+    monkeypatch.setattr(extractor, "_auto_cluster", spy_cluster)
+
+    profile = extract_shadow_profile(profitable_journal, min_support=2)
+    assert len(profile.rules) >= 1
+    # No price source → no price feature promoted → journal-only clustering.
+    assert tuple(captured["numeric_features"]) == extractor._NUMERIC_FEATURES
+
+
+@pytest.mark.unit
+def test_promoted_features_threshold() -> None:
+    df = pd.DataFrame({
+        "holding_days": [1.0, 2.0, 3.0, 4.0],
+        "pnl_pct": [0.1, 0.2, 0.1, 0.2],
+        "entry_hour": [10, 11, 10, 11],
+        "entry_weekday": [1, 2, 3, 4],
+        "entry_rsi14": [55.0, 60.0, float("nan"), float("nan")],  # 2 present
+        "prior_5d_return": [0.01, 0.02, 0.03, 0.04],  # 4 present
+    })
+    promoted = _promoted_numeric_features(df, min_support=3)
+    assert "prior_5d_return" in promoted  # 4 >= 3
+    assert "entry_rsi14" not in promoted  # 2 < 3
+    assert set(_MARKET_KEY_MAP) == {"china_a", "us", "hk", "crypto"}
+
+
+# ---- Degradation branches in the price-fetch / attach path ----
+
+from src.shadow_account.extractor import (  # noqa: E402
+    _auto_cluster,
+    _fetch_price_history,
+)
+
+
+@pytest.mark.unit
+def test_fetch_price_history_symbol_absent_from_map(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Loader available but returns no entry for the requested symbol → None."""
+
+    class _EmptyMapLoader:
+        def fetch(self, codes, start_date, end_date, *, interval="1D", fields=None):
+            return {}  # symbol not present
+
+    monkeypatch.setattr(
+        "backtest.loaders.registry.resolve_loader", lambda market: _EmptyMapLoader(),
+    )
+    out = _fetch_price_history(
+        "600519", "china_a",
+        start=pd.Timestamp("2026-01-01"), end=pd.Timestamp("2026-02-01"),
+    )
+    assert out is None
+
+
+@pytest.mark.unit
+def test_fetch_price_history_empty_frame(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Loader returns an empty frame for the symbol → None."""
+
+    class _EmptyFrameLoader:
+        def fetch(self, codes, start_date, end_date, *, interval="1D", fields=None):
+            return {c: pd.DataFrame(columns=["open", "high", "low", "close", "volume"])
+                    for c in codes}
+
+    monkeypatch.setattr(
+        "backtest.loaders.registry.resolve_loader", lambda market: _EmptyFrameLoader(),
+    )
+    out = _fetch_price_history(
+        "600519", "china_a",
+        start=pd.Timestamp("2026-01-01"), end=pd.Timestamp("2026-02-01"),
+    )
+    assert out is None
+
+
+@pytest.mark.unit
+def test_fetch_price_history_loader_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A loader that raises mid-fetch degrades to None, never propagates."""
+
+    class _BoomLoader:
+        def fetch(self, codes, start_date, end_date, *, interval="1D", fields=None):
+            raise RuntimeError("network down")
+
+    monkeypatch.setattr(
+        "backtest.loaders.registry.resolve_loader", lambda market: _BoomLoader(),
+    )
+    out = _fetch_price_history(
+        "600519", "china_a",
+        start=pd.Timestamp("2026-01-01"), end=pd.Timestamp("2026-02-01"),
+    )
+    assert out is None
+
+
+@pytest.mark.unit
+def test_attach_price_features_batches_one_fetch_per_symbol(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two roundtrips on the same symbol trigger exactly one loader fetch."""
+    dates = pd.bdate_range("2025-12-01", periods=60).strftime("%Y-%m-%d").tolist()
+    frame = _price_frame(dates, [10.0 + 0.05 * i for i in range(60)])
+
+    calls: list[list[str]] = []
+
+    class _CountingLoader:
+        def fetch(self, codes, start_date, end_date, *, interval="1D", fields=None):
+            calls.append(list(codes))
+            lo, hi = pd.Timestamp(start_date), pd.Timestamp(end_date)
+            return {c: frame.loc[lo:hi].copy() for c in codes}
+
+    monkeypatch.setattr(
+        "backtest.loaders.registry.resolve_loader", lambda market: _CountingLoader(),
+    )
+    rows = [
+        {"symbol": "600519", "market": "china_a", "buy_dt": pd.Timestamp("2026-02-10")},
+        {"symbol": "600519", "market": "china_a", "buy_dt": pd.Timestamp("2026-02-20")},
+    ]
+    _attach_price_features(rows)
+    assert len(calls) == 1  # one symbol → one fetch despite two roundtrips
+    assert all(not pd.isna(r["entry_rsi14"]) for r in rows)
+
+
+@pytest.mark.unit
+def test_auto_cluster_median_imputes_partial_nan() -> None:
+    """A promoted feature with some NaN rows is median-imputed, not crashed."""
+    df = pd.DataFrame({
+        "holding_days": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        "pnl_pct": [0.1, 0.2, 0.1, 0.2, 0.1, 0.2],
+        "entry_hour": [10, 11, 10, 11, 10, 11],
+        "entry_weekday": [1, 2, 3, 4, 0, 1],
+        "prior_5d_return": [0.01, 0.02, float("nan"), 0.04, 0.05, float("nan")],
+    })
+    labels = _auto_cluster(
+        df, max_k=3,
+        numeric_features=("holding_days", "pnl_pct", "entry_hour",
+                          "entry_weekday", "prior_5d_return"),
+    )
+    # No exception (NaN would crash StandardScaler/KMeans); one label per row.
+    assert len(labels) == len(df)
+
+
+@pytest.mark.unit
+def test_auto_cluster_all_nan_feature_is_dropped() -> None:
+    """An all-NaN promoted column is dropped, leaving journal features to cluster."""
+    df = pd.DataFrame({
+        "holding_days": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        "pnl_pct": [0.1, 0.2, 0.1, 0.2, 0.1, 0.2],
+        "entry_hour": [10, 11, 10, 11, 10, 11],
+        "entry_weekday": [1, 2, 3, 4, 0, 1],
+        "entry_rsi14": [float("nan")] * 6,  # all NaN
+    })
+    labels = _auto_cluster(
+        df, max_k=3,
+        numeric_features=("holding_days", "pnl_pct", "entry_hour",
+                          "entry_weekday", "entry_rsi14"),
+    )
+    assert len(labels) == len(df)
+
+


### PR DESCRIPTION
## Summary

Shadow Account's `_compute_features()` only learned from journal columns
(`holding_days`, `pnl_pct`, `entry_hour`, `entry_weekday`, `market`), so the
extracted rules were purely behavioral with no market context. This adds two
price-context features per profitable roundtrip, read as-of the buy date:

- `entry_rsi14` — 14-period Wilder RSI at entry
- `prior_5d_return` — trailing 5-bar close-to-close return ending at `buy_dt`

This is the first step you green-lit in #295. I followed the three scoping notes
from that thread:

1. **Reused existing pieces.** RSI mirrors the causal `compute_rsi` shape in
   `agent/src/skills/technical-basic/example_signal_engine.py:13` (re-implemented
   inline because that hyphenated skills dir isn't importable). Prices go through
   the loader registry (`resolve_loader` + `fetch`), the same path
   `backtest/runner.py` uses.
2. **As-of `buy_dt`, no look-ahead.** Both features read only bars dated
   `<= buy_dt`. The fetch window ends at `buy_dt`, so the `(buy_dt, sell_dt]` exit
   window is never touched — look-ahead is structurally impossible, not just
   guarded after the fact.
3. **Kept v1 degradation + offline determinism.** Any failure (unmapped market,
   no source, empty result, insufficient history) drops the feature to NaN and the
   pipeline still runs. All tests use mocked loaders — no network.

A price feature only joins the KMeans feature set when it's present for
`>= min_support` roundtrips; otherwise clustering stays journal-only, exactly as
before. Partial NaNs are median-imputed (that affects grouping only — rule bounds
never read price features).

## Why

Shadow Account extracts rules from journal columns alone, so extracted rules
are purely behavioral with no market context. Adding price-context features
lets clustering see whether profitable roundtrips share common entry conditions
(overbought RSI, recent momentum), making extracted rules actionable rather
than just descriptive.

## Changes

- `agent/src/shadow_account/extractor.py`: `_compute_rsi`, `_fetch_price_history`,
  `_as_of_index`, `_price_features_as_of`, `_attach_price_features` (batches one
  fetch per symbol); `_auto_cluster` takes a `numeric_features` arg instead of the
  module constant; `_promoted_numeric_features` gates promotion.
- `agent/tests/test_shadow_account.py`: 15 new tests + an autouse offline fixture
  so the suite stays network-free.

## Test Plan

- [x] `ruff check` — clean
- [x] `pytest agent/tests/test_shadow_account.py` — 43 passed
- [x] full suite (excl e2e) — 4385 passed, 1 skipped
- [x] RSI causality, look-ahead guard (bars after `buy_dt` don't change values),
  tz-aware `buy_dt`, all three degradation branches, batch-once-per-symbol,
  median-impute / all-NaN-drop in clustering

## Checklist

- [x] No changes to protected areas without prior discussion (#295 green-lit)
- [x] No hardcoded values
- [x] Code follows CONTRIBUTING.md guidelines
- [x] Documentation updated (N/A — no user-facing change)

Refs #295
