### PR TITLE
fix: preserve Gemini thought_signature across AgentLoop dict-history replay

### DIFF
--- a/agent/src/agent/context.py
+++ b/agent/src/agent/context.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
 from datetime import datetime
@@ -228,21 +229,32 @@ class ContextBuilder:
         Returns:
             OpenAI-format assistant message.
         """
+        formatted_tool_calls = []
+        has_extra_content = False
+        for tc in tool_calls:
+            tool_call = {
+                "id": tc.id,
+                "type": "function",
+                "function": {
+                    "name": tc.name,
+                    "arguments": json.dumps(tc.arguments, ensure_ascii=False),
+                },
+            }
+            extra_content = getattr(tc, "extra_content", None)
+            if extra_content:
+                tool_call["extra_content"] = dict(extra_content)
+                has_extra_content = True
+            formatted_tool_calls.append(tool_call)
+
         message = {
             "role": "assistant",
             "content": content,
-            "tool_calls": [
-                {
-                    "id": tc.id,
-                    "type": "function",
-                    "function": {
-                        "name": tc.name,
-                        "arguments": json.dumps(tc.arguments, ensure_ascii=False),
-                    },
-                }
-                for tc in tool_calls
-            ],
+            "tool_calls": formatted_tool_calls,
         }
+        if has_extra_content:
+            message["additional_kwargs"] = {
+                "tool_calls": copy.deepcopy(formatted_tool_calls),
+            }
         if reasoning_content is not None:
             message["reasoning_content"] = reasoning_content
         return message

--- a/agent/src/agent/loop.py
+++ b/agent/src/agent/loop.py
@@ -14,6 +14,7 @@ Tool execution:
 from __future__ import annotations
 
 import concurrent.futures
+import copy
 import json
 import logging
 import os
@@ -269,6 +270,41 @@ def _normalize_tool_run_dir(args: dict[str, Any], memory_run_dir: str | None) ->
     if not candidate.is_absolute():
         normalized["run_dir"] = str((Path(memory_run_dir) / candidate).resolve())
     return normalized
+
+
+def _attach_tool_call_thought_signatures(message: dict[str, Any], tool_calls: list) -> dict[str, Any]:
+    """Attach Gemini thought signatures to assistant replay tool calls.
+
+    ``tool_calls`` is the parsed response model used by AgentLoop. The assistant
+    replay message also needs raw tool-call copies in ``additional_kwargs`` so
+    LangChain keeps Gemini-specific metadata when dict history is converted back
+    into ``AIMessage`` objects for the next request.
+    """
+    signatures = {
+        tc.id: extra_content["thought_signature"]
+        for tc in tool_calls
+        if (extra_content := getattr(tc, "extra_content", None))
+        and extra_content.get("thought_signature")
+    }
+    if not signatures:
+        return message
+
+    for raw_tool_call in message.get("tool_calls", []):
+        signature = signatures.get(raw_tool_call.get("id"))
+        if signature:
+            raw_tool_call.setdefault("extra_content", {})["thought_signature"] = signature
+
+    additional_kwargs = message.setdefault("additional_kwargs", {})
+    raw_tool_calls = additional_kwargs.setdefault(
+        "tool_calls",
+        copy.deepcopy(message.get("tool_calls", [])),
+    )
+    for raw_tool_call in raw_tool_calls:
+        signature = signatures.get(raw_tool_call.get("id"))
+        if signature:
+            raw_tool_call.setdefault("extra_content", {})["thought_signature"] = signature
+
+    return message
 
 
 class AgentLoop:
@@ -544,11 +580,15 @@ class AgentLoop:
                     react_trace.append({"type": "answer", "content": final_content[:500]})
                     break
 
+                assistant_message = context.format_assistant_tool_calls(
+                    response.tool_calls,
+                    content=response.content,
+                    reasoning_content=response.reasoning_content or thinking_text or None,
+                )
                 messages.append(
-                    context.format_assistant_tool_calls(
+                    _attach_tool_call_thought_signatures(
+                        assistant_message,
                         response.tool_calls,
-                        content=response.content,
-                        reasoning_content=response.reasoning_content or thinking_text or None,
                     )
                 )
 

--- a/agent/src/providers/chat.py
+++ b/agent/src/providers/chat.py
@@ -31,11 +31,14 @@ class ToolCallRequest:
         id: Tool call ID (used to match tool_result messages).
         name: Tool name.
         arguments: Tool argument dict.
+        extra_content: Provider-specific tool-call metadata that must be
+            replayed with the assistant turn, such as Gemini thought signatures.
     """
 
     id: str
     name: str
     arguments: Dict[str, Any]
+    extra_content: Dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -159,15 +162,62 @@ class ChatLLM:
                 usage = dict(usage)
             except (TypeError, ValueError):
                 usage = None
+        additional_kwargs = getattr(ai_message, "additional_kwargs", {}) or {}
+        raw_tool_calls = additional_kwargs.get("tool_calls") or []
+        raw_by_id = {
+            raw.get("id"): raw
+            for raw in raw_tool_calls
+            if isinstance(raw, dict) and raw.get("id")
+        }
         return LLMResponse(
             content=ai_message.content,
             tool_calls=[
-                ToolCallRequest(id=tc["id"], name=tc["name"], arguments=tc["args"])
+                ToolCallRequest(
+                    id=tc["id"],
+                    name=tc["name"],
+                    arguments=tc["args"],
+                    extra_content=_merge_tool_call_extra_content(
+                        tc,
+                        raw_by_id.get(tc["id"]),
+                    ),
+                )
                 for tc in ai_message.tool_calls
             ],
-            reasoning_content=ai_message.additional_kwargs.get("reasoning_content"),
+            reasoning_content=additional_kwargs.get("reasoning_content"),
             finish_reason=_dedupe_finish_reason(
                 ai_message.response_metadata.get("finish_reason", "stop")
             ),
             usage_metadata=usage,
         )
+
+
+def _extract_tool_call_extra_content(raw_tool_call: Any) -> Dict[str, Any]:
+    """Extract provider-specific tool-call metadata LangChain would drop."""
+    if not isinstance(raw_tool_call, dict):
+        return {}
+
+    extra_content: Dict[str, Any] = {}
+    raw_extra = raw_tool_call.get("extra_content")
+    if isinstance(raw_extra, dict):
+        extra_content.update(raw_extra)
+
+    function = raw_tool_call.get("function")
+    if isinstance(function, dict):
+        function_extra = function.get("extra_content")
+        if isinstance(function_extra, dict):
+            extra_content.update(function_extra)
+        if function.get("thought_signature"):
+            extra_content["thought_signature"] = function["thought_signature"]
+
+    if raw_tool_call.get("thought_signature"):
+        extra_content["thought_signature"] = raw_tool_call["thought_signature"]
+
+    return extra_content
+
+
+def _merge_tool_call_extra_content(*raw_tool_calls: Any) -> Dict[str, Any]:
+    """Merge provider metadata from standardized and raw tool-call shapes."""
+    extra_content: Dict[str, Any] = {}
+    for raw_tool_call in raw_tool_calls:
+        extra_content.update(_extract_tool_call_extra_content(raw_tool_call))
+    return extra_content

--- a/agent/tests/test_agent_loop_thought_signature.py
+++ b/agent/tests/test_agent_loop_thought_signature.py
@@ -1,0 +1,143 @@
+"""Regression coverage for Gemini thought_signature replay in AgentLoop history."""
+
+from __future__ import annotations
+
+import json
+
+from langchain_core.messages import AIMessage, convert_to_messages
+
+from src.agent.context import ContextBuilder
+from src.agent.loop import _attach_tool_call_thought_signatures
+from src.providers.chat import ChatLLM, ToolCallRequest
+
+
+def _raw_tool_call(
+    call_id: str,
+    name: str,
+    arguments: dict,
+    thought_signature: str | None = None,
+) -> dict:
+    raw = {
+        "id": call_id,
+        "type": "function",
+        "function": {
+            "name": name,
+            "arguments": json.dumps(arguments),
+        },
+    }
+    if thought_signature:
+        raw["extra_content"] = {"thought_signature": thought_signature}
+    return raw
+
+
+def test_dict_history_replay_preserves_thought_signature() -> None:
+    message = ContextBuilder.format_assistant_tool_calls(
+        [
+            ToolCallRequest(
+                id="tc_1",
+                name="get_price",
+                arguments={"symbol": "AAPL"},
+                extra_content={"thought_signature": "sig-iteration-1"},
+            )
+        ],
+        content="",
+    )
+
+    replayed = convert_to_messages([message])[0]
+    raw_tool_call = replayed.additional_kwargs["tool_calls"][0]
+
+    assert message["tool_calls"][0]["extra_content"]["thought_signature"] == "sig-iteration-1"
+    assert raw_tool_call["extra_content"]["thought_signature"] == "sig-iteration-1"
+
+
+def test_multiple_tool_calls_keep_their_own_signatures() -> None:
+    message = ContextBuilder.format_assistant_tool_calls(
+        [
+            ToolCallRequest(
+                id="tc_signed_1",
+                name="get_price",
+                arguments={"symbol": "AAPL"},
+                extra_content={"thought_signature": "sig-a"},
+            ),
+            ToolCallRequest(
+                id="tc_unsigned",
+                name="get_news",
+                arguments={"symbol": "MSFT"},
+            ),
+            ToolCallRequest(
+                id="tc_signed_2",
+                name="get_fundamentals",
+                arguments={"symbol": "GOOG"},
+                extra_content={"thought_signature": "sig-g"},
+            ),
+        ],
+        content="",
+    )
+
+    raw_tool_calls = message["additional_kwargs"]["tool_calls"]
+
+    assert raw_tool_calls[0]["extra_content"]["thought_signature"] == "sig-a"
+    assert "extra_content" not in raw_tool_calls[1]
+    assert raw_tool_calls[2]["extra_content"]["thought_signature"] == "sig-g"
+
+
+def test_in_memory_ai_message_path_preserves_thought_signature() -> None:
+    ai_message = AIMessage(
+        content="",
+        tool_calls=[
+            {"id": "tc_1", "name": "get_price", "args": {"symbol": "AAPL"}},
+        ],
+        additional_kwargs={
+            "tool_calls": [
+                _raw_tool_call(
+                    "tc_1",
+                    "get_price",
+                    {"symbol": "AAPL"},
+                    thought_signature="sig-from-ai-message",
+                )
+            ]
+        },
+    )
+
+    response = ChatLLM._parse_response(ai_message)
+    replay = ContextBuilder.format_assistant_tool_calls(response.tool_calls, content="")
+
+    assert response.tool_calls[0].extra_content["thought_signature"] == "sig-from-ai-message"
+    assert replay["additional_kwargs"]["tool_calls"][0]["extra_content"]["thought_signature"] == \
+        "sig-from-ai-message"
+
+
+def test_loop_helper_attaches_thought_signature_to_dict_history() -> None:
+    message = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            _raw_tool_call("tc_1", "get_price", {"symbol": "AAPL"}),
+            _raw_tool_call("tc_2", "get_news", {"symbol": "MSFT"}),
+        ],
+    }
+    tool_calls = [
+        ToolCallRequest(
+            id="tc_1",
+            name="get_price",
+            arguments={"symbol": "AAPL"},
+            extra_content={"thought_signature": "sig-only-first"},
+        ),
+        ToolCallRequest(id="tc_2", name="get_news", arguments={"symbol": "MSFT"}),
+    ]
+
+    attached = _attach_tool_call_thought_signatures(message, tool_calls)
+    raw_tool_calls = attached["additional_kwargs"]["tool_calls"]
+
+    assert raw_tool_calls[0]["extra_content"]["thought_signature"] == "sig-only-first"
+    assert "extra_content" not in raw_tool_calls[1]
+
+
+def test_unsigned_tool_calls_do_not_emit_signature_metadata() -> None:
+    message = ContextBuilder.format_assistant_tool_calls(
+        [ToolCallRequest(id="tc_1", name="get_price", arguments={"symbol": "AAPL"})],
+        content="",
+    )
+
+    assert "additional_kwargs" not in message
+    assert "extra_content" not in message["tool_calls"][0]


### PR DESCRIPTION
## Summary
Gemini requires the `thought_signature` from a model turn to be replayed on the following tool result, but the AgentLoop dict-history replay dropped the per-tool-call `extra_content` that carries it, breaking multi-step Gemini tool use. This preserves `extra_content` (including `thought_signature`) when formatting tool calls back into request history.

Adds a regression test exercising the dict-history replay path.

Fixes #318
