### PR TITLE
[codex] fix(validation): write strict JSON outputs

### DIFF
--- a/agent/backtest/validation.py
+++ b/agent/backtest/validation.py
@@ -11,6 +11,8 @@ is present, or invoked directly on backtest outputs.
 
 from __future__ import annotations
 
+import json
+import math
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -185,10 +187,7 @@ def walk_forward_analysis(
         win_end = indices[end_idx - 1]
 
         # Per-window trades
-        win_trades = [
-            t for t in trades
-            if win_start <= t.entry_time <= win_end
-        ]
+        win_trades = [t for t in trades if win_start <= t.entry_time <= win_end]
 
         # Per-window metrics
         ret = float(win_eq.iloc[-1] / win_eq.iloc[0] - 1) if win_eq.iloc[0] > 0 else 0.0
@@ -200,21 +199,20 @@ def walk_forward_analysis(
         max_dd = float(dd.min())
 
         win_pnls = [t.pnl for t in win_trades]
-        win_rate = (
-            len([p for p in win_pnls if p > 0]) / len(win_pnls)
-            if win_pnls else 0.0
-        )
+        win_rate = len([p for p in win_pnls if p > 0]) / len(win_pnls) if win_pnls else 0.0
 
-        windows.append({
-            "window": i + 1,
-            "start": str(win_start.date()) if hasattr(win_start, "date") else str(win_start),
-            "end": str(win_end.date()) if hasattr(win_end, "date") else str(win_end),
-            "return": round(ret, 6),
-            "sharpe": round(sharpe, 4),
-            "max_dd": round(max_dd, 6),
-            "trades": len(win_trades),
-            "win_rate": round(win_rate, 4),
-        })
+        windows.append(
+            {
+                "window": i + 1,
+                "start": str(win_start.date()) if hasattr(win_start, "date") else str(win_start),
+                "end": str(win_end.date()) if hasattr(win_end, "date") else str(win_end),
+                "return": round(ret, 6),
+                "sharpe": round(sharpe, 4),
+                "max_dd": round(max_dd, 6),
+                "trades": len(win_trades),
+                "win_rate": round(win_rate, 4),
+            }
+        )
 
     # Consistency metrics
     returns_list = [w["return"] for w in windows]
@@ -266,7 +264,8 @@ def run_validation(
     if "monte_carlo" in v_cfg:
         mc_cfg = v_cfg["monte_carlo"] if isinstance(v_cfg["monte_carlo"], dict) else {}
         results["monte_carlo"] = monte_carlo_test(
-            trades, initial_capital,
+            trades,
+            initial_capital,
             n_simulations=mc_cfg.get("n_simulations", 1000),
             seed=mc_cfg.get("seed", 42),
         )
@@ -274,7 +273,8 @@ def run_validation(
     if "bootstrap" in v_cfg:
         bs_cfg = v_cfg["bootstrap"] if isinstance(v_cfg["bootstrap"], dict) else {}
         results["bootstrap"] = bootstrap_sharpe_ci(
-            equity_curve, bars_per_year=bars_per_year,
+            equity_curve,
+            bars_per_year=bars_per_year,
             n_bootstrap=bs_cfg.get("n_bootstrap", 1000),
             confidence=bs_cfg.get("confidence", 0.95),
             seed=bs_cfg.get("seed", 42),
@@ -283,7 +283,8 @@ def run_validation(
     if "walk_forward" in v_cfg:
         wf_cfg = v_cfg["walk_forward"] if isinstance(v_cfg["walk_forward"], dict) else {}
         results["walk_forward"] = walk_forward_analysis(
-            equity_curve, trades,
+            equity_curve,
+            trades,
             n_windows=wf_cfg.get("n_windows", 5),
             bars_per_year=bars_per_year,
         )
@@ -312,21 +313,23 @@ def _load_trades(run_dir: Path) -> List[TradeRecord]:
     trades = []
     exit_rows = df[df["pnl"] != 0].reset_index(drop=True)
     for _, row in exit_rows.iterrows():
-        trades.append(TradeRecord(
-            symbol=str(row.get("code", "")),
-            direction=1 if row.get("side") == "sell" else -1,
-            entry_price=0.0,
-            exit_price=float(row.get("price", 0)),
-            entry_time=pd.Timestamp(row.get("timestamp", "2000-01-01")),
-            exit_time=pd.Timestamp(row.get("timestamp", "2000-01-01")),
-            size=float(row.get("qty", 0)),
-            leverage=1.0,
-            pnl=float(row.get("pnl", 0)),
-            pnl_pct=float(row.get("return_pct", 0)),
-            exit_reason=str(row.get("reason", "signal")),
-            holding_bars=int(row.get("holding_days", 0)),
-            commission=0.0,
-        ))
+        trades.append(
+            TradeRecord(
+                symbol=str(row.get("code", "")),
+                direction=1 if row.get("side") == "sell" else -1,
+                entry_price=0.0,
+                exit_price=float(row.get("price", 0)),
+                entry_time=pd.Timestamp(row.get("timestamp", "2000-01-01")),
+                exit_time=pd.Timestamp(row.get("timestamp", "2000-01-01")),
+                size=float(row.get("qty", 0)),
+                leverage=1.0,
+                pnl=float(row.get("pnl", 0)),
+                pnl_pct=float(row.get("return_pct", 0)),
+                exit_reason=str(row.get("reason", "signal")),
+                holding_bars=int(row.get("holding_days", 0)),
+                commission=0.0,
+            )
+        )
     return trades
 
 
@@ -355,6 +358,20 @@ def _parse_run_dir(argv: List[str]) -> Path:
     return run_dir
 
 
+def _json_safe(value: Any) -> Any:
+    """Return a JSON-strict copy of validation results."""
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, np.floating):
+        as_float = float(value)
+        return as_float if math.isfinite(as_float) else None
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    return value
+
+
 def main(run_dir: Path) -> Dict[str, Any]:
     """Run all three validations on existing backtest artifacts.
 
@@ -366,8 +383,6 @@ def main(run_dir: Path) -> Dict[str, Any]:
     Returns:
         Validation results dict.
     """
-    import json
-
     # Load config for initial_cash
     config_path = run_dir / "config.json"
     if config_path.exists():
@@ -384,13 +399,17 @@ def main(run_dir: Path) -> Dict[str, Any]:
         "bootstrap": bootstrap_sharpe_ci(equity),
         "walk_forward": walk_forward_analysis(equity, trades),
     }
+    safe_results = _json_safe(results)
 
     # Write results
     out = run_dir / "artifacts" / "validation.json"
-    out.write_text(json.dumps(results, indent=2, ensure_ascii=False), encoding="utf-8")
+    out.write_text(
+        json.dumps(safe_results, indent=2, ensure_ascii=False, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
 
-    print(json.dumps(results, indent=2))
-    return results
+    print(json.dumps(safe_results, indent=2, allow_nan=False))
+    return safe_results
 
 
 if __name__ == "__main__":

--- a/agent/tests/test_validation_cli.py
+++ b/agent/tests/test_validation_cli.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import math
 from pathlib import Path
 import tempfile
 
@@ -41,3 +43,42 @@ def test_accepts_existing_directory() -> None:
         parsed = validation._parse_run_dir(["validation", run_dir])
 
     assert parsed == Path(run_dir)
+
+
+def test_main_writes_strict_json_for_non_finite_results(tmp_path: Path, monkeypatch, capsys) -> None:
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    (tmp_path / "config.json").write_text('{"initial_cash": 1000}', encoding="utf-8")
+
+    monkeypatch.setattr(validation, "_load_equity", lambda _run_dir: object())
+    monkeypatch.setattr(validation, "_load_trades", lambda _run_dir: [])
+    monkeypatch.setattr(
+        validation,
+        "monte_carlo_test",
+        lambda *_args, **_kwargs: {"actual_sharpe": math.nan},
+    )
+    monkeypatch.setattr(
+        validation,
+        "bootstrap_sharpe_ci",
+        lambda *_args, **_kwargs: {"ci": [math.inf, -math.inf, 1.0]},
+    )
+    monkeypatch.setattr(
+        validation,
+        "walk_forward_analysis",
+        lambda *_args, **_kwargs: {"windows": [{"sharpe": math.nan}]},
+    )
+
+    result = validation.main(tmp_path)
+
+    raw = (artifacts / "validation.json").read_text(encoding="utf-8")
+    stdout = capsys.readouterr().out
+    assert "NaN" not in raw
+    assert "Infinity" not in raw
+    assert "NaN" not in stdout
+    assert "Infinity" not in stdout
+
+    loaded = json.loads(raw)
+    assert loaded == result
+    assert loaded["monte_carlo"]["actual_sharpe"] is None
+    assert loaded["bootstrap"]["ci"] == [None, None, 1.0]
+    assert loaded["walk_forward"]["windows"][0]["sharpe"] is None


### PR DESCRIPTION
﻿## Summary

Make the standalone backtest validation CLI write strict JSON when validation metrics contain non-finite floating point values.

## Why

`backtest.validation` can produce nested validation payloads that include floating point metrics. Python's default `json.dumps` can emit `NaN`, `Infinity`, or `-Infinity`, which are not valid JSON tokens for strict parsers. The run-card writer already normalizes this class of value before writing JSON; this applies the same defensive behavior to `artifacts/validation.json` and the CLI stdout path.

## What changed

- Add a small JSON-safe normalization helper for validation results.
- Write `validation.json` with `allow_nan=False` and a trailing newline.
- Print the normalized payload to stdout.
- Add a regression test covering nested `NaN`/`Infinity` values from the validation routines.

## Duplicate check

I checked the current open issues and PRs before opening this draft. The newest open issues are already covered by existing work or are planning/draft-branch discussions: #295 is covered by #302, #282 is covered by #296, and #283 already has a contributor draft branch. I also searched open PRs for validation/strict JSON/non-finite work and found no overlap.

## Validation

- `PYTHONPATH=agent python -m pytest agent/tests/test_validation.py agent/tests/test_validation_cli.py -q`
- `PYTHONPATH=agent python -m py_compile agent/backtest/validation.py agent/tests/test_validation_cli.py`
- `python -m ruff check agent/backtest/validation.py agent/tests/test_validation_cli.py`
- `python -m ruff format --check agent/backtest/validation.py agent/tests/test_validation_cli.py`
- `git diff --check`
