### PR TITLE
fix(api): allow authenticated remote same-origin UI requests

### DIFF
--- a/agent/api_server.py
+++ b/agent/api_server.py
@@ -722,19 +722,43 @@ def _is_loopback_origin(origin: str) -> bool:
         return False
 
 
+def _origin_matches_request_host(origin: str, request: Request) -> bool:
+    """Return whether ``origin`` is the same site serving this request."""
+    try:
+        parsed = urllib.parse.urlsplit(origin)
+    except ValueError:
+        return False
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return False
+
+    origin_host = parsed.hostname.rstrip(".").lower()
+    origin_port = parsed.port
+    request_host = _host_without_port(request.headers.get("host", ""))
+    if origin_host != request_host:
+        return False
+
+    if origin_port is None:
+        origin_port = 443 if parsed.scheme == "https" else 80
+    request_port = request.url.port
+    if request_port is None:
+        request_port = 443 if request.url.scheme == "https" else 80
+    return origin_port == request_port
+
+
 def _reject_cross_site_browser_request(request: Request) -> None:
-    """Reject unsafe browser requests from non-loopback origins.
+    """Reject unsafe browser requests from untrusted cross-site origins.
 
     CORS protects response reads, not blind form/fetch side effects. Keep local
-    CLI/curl clients working while refusing browser-originated cross-site POSTs
-    to local control-plane actions such as shutdown.
+    CLI/curl clients and same-origin browser UI deployments working while
+    refusing browser-originated cross-site POSTs to local control-plane actions
+    such as shutdown.
     """
     sec_fetch_site = request.headers.get("sec-fetch-site", "").lower()
     if sec_fetch_site == "cross-site":
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Cross-site request denied")
 
     origin = request.headers.get("origin")
-    if origin and not _is_loopback_origin(origin):
+    if origin and not (_is_loopback_origin(origin) or _origin_matches_request_host(origin, request)):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Cross-site request denied")
 
 

--- a/agent/tests/test_upload_api.py
+++ b/agent/tests/test_upload_api.py
@@ -69,6 +69,67 @@ def test_loopback_upload_without_browser_origin_still_allowed_when_key_configure
     assert len(_existing_uploads(tmp_path)) == 1
 
 
+def test_remote_same_origin_browser_upload_with_api_key_is_allowed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(api_server, "UPLOADS_DIR", tmp_path)
+    monkeypatch.setattr(api_server, "MAX_UPLOAD_SIZE", 4 * 1024)
+    monkeypatch.setattr(api_server, "_UPLOAD_CHUNK_SIZE", 1024)
+    monkeypatch.setenv("API_AUTH_KEY", "secret")
+    monkeypatch.setattr(api_server, "_API_KEY", "secret")
+    remote_client = TestClient(
+        api_server.app,
+        base_url="http://192.168.1.10:8899",
+        client=("192.168.1.20", 50000),
+    )
+
+    response = remote_client.post(
+        "/upload",
+        headers={
+            "Host": "192.168.1.10:8899",
+            "Origin": "http://192.168.1.10:8899",
+            "Sec-Fetch-Site": "same-origin",
+            "Authorization": "Bearer secret",
+        },
+        files={"file": ("note.txt", b"remote", "text/plain")},
+    )
+
+    assert response.status_code == 200
+    assert len(_existing_uploads(tmp_path)) == 1
+
+
+def test_remote_cross_origin_browser_upload_with_api_key_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(api_server, "UPLOADS_DIR", tmp_path)
+    monkeypatch.setattr(api_server, "MAX_UPLOAD_SIZE", 4 * 1024)
+    monkeypatch.setattr(api_server, "_UPLOAD_CHUNK_SIZE", 1024)
+    monkeypatch.setenv("API_AUTH_KEY", "secret")
+    monkeypatch.setattr(api_server, "_API_KEY", "secret")
+    remote_client = TestClient(
+        api_server.app,
+        base_url="http://192.168.1.10:8899",
+        client=("192.168.1.20", 50000),
+    )
+
+    response = remote_client.post(
+        "/upload",
+        headers={
+            "Host": "192.168.1.10:8899",
+            "Origin": "https://evil.example",
+            "Sec-Fetch-Site": "same-site",
+            "Authorization": "Bearer secret",
+        },
+        files={"file": ("poc.txt", b"x" * 1024, "text/plain")},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Cross-site request denied"
+    assert _existing_uploads(tmp_path) == []
+
+
 def test_upload_under_limit_succeeds(client: TestClient, tmp_path: Path) -> None:
     payload = b"x" * (2 * 1024)  # 2 KB, well under the 4 KB limit
     response = client.post(


### PR DESCRIPTION
## Summary

- Allow unsafe browser requests when the `Origin` exactly matches the request `Host`/port, so authenticated remote Web UI deployments keep working.
- Preserve the cross-site browser rejection added in #293 for attacker-controlled origins.
- Add upload API regressions for remote same-origin success and remote cross-origin rejection with `API_AUTH_KEY` configured.

## Why

Follow-up to #293 and Penn-Live's report that after the merge the app could not be accessed from another machine on the internal network (Mac client -> Windows/WSL server). The cross-site guard rejected every non-loopback browser `Origin`, including legitimate same-origin requests served from `http://<server-lan-ip>:8899`. That blocked remote Web UI POST/upload flows even when the user configured `API_AUTH_KEY`.

This keeps the intended CSRF/DNS-rebinding protection: `Sec-Fetch-Site: cross-site` and mismatched `Origin` values still fail before auth bypasses or side effects.

## Test Plan

- [x] `python3 -m pytest -q agent/tests/test_upload_api.py`
- [x] `python3 -m pytest -q agent/tests/test_upload_api.py agent/tests/test_security_auth_api.py agent/tests/test_settings_api.py`
- [x] Docker validation:
  - `docker run --rm -v "$PWD:/work" -w /work python:3.11-slim sh -lc 'python -m pip install -q pytest fastapi rich python-multipart httpx pydantic && python -m pytest -q agent/tests/test_upload_api.py agent/tests/test_security_auth_api.py agent/tests/test_settings_api.py'`
  - Result: `72 passed, 5 warnings in 0.39s`

## Notes

- `python3 -m ruff check agent/tests/test_upload_api.py` passes.
- `python3 -m ruff check agent/api_server.py agent/tests/test_upload_api.py` still reports pre-existing F821 forward-reference warnings in `agent/api_server.py` around scheduled research types; this patch does not touch that area.
