### PR TITLE
Feat: Adding support for equity markets in india

### DIFF
--- a/agent/SKILL.md
+++ b/agent/SKILL.md
@@ -74,14 +74,17 @@ Feed a CSV broker export (同花顺 / 东财 / 富途 / generic), and the agent 
 5. `scan_shadow_signals` — list today's symbols that match your shadow's entry cadence (research only).
 
 ### Backtesting
-Create and run quantitative strategies across 7 engines (ChinaA, GlobalEquity, Crypto, ChinaFutures, GlobalFutures, Forex + options) with 18 market-data sources (auto-detect + ordered fallback):
+Create and run quantitative strategies across 8 engines (ChinaA, GlobalEquity, IndiaEquity, Crypto, ChinaFutures, GlobalFutures, Forex + options) with 19 market-data sources (auto-detect + ordered fallback):
 - **HK/US equities** via yfinance / stooq / yahoo (free, no API key)
+- **India equities (NSE/BSE)** via yahoo / yfinance using `<SYMBOL>.NS` (NSE, e.g. `RELIANCE.NS`) or `<SCRIP>.BO` (BSE, e.g. `500325.BO`) — free, no API key. The `IndiaEquityEngine` models T+1 delivery, no overnight shorts (set `allow_short` for intraday), configurable circuit bands, 1-share lots, and the STT/stamp-duty/exchange/GST cost stack. Optionally back-fill from your live broker via the `india_broker` source (Shoonya/Dhan; requires broker login).
 - **Cryptocurrency** via OKX or CCXT/100+ exchanges (free, no API key)
 - **China A-shares** via AKShare / baostock / tencent / sina / eastmoney / mootdx (free, no API key) — `TUSHARE_TOKEN` optional for premium quality
 - **Futures, forex, macro** via AKShare (free, no API key)
 - **HK & A-share equities** via Futu (broker login required, optional)
 - **Local CSV/parquet bars** via the `local` loader (offline, no network)
 - **Premium US data** via optional-key finnhub / alphavantage / tiingo / fmp (graceful fallback to free sources)
+
+Factors: the Alpha101 and QLib158 zoos are tagged for the `equity_in` universe, so they compute on NSE/BSE bars (the GTJA191 zoo stays China-only). Live/paper India trading uses the Shoonya / Dhan connectors (paper + read-only live; live order placement is structurally disabled because those brokers expose no paper/live switch).
 
 Example workflow:
 1. Use `list_skills()` to discover strategy patterns

--- a/agent/backtest/engines/_market_hooks.py
+++ b/agent/backtest/engines/_market_hooks.py
@@ -27,6 +27,9 @@ _MARKET_PATTERNS = [
     (re.compile(r"^(51|15|56)\d{4}\.(SZ|SH)$", re.I), "a_share"),
     (re.compile(r"^[A-Z]+\.US$", re.I), "us_equity"),
     (re.compile(r"^\d{3,5}\.HK$", re.I), "hk_equity"),
+    # India equities: NSE (RELIANCE.NS) / BSE (500325.BO); tickers may carry
+    # '&' and '-' (e.g. M&M.NS, BAJAJ-AUTO.NS).
+    (re.compile(r"^[A-Z0-9&.\-]+\.(NS|BO)$", re.I), "india_equity"),
     (re.compile(r"^[A-Z]+-USDT$", re.I), "crypto"),
     (re.compile(r"^[A-Z]+/USDT$", re.I), "crypto"),
     # China futures: product+delivery.exchange (e.g. IF2406.CFFEX, rb2410.SHFE)

--- a/agent/backtest/engines/composite.py
+++ b/agent/backtest/engines/composite.py
@@ -37,6 +37,9 @@ def _build_rule_engines(config: dict, codes: List[str]) -> Dict[str, BaseEngine]
         elif market == "hk_equity":
             from backtest.engines.global_equity import GlobalEquityEngine
             engines["hk_equity"] = GlobalEquityEngine(config, market="hk")
+        elif market == "india_equity":
+            from backtest.engines.india_equity import IndiaEquityEngine
+            engines["india_equity"] = IndiaEquityEngine(config)
         elif market == "crypto":
             from backtest.engines.crypto import CryptoEngine
             engines["crypto"] = CryptoEngine(config)

--- a/agent/backtest/engines/global_equity.py
+++ b/agent/backtest/engines/global_equity.py
@@ -11,6 +11,9 @@ Market rules:
     - Stamp tax 0.1% bilateral + levies
     - Lot-size rounding (simplified to 100 shares)
     - Higher slippage than US
+
+India (NSE/BSE) is handled by the dedicated ``backtest.engines.india_equity``
+``IndiaEquityEngine`` (T+1 delivery, circuit bands, STT/stamp/GST stack).
 """
 
 from __future__ import annotations

--- a/agent/backtest/engines/india_equity.py
+++ b/agent/backtest/engines/india_equity.py
@@ -1,0 +1,145 @@
+"""India equity (NSE / BSE) backtest engine.
+
+Models the Indian cash-equity **delivery** segment on daily bars. Intraday
+(MIS) mechanics are not represented by a daily-bar engine, so the defaults
+reflect overnight delivery rules; the knobs below let advanced users approximate
+intraday behaviour.
+
+Market rules:
+  - T+1 settlement: shares bought today cannot be sold the same bar (delivery).
+  - No short selling by default: retail cannot hold overnight short delivery
+    positions. Set ``allow_short=True`` to model intraday (MIS) shorting.
+  - Circuit bands: per-scrip price bands vary (2/5/10/20%); the exact band is
+    not derivable from the symbol alone, so a single configurable band applies
+    (default ±20%, the widest common band). Set ``price_limit`` to ``0`` /
+    ``None`` to disable.
+  - Lot size: 1 share for cash equity (F&O lot sizes are not modelled here).
+
+Cost stack (delivery, discount-broker defaults; all config-driven). NOTE: SEBI/
+exchange tariffs change periodically — verify ``in_*`` rates against a current
+broker schedule before relying on absolute cost figures:
+  - Brokerage: ₹0 (delivery on discount brokers)            [in_brokerage]
+  - STT: 0.1% on buy + 0.1% on sell (bilateral)             [in_stt]
+  - Exchange transaction charge: NSE ~0.00297% (bilateral)  [in_exchange_txn]
+  - SEBI turnover fee: ₹10/crore = 0.0001% (bilateral)      [in_sebi_fee]
+  - Stamp duty: 0.015% on buy only                          [in_stamp_duty]
+  - GST: 18% on (brokerage + exchange txn + SEBI fee)       [in_gst]
+  - DP charge: flat per-scrip on sell (default ₹0)          [in_dp_charge]
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from backtest.engines.base import BaseEngine
+from backtest.engines.china_a import _calc_pct_change
+
+
+class IndiaEquityEngine(BaseEngine):
+    """NSE / BSE cash-equity (delivery) engine.
+
+    Config keys (all optional; defaults shown in the module docstring):
+      - allow_short: bool, default False
+      - price_limit: float fraction or None, default 0.20
+      - slippage: default 0.001
+      - in_brokerage / in_stt / in_exchange_txn / in_sebi_fee /
+        in_stamp_duty / in_gst / in_dp_charge
+    """
+
+    def __init__(self, config: dict):
+        config = {**config, "leverage": 1.0}  # cash delivery: no leverage
+        super().__init__(config)
+        self.allow_short: bool = bool(config.get("allow_short", False))
+        self.price_limit = config.get("price_limit", 0.20)
+        self.slippage_rate: float = config.get("slippage", 0.001)
+        # Cost stack
+        self.in_brokerage: float = config.get("in_brokerage", 0.0)
+        self.in_stt: float = config.get("in_stt", 0.001)
+        self.in_exchange_txn: float = config.get("in_exchange_txn", 0.0000297)
+        self.in_sebi_fee: float = config.get("in_sebi_fee", 0.000001)
+        self.in_stamp_duty: float = config.get("in_stamp_duty", 0.00015)
+        self.in_gst: float = config.get("in_gst", 0.18)
+        self.in_dp_charge: float = config.get("in_dp_charge", 0.0)
+
+    def can_execute(self, symbol: str, direction: int, bar: pd.Series) -> bool:
+        """India delivery execution rules.
+
+        Args:
+            symbol: NSE/BSE symbol (e.g. ``RELIANCE.NS``).
+            direction: 1 (buy), -1 (short), 0 (sell/close).
+            bar: Current bar (needs ``close`` + ``pre_close``/``pct_chg`` for
+                circuit checks).
+
+        Returns:
+            True if the trade is allowed.
+        """
+        # 1. Short selling: blocked unless explicitly modelling intraday (MIS).
+        if direction == -1 and not self.allow_short:
+            return False
+
+        # 2. T+1: can't sell shares bought today (delivery).
+        if direction == 0:
+            pos = self.positions.get(symbol)
+            if pos is not None:
+                bar_date = _bar_date(bar)
+                entry_date = pos.entry_time.date() if hasattr(pos.entry_time, "date") else None
+                if bar_date is not None and entry_date is not None and bar_date == entry_date:
+                    return False
+
+        # 3. Circuit bands (single configurable band; disabled when falsy).
+        if self.price_limit:
+            pct_chg = _calc_pct_change(bar)
+            if pct_chg is not None:
+                limit = float(self.price_limit)
+                if direction == 1 and pct_chg >= limit - 0.001:
+                    return False  # upper circuit: can't buy
+                if direction == 0 and pct_chg <= -limit + 0.001:
+                    return False  # lower circuit: can't sell
+
+        return True
+
+    def round_size(self, raw_size: float, price: float) -> float:
+        """Cash equity trades in 1-share lots."""
+        return float(max(int(raw_size), 0))
+
+    def calc_commission(self, size: float, price: float, _direction: int, is_open: bool) -> float:
+        """India delivery cost stack (see module docstring).
+
+        ``_direction`` is unused — reserved for future asymmetric long/short
+        (intraday MIS) schedules.
+        """
+        notional = size * price
+        brokerage = notional * self.in_brokerage
+        exchange_txn = notional * self.in_exchange_txn        # bilateral
+        sebi_fee = notional * self.in_sebi_fee                # bilateral
+        gst = (brokerage + exchange_txn + sebi_fee) * self.in_gst
+        stt = notional * self.in_stt                          # bilateral (delivery)
+        comm = brokerage + exchange_txn + sebi_fee + gst + stt
+        if is_open:
+            comm += notional * self.in_stamp_duty             # stamp duty: buy-only
+        else:
+            comm += self.in_dp_charge                         # DP charge: sell-only, flat
+        return comm
+
+    def apply_slippage(self, price: float, direction: int) -> float:
+        """India slippage (configurable)."""
+        return price * (1 + direction * self.slippage_rate)
+
+
+# ── Helpers ──
+
+
+def _bar_date(bar: pd.Series):
+    """Extract date from bar, handling various column names."""
+    for col in ("trade_date", "date"):
+        if col in bar.index:
+            val = bar[col]
+            if hasattr(val, "date"):
+                return val.date()
+            try:
+                return pd.Timestamp(val).date()
+            except Exception:
+                pass
+    if hasattr(bar, "name") and hasattr(bar.name, "date"):
+        return bar.name.date()
+    return None

--- a/agent/backtest/loaders/india_broker_loader.py
+++ b/agent/backtest/loaders/india_broker_loader.py
@@ -1,0 +1,175 @@
+"""India broker data bridge: feed Shoonya / Dhan history into the backtest layer.
+
+The Shoonya (Finvasia) and Dhan connectors already expose live-account market
+data via ``get_historical_bars`` (read path). This loader adapts that envelope
+into the standard OHLCV frame so a user's *broker* history can back the same
+backtests as the public Yahoo feed — useful when matching a live account exactly
+or pulling symbols Yahoo lacks.
+
+It is an OPT-IN source (``requires_auth``): ``is_available`` is True only when a
+broker SDK is importable AND a broker is configured, so it trails Yahoo/yfinance
+in the ``india_equity`` fallback chain and never fires in CI / unconfigured runs.
+
+Symbol convention: project ``RELIANCE.NS`` / ``500325.BO`` → broker ``RELIANCE``
+on exchange ``NSE`` / ``BSE`` (the suffix selects the exchange; the base symbol
+is passed bare).
+
+Limitation: broker endpoints return a bounded window of *recent* bars (period +
+limit), not an arbitrary historical start. This loader requests enough bars to
+cover the window and clips to ``[start_date, end_date]``; very old ranges may
+come back short. For deep history prefer Yahoo.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+import pandas as pd
+
+from backtest.loaders.base import validate_date_range
+from backtest.loaders.registry import register
+
+logger = logging.getLogger(__name__)
+
+_OUTPUT_COLUMNS = ["open", "high", "low", "close", "volume"]
+# Project interval -> broker ``period`` token (both connectors share this set).
+_PERIOD_MAP = {"1D": "1d", "1H": "1h", "5m": "5m", "15m": "15m", "30m": "30m", "1m": "1m"}
+
+
+def _resolve_broker():
+    """Return ``(broker_key, sdk_module)`` for the first available India broker.
+
+    Prefers Shoonya, then Dhan. Returns ``(None, None)`` when neither the SDK
+    nor a config is present. Import is deferred and defensive so a missing
+    ``src.trading`` package or broker SDK simply means "unavailable", never a
+    crash in the loader registry.
+    """
+    try:
+        from src.trading.connectors.shoonya import sdk as shoonya_sdk
+
+        if shoonya_sdk.shoonya_available():
+            return "shoonya", shoonya_sdk
+    except Exception as exc:  # noqa: BLE001 — optional dependency / config
+        logger.debug("shoonya bridge unavailable: %s", exc)
+    try:
+        from src.trading.connectors.dhan import sdk as dhan_sdk
+
+        if dhan_sdk.dhan_available():
+            return "dhan", dhan_sdk
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("dhan bridge unavailable: %s", exc)
+    return None, None
+
+
+def _exchange_for(code: str) -> str:
+    """Map the project suffix to the broker exchange code (NSE / BSE)."""
+    return "BSE" if code.strip().upper().endswith(".BO") else "NSE"
+
+
+def _base_symbol(code: str) -> str:
+    """Strip the ``.NS`` / ``.BO`` suffix, leaving the broker's bare symbol."""
+    cleaned = code.strip()
+    upper = cleaned.upper()
+    if upper.endswith((".NS", ".BO")):
+        return cleaned[:-3]
+    return cleaned
+
+
+def _bars_to_frame(bars: list[dict], start_date: str, end_date: str) -> Optional[pd.DataFrame]:
+    """Convert the broker ``bars`` list into a clipped OHLCV frame, or ``None``."""
+    if not bars:
+        return None
+    frame = pd.DataFrame(bars)
+    if "time" not in frame.columns:
+        return None
+    # ``time`` is epoch seconds (Shoonya ssboe / Dhan candle[0]) or an ISO string.
+    ts = pd.to_numeric(frame["time"], errors="coerce")
+    if ts.notna().any():
+        index = pd.to_datetime(ts, unit="s", errors="coerce")
+    else:
+        index = pd.to_datetime(frame["time"], errors="coerce")
+    frame = frame.drop(columns=["time"])
+    frame.index = pd.DatetimeIndex(index).tz_localize(None)
+    frame.index.name = "trade_date"
+
+    for col in _OUTPUT_COLUMNS:
+        if col not in frame.columns:
+            frame[col] = 0.0 if col == "volume" else pd.NA
+    frame = frame[_OUTPUT_COLUMNS].apply(pd.to_numeric, errors="coerce")
+    frame = frame.dropna(subset=["open", "high", "low", "close"]).sort_index()
+
+    lower = pd.Timestamp(start_date).normalize()
+    upper = pd.Timestamp(end_date).normalize() + pd.Timedelta(days=1)
+    frame = frame[(frame.index >= lower) & (frame.index < upper)]
+    return frame.astype(float) if not frame.empty else None
+
+
+@register
+class DataLoader:
+    """Shoonya / Dhan history adapter for the ``india_equity`` market."""
+
+    name = "india_broker"
+    markets = {"india_equity"}
+    requires_auth = True
+
+    def __init__(self) -> None:
+        pass
+
+    def is_available(self) -> bool:
+        """True only when an India broker SDK is importable and configured."""
+        broker, _ = _resolve_broker()
+        return broker is not None
+
+    def fetch(
+        self,
+        codes: List[str],
+        start_date: str,
+        end_date: str,
+        *,
+        interval: str = "1D",
+        fields: Optional[List[str]] = None,
+    ) -> Dict[str, pd.DataFrame]:
+        """Fetch OHLCV history for ``codes`` from the configured India broker."""
+        del fields
+        if not codes:
+            return {}
+        validate_date_range(start_date, end_date)
+
+        broker, sdk = _resolve_broker()
+        if sdk is None:
+            return {}
+
+        period = _PERIOD_MAP.get(str(interval).strip(), "1d")
+        # Request enough bars to cover the window (business days + headroom).
+        span_days = max((pd.Timestamp(end_date) - pd.Timestamp(start_date)).days, 1)
+        limit = min(max(span_days, 30), 2000)
+
+        result: Dict[str, pd.DataFrame] = {}
+        for code in codes:
+            try:
+                envelope = sdk.get_historical_bars(
+                    _base_symbol(code),
+                    exchange=_exchange_for(code),
+                    period=period,
+                    limit=limit,
+                )
+            except TypeError:
+                # Dhan uses ``exchange_segment``; retry without the ``exchange`` kw.
+                try:
+                    envelope = sdk.get_historical_bars(
+                        _base_symbol(code), period=period, limit=limit
+                    )
+                except Exception as exc:  # noqa: BLE001 — one bad symbol never aborts
+                    logger.warning("%s bridge failed for %s: %s", broker, code, exc)
+                    continue
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("%s bridge failed for %s: %s", broker, code, exc)
+                continue
+
+            if not isinstance(envelope, dict) or str(envelope.get("status", "")).lower() != "ok":
+                continue
+            frame = _bars_to_frame(envelope.get("bars", []), start_date, end_date)
+            if frame is not None and not frame.empty:
+                result[code] = frame
+        return result

--- a/agent/backtest/loaders/registry.py
+++ b/agent/backtest/loaders/registry.py
@@ -48,6 +48,7 @@ VALID_SOURCES: set[str] = {
     "alphavantage",
     "tiingo",
     "fmp",
+    "india_broker",
     "local",
     "auto",
 }
@@ -92,6 +93,7 @@ def _ensure_registered() -> None:
         "backtest.loaders.alphavantage_loader",
         "backtest.loaders.tiingo_loader",
         "backtest.loaders.fmp_loader",
+        "backtest.loaders.india_broker_loader",
         "backtest.loaders.local_loader",
     ]
     import importlib
@@ -125,6 +127,7 @@ FALLBACK_CHAINS: dict[str, list[str]] = {
     "a_share":   ["tencent", "mootdx", "eastmoney", "baostock", "akshare", "tushare", "local"],
     "us_equity": ["yahoo", "stooq", "sina", "eastmoney", "yfinance", "tiingo", "fmp", "finnhub", "alphavantage", "akshare", "local"],
     "hk_equity": ["eastmoney", "yahoo", "futu", "yfinance", "akshare", "local"],
+    "india_equity": ["yahoo", "yfinance", "india_broker", "local"],
     "crypto":    ["okx", "ccxt", "yfinance", "local"],
     "futures":   ["tushare", "akshare", "local"],
     "fund":      ["tushare", "akshare", "local"],

--- a/agent/backtest/loaders/yahoo_client.py
+++ b/agent/backtest/loaders/yahoo_client.py
@@ -14,6 +14,8 @@ first call that needs them and refreshes them once on a 401 (the documented
 Symbol convention (Vibe-Trading -> Yahoo):
   * US ``AAPL.US`` -> ``AAPL`` (Yahoo carries US tickers bare)
   * HK ``00700.HK`` -> ``0700.HK`` (Yahoo drops the leading zero to 4 digits)
+  * India ``RELIANCE.NS`` / ``500325.BO`` -> unchanged (Yahoo carries the
+    ``.NS``/``.BO`` suffix verbatim)
   * Anything else is passed through unchanged (e.g. ``BTC-USD``, ``^GSPC``).
 
 This module is provider-specific glue only; it returns plain Python
@@ -72,7 +74,8 @@ def map_symbol(symbol: str) -> str:
 
     Returns:
         The Yahoo ticker: ``.US`` suffix stripped; ``.HK`` codes normalized to
-        a 4-digit base (``00700.HK`` -> ``0700.HK``); everything else unchanged.
+        a 4-digit base (``00700.HK`` -> ``0700.HK``); India ``.NS``/``.BO`` and
+        everything else unchanged (Yahoo carries those suffixes verbatim).
     """
     cleaned = symbol.strip()
     upper = cleaned.upper()

--- a/agent/backtest/loaders/yahoo_loader.py
+++ b/agent/backtest/loaders/yahoo_loader.py
@@ -38,9 +38,9 @@ _INTERVAL_MAP = {
 }
 
 
-def _is_us_or_hk(code: str) -> bool:
-    """Return whether *code* is a US or HK equity symbol this loader handles."""
-    return code.strip().upper().endswith((".US", ".HK"))
+def _is_supported(code: str) -> bool:
+    """Return whether *code* is a symbol this loader handles (US/HK/India)."""
+    return code.strip().upper().endswith((".US", ".HK", ".NS", ".BO"))
 
 
 def _to_yahoo_interval(interval: str) -> str:
@@ -158,7 +158,7 @@ class DataLoader:
     """Yahoo Finance US/HK equity OHLCV loader (free, direct HTTP, no auth)."""
 
     name = "yahoo"
-    markets = {"us_equity", "hk_equity"}
+    markets = {"us_equity", "hk_equity", "india_equity"}
     requires_auth = False
 
     def is_available(self) -> bool:
@@ -229,10 +229,10 @@ class DataLoader:
             interval: Backtest interval string.
 
         Returns:
-            The OHLCV DataFrame for *code*, ``None`` if it is not a US/HK symbol
-            or Yahoo returns no usable bars.
+            The OHLCV DataFrame for *code*, ``None`` if it is not a US/HK/India
+            symbol or Yahoo returns no usable bars.
         """
-        if not _is_us_or_hk(code):
+        if not _is_supported(code):
             return None
 
         # period2 is exclusive on Yahoo; extend one day past end_date so the

--- a/agent/backtest/loaders/yfinance_loader.py
+++ b/agent/backtest/loaders/yfinance_loader.py
@@ -57,6 +57,7 @@ def _to_yfinance_symbol(code: str) -> str:
         return upper[:-5] + "-USD"
     if upper.endswith("-USDC"):
         return upper[:-5] + "-USD"
+    # India NSE/BSE (RELIANCE.NS, 500325.BO): yfinance carries the suffix as-is.
     return upper
 
 
@@ -210,7 +211,7 @@ class DataLoader:
     """Fetch HK/US equity bars from Yahoo Finance via yfinance."""
 
     name = "yfinance"
-    markets = {"us_equity", "hk_equity", "crypto"}
+    markets = {"us_equity", "hk_equity", "india_equity", "crypto"}
     requires_auth = False
 
     def is_available(self) -> bool:

--- a/agent/backtest/runner.py
+++ b/agent/backtest/runner.py
@@ -300,6 +300,7 @@ _MARKET_TO_SOURCE = {
     "a_share": "tushare",
     "us_equity": "yfinance",
     "hk_equity": "yfinance",
+    "india_equity": "yahoo",
     "crypto": "okx",
     "futures": "tushare",
     "fund": "tushare",
@@ -569,6 +570,13 @@ def _create_market_engine(source: str, config: dict, codes: List[str]):
     if "forex" in markets:
         from backtest.engines.forex import ForexEngine
         return ForexEngine(config)
+
+    # India equity routing — must precede source-based routing because India's
+    # effective source is ``yahoo``, which has no Wave-1 branch and would
+    # otherwise fall through to the crypto default.
+    if "india_equity" in markets:
+        from backtest.engines.india_equity import IndiaEquityEngine
+        return IndiaEquityEngine(config)
 
     # Original routing (Wave 1)
     if source in ("okx", "ccxt"):

--- a/agent/src/factors/base.py
+++ b/agent/src/factors/base.py
@@ -28,6 +28,7 @@ class Market(str, Enum):
     EQUITY_US = "equity_us"
     EQUITY_CN = "equity_cn"
     EQUITY_HK = "equity_hk"
+    EQUITY_IN = "equity_in"
     CRYPTO = "crypto"
     FUTURES = "futures"
 
@@ -249,8 +250,10 @@ def vwap(panel: dict[str, pd.DataFrame], market: Market | str) -> pd.DataFrame:
       scale. We multiply ``amount`` by 1000 (CNY) and divide by
       ``volume * 100`` (shares); ``+1`` keeps the denominator positive on
       suspended bars.
-    - ``equity_us`` / ``equity_hk`` / ``futures``: typical price ``(H + L + C + O) / 4``
-      when ``panel["vwap"]`` is absent.
+    - ``equity_us`` / ``equity_hk`` / ``equity_in`` / ``futures``: typical price
+      ``(H + L + C + O) / 4`` when ``panel["vwap"]`` is absent. India (NSE/BSE)
+      bars from Yahoo carry raw price/volume (no Tushare 千元/手 scaling), so the
+      typical-price form applies unchanged.
     - ``crypto``: prefer ``panel["vwap"]`` if provided, else typical price.
 
     Any missing required column → NaN propagation; never silent zero.

--- a/agent/src/factors/registry.py
+++ b/agent/src/factors/registry.py
@@ -61,7 +61,7 @@ Theme = Literal[
 
 PanelColumn = Literal["open", "high", "low", "close", "volume", "vwap", "amount"]
 
-Universe = Literal["equity_us", "equity_cn", "equity_hk", "crypto", "futures"]
+Universe = Literal["equity_us", "equity_cn", "equity_hk", "equity_in", "crypto", "futures"]
 
 
 class AlphaMeta(BaseModel):

--- a/agent/src/factors/zoo/alpha101/alpha_001.py
+++ b/agent/src/factors/zoo/alpha101/alpha_001.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 25,

--- a/agent/src/factors/zoo/alpha101/alpha_002.py
+++ b/agent/src/factors/zoo/alpha101/alpha_002.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['open', 'close', 'volume'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/alpha101/alpha_003.py
+++ b/agent/src/factors/zoo/alpha101/alpha_003.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['open', 'volume', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/alpha101/alpha_004.py
+++ b/agent/src/factors/zoo/alpha101/alpha_004.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['low', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 9,

--- a/agent/src/factors/zoo/alpha101/alpha_005.py
+++ b/agent/src/factors/zoo/alpha101/alpha_005.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['open', 'close', 'vwap'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/alpha101/alpha_006.py
+++ b/agent/src/factors/zoo/alpha101/alpha_006.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['open', 'volume', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/alpha101/alpha_007.py
+++ b/agent/src/factors/zoo/alpha101/alpha_007.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['close', 'volume'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 67,

--- a/agent/src/factors/zoo/alpha101/alpha_008.py
+++ b/agent/src/factors/zoo/alpha101/alpha_008.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['open', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 15,

--- a/agent/src/factors/zoo/alpha101/alpha_009.py
+++ b/agent/src/factors/zoo/alpha101/alpha_009.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 6,

--- a/agent/src/factors/zoo/alpha101/alpha_010.py
+++ b/agent/src/factors/zoo/alpha101/alpha_010.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/alpha101/alpha_011.py
+++ b/agent/src/factors/zoo/alpha101/alpha_011.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['close', 'volume', 'vwap'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/alpha101/alpha_012.py
+++ b/agent/src/factors/zoo/alpha101/alpha_012.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['close', 'volume'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 2,

--- a/agent/src/factors/zoo/alpha101/alpha_013.py
+++ b/agent/src/factors/zoo/alpha101/alpha_013.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['close', 'volume'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/alpha101/alpha_014.py
+++ b/agent/src/factors/zoo/alpha101/alpha_014.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['open', 'close', 'volume'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/alpha101/alpha_015.py
+++ b/agent/src/factors/zoo/alpha101/alpha_015.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['high', 'volume', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 6,

--- a/agent/src/factors/zoo/alpha101/alpha_016.py
+++ b/agent/src/factors/zoo/alpha101/alpha_016.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['high', 'volume', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/alpha101/alpha_017.py
+++ b/agent/src/factors/zoo/alpha101/alpha_017.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['close', 'volume'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 25,

--- a/agent/src/factors/zoo/alpha101/alpha_018.py
+++ b/agent/src/factors/zoo/alpha101/alpha_018.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['open', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/alpha101/alpha_019.py
+++ b/agent/src/factors/zoo/alpha101/alpha_019.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 250,

--- a/agent/src/factors/zoo/alpha101/alpha_020.py
+++ b/agent/src/factors/zoo/alpha101/alpha_020.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['open', 'high', 'low', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 2,

--- a/agent/src/factors/zoo/alpha101/alpha_021.py
+++ b/agent/src/factors/zoo/alpha101/alpha_021.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['close', 'volume'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 20,

--- a/agent/src/factors/zoo/alpha101/alpha_022.py
+++ b/agent/src/factors/zoo/alpha101/alpha_022.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['high', 'close', 'volume'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 25,

--- a/agent/src/factors/zoo/alpha101/alpha_023.py
+++ b/agent/src/factors/zoo/alpha101/alpha_023.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['high', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 20,

--- a/agent/src/factors/zoo/alpha101/alpha_024.py
+++ b/agent/src/factors/zoo/alpha101/alpha_024.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 200,

--- a/agent/src/factors/zoo/alpha101/alpha_025.py
+++ b/agent/src/factors/zoo/alpha101/alpha_025.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['high', 'close', 'volume', 'vwap'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 21,

--- a/agent/src/factors/zoo/alpha101/alpha_026.py
+++ b/agent/src/factors/zoo/alpha101/alpha_026.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['high', 'volume', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 13,

--- a/agent/src/factors/zoo/alpha101/alpha_027.py
+++ b/agent/src/factors/zoo/alpha101/alpha_027.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['volume', 'vwap', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/alpha101/alpha_028.py
+++ b/agent/src/factors/zoo/alpha101/alpha_028.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['high', 'low', 'close', 'volume'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 25,

--- a/agent/src/factors/zoo/alpha101/alpha_029.py
+++ b/agent/src/factors/zoo/alpha101/alpha_029.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['close', 'volume'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 12,

--- a/agent/src/factors/zoo/alpha101/alpha_030.py
+++ b/agent/src/factors/zoo/alpha101/alpha_030.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['close', 'volume'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 20,

--- a/agent/src/factors/zoo/alpha101/alpha_031.py
+++ b/agent/src/factors/zoo/alpha101/alpha_031.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['low', 'close', 'volume'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 25,

--- a/agent/src/factors/zoo/alpha101/alpha_032.py
+++ b/agent/src/factors/zoo/alpha101/alpha_032.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['close', 'vwap'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 235,

--- a/agent/src/factors/zoo/alpha101/alpha_033.py
+++ b/agent/src/factors/zoo/alpha101/alpha_033.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['open', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 1,

--- a/agent/src/factors/zoo/alpha101/alpha_034.py
+++ b/agent/src/factors/zoo/alpha101/alpha_034.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 6,

--- a/agent/src/factors/zoo/alpha101/alpha_035.py
+++ b/agent/src/factors/zoo/alpha101/alpha_035.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['high', 'low', 'close', 'volume'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 33,

--- a/agent/src/factors/zoo/alpha101/alpha_036.py
+++ b/agent/src/factors/zoo/alpha101/alpha_036.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['open', 'close', 'volume', 'vwap'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 200,

--- a/agent/src/factors/zoo/alpha101/alpha_037.py
+++ b/agent/src/factors/zoo/alpha101/alpha_037.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['open', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 201,

--- a/agent/src/factors/zoo/alpha101/alpha_038.py
+++ b/agent/src/factors/zoo/alpha101/alpha_038.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['open', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/alpha101/alpha_039.py
+++ b/agent/src/factors/zoo/alpha101/alpha_039.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['close', 'volume'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 250,

--- a/agent/src/factors/zoo/alpha101/alpha_040.py
+++ b/agent/src/factors/zoo/alpha101/alpha_040.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['high', 'volume', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/alpha101/alpha_041.py
+++ b/agent/src/factors/zoo/alpha101/alpha_041.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['high', 'low', 'vwap', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 1,

--- a/agent/src/factors/zoo/alpha101/alpha_042.py
+++ b/agent/src/factors/zoo/alpha101/alpha_042.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['close', 'vwap'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 1,

--- a/agent/src/factors/zoo/alpha101/alpha_043.py
+++ b/agent/src/factors/zoo/alpha101/alpha_043.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['close', 'volume'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 39,

--- a/agent/src/factors/zoo/alpha101/alpha_044.py
+++ b/agent/src/factors/zoo/alpha101/alpha_044.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['high', 'volume', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/alpha101/alpha_045.py
+++ b/agent/src/factors/zoo/alpha101/alpha_045.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['close', 'volume'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 25,

--- a/agent/src/factors/zoo/alpha101/alpha_046.py
+++ b/agent/src/factors/zoo/alpha101/alpha_046.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 21,

--- a/agent/src/factors/zoo/alpha101/alpha_047.py
+++ b/agent/src/factors/zoo/alpha101/alpha_047.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['high', 'close', 'volume', 'vwap'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 25,

--- a/agent/src/factors/zoo/alpha101/alpha_048.py
+++ b/agent/src/factors/zoo/alpha101/alpha_048.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['close'],
     'extras_required': [],
     'requires_sector': True,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 251,

--- a/agent/src/factors/zoo/alpha101/alpha_049.py
+++ b/agent/src/factors/zoo/alpha101/alpha_049.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 21,

--- a/agent/src/factors/zoo/alpha101/alpha_050.py
+++ b/agent/src/factors/zoo/alpha101/alpha_050.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['volume', 'vwap', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/alpha101/alpha_051.py
+++ b/agent/src/factors/zoo/alpha101/alpha_051.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 21,

--- a/agent/src/factors/zoo/alpha101/alpha_052.py
+++ b/agent/src/factors/zoo/alpha101/alpha_052.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['low', 'close', 'volume'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 240,

--- a/agent/src/factors/zoo/alpha101/alpha_053.py
+++ b/agent/src/factors/zoo/alpha101/alpha_053.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['high', 'low', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/alpha101/alpha_054.py
+++ b/agent/src/factors/zoo/alpha101/alpha_054.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['open', 'high', 'low', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 1,

--- a/agent/src/factors/zoo/alpha101/alpha_055.py
+++ b/agent/src/factors/zoo/alpha101/alpha_055.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['high', 'low', 'close', 'volume'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 17,

--- a/agent/src/factors/zoo/alpha101/alpha_056.py
+++ b/agent/src/factors/zoo/alpha101/alpha_056.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['close'],
     'extras_required': [],
     'requires_sector': True,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/alpha101/alpha_057.py
+++ b/agent/src/factors/zoo/alpha101/alpha_057.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['close', 'vwap'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 32,

--- a/agent/src/factors/zoo/alpha101/alpha_058.py
+++ b/agent/src/factors/zoo/alpha101/alpha_058.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['volume', 'vwap', 'close'],
     'extras_required': [],
     'requires_sector': True,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 25,

--- a/agent/src/factors/zoo/alpha101/alpha_059.py
+++ b/agent/src/factors/zoo/alpha101/alpha_059.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['volume', 'vwap', 'close'],
     'extras_required': [],
     'requires_sector': True,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 30,

--- a/agent/src/factors/zoo/alpha101/alpha_060.py
+++ b/agent/src/factors/zoo/alpha101/alpha_060.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['high', 'low', 'close', 'volume'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/alpha101/alpha_061.py
+++ b/agent/src/factors/zoo/alpha101/alpha_061.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['volume', 'vwap', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 197,

--- a/agent/src/factors/zoo/alpha101/alpha_062.py
+++ b/agent/src/factors/zoo/alpha101/alpha_062.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['open', 'high', 'low', 'volume', 'vwap', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 35,

--- a/agent/src/factors/zoo/alpha101/alpha_063.py
+++ b/agent/src/factors/zoo/alpha101/alpha_063.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['open', 'close', 'volume', 'vwap'],
     'extras_required': [],
     'requires_sector': True,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 204,

--- a/agent/src/factors/zoo/alpha101/alpha_064.py
+++ b/agent/src/factors/zoo/alpha101/alpha_064.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['open', 'high', 'low', 'volume', 'vwap', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 136,

--- a/agent/src/factors/zoo/alpha101/alpha_065.py
+++ b/agent/src/factors/zoo/alpha101/alpha_065.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['open', 'volume', 'vwap', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 65,

--- a/agent/src/factors/zoo/alpha101/alpha_066.py
+++ b/agent/src/factors/zoo/alpha101/alpha_066.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['open', 'high', 'low', 'vwap', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 18,

--- a/agent/src/factors/zoo/alpha101/alpha_067.py
+++ b/agent/src/factors/zoo/alpha101/alpha_067.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['high', 'volume', 'vwap', 'close'],
     'extras_required': [],
     'requires_sector': True,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 25,

--- a/agent/src/factors/zoo/alpha101/alpha_068.py
+++ b/agent/src/factors/zoo/alpha101/alpha_068.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['high', 'low', 'close', 'volume'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 36,

--- a/agent/src/factors/zoo/alpha101/alpha_069.py
+++ b/agent/src/factors/zoo/alpha101/alpha_069.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['close', 'volume', 'vwap'],
     'extras_required': [],
     'requires_sector': True,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 32,

--- a/agent/src/factors/zoo/alpha101/alpha_070.py
+++ b/agent/src/factors/zoo/alpha101/alpha_070.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['close', 'volume', 'vwap'],
     'extras_required': [],
     'requires_sector': True,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 84,

--- a/agent/src/factors/zoo/alpha101/alpha_071.py
+++ b/agent/src/factors/zoo/alpha101/alpha_071.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['open', 'low', 'close', 'volume', 'vwap'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 226,

--- a/agent/src/factors/zoo/alpha101/alpha_072.py
+++ b/agent/src/factors/zoo/alpha101/alpha_072.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['high', 'low', 'volume', 'vwap', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 57,

--- a/agent/src/factors/zoo/alpha101/alpha_073.py
+++ b/agent/src/factors/zoo/alpha101/alpha_073.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['open', 'low', 'vwap', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 21,

--- a/agent/src/factors/zoo/alpha101/alpha_074.py
+++ b/agent/src/factors/zoo/alpha101/alpha_074.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['high', 'close', 'volume', 'vwap'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 60,

--- a/agent/src/factors/zoo/alpha101/alpha_075.py
+++ b/agent/src/factors/zoo/alpha101/alpha_075.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['low', 'volume', 'vwap', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 61,

--- a/agent/src/factors/zoo/alpha101/alpha_076.py
+++ b/agent/src/factors/zoo/alpha101/alpha_076.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['low', 'volume', 'vwap', 'close'],
     'extras_required': [],
     'requires_sector': True,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 141,

--- a/agent/src/factors/zoo/alpha101/alpha_077.py
+++ b/agent/src/factors/zoo/alpha101/alpha_077.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['high', 'low', 'volume', 'vwap', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 47,

--- a/agent/src/factors/zoo/alpha101/alpha_078.py
+++ b/agent/src/factors/zoo/alpha101/alpha_078.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['low', 'volume', 'vwap', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 46,

--- a/agent/src/factors/zoo/alpha101/alpha_079.py
+++ b/agent/src/factors/zoo/alpha101/alpha_079.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['open', 'close', 'volume', 'vwap'],
     'extras_required': [],
     'requires_sector': True,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 172,

--- a/agent/src/factors/zoo/alpha101/alpha_080.py
+++ b/agent/src/factors/zoo/alpha101/alpha_080.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['open', 'high', 'volume', 'close'],
     'extras_required': [],
     'requires_sector': True,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 19,

--- a/agent/src/factors/zoo/alpha101/alpha_081.py
+++ b/agent/src/factors/zoo/alpha101/alpha_081.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['volume', 'vwap', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 70,

--- a/agent/src/factors/zoo/alpha101/alpha_082.py
+++ b/agent/src/factors/zoo/alpha101/alpha_082.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['open', 'volume', 'close'],
     'extras_required': [],
     'requires_sector': True,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 35,

--- a/agent/src/factors/zoo/alpha101/alpha_083.py
+++ b/agent/src/factors/zoo/alpha101/alpha_083.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['high', 'low', 'close', 'volume', 'vwap'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 7,

--- a/agent/src/factors/zoo/alpha101/alpha_084.py
+++ b/agent/src/factors/zoo/alpha101/alpha_084.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['close', 'vwap'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 35,

--- a/agent/src/factors/zoo/alpha101/alpha_085.py
+++ b/agent/src/factors/zoo/alpha101/alpha_085.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['high', 'low', 'close', 'volume'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 39,

--- a/agent/src/factors/zoo/alpha101/alpha_086.py
+++ b/agent/src/factors/zoo/alpha101/alpha_086.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['open', 'close', 'volume', 'vwap'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 44,

--- a/agent/src/factors/zoo/alpha101/alpha_087.py
+++ b/agent/src/factors/zoo/alpha101/alpha_087.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['close', 'vwap', 'volume'],
     'extras_required': [],
     'requires_sector': True,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 110,

--- a/agent/src/factors/zoo/alpha101/alpha_088.py
+++ b/agent/src/factors/zoo/alpha101/alpha_088.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['open', 'high', 'low', 'close', 'volume'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 94,

--- a/agent/src/factors/zoo/alpha101/alpha_089.py
+++ b/agent/src/factors/zoo/alpha101/alpha_089.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['low', 'volume', 'vwap', 'close'],
     'extras_required': [],
     'requires_sector': True,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 30,

--- a/agent/src/factors/zoo/alpha101/alpha_090.py
+++ b/agent/src/factors/zoo/alpha101/alpha_090.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['low', 'close', 'volume'],
     'extras_required': [],
     'requires_sector': True,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 46,

--- a/agent/src/factors/zoo/alpha101/alpha_091.py
+++ b/agent/src/factors/zoo/alpha101/alpha_091.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['close', 'volume', 'vwap'],
     'extras_required': [],
     'requires_sector': True,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 35,

--- a/agent/src/factors/zoo/alpha101/alpha_092.py
+++ b/agent/src/factors/zoo/alpha101/alpha_092.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['open', 'high', 'low', 'close', 'volume'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 49,

--- a/agent/src/factors/zoo/alpha101/alpha_093.py
+++ b/agent/src/factors/zoo/alpha101/alpha_093.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['close', 'volume', 'vwap'],
     'extras_required': [],
     'requires_sector': True,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 123,

--- a/agent/src/factors/zoo/alpha101/alpha_094.py
+++ b/agent/src/factors/zoo/alpha101/alpha_094.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['volume', 'vwap', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 82,

--- a/agent/src/factors/zoo/alpha101/alpha_095.py
+++ b/agent/src/factors/zoo/alpha101/alpha_095.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['open', 'high', 'low', 'volume', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 63,

--- a/agent/src/factors/zoo/alpha101/alpha_096.py
+++ b/agent/src/factors/zoo/alpha101/alpha_096.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['close', 'volume', 'vwap'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 103,

--- a/agent/src/factors/zoo/alpha101/alpha_097.py
+++ b/agent/src/factors/zoo/alpha101/alpha_097.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['low', 'volume', 'vwap', 'close'],
     'extras_required': [],
     'requires_sector': True,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 128,

--- a/agent/src/factors/zoo/alpha101/alpha_098.py
+++ b/agent/src/factors/zoo/alpha101/alpha_098.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['open', 'volume', 'vwap', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 56,

--- a/agent/src/factors/zoo/alpha101/alpha_099.py
+++ b/agent/src/factors/zoo/alpha101/alpha_099.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['high', 'low', 'volume', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 68,

--- a/agent/src/factors/zoo/alpha101/alpha_100.py
+++ b/agent/src/factors/zoo/alpha101/alpha_100.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['high', 'low', 'close', 'volume'],
     'extras_required': [],
     'requires_sector': True,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 30,

--- a/agent/src/factors/zoo/alpha101/alpha_101.py
+++ b/agent/src/factors/zoo/alpha101/alpha_101.py
@@ -43,7 +43,7 @@ __alpha_meta__ = {
     'columns_required': ['open', 'high', 'low', 'close'],
     'extras_required': [],
     'requires_sector': False,
-    'universe': ['equity_us'],
+    'universe': ['equity_us', 'equity_in'],
     'frequency': ['1D'],
     'decay_horizon': 5,
     'min_warmup_bars': 1,

--- a/agent/src/factors/zoo/qlib158/beta10.py
+++ b/agent/src/factors/zoo/qlib158/beta10.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '(\\\\mathrm{close}_t - \\\\mathrm{close}_{{t-10}}) / (10\\\\,\\\\mathrm{close})',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 10,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/qlib158/beta20.py
+++ b/agent/src/factors/zoo/qlib158/beta20.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '(\\\\mathrm{close}_t - \\\\mathrm{close}_{{t-20}}) / (20\\\\,\\\\mathrm{close})',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 20,
     'min_warmup_bars': 20,

--- a/agent/src/factors/zoo/qlib158/beta30.py
+++ b/agent/src/factors/zoo/qlib158/beta30.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '(\\\\mathrm{close}_t - \\\\mathrm{close}_{{t-30}}) / (30\\\\,\\\\mathrm{close})',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 30,
     'min_warmup_bars': 30,

--- a/agent/src/factors/zoo/qlib158/beta5.py
+++ b/agent/src/factors/zoo/qlib158/beta5.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '(\\\\mathrm{close}_t - \\\\mathrm{close}_{{t-5}}) / (5\\\\,\\\\mathrm{close})',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/qlib158/beta60.py
+++ b/agent/src/factors/zoo/qlib158/beta60.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '(\\\\mathrm{close}_t - \\\\mathrm{close}_{{t-60}}) / (60\\\\,\\\\mathrm{close})',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 60,
     'min_warmup_bars': 60,

--- a/agent/src/factors/zoo/qlib158/cntd10.py
+++ b/agent/src/factors/zoo/qlib158/cntd10.py
@@ -15,7 +15,7 @@ __alpha_meta__ = {
     'theme': ['reversal'],
     'formula_latex': '\\\\mathrm{CNTP}_10 - \\\\mathrm{CNTN}_10',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 10,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/qlib158/cntd20.py
+++ b/agent/src/factors/zoo/qlib158/cntd20.py
@@ -15,7 +15,7 @@ __alpha_meta__ = {
     'theme': ['reversal'],
     'formula_latex': '\\\\mathrm{CNTP}_20 - \\\\mathrm{CNTN}_20',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 20,
     'min_warmup_bars': 20,

--- a/agent/src/factors/zoo/qlib158/cntd30.py
+++ b/agent/src/factors/zoo/qlib158/cntd30.py
@@ -15,7 +15,7 @@ __alpha_meta__ = {
     'theme': ['reversal'],
     'formula_latex': '\\\\mathrm{CNTP}_30 - \\\\mathrm{CNTN}_30',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 30,
     'min_warmup_bars': 30,

--- a/agent/src/factors/zoo/qlib158/cntd5.py
+++ b/agent/src/factors/zoo/qlib158/cntd5.py
@@ -15,7 +15,7 @@ __alpha_meta__ = {
     'theme': ['reversal'],
     'formula_latex': '\\\\mathrm{CNTP}_5 - \\\\mathrm{CNTN}_5',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/qlib158/cntd60.py
+++ b/agent/src/factors/zoo/qlib158/cntd60.py
@@ -15,7 +15,7 @@ __alpha_meta__ = {
     'theme': ['reversal'],
     'formula_latex': '\\\\mathrm{CNTP}_60 - \\\\mathrm{CNTN}_60',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 60,
     'min_warmup_bars': 60,

--- a/agent/src/factors/zoo/qlib158/cntn10.py
+++ b/agent/src/factors/zoo/qlib158/cntn10.py
@@ -15,7 +15,7 @@ __alpha_meta__ = {
     'theme': ['reversal'],
     'formula_latex': '\\\\mathrm{rolling\\\\_mean}(\\\\mathrm{1}[\\\\mathrm{close}<\\\\mathrm{close}_{{-1}}], 10)',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 10,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/qlib158/cntn20.py
+++ b/agent/src/factors/zoo/qlib158/cntn20.py
@@ -15,7 +15,7 @@ __alpha_meta__ = {
     'theme': ['reversal'],
     'formula_latex': '\\\\mathrm{rolling\\\\_mean}(\\\\mathrm{1}[\\\\mathrm{close}<\\\\mathrm{close}_{{-1}}], 20)',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 20,
     'min_warmup_bars': 20,

--- a/agent/src/factors/zoo/qlib158/cntn30.py
+++ b/agent/src/factors/zoo/qlib158/cntn30.py
@@ -15,7 +15,7 @@ __alpha_meta__ = {
     'theme': ['reversal'],
     'formula_latex': '\\\\mathrm{rolling\\\\_mean}(\\\\mathrm{1}[\\\\mathrm{close}<\\\\mathrm{close}_{{-1}}], 30)',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 30,
     'min_warmup_bars': 30,

--- a/agent/src/factors/zoo/qlib158/cntn5.py
+++ b/agent/src/factors/zoo/qlib158/cntn5.py
@@ -15,7 +15,7 @@ __alpha_meta__ = {
     'theme': ['reversal'],
     'formula_latex': '\\\\mathrm{rolling\\\\_mean}(\\\\mathrm{1}[\\\\mathrm{close}<\\\\mathrm{close}_{{-1}}], 5)',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/qlib158/cntn60.py
+++ b/agent/src/factors/zoo/qlib158/cntn60.py
@@ -15,7 +15,7 @@ __alpha_meta__ = {
     'theme': ['reversal'],
     'formula_latex': '\\\\mathrm{rolling\\\\_mean}(\\\\mathrm{1}[\\\\mathrm{close}<\\\\mathrm{close}_{{-1}}], 60)',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 60,
     'min_warmup_bars': 60,

--- a/agent/src/factors/zoo/qlib158/cntp10.py
+++ b/agent/src/factors/zoo/qlib158/cntp10.py
@@ -15,7 +15,7 @@ __alpha_meta__ = {
     'theme': ['reversal'],
     'formula_latex': '\\\\mathrm{rolling\\\\_mean}(\\\\mathrm{1}[\\\\mathrm{close}>\\\\mathrm{close}_{{-1}}], 10)',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 10,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/qlib158/cntp20.py
+++ b/agent/src/factors/zoo/qlib158/cntp20.py
@@ -15,7 +15,7 @@ __alpha_meta__ = {
     'theme': ['reversal'],
     'formula_latex': '\\\\mathrm{rolling\\\\_mean}(\\\\mathrm{1}[\\\\mathrm{close}>\\\\mathrm{close}_{{-1}}], 20)',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 20,
     'min_warmup_bars': 20,

--- a/agent/src/factors/zoo/qlib158/cntp30.py
+++ b/agent/src/factors/zoo/qlib158/cntp30.py
@@ -15,7 +15,7 @@ __alpha_meta__ = {
     'theme': ['reversal'],
     'formula_latex': '\\\\mathrm{rolling\\\\_mean}(\\\\mathrm{1}[\\\\mathrm{close}>\\\\mathrm{close}_{{-1}}], 30)',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 30,
     'min_warmup_bars': 30,

--- a/agent/src/factors/zoo/qlib158/cntp5.py
+++ b/agent/src/factors/zoo/qlib158/cntp5.py
@@ -15,7 +15,7 @@ __alpha_meta__ = {
     'theme': ['reversal'],
     'formula_latex': '\\\\mathrm{rolling\\\\_mean}(\\\\mathrm{1}[\\\\mathrm{close}>\\\\mathrm{close}_{{-1}}], 5)',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/qlib158/cntp60.py
+++ b/agent/src/factors/zoo/qlib158/cntp60.py
@@ -15,7 +15,7 @@ __alpha_meta__ = {
     'theme': ['reversal'],
     'formula_latex': '\\\\mathrm{rolling\\\\_mean}(\\\\mathrm{1}[\\\\mathrm{close}>\\\\mathrm{close}_{{-1}}], 60)',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 60,
     'min_warmup_bars': 60,

--- a/agent/src/factors/zoo/qlib158/cord10.py
+++ b/agent/src/factors/zoo/qlib158/cord10.py
@@ -17,7 +17,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'microstructure'],
     'formula_latex': '\\\\mathrm{ts\\\\_corr}(\\\\mathrm{close}/\\\\mathrm{close}_{{-1}}, \\\\log((\\\\mathrm{volume}+1)/(\\\\mathrm{volume}_{{-1}}+1)), 10)',
     'columns_required': ['close', 'volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 10,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/qlib158/cord20.py
+++ b/agent/src/factors/zoo/qlib158/cord20.py
@@ -17,7 +17,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'microstructure'],
     'formula_latex': '\\\\mathrm{ts\\\\_corr}(\\\\mathrm{close}/\\\\mathrm{close}_{{-1}}, \\\\log((\\\\mathrm{volume}+1)/(\\\\mathrm{volume}_{{-1}}+1)), 20)',
     'columns_required': ['close', 'volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 20,
     'min_warmup_bars': 20,

--- a/agent/src/factors/zoo/qlib158/cord30.py
+++ b/agent/src/factors/zoo/qlib158/cord30.py
@@ -17,7 +17,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'microstructure'],
     'formula_latex': '\\\\mathrm{ts\\\\_corr}(\\\\mathrm{close}/\\\\mathrm{close}_{{-1}}, \\\\log((\\\\mathrm{volume}+1)/(\\\\mathrm{volume}_{{-1}}+1)), 30)',
     'columns_required': ['close', 'volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 30,
     'min_warmup_bars': 30,

--- a/agent/src/factors/zoo/qlib158/cord5.py
+++ b/agent/src/factors/zoo/qlib158/cord5.py
@@ -17,7 +17,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'microstructure'],
     'formula_latex': '\\\\mathrm{ts\\\\_corr}(\\\\mathrm{close}/\\\\mathrm{close}_{{-1}}, \\\\log((\\\\mathrm{volume}+1)/(\\\\mathrm{volume}_{{-1}}+1)), 5)',
     'columns_required': ['close', 'volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/qlib158/cord60.py
+++ b/agent/src/factors/zoo/qlib158/cord60.py
@@ -17,7 +17,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'microstructure'],
     'formula_latex': '\\\\mathrm{ts\\\\_corr}(\\\\mathrm{close}/\\\\mathrm{close}_{{-1}}, \\\\log((\\\\mathrm{volume}+1)/(\\\\mathrm{volume}_{{-1}}+1)), 60)',
     'columns_required': ['close', 'volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 60,
     'min_warmup_bars': 60,

--- a/agent/src/factors/zoo/qlib158/corr10.py
+++ b/agent/src/factors/zoo/qlib158/corr10.py
@@ -17,7 +17,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'microstructure'],
     'formula_latex': '\\\\mathrm{ts\\\\_corr}(\\\\mathrm{close}, \\\\log(\\\\mathrm{volume}+1), 10)',
     'columns_required': ['close', 'volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 10,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/qlib158/corr20.py
+++ b/agent/src/factors/zoo/qlib158/corr20.py
@@ -17,7 +17,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'microstructure'],
     'formula_latex': '\\\\mathrm{ts\\\\_corr}(\\\\mathrm{close}, \\\\log(\\\\mathrm{volume}+1), 20)',
     'columns_required': ['close', 'volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 20,
     'min_warmup_bars': 20,

--- a/agent/src/factors/zoo/qlib158/corr30.py
+++ b/agent/src/factors/zoo/qlib158/corr30.py
@@ -17,7 +17,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'microstructure'],
     'formula_latex': '\\\\mathrm{ts\\\\_corr}(\\\\mathrm{close}, \\\\log(\\\\mathrm{volume}+1), 30)',
     'columns_required': ['close', 'volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 30,
     'min_warmup_bars': 30,

--- a/agent/src/factors/zoo/qlib158/corr5.py
+++ b/agent/src/factors/zoo/qlib158/corr5.py
@@ -17,7 +17,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'microstructure'],
     'formula_latex': '\\\\mathrm{ts\\\\_corr}(\\\\mathrm{close}, \\\\log(\\\\mathrm{volume}+1), 5)',
     'columns_required': ['close', 'volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/qlib158/corr60.py
+++ b/agent/src/factors/zoo/qlib158/corr60.py
@@ -17,7 +17,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'microstructure'],
     'formula_latex': '\\\\mathrm{ts\\\\_corr}(\\\\mathrm{close}, \\\\log(\\\\mathrm{volume}+1), 60)',
     'columns_required': ['close', 'volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 60,
     'min_warmup_bars': 60,

--- a/agent/src/factors/zoo/qlib158/imax10.py
+++ b/agent/src/factors/zoo/qlib158/imax10.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_argmax}(\\\\mathrm{high}, 10) / 10',
     'columns_required': ['high'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 10,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/qlib158/imax20.py
+++ b/agent/src/factors/zoo/qlib158/imax20.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_argmax}(\\\\mathrm{high}, 20) / 20',
     'columns_required': ['high'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 20,
     'min_warmup_bars': 20,

--- a/agent/src/factors/zoo/qlib158/imax30.py
+++ b/agent/src/factors/zoo/qlib158/imax30.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_argmax}(\\\\mathrm{high}, 30) / 30',
     'columns_required': ['high'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 30,
     'min_warmup_bars': 30,

--- a/agent/src/factors/zoo/qlib158/imax5.py
+++ b/agent/src/factors/zoo/qlib158/imax5.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_argmax}(\\\\mathrm{high}, 5) / 5',
     'columns_required': ['high'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/qlib158/imax60.py
+++ b/agent/src/factors/zoo/qlib158/imax60.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_argmax}(\\\\mathrm{high}, 60) / 60',
     'columns_required': ['high'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 60,
     'min_warmup_bars': 60,

--- a/agent/src/factors/zoo/qlib158/imin10.py
+++ b/agent/src/factors/zoo/qlib158/imin10.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_argmin}(\\\\mathrm{low}, 10) / 10',
     'columns_required': ['low'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 10,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/qlib158/imin20.py
+++ b/agent/src/factors/zoo/qlib158/imin20.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_argmin}(\\\\mathrm{low}, 20) / 20',
     'columns_required': ['low'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 20,
     'min_warmup_bars': 20,

--- a/agent/src/factors/zoo/qlib158/imin30.py
+++ b/agent/src/factors/zoo/qlib158/imin30.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_argmin}(\\\\mathrm{low}, 30) / 30',
     'columns_required': ['low'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 30,
     'min_warmup_bars': 30,

--- a/agent/src/factors/zoo/qlib158/imin5.py
+++ b/agent/src/factors/zoo/qlib158/imin5.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_argmin}(\\\\mathrm{low}, 5) / 5',
     'columns_required': ['low'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/qlib158/imin60.py
+++ b/agent/src/factors/zoo/qlib158/imin60.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_argmin}(\\\\mathrm{low}, 60) / 60',
     'columns_required': ['low'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 60,
     'min_warmup_bars': 60,

--- a/agent/src/factors/zoo/qlib158/imxd10.py
+++ b/agent/src/factors/zoo/qlib158/imxd10.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '(\\\\mathrm{ts\\\\_argmax}(\\\\mathrm{high}, 10) - \\\\mathrm{ts\\\\_argmin}(\\\\mathrm{low}, 10)) / 10',
     'columns_required': ['high', 'low'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 10,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/qlib158/imxd20.py
+++ b/agent/src/factors/zoo/qlib158/imxd20.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '(\\\\mathrm{ts\\\\_argmax}(\\\\mathrm{high}, 20) - \\\\mathrm{ts\\\\_argmin}(\\\\mathrm{low}, 20)) / 20',
     'columns_required': ['high', 'low'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 20,
     'min_warmup_bars': 20,

--- a/agent/src/factors/zoo/qlib158/imxd30.py
+++ b/agent/src/factors/zoo/qlib158/imxd30.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '(\\\\mathrm{ts\\\\_argmax}(\\\\mathrm{high}, 30) - \\\\mathrm{ts\\\\_argmin}(\\\\mathrm{low}, 30)) / 30',
     'columns_required': ['high', 'low'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 30,
     'min_warmup_bars': 30,

--- a/agent/src/factors/zoo/qlib158/imxd5.py
+++ b/agent/src/factors/zoo/qlib158/imxd5.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '(\\\\mathrm{ts\\\\_argmax}(\\\\mathrm{high}, 5) - \\\\mathrm{ts\\\\_argmin}(\\\\mathrm{low}, 5)) / 5',
     'columns_required': ['high', 'low'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/qlib158/imxd60.py
+++ b/agent/src/factors/zoo/qlib158/imxd60.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '(\\\\mathrm{ts\\\\_argmax}(\\\\mathrm{high}, 60) - \\\\mathrm{ts\\\\_argmin}(\\\\mathrm{low}, 60)) / 60',
     'columns_required': ['high', 'low'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 60,
     'min_warmup_bars': 60,

--- a/agent/src/factors/zoo/qlib158/klen.py
+++ b/agent/src/factors/zoo/qlib158/klen.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['microstructure'],
     'formula_latex': '(\\\\mathrm{high} - \\\\mathrm{low}) / \\\\mathrm{open}',
     'columns_required': ['open', 'high', 'low'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 1,
     'min_warmup_bars': 1,

--- a/agent/src/factors/zoo/qlib158/klow.py
+++ b/agent/src/factors/zoo/qlib158/klow.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['microstructure'],
     'formula_latex': '(\\\\min(\\\\mathrm{open}, \\\\mathrm{close}) - \\\\mathrm{low}) / \\\\mathrm{open}',
     'columns_required': ['open', 'low', 'close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 1,
     'min_warmup_bars': 1,

--- a/agent/src/factors/zoo/qlib158/klow2.py
+++ b/agent/src/factors/zoo/qlib158/klow2.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['microstructure'],
     'formula_latex': '(\\\\min(\\\\mathrm{open}, \\\\mathrm{close}) - \\\\mathrm{low}) / (\\\\mathrm{high} - \\\\mathrm{low})',
     'columns_required': ['open', 'high', 'low', 'close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 1,
     'min_warmup_bars': 1,

--- a/agent/src/factors/zoo/qlib158/kmid.py
+++ b/agent/src/factors/zoo/qlib158/kmid.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['microstructure'],
     'formula_latex': '(\\\\mathrm{close} - \\\\mathrm{open}) / \\\\mathrm{open}',
     'columns_required': ['open', 'close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 1,
     'min_warmup_bars': 1,

--- a/agent/src/factors/zoo/qlib158/kmid2.py
+++ b/agent/src/factors/zoo/qlib158/kmid2.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['microstructure'],
     'formula_latex': '(\\\\mathrm{close} - \\\\mathrm{open}) / (\\\\mathrm{high} - \\\\mathrm{low})',
     'columns_required': ['open', 'high', 'low', 'close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 1,
     'min_warmup_bars': 1,

--- a/agent/src/factors/zoo/qlib158/ksft.py
+++ b/agent/src/factors/zoo/qlib158/ksft.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['microstructure'],
     'formula_latex': '(2\\\\,\\\\mathrm{close} - \\\\mathrm{high} - \\\\mathrm{low}) / \\\\mathrm{open}',
     'columns_required': ['open', 'high', 'low', 'close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 1,
     'min_warmup_bars': 1,

--- a/agent/src/factors/zoo/qlib158/ksft2.py
+++ b/agent/src/factors/zoo/qlib158/ksft2.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['microstructure'],
     'formula_latex': '(2\\\\,\\\\mathrm{close} - \\\\mathrm{high} - \\\\mathrm{low}) / (\\\\mathrm{high} - \\\\mathrm{low})',
     'columns_required': ['open', 'high', 'low', 'close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 1,
     'min_warmup_bars': 1,

--- a/agent/src/factors/zoo/qlib158/kup.py
+++ b/agent/src/factors/zoo/qlib158/kup.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['microstructure'],
     'formula_latex': '(\\\\mathrm{high} - \\\\max(\\\\mathrm{open}, \\\\mathrm{close})) / \\\\mathrm{open}',
     'columns_required': ['open', 'high', 'close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 1,
     'min_warmup_bars': 1,

--- a/agent/src/factors/zoo/qlib158/kup2.py
+++ b/agent/src/factors/zoo/qlib158/kup2.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['microstructure'],
     'formula_latex': '(\\\\mathrm{high} - \\\\max(\\\\mathrm{open}, \\\\mathrm{close})) / (\\\\mathrm{high} - \\\\mathrm{low})',
     'columns_required': ['open', 'high', 'low', 'close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 1,
     'min_warmup_bars': 1,

--- a/agent/src/factors/zoo/qlib158/ma10.py
+++ b/agent/src/factors/zoo/qlib158/ma10.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_mean}(\\\\mathrm{close}, 10) / \\\\mathrm{close}',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 10,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/qlib158/ma20.py
+++ b/agent/src/factors/zoo/qlib158/ma20.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_mean}(\\\\mathrm{close}, 20) / \\\\mathrm{close}',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 20,
     'min_warmup_bars': 20,

--- a/agent/src/factors/zoo/qlib158/ma30.py
+++ b/agent/src/factors/zoo/qlib158/ma30.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_mean}(\\\\mathrm{close}, 30) / \\\\mathrm{close}',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 30,
     'min_warmup_bars': 30,

--- a/agent/src/factors/zoo/qlib158/ma5.py
+++ b/agent/src/factors/zoo/qlib158/ma5.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_mean}(\\\\mathrm{close}, 5) / \\\\mathrm{close}',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/qlib158/ma60.py
+++ b/agent/src/factors/zoo/qlib158/ma60.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_mean}(\\\\mathrm{close}, 60) / \\\\mathrm{close}',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 60,
     'min_warmup_bars': 60,

--- a/agent/src/factors/zoo/qlib158/max10.py
+++ b/agent/src/factors/zoo/qlib158/max10.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_max}(\\\\mathrm{high}, 10) / \\\\mathrm{close}',
     'columns_required': ['high', 'close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 10,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/qlib158/max20.py
+++ b/agent/src/factors/zoo/qlib158/max20.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_max}(\\\\mathrm{high}, 20) / \\\\mathrm{close}',
     'columns_required': ['high', 'close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 20,
     'min_warmup_bars': 20,

--- a/agent/src/factors/zoo/qlib158/max30.py
+++ b/agent/src/factors/zoo/qlib158/max30.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_max}(\\\\mathrm{high}, 30) / \\\\mathrm{close}',
     'columns_required': ['high', 'close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 30,
     'min_warmup_bars': 30,

--- a/agent/src/factors/zoo/qlib158/max5.py
+++ b/agent/src/factors/zoo/qlib158/max5.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_max}(\\\\mathrm{high}, 5) / \\\\mathrm{close}',
     'columns_required': ['high', 'close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/qlib158/max60.py
+++ b/agent/src/factors/zoo/qlib158/max60.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_max}(\\\\mathrm{high}, 60) / \\\\mathrm{close}',
     'columns_required': ['high', 'close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 60,
     'min_warmup_bars': 60,

--- a/agent/src/factors/zoo/qlib158/min10.py
+++ b/agent/src/factors/zoo/qlib158/min10.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_min}(\\\\mathrm{low}, 10) / \\\\mathrm{close}',
     'columns_required': ['low', 'close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 10,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/qlib158/min20.py
+++ b/agent/src/factors/zoo/qlib158/min20.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_min}(\\\\mathrm{low}, 20) / \\\\mathrm{close}',
     'columns_required': ['low', 'close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 20,
     'min_warmup_bars': 20,

--- a/agent/src/factors/zoo/qlib158/min30.py
+++ b/agent/src/factors/zoo/qlib158/min30.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_min}(\\\\mathrm{low}, 30) / \\\\mathrm{close}',
     'columns_required': ['low', 'close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 30,
     'min_warmup_bars': 30,

--- a/agent/src/factors/zoo/qlib158/min5.py
+++ b/agent/src/factors/zoo/qlib158/min5.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_min}(\\\\mathrm{low}, 5) / \\\\mathrm{close}',
     'columns_required': ['low', 'close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/qlib158/min60.py
+++ b/agent/src/factors/zoo/qlib158/min60.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_min}(\\\\mathrm{low}, 60) / \\\\mathrm{close}',
     'columns_required': ['low', 'close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 60,
     'min_warmup_bars': 60,

--- a/agent/src/factors/zoo/qlib158/qtld10.py
+++ b/agent/src/factors/zoo/qlib158/qtld10.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{quantile}_{{0.2}}(\\\\mathrm{close}, 10) / \\\\mathrm{close}',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 10,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/qlib158/qtld20.py
+++ b/agent/src/factors/zoo/qlib158/qtld20.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{quantile}_{{0.2}}(\\\\mathrm{close}, 20) / \\\\mathrm{close}',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 20,
     'min_warmup_bars': 20,

--- a/agent/src/factors/zoo/qlib158/qtld30.py
+++ b/agent/src/factors/zoo/qlib158/qtld30.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{quantile}_{{0.2}}(\\\\mathrm{close}, 30) / \\\\mathrm{close}',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 30,
     'min_warmup_bars': 30,

--- a/agent/src/factors/zoo/qlib158/qtld5.py
+++ b/agent/src/factors/zoo/qlib158/qtld5.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{quantile}_{{0.2}}(\\\\mathrm{close}, 5) / \\\\mathrm{close}',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/qlib158/qtld60.py
+++ b/agent/src/factors/zoo/qlib158/qtld60.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{quantile}_{{0.2}}(\\\\mathrm{close}, 60) / \\\\mathrm{close}',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 60,
     'min_warmup_bars': 60,

--- a/agent/src/factors/zoo/qlib158/qtlu10.py
+++ b/agent/src/factors/zoo/qlib158/qtlu10.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{quantile}_{{0.8}}(\\\\mathrm{close}, 10) / \\\\mathrm{close}',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 10,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/qlib158/qtlu20.py
+++ b/agent/src/factors/zoo/qlib158/qtlu20.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{quantile}_{{0.8}}(\\\\mathrm{close}, 20) / \\\\mathrm{close}',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 20,
     'min_warmup_bars': 20,

--- a/agent/src/factors/zoo/qlib158/qtlu30.py
+++ b/agent/src/factors/zoo/qlib158/qtlu30.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{quantile}_{{0.8}}(\\\\mathrm{close}, 30) / \\\\mathrm{close}',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 30,
     'min_warmup_bars': 30,

--- a/agent/src/factors/zoo/qlib158/qtlu5.py
+++ b/agent/src/factors/zoo/qlib158/qtlu5.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{quantile}_{{0.8}}(\\\\mathrm{close}, 5) / \\\\mathrm{close}',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/qlib158/qtlu60.py
+++ b/agent/src/factors/zoo/qlib158/qtlu60.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{quantile}_{{0.8}}(\\\\mathrm{close}, 60) / \\\\mathrm{close}',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 60,
     'min_warmup_bars': 60,

--- a/agent/src/factors/zoo/qlib158/rank10.py
+++ b/agent/src/factors/zoo/qlib158/rank10.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_rank}(\\\\mathrm{close}, 10)',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 10,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/qlib158/rank20.py
+++ b/agent/src/factors/zoo/qlib158/rank20.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_rank}(\\\\mathrm{close}, 20)',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 20,
     'min_warmup_bars': 20,

--- a/agent/src/factors/zoo/qlib158/rank30.py
+++ b/agent/src/factors/zoo/qlib158/rank30.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_rank}(\\\\mathrm{close}, 30)',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 30,
     'min_warmup_bars': 30,

--- a/agent/src/factors/zoo/qlib158/rank5.py
+++ b/agent/src/factors/zoo/qlib158/rank5.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_rank}(\\\\mathrm{close}, 5)',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/qlib158/rank60.py
+++ b/agent/src/factors/zoo/qlib158/rank60.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_rank}(\\\\mathrm{close}, 60)',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 60,
     'min_warmup_bars': 60,

--- a/agent/src/factors/zoo/qlib158/resi10.py
+++ b/agent/src/factors/zoo/qlib158/resi10.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '(\\\\mathrm{close} - \\\\mathrm{ts\\\\_mean}(\\\\mathrm{close}, 10)) / \\\\mathrm{close}',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 10,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/qlib158/resi20.py
+++ b/agent/src/factors/zoo/qlib158/resi20.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '(\\\\mathrm{close} - \\\\mathrm{ts\\\\_mean}(\\\\mathrm{close}, 20)) / \\\\mathrm{close}',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 20,
     'min_warmup_bars': 20,

--- a/agent/src/factors/zoo/qlib158/resi30.py
+++ b/agent/src/factors/zoo/qlib158/resi30.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '(\\\\mathrm{close} - \\\\mathrm{ts\\\\_mean}(\\\\mathrm{close}, 30)) / \\\\mathrm{close}',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 30,
     'min_warmup_bars': 30,

--- a/agent/src/factors/zoo/qlib158/resi5.py
+++ b/agent/src/factors/zoo/qlib158/resi5.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '(\\\\mathrm{close} - \\\\mathrm{ts\\\\_mean}(\\\\mathrm{close}, 5)) / \\\\mathrm{close}',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/qlib158/resi60.py
+++ b/agent/src/factors/zoo/qlib158/resi60.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '(\\\\mathrm{close} - \\\\mathrm{ts\\\\_mean}(\\\\mathrm{close}, 60)) / \\\\mathrm{close}',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 60,
     'min_warmup_bars': 60,

--- a/agent/src/factors/zoo/qlib158/roc10.py
+++ b/agent/src/factors/zoo/qlib158/roc10.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{close}_t / \\\\mathrm{close}_{{t-10}} - 1',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 10,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/qlib158/roc20.py
+++ b/agent/src/factors/zoo/qlib158/roc20.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{close}_t / \\\\mathrm{close}_{{t-20}} - 1',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 20,
     'min_warmup_bars': 20,

--- a/agent/src/factors/zoo/qlib158/roc30.py
+++ b/agent/src/factors/zoo/qlib158/roc30.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{close}_t / \\\\mathrm{close}_{{t-30}} - 1',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 30,
     'min_warmup_bars': 30,

--- a/agent/src/factors/zoo/qlib158/roc5.py
+++ b/agent/src/factors/zoo/qlib158/roc5.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{close}_t / \\\\mathrm{close}_{{t-5}} - 1',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/qlib158/roc60.py
+++ b/agent/src/factors/zoo/qlib158/roc60.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{close}_t / \\\\mathrm{close}_{{t-60}} - 1',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 60,
     'min_warmup_bars': 60,

--- a/agent/src/factors/zoo/qlib158/rsqr10.py
+++ b/agent/src/factors/zoo/qlib158/rsqr10.py
@@ -17,7 +17,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_corr}(\\\\mathrm{close}, t, 10)^2',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 10,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/qlib158/rsqr20.py
+++ b/agent/src/factors/zoo/qlib158/rsqr20.py
@@ -17,7 +17,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_corr}(\\\\mathrm{close}, t, 20)^2',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 20,
     'min_warmup_bars': 20,

--- a/agent/src/factors/zoo/qlib158/rsqr30.py
+++ b/agent/src/factors/zoo/qlib158/rsqr30.py
@@ -17,7 +17,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_corr}(\\\\mathrm{close}, t, 30)^2',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 30,
     'min_warmup_bars': 30,

--- a/agent/src/factors/zoo/qlib158/rsqr5.py
+++ b/agent/src/factors/zoo/qlib158/rsqr5.py
@@ -17,7 +17,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_corr}(\\\\mathrm{close}, t, 5)^2',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/qlib158/rsqr60.py
+++ b/agent/src/factors/zoo/qlib158/rsqr60.py
@@ -17,7 +17,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_corr}(\\\\mathrm{close}, t, 60)^2',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 60,
     'min_warmup_bars': 60,

--- a/agent/src/factors/zoo/qlib158/rsv10.py
+++ b/agent/src/factors/zoo/qlib158/rsv10.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '(\\\\mathrm{close} - \\\\mathrm{ts\\\\_min}(\\\\mathrm{low}, 10)) / (\\\\mathrm{ts\\\\_max}(\\\\mathrm{high}, 10) - \\\\mathrm{ts\\\\_min}(\\\\mathrm{low}, 10))',
     'columns_required': ['high', 'low', 'close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 10,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/qlib158/rsv20.py
+++ b/agent/src/factors/zoo/qlib158/rsv20.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '(\\\\mathrm{close} - \\\\mathrm{ts\\\\_min}(\\\\mathrm{low}, 20)) / (\\\\mathrm{ts\\\\_max}(\\\\mathrm{high}, 20) - \\\\mathrm{ts\\\\_min}(\\\\mathrm{low}, 20))',
     'columns_required': ['high', 'low', 'close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 20,
     'min_warmup_bars': 20,

--- a/agent/src/factors/zoo/qlib158/rsv30.py
+++ b/agent/src/factors/zoo/qlib158/rsv30.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '(\\\\mathrm{close} - \\\\mathrm{ts\\\\_min}(\\\\mathrm{low}, 30)) / (\\\\mathrm{ts\\\\_max}(\\\\mathrm{high}, 30) - \\\\mathrm{ts\\\\_min}(\\\\mathrm{low}, 30))',
     'columns_required': ['high', 'low', 'close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 30,
     'min_warmup_bars': 30,

--- a/agent/src/factors/zoo/qlib158/rsv5.py
+++ b/agent/src/factors/zoo/qlib158/rsv5.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '(\\\\mathrm{close} - \\\\mathrm{ts\\\\_min}(\\\\mathrm{low}, 5)) / (\\\\mathrm{ts\\\\_max}(\\\\mathrm{high}, 5) - \\\\mathrm{ts\\\\_min}(\\\\mathrm{low}, 5))',
     'columns_required': ['high', 'low', 'close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/qlib158/rsv60.py
+++ b/agent/src/factors/zoo/qlib158/rsv60.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '(\\\\mathrm{close} - \\\\mathrm{ts\\\\_min}(\\\\mathrm{low}, 60)) / (\\\\mathrm{ts\\\\_max}(\\\\mathrm{high}, 60) - \\\\mathrm{ts\\\\_min}(\\\\mathrm{low}, 60))',
     'columns_required': ['high', 'low', 'close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 60,
     'min_warmup_bars': 60,

--- a/agent/src/factors/zoo/qlib158/std10.py
+++ b/agent/src/factors/zoo/qlib158/std10.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_std}(\\\\mathrm{close}, 10) / \\\\mathrm{close}',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 10,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/qlib158/std20.py
+++ b/agent/src/factors/zoo/qlib158/std20.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_std}(\\\\mathrm{close}, 20) / \\\\mathrm{close}',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 20,
     'min_warmup_bars': 20,

--- a/agent/src/factors/zoo/qlib158/std30.py
+++ b/agent/src/factors/zoo/qlib158/std30.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_std}(\\\\mathrm{close}, 30) / \\\\mathrm{close}',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 30,
     'min_warmup_bars': 30,

--- a/agent/src/factors/zoo/qlib158/std5.py
+++ b/agent/src/factors/zoo/qlib158/std5.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_std}(\\\\mathrm{close}, 5) / \\\\mathrm{close}',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/qlib158/std60.py
+++ b/agent/src/factors/zoo/qlib158/std60.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['momentum'],
     'formula_latex': '\\\\mathrm{ts\\\\_std}(\\\\mathrm{close}, 60) / \\\\mathrm{close}',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 60,
     'min_warmup_bars': 60,

--- a/agent/src/factors/zoo/qlib158/sumd10.py
+++ b/agent/src/factors/zoo/qlib158/sumd10.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['reversal'],
     'formula_latex': '\\\\mathrm{SUMP}_w - \\\\mathrm{SUMN}_w',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 10,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/qlib158/sumd20.py
+++ b/agent/src/factors/zoo/qlib158/sumd20.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['reversal'],
     'formula_latex': '\\\\mathrm{SUMP}_w - \\\\mathrm{SUMN}_w',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 20,
     'min_warmup_bars': 20,

--- a/agent/src/factors/zoo/qlib158/sumd30.py
+++ b/agent/src/factors/zoo/qlib158/sumd30.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['reversal'],
     'formula_latex': '\\\\mathrm{SUMP}_w - \\\\mathrm{SUMN}_w',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 30,
     'min_warmup_bars': 30,

--- a/agent/src/factors/zoo/qlib158/sumd5.py
+++ b/agent/src/factors/zoo/qlib158/sumd5.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['reversal'],
     'formula_latex': '\\\\mathrm{SUMP}_w - \\\\mathrm{SUMN}_w',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/qlib158/sumd60.py
+++ b/agent/src/factors/zoo/qlib158/sumd60.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['reversal'],
     'formula_latex': '\\\\mathrm{SUMP}_w - \\\\mathrm{SUMN}_w',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 60,
     'min_warmup_bars': 60,

--- a/agent/src/factors/zoo/qlib158/sumn10.py
+++ b/agent/src/factors/zoo/qlib158/sumn10.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['reversal'],
     'formula_latex': '\\\\sum \\\\max(-\\\\Delta\\\\mathrm{close}, 0) / \\\\sum |\\\\Delta\\\\mathrm{close}|',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 10,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/qlib158/sumn20.py
+++ b/agent/src/factors/zoo/qlib158/sumn20.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['reversal'],
     'formula_latex': '\\\\sum \\\\max(-\\\\Delta\\\\mathrm{close}, 0) / \\\\sum |\\\\Delta\\\\mathrm{close}|',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 20,
     'min_warmup_bars': 20,

--- a/agent/src/factors/zoo/qlib158/sumn30.py
+++ b/agent/src/factors/zoo/qlib158/sumn30.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['reversal'],
     'formula_latex': '\\\\sum \\\\max(-\\\\Delta\\\\mathrm{close}, 0) / \\\\sum |\\\\Delta\\\\mathrm{close}|',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 30,
     'min_warmup_bars': 30,

--- a/agent/src/factors/zoo/qlib158/sumn5.py
+++ b/agent/src/factors/zoo/qlib158/sumn5.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['reversal'],
     'formula_latex': '\\\\sum \\\\max(-\\\\Delta\\\\mathrm{close}, 0) / \\\\sum |\\\\Delta\\\\mathrm{close}|',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/qlib158/sumn60.py
+++ b/agent/src/factors/zoo/qlib158/sumn60.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['reversal'],
     'formula_latex': '\\\\sum \\\\max(-\\\\Delta\\\\mathrm{close}, 0) / \\\\sum |\\\\Delta\\\\mathrm{close}|',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 60,
     'min_warmup_bars': 60,

--- a/agent/src/factors/zoo/qlib158/sump10.py
+++ b/agent/src/factors/zoo/qlib158/sump10.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['reversal'],
     'formula_latex': '\\\\sum \\\\max(\\\\Delta\\\\mathrm{close}, 0) / \\\\sum |\\\\Delta\\\\mathrm{close}|',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 10,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/qlib158/sump20.py
+++ b/agent/src/factors/zoo/qlib158/sump20.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['reversal'],
     'formula_latex': '\\\\sum \\\\max(\\\\Delta\\\\mathrm{close}, 0) / \\\\sum |\\\\Delta\\\\mathrm{close}|',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 20,
     'min_warmup_bars': 20,

--- a/agent/src/factors/zoo/qlib158/sump30.py
+++ b/agent/src/factors/zoo/qlib158/sump30.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['reversal'],
     'formula_latex': '\\\\sum \\\\max(\\\\Delta\\\\mathrm{close}, 0) / \\\\sum |\\\\Delta\\\\mathrm{close}|',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 30,
     'min_warmup_bars': 30,

--- a/agent/src/factors/zoo/qlib158/sump5.py
+++ b/agent/src/factors/zoo/qlib158/sump5.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['reversal'],
     'formula_latex': '\\\\sum \\\\max(\\\\Delta\\\\mathrm{close}, 0) / \\\\sum |\\\\Delta\\\\mathrm{close}|',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/qlib158/sump60.py
+++ b/agent/src/factors/zoo/qlib158/sump60.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['reversal'],
     'formula_latex': '\\\\sum \\\\max(\\\\Delta\\\\mathrm{close}, 0) / \\\\sum |\\\\Delta\\\\mathrm{close}|',
     'columns_required': ['close'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 60,
     'min_warmup_bars': 60,

--- a/agent/src/factors/zoo/qlib158/vma10.py
+++ b/agent/src/factors/zoo/qlib158/vma10.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'volatility'],
     'formula_latex': '\\\\mathrm{ts\\\\_mean}(\\\\mathrm{volume}, 10) / \\\\mathrm{volume}',
     'columns_required': ['volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 10,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/qlib158/vma20.py
+++ b/agent/src/factors/zoo/qlib158/vma20.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'volatility'],
     'formula_latex': '\\\\mathrm{ts\\\\_mean}(\\\\mathrm{volume}, 20) / \\\\mathrm{volume}',
     'columns_required': ['volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 20,
     'min_warmup_bars': 20,

--- a/agent/src/factors/zoo/qlib158/vma30.py
+++ b/agent/src/factors/zoo/qlib158/vma30.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'volatility'],
     'formula_latex': '\\\\mathrm{ts\\\\_mean}(\\\\mathrm{volume}, 30) / \\\\mathrm{volume}',
     'columns_required': ['volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 30,
     'min_warmup_bars': 30,

--- a/agent/src/factors/zoo/qlib158/vma5.py
+++ b/agent/src/factors/zoo/qlib158/vma5.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'volatility'],
     'formula_latex': '\\\\mathrm{ts\\\\_mean}(\\\\mathrm{volume}, 5) / \\\\mathrm{volume}',
     'columns_required': ['volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/qlib158/vma60.py
+++ b/agent/src/factors/zoo/qlib158/vma60.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'volatility'],
     'formula_latex': '\\\\mathrm{ts\\\\_mean}(\\\\mathrm{volume}, 60) / \\\\mathrm{volume}',
     'columns_required': ['volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 60,
     'min_warmup_bars': 60,

--- a/agent/src/factors/zoo/qlib158/vstd10.py
+++ b/agent/src/factors/zoo/qlib158/vstd10.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'volatility'],
     'formula_latex': '\\\\mathrm{ts\\\\_std}(\\\\mathrm{volume}, 10) / \\\\mathrm{volume}',
     'columns_required': ['volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 10,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/qlib158/vstd20.py
+++ b/agent/src/factors/zoo/qlib158/vstd20.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'volatility'],
     'formula_latex': '\\\\mathrm{ts\\\\_std}(\\\\mathrm{volume}, 20) / \\\\mathrm{volume}',
     'columns_required': ['volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 20,
     'min_warmup_bars': 20,

--- a/agent/src/factors/zoo/qlib158/vstd30.py
+++ b/agent/src/factors/zoo/qlib158/vstd30.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'volatility'],
     'formula_latex': '\\\\mathrm{ts\\\\_std}(\\\\mathrm{volume}, 30) / \\\\mathrm{volume}',
     'columns_required': ['volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 30,
     'min_warmup_bars': 30,

--- a/agent/src/factors/zoo/qlib158/vstd5.py
+++ b/agent/src/factors/zoo/qlib158/vstd5.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'volatility'],
     'formula_latex': '\\\\mathrm{ts\\\\_std}(\\\\mathrm{volume}, 5) / \\\\mathrm{volume}',
     'columns_required': ['volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/qlib158/vstd60.py
+++ b/agent/src/factors/zoo/qlib158/vstd60.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'volatility'],
     'formula_latex': '\\\\mathrm{ts\\\\_std}(\\\\mathrm{volume}, 60) / \\\\mathrm{volume}',
     'columns_required': ['volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 60,
     'min_warmup_bars': 60,

--- a/agent/src/factors/zoo/qlib158/vsumd10.py
+++ b/agent/src/factors/zoo/qlib158/vsumd10.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'volatility'],
     'formula_latex': '\\\\mathrm{VSUMP}_w - \\\\mathrm{VSUMN}_w',
     'columns_required': ['volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 10,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/qlib158/vsumd20.py
+++ b/agent/src/factors/zoo/qlib158/vsumd20.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'volatility'],
     'formula_latex': '\\\\mathrm{VSUMP}_w - \\\\mathrm{VSUMN}_w',
     'columns_required': ['volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 20,
     'min_warmup_bars': 20,

--- a/agent/src/factors/zoo/qlib158/vsumd30.py
+++ b/agent/src/factors/zoo/qlib158/vsumd30.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'volatility'],
     'formula_latex': '\\\\mathrm{VSUMP}_w - \\\\mathrm{VSUMN}_w',
     'columns_required': ['volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 30,
     'min_warmup_bars': 30,

--- a/agent/src/factors/zoo/qlib158/vsumd5.py
+++ b/agent/src/factors/zoo/qlib158/vsumd5.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'volatility'],
     'formula_latex': '\\\\mathrm{VSUMP}_w - \\\\mathrm{VSUMN}_w',
     'columns_required': ['volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/qlib158/vsumd60.py
+++ b/agent/src/factors/zoo/qlib158/vsumd60.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'volatility'],
     'formula_latex': '\\\\mathrm{VSUMP}_w - \\\\mathrm{VSUMN}_w',
     'columns_required': ['volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 60,
     'min_warmup_bars': 60,

--- a/agent/src/factors/zoo/qlib158/vsumn10.py
+++ b/agent/src/factors/zoo/qlib158/vsumn10.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'volatility'],
     'formula_latex': '\\\\sum \\\\max(-\\\\Delta v, 0) / \\\\sum |\\\\Delta v|',
     'columns_required': ['volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 10,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/qlib158/vsumn20.py
+++ b/agent/src/factors/zoo/qlib158/vsumn20.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'volatility'],
     'formula_latex': '\\\\sum \\\\max(-\\\\Delta v, 0) / \\\\sum |\\\\Delta v|',
     'columns_required': ['volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 20,
     'min_warmup_bars': 20,

--- a/agent/src/factors/zoo/qlib158/vsumn30.py
+++ b/agent/src/factors/zoo/qlib158/vsumn30.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'volatility'],
     'formula_latex': '\\\\sum \\\\max(-\\\\Delta v, 0) / \\\\sum |\\\\Delta v|',
     'columns_required': ['volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 30,
     'min_warmup_bars': 30,

--- a/agent/src/factors/zoo/qlib158/vsumn5.py
+++ b/agent/src/factors/zoo/qlib158/vsumn5.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'volatility'],
     'formula_latex': '\\\\sum \\\\max(-\\\\Delta v, 0) / \\\\sum |\\\\Delta v|',
     'columns_required': ['volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/qlib158/vsumn60.py
+++ b/agent/src/factors/zoo/qlib158/vsumn60.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'volatility'],
     'formula_latex': '\\\\sum \\\\max(-\\\\Delta v, 0) / \\\\sum |\\\\Delta v|',
     'columns_required': ['volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 60,
     'min_warmup_bars': 60,

--- a/agent/src/factors/zoo/qlib158/vsump10.py
+++ b/agent/src/factors/zoo/qlib158/vsump10.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'volatility'],
     'formula_latex': '\\\\sum \\\\max(\\\\Delta v, 0) / \\\\sum |\\\\Delta v|',
     'columns_required': ['volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 10,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/qlib158/vsump20.py
+++ b/agent/src/factors/zoo/qlib158/vsump20.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'volatility'],
     'formula_latex': '\\\\sum \\\\max(\\\\Delta v, 0) / \\\\sum |\\\\Delta v|',
     'columns_required': ['volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 20,
     'min_warmup_bars': 20,

--- a/agent/src/factors/zoo/qlib158/vsump30.py
+++ b/agent/src/factors/zoo/qlib158/vsump30.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'volatility'],
     'formula_latex': '\\\\sum \\\\max(\\\\Delta v, 0) / \\\\sum |\\\\Delta v|',
     'columns_required': ['volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 30,
     'min_warmup_bars': 30,

--- a/agent/src/factors/zoo/qlib158/vsump5.py
+++ b/agent/src/factors/zoo/qlib158/vsump5.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'volatility'],
     'formula_latex': '\\\\sum \\\\max(\\\\Delta v, 0) / \\\\sum |\\\\Delta v|',
     'columns_required': ['volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/qlib158/vsump60.py
+++ b/agent/src/factors/zoo/qlib158/vsump60.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'volatility'],
     'formula_latex': '\\\\sum \\\\max(\\\\Delta v, 0) / \\\\sum |\\\\Delta v|',
     'columns_required': ['volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 60,
     'min_warmup_bars': 60,

--- a/agent/src/factors/zoo/qlib158/wvma10.py
+++ b/agent/src/factors/zoo/qlib158/wvma10.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'volatility'],
     'formula_latex': '\\\\mathrm{ts\\\\_std}(\\\\mathrm{ret}\\\\cdot v, 10) / \\\\mathrm{ts\\\\_mean}(|\\\\mathrm{ret}|\\\\cdot v, 10)',
     'columns_required': ['close', 'volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 10,
     'min_warmup_bars': 10,

--- a/agent/src/factors/zoo/qlib158/wvma20.py
+++ b/agent/src/factors/zoo/qlib158/wvma20.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'volatility'],
     'formula_latex': '\\\\mathrm{ts\\\\_std}(\\\\mathrm{ret}\\\\cdot v, 20) / \\\\mathrm{ts\\\\_mean}(|\\\\mathrm{ret}|\\\\cdot v, 20)',
     'columns_required': ['close', 'volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 20,
     'min_warmup_bars': 20,

--- a/agent/src/factors/zoo/qlib158/wvma30.py
+++ b/agent/src/factors/zoo/qlib158/wvma30.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'volatility'],
     'formula_latex': '\\\\mathrm{ts\\\\_std}(\\\\mathrm{ret}\\\\cdot v, 30) / \\\\mathrm{ts\\\\_mean}(|\\\\mathrm{ret}|\\\\cdot v, 30)',
     'columns_required': ['close', 'volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 30,
     'min_warmup_bars': 30,

--- a/agent/src/factors/zoo/qlib158/wvma5.py
+++ b/agent/src/factors/zoo/qlib158/wvma5.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'volatility'],
     'formula_latex': '\\\\mathrm{ts\\\\_std}(\\\\mathrm{ret}\\\\cdot v, 5) / \\\\mathrm{ts\\\\_mean}(|\\\\mathrm{ret}|\\\\cdot v, 5)',
     'columns_required': ['close', 'volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 5,
     'min_warmup_bars': 5,

--- a/agent/src/factors/zoo/qlib158/wvma60.py
+++ b/agent/src/factors/zoo/qlib158/wvma60.py
@@ -16,7 +16,7 @@ __alpha_meta__ = {
     'theme': ['volume', 'volatility'],
     'formula_latex': '\\\\mathrm{ts\\\\_std}(\\\\mathrm{ret}\\\\cdot v, 60) / \\\\mathrm{ts\\\\_mean}(|\\\\mathrm{ret}|\\\\cdot v, 60)',
     'columns_required': ['close', 'volume'],
-    'universe': ['equity_us', 'equity_cn', 'equity_hk'],
+    'universe': ['equity_us', 'equity_cn', 'equity_hk', 'equity_in'],
     'frequency': ['1d'],
     'decay_horizon': 60,
     'min_warmup_bars': 60,

--- a/agent/src/live/enforcement.py
+++ b/agent/src/live/enforcement.py
@@ -58,10 +58,15 @@ _ASSET_CLASS_MARKET: dict[AssetClass, str] = {
     AssetClass.US_EQUITY: "us_equity",
     AssetClass.US_ETF: "us_equity",
     AssetClass.HK_EQUITY: "hk_equity",
+    AssetClass.IN_EQUITY: "india_equity",
     AssetClass.CRYPTO: "crypto",
     # CN_EQUITY has no loader market wired here, so market-cap / liquidity floors
     # for A-shares fail closed (deny) rather than wave through — intentional. If
     # ever wired, the registry's A-share market key is "a_share" (not "cn_equity").
+    # IN_EQUITY routes to the "india_equity" loader chain (Yahoo) for liquidity
+    # floors; market-cap floors stay US-only (see ``market_cap_usd``), so an
+    # India market-cap floor fails closed like CN — intentional until a metadata
+    # source is wired.
 }
 
 #: Breach ``kind`` values. ``universe``/``instrument`` are structural (DENY);

--- a/agent/src/live/mandate/model.py
+++ b/agent/src/live/mandate/model.py
@@ -30,6 +30,7 @@ class AssetClass(str, Enum):
     US_ETF = "us_etf"
     HK_EQUITY = "hk_equity"
     CN_EQUITY = "cn_equity"
+    IN_EQUITY = "in_equity"
     CRYPTO = "crypto"
 
 

--- a/agent/src/market_data.py
+++ b/agent/src/market_data.py
@@ -23,6 +23,9 @@ _SOURCE_PATTERNS = [
     (re.compile(r"^\d{6}\.(SZ|SH|BJ)$", re.I), "tencent"),
     (re.compile(r"^[A-Z]+\.US$", re.I), "yahoo"),
     (re.compile(r"^\d{3,5}\.HK$", re.I), "yahoo"),
+    # India: NSE (RELIANCE.NS) / BSE (500325.BO). Tickers may carry '&' and '-'
+    # (e.g. M&M.NS, BAJAJ-AUTO.NS). Served by Yahoo's public chart endpoint.
+    (re.compile(r"^[A-Z0-9&.\-]+\.(NS|BO)$", re.I), "yahoo"),
     (re.compile(r"^[A-Z]+-USDT$", re.I), "okx"),
     (re.compile(r"^[A-Z]+/USDT$", re.I), "ccxt"),
 ]

--- a/agent/tests/factors/test_india_universe.py
+++ b/agent/tests/factors/test_india_universe.py
@@ -1,0 +1,80 @@
+"""India (equity_in) factor-universe coverage against the bundled zoo.
+
+Verifies that the ``equity_in`` universe was wired end-to-end:
+  - Alpha101 (OHLCV-generic) and QLib158 (multi-market) factors are listed
+    for ``equity_in``.
+  - GTJA191 (China-scale, Tushare-specific) is NOT exposed for India.
+  - A representative alpha computes cleanly on a synthetic NSE-shape panel
+    whose ``vwap`` is built the India way (typical price, no Tushare scaling).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.factors.base import vwap
+from src.factors.registry import Registry
+
+
+@pytest.fixture(scope="module")
+def registry() -> Registry:
+    return Registry()
+
+
+def _india_panel(n_rows: int = 40, symbols=("RELIANCE.NS", "TCS.NS")) -> dict:
+    """Synthetic NSE-shape OHLCV panel; vwap injected as India typical price."""
+    rng = np.random.RandomState(7)
+    idx = pd.bdate_range("2024-01-01", periods=n_rows)
+    cols = list(symbols)
+    close = pd.DataFrame(
+        100.0 + np.cumsum(rng.randn(n_rows, len(cols)), axis=0), index=idx, columns=cols
+    ).abs() + 1.0
+    open_ = close.shift(1).fillna(close.iloc[0])
+    high = pd.DataFrame(
+        np.maximum(close.to_numpy(), open_.to_numpy()) + rng.rand(n_rows, len(cols)),
+        index=idx, columns=cols,
+    )
+    low = (
+        pd.DataFrame(
+            np.minimum(close.to_numpy(), open_.to_numpy()) - rng.rand(n_rows, len(cols)),
+            index=idx, columns=cols,
+        ).abs()
+        + 0.01
+    )
+    volume = pd.DataFrame(
+        rng.randint(1_000, 100_000, size=(n_rows, len(cols))).astype(float),
+        index=idx, columns=cols,
+    )
+    panel = {"open": open_, "high": high, "low": low, "close": close, "volume": volume}
+    panel["vwap"] = vwap(panel, "equity_in")  # typical price; no amount needed
+    return panel
+
+
+def test_alpha101_and_qlib158_listed_for_india(registry: Registry) -> None:
+    listed = set(registry.list(universe="equity_in"))
+    assert sum(a.startswith("alpha101_") for a in listed) == 101
+    assert sum(a.startswith("qlib158_") for a in listed) == 154
+
+
+def test_china_scale_gtja191_not_listed_for_india(registry: Registry) -> None:
+    listed = set(registry.list(universe="equity_in"))
+    assert not any(a.startswith("gtja191_") for a in listed)
+
+
+def test_india_vwap_uses_typical_price() -> None:
+    panel = _india_panel()
+    expected = (panel["open"] + panel["high"] + panel["low"] + panel["close"]) / 4.0
+    pd.testing.assert_frame_equal(panel["vwap"], expected)
+
+
+@pytest.mark.parametrize("alpha_id", ["alpha101_001", "alpha101_054", "qlib158_kmid"])
+def test_representative_factor_computes_on_india_panel(
+    registry: Registry, alpha_id: str
+) -> None:
+    listed = set(registry.list(universe="equity_in"))
+    assert alpha_id in listed
+    out = registry.compute(alpha_id, _india_panel())
+    assert out.shape[1] == 2  # two NSE symbols
+    assert np.isfinite(out.to_numpy()[~pd.isna(out.to_numpy())]).all()

--- a/agent/tests/test_india_backtest_smoke.py
+++ b/agent/tests/test_india_backtest_smoke.py
@@ -1,0 +1,96 @@
+"""End-to-end smoke test: backtest runs on Indian (NSE) symbols.
+
+Drives ``IndiaEquityEngine`` so strategies can run on NSE/BSE data with the
+India cost stack. This test feeds NSE bars through a fake loader + trivial long
+signal and asserts:
+
+  1. The backtest completes and emits metrics + a run card.
+  2. India trading costs are actually applied — the identical strategy on the
+     zero-commission US engine ends with strictly more cash than on the India
+     engine.
+
+All data is in-memory; no network access.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from backtest.engines.global_equity import GlobalEquityEngine
+from backtest.engines.india_equity import IndiaEquityEngine
+
+
+def _nse_bars() -> pd.DataFrame:
+    dates = pd.bdate_range("2024-04-01", periods=5)
+    return pd.DataFrame(
+        {
+            "open": [100.0, 102.0, 104.0, 106.0, 108.0],
+            "high": [101.0, 103.0, 105.0, 107.0, 109.0],
+            "low": [99.0, 101.0, 103.0, 105.0, 107.0],
+            "close": [102.0, 104.0, 106.0, 108.0, 110.0],
+            "volume": [10_000, 10_000, 10_000, 10_000, 10_000],
+        },
+        index=dates,
+    )
+
+
+class _FakeLoader:
+    def __init__(self, code: str, bars: pd.DataFrame) -> None:
+        self._code = code
+        self._bars = bars
+
+    def fetch(self, *args, **kwargs):
+        return {self._code: self._bars.copy()}
+
+
+class _LongSignal:
+    """Allocate fully long to the single instrument every bar."""
+
+    def __init__(self, code: str) -> None:
+        self._code = code
+
+    def generate(self, data_map):
+        idx = data_map[self._code].index
+        return {self._code: pd.Series(1.0, index=idx)}
+
+
+def _run(engine, code: str, run_dir: Path) -> dict:
+    bars = _nse_bars()
+    return engine.run_backtest(
+        {
+            "codes": [code],
+            "start_date": "2024-04-01",
+            "end_date": "2024-04-30",
+            "source": "yahoo",
+            "initial_cash": 1_000_000,
+        },
+        _FakeLoader(code, bars),
+        _LongSignal(code),
+        run_dir,
+    )
+
+
+def test_india_backtest_completes_and_emits_run_card(tmp_path: Path) -> None:
+    engine = IndiaEquityEngine({"initial_cash": 1_000_000})
+    metrics = _run(engine, "RELIANCE.NS", tmp_path)
+
+    assert metrics  # non-empty metrics dict
+    assert (tmp_path / "run_card.json").exists()
+    # The equity curve must have advanced through the bars.
+    assert metrics.get("final_value") is not None
+    assert metrics["trade_count"] >= 1
+
+
+def test_india_costs_are_applied_vs_zero_commission_us(tmp_path: Path) -> None:
+    """Identical data + signal: the India engine pays costs the US engine does not."""
+    in_engine = IndiaEquityEngine({"initial_cash": 1_000_000})
+    us_engine = GlobalEquityEngine({"initial_cash": 1_000_000}, market="us")
+
+    in_metrics = _run(in_engine, "RELIANCE.NS", tmp_path / "in")
+    us_metrics = _run(us_engine, "AAPL.US", tmp_path / "us")
+
+    # Same price path; the only difference is India's cost stack, so India must
+    # end strictly poorer than the zero-commission US run.
+    assert in_metrics["final_value"] < us_metrics["final_value"]

--- a/agent/tests/test_india_broker_loader.py
+++ b/agent/tests/test_india_broker_loader.py
@@ -1,0 +1,81 @@
+"""India broker data-bridge loader: envelope adaptation + availability gating.
+
+The loader adapts Shoonya/Dhan ``get_historical_bars`` into the OHLCV frame.
+Tests inject a fake broker SDK via ``_resolve_broker`` so no real SDK/creds are
+needed; the loader stays unavailable (and inert) when no broker is configured.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pandas as pd
+
+from backtest.loaders import india_broker_loader as mod
+from backtest.loaders.india_broker_loader import DataLoader, _base_symbol, _exchange_for
+
+
+def _epoch(date_str: str) -> int:
+    d = pd.Timestamp(date_str).date()
+    return int(dt.datetime(d.year, d.month, d.day, tzinfo=dt.timezone.utc).timestamp())
+
+
+class _FakeSDK:
+    """Minimal stand-in exposing ``get_historical_bars`` like the real connectors."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def get_historical_bars(self, symbol, *, exchange="NSE", period="1d", limit=90):
+        self.calls.append({"symbol": symbol, "exchange": exchange, "period": period})
+        return {
+            "status": "ok",
+            "symbol": symbol,
+            "bars": [
+                {"time": _epoch("2024-04-01"), "open": 100, "high": 101, "low": 99, "close": 100.5, "volume": 1000},
+                {"time": _epoch("2024-04-02"), "open": 100.5, "high": 102, "low": 100, "close": 101.5, "volume": 1200},
+                {"time": _epoch("2024-05-10"), "open": 110, "high": 112, "low": 109, "close": 111, "volume": 1500},
+            ],
+        }
+
+
+def test_symbol_and_exchange_mapping() -> None:
+    assert _base_symbol("RELIANCE.NS") == "RELIANCE"
+    assert _base_symbol("500325.BO") == "500325"
+    assert _exchange_for("RELIANCE.NS") == "NSE"
+    assert _exchange_for("500325.BO") == "BSE"
+
+
+def test_unavailable_when_no_broker(monkeypatch) -> None:
+    monkeypatch.setattr(mod, "_resolve_broker", lambda: (None, None))
+    loader = DataLoader()
+    assert loader.is_available() is False
+    assert loader.fetch(["RELIANCE.NS"], "2024-04-01", "2024-04-30") == {}
+
+
+def test_fetch_parses_and_clips_window(monkeypatch) -> None:
+    fake = _FakeSDK()
+    monkeypatch.setattr(mod, "_resolve_broker", lambda: ("shoonya", fake))
+    loader = DataLoader()
+    assert loader.is_available() is True
+
+    out = loader.fetch(["RELIANCE.NS"], "2024-04-01", "2024-04-30")
+    assert "RELIANCE.NS" in out
+    df = out["RELIANCE.NS"]
+    # The 2024-05-10 bar is outside the window and must be clipped away.
+    assert len(df) == 2
+    assert list(df.columns) == ["open", "high", "low", "close", "volume"]
+    assert df.index.name == "trade_date"
+    # Broker received the bare symbol on the right exchange.
+    assert fake.calls[0]["symbol"] == "RELIANCE"
+    assert fake.calls[0]["exchange"] == "NSE"
+
+
+def test_error_envelope_yields_no_data(monkeypatch) -> None:
+    class _ErrSDK:
+        def get_historical_bars(self, symbol, **kw):
+            return {"status": "error", "error": "no session"}
+
+    monkeypatch.setattr(mod, "_resolve_broker", lambda: ("dhan", _ErrSDK()))
+    loader = DataLoader()
+    assert loader.fetch(["TCS.NS"], "2024-04-01", "2024-04-30") == {}

--- a/agent/tests/test_india_equity_engine.py
+++ b/agent/tests/test_india_equity_engine.py
@@ -1,0 +1,177 @@
+"""Tests for IndiaEquityEngine (NSE / BSE delivery) market rules.
+
+Validates:
+  - No short selling by default; allow_short opt-in
+  - T+1: can't sell shares bought the same bar
+  - Configurable circuit band blocks buys at upper / sells at lower limit
+  - 1-share lots
+  - India delivery cost stack (STT bilateral, stamp duty buy-only, GST, DP)
+  - Engine routing (runner single-market + composite cross-market)
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pandas as pd
+import pytest
+
+from backtest.engines.india_equity import IndiaEquityEngine
+from backtest.models import Position
+
+
+def _engine(**overrides) -> IndiaEquityEngine:
+    config = {"initial_cash": 1_000_000}
+    config.update(overrides)
+    return IndiaEquityEngine(config)
+
+
+def _bar(close: float = 100.0, pre_close: float | None = None) -> pd.Series:
+    data = {"close": close, "open": close}
+    if pre_close is not None:
+        data["pre_close"] = pre_close
+    return pd.Series(data)
+
+
+# ---------------------------------------------------------------------------
+# can_execute: shorting, T+1, circuit bands
+# ---------------------------------------------------------------------------
+
+
+class TestCanExecute:
+    def test_long_allowed(self) -> None:
+        assert _engine().can_execute("RELIANCE.NS", 1, _bar()) is True
+
+    def test_short_blocked_by_default(self) -> None:
+        assert _engine().can_execute("RELIANCE.NS", -1, _bar()) is False
+
+    def test_short_allowed_when_opted_in(self) -> None:
+        assert _engine(allow_short=True).can_execute("RELIANCE.NS", -1, _bar()) is True
+
+    def test_t1_blocks_same_bar_sell(self) -> None:
+        engine = _engine()
+        ts = pd.Timestamp("2024-04-01")
+        engine.positions["RELIANCE.NS"] = Position(
+            symbol="RELIANCE.NS", direction=1, size=10, entry_price=100.0, entry_time=ts,
+        )
+        bar = _bar()
+        bar.name = ts  # same date as entry -> T+1 blocks the sell
+        assert engine.can_execute("RELIANCE.NS", 0, bar) is False
+
+    def test_t1_allows_next_bar_sell(self) -> None:
+        engine = _engine()
+        engine.positions["RELIANCE.NS"] = Position(
+            symbol="RELIANCE.NS", direction=1, size=10, entry_price=100.0,
+            entry_time=pd.Timestamp("2024-04-01"),
+        )
+        bar = _bar()
+        bar.name = pd.Timestamp("2024-04-02")  # later date -> allowed
+        assert engine.can_execute("RELIANCE.NS", 0, bar) is True
+
+    def test_upper_circuit_blocks_buy(self) -> None:
+        engine = _engine(price_limit=0.20)
+        bar = _bar(close=120.0, pre_close=100.0)  # +20% -> upper band
+        assert engine.can_execute("RELIANCE.NS", 1, bar) is False
+
+    def test_lower_circuit_blocks_sell(self) -> None:
+        engine = _engine(price_limit=0.20)
+        engine.positions["RELIANCE.NS"] = Position(
+            symbol="RELIANCE.NS", direction=1, size=10, entry_price=100.0,
+            entry_time=pd.Timestamp("2024-04-01"),
+        )
+        bar = _bar(close=80.0, pre_close=100.0)  # -20% -> lower band
+        bar.name = pd.Timestamp("2024-04-02")
+        assert engine.can_execute("RELIANCE.NS", 0, bar) is False
+
+    def test_circuit_disabled_allows_trade_at_limit(self) -> None:
+        engine = _engine(price_limit=0)
+        bar = _bar(close=120.0, pre_close=100.0)
+        assert engine.can_execute("RELIANCE.NS", 1, bar) is True
+
+
+# ---------------------------------------------------------------------------
+# round_size: 1-share lots
+# ---------------------------------------------------------------------------
+
+
+class TestRoundSize:
+    def test_one_share_lots(self) -> None:
+        engine = _engine()
+        assert engine.round_size(10.9, 100.0) == 10.0
+        assert engine.round_size(0.4, 100.0) == 0.0
+        assert engine.round_size(-3.0, 100.0) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# calc_commission: India delivery stack
+# ---------------------------------------------------------------------------
+
+
+class TestCommission:
+    def test_nonzero_cost(self) -> None:
+        assert _engine().calc_commission(100, 1000.0, 1, is_open=True) > 0
+
+    def test_buy_costs_more_than_sell_due_to_stamp_duty(self) -> None:
+        engine = _engine(in_dp_charge=0.0)
+        comm_buy = engine.calc_commission(100, 1000.0, 1, is_open=True)
+        comm_sell = engine.calc_commission(100, 1000.0, 1, is_open=False)
+        notional = 100 * 1000.0
+        assert comm_buy - comm_sell == pytest.approx(notional * engine.in_stamp_duty, abs=1e-6)
+
+    def test_sell_components_exact(self) -> None:
+        engine = _engine()
+        size, price = 100, 1000.0
+        notional = size * price
+        comm = engine.calc_commission(size, price, 1, is_open=False)  # sell
+        brokerage = notional * engine.in_brokerage
+        exchange_txn = notional * engine.in_exchange_txn
+        sebi_fee = notional * engine.in_sebi_fee
+        gst = (brokerage + exchange_txn + sebi_fee) * engine.in_gst
+        stt = notional * engine.in_stt
+        expected = brokerage + exchange_txn + sebi_fee + gst + stt + engine.in_dp_charge
+        assert comm == pytest.approx(expected, abs=1e-6)
+
+    def test_dp_charge_applied_on_sell_only(self) -> None:
+        engine = _engine(in_dp_charge=13.5)
+        buy = engine.calc_commission(100, 1000.0, 1, is_open=True)
+        sell = engine.calc_commission(100, 1000.0, 1, is_open=False)
+        # Sell carries the flat DP charge; buy carries stamp duty instead.
+        assert sell >= 13.5
+        assert buy == pytest.approx(
+            sell - 13.5 + 100 * 1000.0 * engine.in_stamp_duty, abs=1e-6
+        )
+
+
+# ---------------------------------------------------------------------------
+# apply_slippage + leverage
+# ---------------------------------------------------------------------------
+
+
+class TestSlippageAndLeverage:
+    def test_slippage_default(self) -> None:
+        assert _engine().apply_slippage(100.0, 1) == pytest.approx(100.1)
+
+    def test_no_leverage(self) -> None:
+        # Cash delivery is forced to 1.0 leverage regardless of config input.
+        assert _engine(leverage=5.0).default_leverage == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Engine routing
+# ---------------------------------------------------------------------------
+
+
+class TestRouting:
+    def test_single_market_india_routes_to_india_engine(self) -> None:
+        from backtest.runner import _create_market_engine
+
+        engine = _create_market_engine("yahoo", {"initial_cash": 100_000}, ["RELIANCE.NS"])
+        assert isinstance(engine, IndiaEquityEngine)
+
+    def test_cross_market_with_india_builds_india_subengine(self) -> None:
+        from backtest.engines.composite import _build_rule_engines
+
+        engines = _build_rule_engines(
+            {"initial_cash": 100_000}, ["RELIANCE.NS", "AAPL.US"]
+        )
+        assert isinstance(engines["india_equity"], IndiaEquityEngine)

--- a/agent/tests/test_india_mandate.py
+++ b/agent/tests/test_india_mandate.py
@@ -1,0 +1,100 @@
+"""India (IN_EQUITY) mandate-enforcement wiring.
+
+Confirms the ``in_equity`` asset class flows through the live mandate gate:
+  - An IN_EQUITY order is denied (structural universe breach) when the mandate
+    does not permit it.
+  - It passes the asset-class gate when the mandate permits IN_EQUITY.
+  - The enforcement loader chain resolves IN_EQUITY to the india_equity market.
+"""
+
+from __future__ import annotations
+
+from src.live.enforcement import (
+    BREACH_KIND_UNIVERSE,
+    OrderIntent,
+    _resolve_loader,
+    check_mandate,
+)
+from src.live.mandate.model import (
+    MANDATE_SCHEMA_VERSION,
+    AssetClass,
+    ConsentMeta,
+    HardCaps,
+    InstrumentType,
+    Mandate,
+    UniverseConstraint,
+)
+
+
+def _mandate(asset_classes: tuple[AssetClass, ...]) -> Mandate:
+    return Mandate(
+        schema_version=MANDATE_SCHEMA_VERSION,
+        flatten_on_halt=False,
+        hard_caps=HardCaps(
+            account_funding_usd=100_000.0,
+            max_order_notional_usd=10_000.0,
+            max_total_exposure_usd=100_000.0,
+            max_leverage=1.0,
+            allowed_instruments=(InstrumentType.EQUITY,),
+            max_trades_per_day=10,
+        ),
+        universe=UniverseConstraint(
+            asset_classes=asset_classes,
+            min_market_cap_usd=None,
+            min_avg_daily_volume_usd=None,
+            exclude_symbols=(),
+        ),
+        consent=ConsentMeta(
+            created_at="2026-06-01T00:00:00Z",
+            consent_token_sha256="b" * 64,
+            broker="shoonya",
+            account_ref="shoonya_acct_opaque",
+            expires_at="2099-01-01T00:00:00Z",
+        ),
+    )
+
+
+def _india_intent() -> OrderIntent:
+    return OrderIntent(
+        symbol="RELIANCE",
+        side="buy",
+        notional_usd=1_000.0,
+        quantity=None,
+        instrument_type=InstrumentType.EQUITY,
+        asset_class=AssetClass.IN_EQUITY,
+    )
+
+
+def test_in_equity_denied_when_not_permitted() -> None:
+    breach = check_mandate(
+        _mandate((AssetClass.US_EQUITY,)),
+        _india_intent(),
+        None,
+        None,
+        broker="shoonya",
+        remote_tool="place_order",
+        daily_count=0,
+    )
+    assert breach is not None
+    assert breach.kind == BREACH_KIND_UNIVERSE
+    assert breach.limit == "asset_classes"
+
+
+def test_in_equity_passes_asset_class_gate_when_permitted() -> None:
+    breach = check_mandate(
+        _mandate((AssetClass.IN_EQUITY,)),
+        _india_intent(),
+        None,
+        None,
+        broker="shoonya",
+        remote_tool="place_order",
+        daily_count=0,
+    )
+    # It must not be rejected by the asset-class gate (other quantitative checks
+    # are out of scope for this wiring test).
+    assert breach is None or breach.limit != "asset_classes"
+
+
+def test_in_equity_resolves_to_india_equity_loader() -> None:
+    loader = _resolve_loader(AssetClass.IN_EQUITY)
+    assert "india_equity" in loader.markets

--- a/agent/tests/test_market_data.py
+++ b/agent/tests/test_market_data.py
@@ -39,6 +39,11 @@ from src.market_data import (
         ("AAPL.US", "yahoo"),
         ("700.HK", "yahoo"),
         ("00700.HK", "yahoo"),
+        ("RELIANCE.NS", "yahoo"),  # India NSE
+        ("TCS.NS", "yahoo"),
+        ("M&M.NS", "yahoo"),  # ampersand in ticker
+        ("BAJAJ-AUTO.NS", "yahoo"),  # hyphen in ticker
+        ("500325.BO", "yahoo"),  # India BSE (numeric scrip code)
         ("BTC-USDT", "okx"),
         ("ETH/USDT", "ccxt"),
         ("local:my_file", "local"),

--- a/agent/tests/test_market_detection.py
+++ b/agent/tests/test_market_detection.py
@@ -50,6 +50,12 @@ class TestDetectMarket:
             ("0700.HK", "hk_equity"),
             ("9988.HK", "hk_equity"),
             ("00005.HK", "hk_equity"),
+            # India equity (NSE / BSE)
+            ("RELIANCE.NS", "india_equity"),
+            ("TCS.NS", "india_equity"),
+            ("M&M.NS", "india_equity"),  # ampersand
+            ("BAJAJ-AUTO.NS", "india_equity"),  # hyphen
+            ("500325.BO", "india_equity"),  # numeric BSE scrip code
             # Crypto
             ("BTC-USDT", "crypto"),
             ("ETH-USDT", "crypto"),
@@ -93,6 +99,8 @@ class TestDetectSource:
             ("000001.SZ", "tushare"),
             ("AAPL.US", "yfinance"),
             ("0700.HK", "yfinance"),
+            ("RELIANCE.NS", "yahoo"),
+            ("500325.BO", "yahoo"),
             ("BTC-USDT", "okx"),
             ("IF2406.CFFEX", "tushare"),
             ("EUR/USD", "akshare"),

--- a/agent/tests/test_registry.py
+++ b/agent/tests/test_registry.py
@@ -133,7 +133,7 @@ class TestProtocol:
 
 class TestFallbackChains:
     def test_all_expected_markets_present(self) -> None:
-        expected = {"a_share", "us_equity", "hk_equity", "crypto", "futures", "fund", "macro", "forex"}
+        expected = {"a_share", "us_equity", "hk_equity", "india_equity", "crypto", "futures", "fund", "macro", "forex"}
         assert expected == set(FALLBACK_CHAINS.keys())
 
     def test_chains_are_non_empty(self) -> None:

--- a/agent/tests/test_yahoo_loader.py
+++ b/agent/tests/test_yahoo_loader.py
@@ -14,7 +14,7 @@ from backtest.loaders.yahoo_loader import (
     DataLoader,
     _epoch_seconds,
     _is_intraday_interval,
-    _is_us_or_hk,
+    _is_supported,
     _rows_to_frame,
     _to_yahoo_interval,
 )
@@ -54,20 +54,25 @@ def _intraday_stamped_row(date_str: str, open_, high, low, close, volume):
 
 
 class TestSymbolGating:
-    """_is_us_or_hk only accepts US/HK suffixes."""
+    """_is_supported accepts US/HK/India suffixes only."""
 
     def test_accepts_us(self):
-        assert _is_us_or_hk("AAPL.US") is True
-        assert _is_us_or_hk("aapl.us") is True
+        assert _is_supported("AAPL.US") is True
+        assert _is_supported("aapl.us") is True
 
     def test_accepts_hk(self):
-        assert _is_us_or_hk("00700.HK") is True
-        assert _is_us_or_hk("00700.hk") is True
+        assert _is_supported("00700.HK") is True
+        assert _is_supported("00700.hk") is True
+
+    def test_accepts_india(self):
+        assert _is_supported("RELIANCE.NS") is True
+        assert _is_supported("reliance.ns") is True
+        assert _is_supported("500325.BO") is True
 
     def test_rejects_others(self):
-        assert _is_us_or_hk("601398.SH") is False
-        assert _is_us_or_hk("BTC-USDT") is False
-        assert _is_us_or_hk("") is False
+        assert _is_supported("601398.SH") is False
+        assert _is_supported("BTC-USDT") is False
+        assert _is_supported("") is False
 
 
 class TestIntervalMap:
@@ -229,7 +234,22 @@ class TestFetch:
         assert kwargs["period2"] == _epoch("2024-01-31") + 86400
         assert kwargs["interval"] == "1d"
 
-    def test_non_us_hk_symbol_skipped(self):
+    def test_fetch_india_symbol(self):
+        rows = [
+            _row("2024-01-02", 10, 11, 9, 10.5, 1000),
+            _row("2024-01-03", 10.5, 12, 10, 11.5, 2000),
+        ]
+        with patch(
+            "backtest.loaders.yahoo_loader.yahoo_client.get_chart",
+            return_value=rows,
+        ) as mock_chart:
+            out = DataLoader().fetch(["RELIANCE.NS"], "2024-01-01", "2024-01-31")
+        assert "RELIANCE.NS" in out
+        assert len(out["RELIANCE.NS"]) == 2
+        # NSE symbol passes through to the client verbatim (Yahoo keeps .NS).
+        assert mock_chart.call_args.args[0] == "RELIANCE.NS"
+
+    def test_non_us_hk_india_symbol_skipped(self):
         with patch(
             "backtest.loaders.yahoo_loader.yahoo_client.get_chart"
         ) as mock_chart:
@@ -277,6 +297,6 @@ class TestLoaderMetadata:
     def test_name_and_markets(self):
         loader = DataLoader()
         assert loader.name == "yahoo"
-        assert loader.markets == {"us_equity", "hk_equity"}
+        assert loader.markets == {"us_equity", "hk_equity", "india_equity"}
         assert loader.requires_auth is False
         assert loader.is_available() is True


### PR DESCRIPTION
## Summary

  - Add first-class **Indian equity (NSE/BSE)** support across the full stack: data ingestion → dedicated backtest engine → `equity_in` factor universe → live/paper broker + mandate wiring.
  - New `IndiaEquityEngine` modeling T+1 delivery, no overnight shorts (`allow_short` opt-in), configurable circuit bands, 1-share lots, and the STT / stamp-duty / exchange / SEBI / GST cost stack.
  - Route `.NS`/`.BO` symbols to Yahoo (native NSE/BSE coverage), with yfinance and an opt-in Shoonya/Dhan broker data bridge as fallbacks.

  ## Why

  Indian symbols previously had **zero** research support: they silently misrouted to China infrastructure (`tushare` loader + `ChinaAEngine`), producing wrong fills and costs. India was the only market with
  live broker connectors (Shoonya/Dhan) but no data/backtest/factor path. This wires the broken middle so the existing strategies, factors, and metrics work on NSE/BSE.

  ## Changes

  - **Data ingestion:** `.NS`/`.BO` routing in `market_data.py` + `_market_hooks.py` (new `india_equity` market type); extended `yahoo_loader`/`yahoo_client` and `yfinance_loader` to accept the suffixes;
  `india_equity` fallback chain in `registry.py`; `runner.py` source map. Regexes allow `&`/`-` (e.g. `M&M.NS`, `BAJAJ-AUTO.NS`).
  - **Engine:** new `backtest/engines/india_equity.py`; wired into `composite.py` and `runner.py` single-market routing (precedes source-based routing so India's `yahoo` source can't fall through to the
  crypto default).
  - **Factors:** added `equity_in` to the `Universe` literal and `Market` enum (vwap uses the typical-price branch — India bars carry raw price/volume, no Tushare scaling); tagged all 101 Alpha101 and 154
  QLib158 factors for `equity_in`. GTJA191 left China-only (Tushare-scale math).
  - **Live/paper:** added `AssetClass.IN_EQUITY` and wired it into the mandate-enforcement loader chain; new `backtest/loaders/india_broker_loader.py` bridges Shoonya/Dhan `get_historical_bars` into the
  backtest layer (opt-in `india_broker` source, unavailable without broker creds). Live order *placement* stays structurally disabled (those brokers expose no paper/live switch).
  - **Docs:** `SKILL.md` updated (8 engines, 19 sources, India symbol convention, factor coverage, paper/read-only-live limitation).
  - Cost-stack rates and circuit band are config-driven defaults (documented), not magic constants.

  ## Test Plan

  - [ ] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
  - [x] New tests added — `test_india_equity_engine.py`, `test_india_backtest_smoke.py`, `test_india_mandate.py`, `test_india_broker_loader.py`, `tests/factors/test_india_universe.py`, plus India cases in
  `test_market_data.py`, `test_market_detection.py`, `test_yahoo_loader.py`, `test_registry.py`
  - [x] Tested manually — registry loads 456 factors (0 failures), 255 listed for `equity_in`; representative Alpha101/QLib158 factors compute on a synthetic NSE panel; end-to-end India backtest emits metrics
  + run card and shows India costs applied vs the zero-commission US engine; factor purity + lookahead gates pass (911); `tools/ci_grep_gates.sh` all gates pass; `ruff check` clean across the contribution
  footprint

  ## Checklist

  - [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
  - [x] No hardcoded values (API keys, file paths, magic numbers) — India cost/band defaults are config-overridable
  - [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines — `ruff check` (the configured gate) passes on all new/changed files; public signatures type-annotated; Google-style docstrings
  - [x] Documentation updated (if user-facing change) — `SKILL.md`

  ---

  **Reviewer notes**
  - The first Test Plan box is left unchecked: I verified targeted suites + ruff locally, but not the full `pytest --ignore=agent/tests/e2e_backtest` run (the sandbox lacks some optional deps, e.g.
  `fastmcp`). Please let CI confirm the full suite.
  - Exact SEBI/STT/exchange tariffs and any F&O lot sizes should be verified against a current broker schedule before relying on absolute cost figures (rates change periodically); they're exposed as config
  knobs.
  - The `india_broker` bridge returns a bounded window of *recent* bars (broker API limit) — use Yahoo for deep history.
  - `black` was not run: the repo is not black-conformant (untouched core files fail `black -l120`), so formatting only these files would diverge from house style. Files conform to the configured `ruff` gate
  instead.