### PR TITLE
feat(live): add broker-agnostic PreTradeAdvisoryInterface (#317)

### DIFF
--- a/agent/src/live/advisory/__init__.py
+++ b/agent/src/live/advisory/__init__.py
@@ -1,0 +1,242 @@
+"""Pre-trade advisory interface — observational risk assessments on live orders.
+
+The advisory layer sits **outside** the mandate gate. It provides a
+broker-agnostic hook for external services (e.g. invinoveritas ``/review``,
+local rule engines, MCP advisory providers) to render a *risk opinion* on a
+proposed order. Advisory verdicts are **purely observational**: they never block,
+deny, or alter order execution. The mandate gate
+(:func:`src.live.enforcement.check_mandate`) remains the sole authority for
+order allow/deny decisions.
+
+Key design principles:
+
+* **Fail-open**: any provider exception is caught and converted to
+  :attr:`Verdict.REVIEW_UNAVAILABLE` — the order proceeds unaffected.
+* **Default-off**: advisory review is activated only when the environment
+  variable ``VIBE_TRADING_ENABLE_ADVISORY`` is set to a truthy value.
+* **Broker-agnostic**: :class:`AdvisoryContext` decouples providers from
+  broker-specific payload shapes, carrying only the normalized fields a risk
+  reviewer needs.
+* **Audit-embedded**: the aggregated verdict is included in the existing
+  ``gate_decision["advisory"]`` audit field — no new audit event kind.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class Verdict(str, Enum):
+    """Advisory verdict on a proposed order.
+
+    Values align with the invinoveritas ``/review`` contract (``approve``,
+    ``approve_with_concerns``, ``reject``) plus a fourth ``review_unavailable``
+    sentinel emitted when a provider fails or times out.
+    """
+
+    APPROVE = "approve"
+    APPROVE_WITH_CONCERNS = "approve_with_concerns"
+    REJECT = "reject"
+    REVIEW_UNAVAILABLE = "review_unavailable"
+
+
+# Severity ordering for worst-case aggregation: higher index = more severe.
+_VERDICT_SEVERITY: dict[Verdict, int] = {
+    Verdict.APPROVE: 0,
+    Verdict.APPROVE_WITH_CONCERNS: 1,
+    Verdict.REVIEW_UNAVAILABLE: 2,
+    Verdict.REJECT: 3,
+}
+
+
+@dataclass(frozen=True)
+class AdvisoryContext:
+    """Broker-agnostic input for an advisory review.
+
+    Carries the normalized fields a risk reviewer needs, decoupled from any
+    specific broker's order payload or account snapshot shape.
+
+    Attributes:
+        symbol: Normalized upper-case symbol (e.g. ``AAPL``, ``BTC-USDT``).
+        side: ``"buy"`` or ``"sell"``.
+        notional_usd: Order notional in USD.
+        account_equity: Current account equity in USD.
+        account_drawdown: Current drawdown as a fraction (0.0 = no drawdown,
+            1.0 = fully drawn down). Approximated from mandate funding when
+            the broker does not supply a high-water mark.
+        open_position_count: Number of currently open positions.
+        total_exposure_usd: Sum of all open position market values in USD.
+        funding_usd: Mandate's ``account_funding_usd`` (the committed capital
+            ceiling).
+    """
+
+    symbol: str
+    side: str
+    notional_usd: float
+    account_equity: float
+    account_drawdown: float
+    open_position_count: int
+    total_exposure_usd: float
+    funding_usd: float
+
+
+@dataclass(frozen=True)
+class AdvisoryResult:
+    """Output from a single advisory provider.
+
+    Attributes:
+        verdict: The provider's assessment of the proposed order.
+        confidence: Optional confidence score in ``[0.0, 1.0]``.
+        summary: Short human-readable summary of the assessment.
+        concerns: Tuple of concern strings (may be empty).
+        provider: Identifier of the originating provider.
+        detail: Arbitrary provider-specific metadata.
+        created_at: ISO-8601 UTC timestamp, auto-filled on construction.
+    """
+
+    verdict: Verdict
+    confidence: float | None = None
+    summary: str = ""
+    concerns: tuple[str, ...] = ()
+    provider: str = ""
+    detail: dict[str, Any] = field(default_factory=dict)
+    created_at: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.created_at:
+            object.__setattr__(
+                self,
+                "created_at",
+                datetime.now(timezone.utc).isoformat(),
+            )
+
+
+class PreTradeAdvisoryInterface(ABC):
+    """Abstract base for pre-trade advisory providers.
+
+    Implementations must expose a :attr:`provider_id` and implement
+    :meth:`review`. The orchestrator catches all exceptions from ``review()``
+    and converts them to :attr:`Verdict.REVIEW_UNAVAILABLE`, so providers may
+    raise freely on internal failure.
+    """
+
+    @property
+    @abstractmethod
+    def provider_id(self) -> str:
+        """Unique identifier for this advisory provider."""
+
+    @abstractmethod
+    def review(self, context: AdvisoryContext) -> AdvisoryResult:
+        """Assess the proposed order described by *context*.
+
+        Args:
+            context: Normalized pre-trade context.
+
+        Returns:
+            An :class:`AdvisoryResult` carrying the provider's verdict.
+        """
+
+
+@dataclass(frozen=True)
+class AggregatedVerdict:
+    """Aggregated result from running all advisory providers.
+
+    The overall :attr:`verdict` is the **worst-case** across all individual
+    provider results (most severe verdict wins).
+
+    Attributes:
+        verdict: Worst-case verdict across all providers.
+        results: Tuple of individual provider results.
+    """
+
+    verdict: Verdict
+    results: tuple[AdvisoryResult, ...]
+
+    @property
+    def all_concerns(self) -> tuple[str, ...]:
+        """Flattened de-duplicated concerns from every provider result."""
+        seen: list[str] = []
+        seen_set: set[str] = set()
+        for result in self.results:
+            for concern in result.concerns:
+                if concern not in seen_set:
+                    seen.append(concern)
+                    seen_set.add(concern)
+        return tuple(seen)
+
+
+class AdvisoryOrchestrator:
+    """Run advisory providers sequentially, aggregate worst-case verdict.
+
+    Each provider's :meth:`~PreTradeAdvisoryInterface.review` is called in
+    order. Any exception is caught and converted to an
+    :class:`AdvisoryResult` with :attr:`Verdict.REVIEW_UNAVAILABLE` so the
+    order is never blocked by a failing advisory provider.
+
+    Args:
+        providers: Ordered list of advisory providers to consult.
+    """
+
+    def __init__(self, providers: list[PreTradeAdvisoryInterface]) -> None:
+        self._providers = list(providers)
+
+    @property
+    def providers(self) -> list[PreTradeAdvisoryInterface]:
+        """The configured provider list (read-only copy)."""
+        return list(self._providers)
+
+    def review(self, context: AdvisoryContext) -> AggregatedVerdict:
+        """Run every provider and return the aggregated worst-case verdict.
+
+        An empty provider list yields an :class:`AggregatedVerdict` with
+        :attr:`Verdict.APPROVE` and no results — the caller may interpret this
+        as "no advisory configured, proceed normally".
+
+        Args:
+            context: Normalized pre-trade context passed to each provider.
+
+        Returns:
+            Aggregated verdict with all individual results.
+        """
+        if not self._providers:
+            return AggregatedVerdict(verdict=Verdict.APPROVE, results=())
+
+        results: list[AdvisoryResult] = []
+        for provider in self._providers:
+            try:
+                result = provider.review(context)
+            except Exception as exc:
+                logger.warning(
+                    "advisory provider %s failed: %s",
+                    getattr(provider, "provider_id", "<unknown>"),
+                    exc,
+                )
+                result = AdvisoryResult(
+                    verdict=Verdict.REVIEW_UNAVAILABLE,
+                    summary=f"provider error: {exc}",
+                    provider=getattr(provider, "provider_id", "<unknown>"),
+                )
+            results.append(result)
+
+        worst = max(results, key=lambda r: _VERDICT_SEVERITY.get(r.verdict, 0))
+        return AggregatedVerdict(
+            verdict=worst.verdict,
+            results=tuple(results),
+        )
+
+
+__all__ = [
+    "AdvisoryContext",
+    "AdvisoryOrchestrator",
+    "AdvisoryResult",
+    "AggregatedVerdict",
+    "PreTradeAdvisoryInterface",
+    "Verdict",
+]

--- a/agent/src/live/advisory/__init__.py
+++ b/agent/src/live/advisory/__init__.py
@@ -68,9 +68,9 @@ class AdvisoryContext:
         side: ``"buy"`` or ``"sell"``.
         notional_usd: Order notional in USD.
         account_equity: Current account equity in USD.
-        account_drawdown: Current drawdown as a fraction (0.0 = no drawdown,
-            1.0 = fully drawn down). Approximated from mandate funding when
-            the broker does not supply a high-water mark.
+        utilization_ratio: Funding utilization as a fraction (0.0 = unused,
+            1.0 = fully utilized). Approximated from mandate funding cap
+            when the broker does not supply a high-water mark.
         open_position_count: Number of currently open positions.
         total_exposure_usd: Sum of all open position market values in USD.
         funding_usd: Mandate's ``account_funding_usd`` (the committed capital
@@ -81,7 +81,7 @@ class AdvisoryContext:
     side: str
     notional_usd: float
     account_equity: float
-    account_drawdown: float
+    utilization_ratio: float
     open_position_count: int
     total_exposure_usd: float
     funding_usd: float
@@ -217,10 +217,11 @@ class AdvisoryOrchestrator:
                     "advisory provider %s failed: %s",
                     getattr(provider, "provider_id", "<unknown>"),
                     exc,
+                    exc_info=True,
                 )
                 result = AdvisoryResult(
                     verdict=Verdict.REVIEW_UNAVAILABLE,
-                    summary=f"provider error: {exc}",
+                    summary=f"provider error: {type(exc).__name__}",
                     provider=getattr(provider, "provider_id", "<unknown>"),
                 )
             results.append(result)
@@ -232,6 +233,33 @@ class AdvisoryOrchestrator:
         )
 
 
+# -- Provider registry -------------------------------------------------------
+
+_advisory_providers: list[PreTradeAdvisoryInterface] = []
+
+
+def register_advisory_provider(provider: PreTradeAdvisoryInterface) -> None:
+    """Register an advisory provider to be consulted on each review.
+
+    Providers are consulted in registration order. Call
+    :func:`clear_advisory_providers` to remove all registered providers.
+
+    Args:
+        provider: An advisory provider instance.
+    """
+    _advisory_providers.append(provider)
+
+
+def clear_advisory_providers() -> None:
+    """Remove all registered advisory providers."""
+    _advisory_providers.clear()
+
+
+def get_advisory_providers() -> list[PreTradeAdvisoryInterface]:
+    """Return a copy of the current advisory provider list."""
+    return list(_advisory_providers)
+
+
 __all__ = [
     "AdvisoryContext",
     "AdvisoryOrchestrator",
@@ -239,4 +267,7 @@ __all__ = [
     "AggregatedVerdict",
     "PreTradeAdvisoryInterface",
     "Verdict",
+    "clear_advisory_providers",
+    "get_advisory_providers",
+    "register_advisory_provider",
 ]

--- a/agent/src/live/advisory/mock.py
+++ b/agent/src/live/advisory/mock.py
@@ -1,0 +1,88 @@
+"""Mock advisory provider for testing.
+
+:class:`MockAdvisory` is a configurable in-memory implementation of
+:class:`~src.live.advisory.PreTradeAdvisoryInterface` that records every
+invocation and supports deterministic verdict injection, optional delay, and
+forced failure — everything a test suite needs to exercise the advisory
+orchestrator and gate integration without any network dependency.
+"""
+
+from __future__ import annotations
+
+import time
+
+from src.live.advisory import (
+    AdvisoryContext,
+    AdvisoryResult,
+    PreTradeAdvisoryInterface,
+    Verdict,
+)
+
+
+class MockAdvisory(PreTradeAdvisoryInterface):
+    """Configurable mock advisory provider.
+
+    Args:
+        verdict: Verdict to return on every :meth:`review` call.
+        concerns: Concern strings attached to every result.
+        summary: Summary text attached to every result.
+        confidence: Optional confidence score in ``[0.0, 1.0]``.
+        delay_s: Artificial delay in seconds before returning (simulates
+            slow providers / timeout scenarios).
+        raise_on_review: When ``True``, :meth:`review` raises
+            :class:`RuntimeError` instead of returning a result.
+        provider_id: Identifier stamped onto every result.
+    """
+
+    def __init__(
+        self,
+        verdict: Verdict = Verdict.APPROVE,
+        concerns: tuple[str, ...] = (),
+        summary: str = "",
+        confidence: float | None = None,
+        delay_s: float = 0,
+        raise_on_review: bool = False,
+        provider_id: str = "mock",
+    ) -> None:
+        self._verdict = verdict
+        self._concerns = concerns
+        self._summary = summary
+        self._confidence = confidence
+        self._delay_s = delay_s
+        self._raise_on_review = raise_on_review
+        self._provider_id = provider_id
+        self.call_history: list[AdvisoryContext] = []
+
+    @property
+    def provider_id(self) -> str:
+        """Unique identifier for this advisory provider."""
+        return self._provider_id
+
+    def review(self, context: AdvisoryContext) -> AdvisoryResult:
+        """Return the configured verdict, or raise if configured to fail.
+
+        Every invocation appends *context* to :attr:`call_history` before any
+        delay or exception, so tests can assert the context was received even
+        when the provider is configured to fail.
+
+        Args:
+            context: Normalized pre-trade context.
+
+        Returns:
+            An :class:`AdvisoryResult` carrying the injected verdict.
+
+        Raises:
+            RuntimeError: When ``raise_on_review`` is ``True``.
+        """
+        self.call_history.append(context)
+        if self._delay_s > 0:
+            time.sleep(self._delay_s)
+        if self._raise_on_review:
+            raise RuntimeError("mock advisory failure")
+        return AdvisoryResult(
+            verdict=self._verdict,
+            concerns=self._concerns,
+            summary=self._summary,
+            confidence=self._confidence,
+            provider=self._provider_id,
+        )

--- a/agent/src/live/enforcement.py
+++ b/agent/src/live/enforcement.py
@@ -707,3 +707,12 @@ def market_cap_usd(symbol: str, asset_class: AssetClass) -> float | None:
     cap = info.get("marketCap")
     parsed = _as_float(cap)
     return parsed if parsed and parsed > 0 else None
+
+
+# -- Public aliases for cross-module use (advisory layer) --------------------
+# These expose internal helpers to the advisory module without requiring
+# callers to import underscore-prefixed private names.
+
+account_balance_market_value = _account_balance_market_value
+coerce_position_rows = _coerce_position_rows
+positions_market_value = _positions_market_value

--- a/agent/src/live/order_guard.py
+++ b/agent/src/live/order_guard.py
@@ -38,9 +38,15 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from datetime import datetime, timezone
 from typing import Any
 
+from src.live.advisory import (
+    AdvisoryContext,
+    AdvisoryOrchestrator,
+    Verdict,
+)
 from src.live.audit import LiveActionEvent, write_live_action
 from src.live.enforcement import (
     BREACH_KIND_INSTRUMENT,
@@ -73,6 +79,12 @@ _QUOTE_TOOLS = ("get_quotes",)
 _DECISION_ALLOW = "allow"
 _DECISION_DENY = "deny"
 _DECISION_PAUSE = "pause_for_reauth"
+
+#: Environment variable controlling advisory review activation.
+#: Truthy values (case-insensitive): ``"1"``, ``"true"``, ``"yes"``.
+#: Default: off (advisory layer is purely observational and opt-in).
+_ADVISORY_ENABLED_ENV = "VIBE_TRADING_ENABLE_ADVISORY"
+_ADVISORY_TRUTHY = frozenset({"1", "true", "yes"})
 
 
 class LiveOrderGuardTool(MCPRemoteTool):
@@ -177,7 +189,10 @@ class LiveOrderGuardTool(MCPRemoteTool):
         )
 
         if breach is None:
-            return self._allow(mandate=mandate, intent=intent, kwargs=kwargs)
+            return self._allow(
+                mandate=mandate, intent=intent, kwargs=kwargs,
+                positions=positions, balance=balance,
+            )
 
         if breach.kind in (BREACH_KIND_UNIVERSE, BREACH_KIND_INSTRUMENT):
             return self._deny_breach(breach, mandate=mandate, intent=intent, reauth=False)
@@ -288,7 +303,15 @@ class LiveOrderGuardTool(MCPRemoteTool):
 
     # -- decision helpers ---------------------------------------------------
 
-    def _allow(self, *, mandate: Mandate, intent: OrderIntent, kwargs: dict) -> str:
+    def _allow(
+        self,
+        *,
+        mandate: Mandate,
+        intent: OrderIntent,
+        kwargs: dict,
+        positions: object = None,
+        balance: object = None,
+    ) -> str:
         """Forward the order unchanged; consume a count + audit only on success.
 
         ``MCPServerAdapter.call_tool`` does NOT raise on broker/network failure —
@@ -305,6 +328,7 @@ class LiveOrderGuardTool(MCPRemoteTool):
         under :data:`LIVE_ACTION_RESULT_KEY` so the api_server SSE relay can emit
         a ``live.action`` event without touching the agent loop (H5).
         """
+        advisory = self._advisory_review(intent, positions, balance, mandate)
         forwarded = super().execute(**kwargs)
         broker_response = self._safe_json(forwarded)
         is_error = self._is_error_envelope(broker_response)
@@ -316,6 +340,14 @@ class LiveOrderGuardTool(MCPRemoteTool):
             "max_leverage", "max_trades_per_day", "account_funding_usd",
             "universe_floors",
         ]
+        if advisory is not None:
+            checked.append("advisory")
+        gate_decision: dict[str, Any] = {
+            "allowed": True,
+            "decision": _DECISION_ALLOW,
+            "checked_limits": checked,
+            "advisory": advisory,
+        }
         if is_error:
             record = self._audit(
                 kind="order_rejected",
@@ -324,7 +356,7 @@ class LiveOrderGuardTool(MCPRemoteTool):
                 intent=intent,
                 broker_request=dict(kwargs),
                 broker_response=broker_response,
-                gate_decision={"allowed": True, "decision": _DECISION_ALLOW, "checked_limits": checked},
+                gate_decision=gate_decision,
                 error=self._error_message(broker_response),
             )
         else:
@@ -337,9 +369,86 @@ class LiveOrderGuardTool(MCPRemoteTool):
                 intent=intent,
                 broker_request=dict(kwargs),
                 broker_response=broker_response,
-                gate_decision={"allowed": True, "decision": _DECISION_ALLOW, "checked_limits": checked},
+                gate_decision=gate_decision,
             )
         return self._embed_live_action(forwarded, record)
+
+    # -- advisory review (observational, never blocks) ----------------------
+
+    def _advisory_review(
+        self,
+        intent: OrderIntent,
+        positions: object,
+        balance: object,
+        mandate: Mandate,
+    ) -> dict | None:
+        """Run advisory providers if enabled; return verdict dict or None.
+
+        Returns None when advisory is disabled or no providers are configured.
+        Returns a dict with ``verdict``, ``concerns``, ``results`` keys otherwise.
+        Never raises — all exceptions are caught and converted to
+        REVIEW_UNAVAILABLE.
+        """
+        env_val = os.getenv(_ADVISORY_ENABLED_ENV, "").strip().lower()
+        if env_val not in _ADVISORY_TRUTHY:
+            return None
+
+        try:
+            from src.live.enforcement import (
+                _account_balance_market_value,
+                _coerce_position_rows,
+                _positions_market_value,
+            )
+
+            equity = _account_balance_market_value(balance) or 0.0
+            exposure = _positions_market_value(positions) or 0.0
+            funding_usd = mandate.hard_caps.account_funding_usd
+
+            if equity > 0 and funding_usd > 0:
+                drawdown = max(0.0, 1.0 - equity / funding_usd)
+            else:
+                drawdown = 0.0
+
+            pos_rows = _coerce_position_rows(positions)
+            open_count = len(pos_rows) if pos_rows is not None else 0
+
+            context = AdvisoryContext(
+                symbol=intent.symbol,
+                side=intent.side,
+                notional_usd=intent.notional_usd or 0.0,
+                account_equity=equity,
+                account_drawdown=drawdown,
+                open_position_count=open_count,
+                total_exposure_usd=exposure,
+                funding_usd=funding_usd,
+            )
+
+            orchestrator = AdvisoryOrchestrator([])
+            if not orchestrator.providers:
+                return None
+
+            aggregated = orchestrator.review(context)
+            return {
+                "verdict": aggregated.verdict.value,
+                "concerns": list(aggregated.all_concerns),
+                "results": [
+                    {
+                        "verdict": r.verdict.value,
+                        "summary": r.summary,
+                        "concerns": list(r.concerns),
+                        "provider": r.provider,
+                        "confidence": r.confidence,
+                    }
+                    for r in aggregated.results
+                ],
+            }
+        except Exception as exc:
+            logger.warning("advisory review failed: %s", exc)
+            return {
+                "verdict": Verdict.REVIEW_UNAVAILABLE.value,
+                "concerns": [],
+                "error": str(exc),
+            }
 
     def _deny(
         self,

--- a/agent/src/live/order_guard.py
+++ b/agent/src/live/order_guard.py
@@ -46,6 +46,7 @@ from src.live.advisory import (
     AdvisoryContext,
     AdvisoryOrchestrator,
     Verdict,
+    get_advisory_providers,
 )
 from src.live.audit import LiveActionEvent, write_live_action
 from src.live.enforcement import (
@@ -393,23 +394,30 @@ class LiveOrderGuardTool(MCPRemoteTool):
         if env_val not in _ADVISORY_TRUTHY:
             return None
 
+        providers = get_advisory_providers()
+        if not providers:
+            logger.info(
+                "advisory enabled but no providers registered — skipping review"
+            )
+            return None
+
         try:
             from src.live.enforcement import (
-                _account_balance_market_value,
-                _coerce_position_rows,
-                _positions_market_value,
+                account_balance_market_value,
+                coerce_position_rows,
+                positions_market_value,
             )
 
-            equity = _account_balance_market_value(balance) or 0.0
-            exposure = _positions_market_value(positions) or 0.0
+            equity = account_balance_market_value(balance) or 0.0
+            exposure = positions_market_value(positions) or 0.0
             funding_usd = mandate.hard_caps.account_funding_usd
 
             if equity > 0 and funding_usd > 0:
-                drawdown = max(0.0, 1.0 - equity / funding_usd)
+                utilization = max(0.0, 1.0 - equity / funding_usd)
             else:
-                drawdown = 0.0
+                utilization = 0.0
 
-            pos_rows = _coerce_position_rows(positions)
+            pos_rows = coerce_position_rows(positions)
             open_count = len(pos_rows) if pos_rows is not None else 0
 
             context = AdvisoryContext(
@@ -417,16 +425,13 @@ class LiveOrderGuardTool(MCPRemoteTool):
                 side=intent.side,
                 notional_usd=intent.notional_usd or 0.0,
                 account_equity=equity,
-                account_drawdown=drawdown,
+                utilization_ratio=utilization,
                 open_position_count=open_count,
                 total_exposure_usd=exposure,
                 funding_usd=funding_usd,
             )
 
-            orchestrator = AdvisoryOrchestrator([])
-            if not orchestrator.providers:
-                return None
-
+            orchestrator = AdvisoryOrchestrator(providers)
             aggregated = orchestrator.review(context)
             return {
                 "verdict": aggregated.verdict.value,
@@ -443,11 +448,11 @@ class LiveOrderGuardTool(MCPRemoteTool):
                 ],
             }
         except Exception as exc:
-            logger.warning("advisory review failed: %s", exc)
+            logger.warning("advisory review failed: %s", exc, exc_info=True)
             return {
                 "verdict": Verdict.REVIEW_UNAVAILABLE.value,
                 "concerns": [],
-                "error": str(exc),
+                "error": type(exc).__name__,
             }
 
     def _deny(

--- a/agent/tests/test_advisory.py
+++ b/agent/tests/test_advisory.py
@@ -1,0 +1,343 @@
+"""Advisory interface and gate integration tests (#317).
+
+Covers the PreTradeAdvisoryInterface contract, MockAdvisory behavior,
+AdvisoryOrchestrator fail-open semantics, and LiveOrderGuardTool advisory
+wiring (disabled by default, enabled with env var, observational only).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import FrozenInstanceError
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import src.live.paths as paths
+from src.live.advisory import (
+    AdvisoryContext,
+    AdvisoryOrchestrator,
+    AdvisoryResult,
+    AggregatedVerdict,
+    Verdict,
+)
+from src.live.advisory.mock import MockAdvisory
+from src.live.mandate.model import (
+    MANDATE_SCHEMA_VERSION,
+    AssetClass,
+    ConsentMeta,
+    HardCaps,
+    InstrumentType,
+    Mandate,
+    UniverseConstraint,
+)
+from src.live.order_guard import LiveOrderGuardTool
+from src.tools.mcp import MCPRemoteToolSpec
+
+
+@pytest.fixture
+def live_runtime(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setattr(paths, "get_runtime_root", lambda: tmp_path)
+    return tmp_path
+
+
+class _MockAdapter:
+    def __init__(self, *, positions: Any = None, balance: Any = 5000.0) -> None:
+        self.server_name = "robinhood"
+        self._positions = positions if positions is not None else []
+        self._balance = balance
+        self.order_calls: list[dict[str, Any]] = []
+
+    def call_tool(
+        self, remote_name: str, arguments: dict, *, local_name: str | None = None
+    ) -> dict:
+        if remote_name in ("get_positions", "list_positions"):
+            return {"positions": self._positions, "status": "ok"}
+        if remote_name in ("get_account", "get_balance", "get_buying_power"):
+            return {"equity": self._balance, "status": "ok"}
+        self.order_calls.append({"remote": remote_name, "arguments": arguments})
+        return {"status": "ok", "order_id": "rh_test_1", "state": "accepted"}
+
+
+def _spec() -> MCPRemoteToolSpec:
+    return MCPRemoteToolSpec(
+        server_name="robinhood",
+        remote_name="place_order",
+        local_name="mcp_robinhood_place_order",
+        description="Place an order.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "symbol": {"type": "string"},
+                "side": {"type": "string"},
+                "instrument_type": {"type": "string"},
+                "notional_usd": {"type": "number"},
+                "quantity": {"type": "number"},
+            },
+            "additionalProperties": True,
+        },
+    )
+
+
+def _mandate(**caps_overrides: Any) -> Mandate:
+    created = datetime.now(timezone.utc)
+    caps: dict[str, Any] = {
+        "account_funding_usd": 5000.0,
+        "max_order_notional_usd": 750.0,
+        "max_total_exposure_usd": 5000.0,
+        "max_leverage": 1.0,
+        "allowed_instruments": (InstrumentType.EQUITY, InstrumentType.ETF),
+        "max_trades_per_day": 5,
+    }
+    caps.update(caps_overrides)
+    return Mandate(
+        schema_version=MANDATE_SCHEMA_VERSION,
+        hard_caps=HardCaps(**caps),
+        universe=UniverseConstraint(
+            asset_classes=(AssetClass.US_EQUITY, AssetClass.US_ETF),
+            min_market_cap_usd=None,
+            min_avg_daily_volume_usd=None,
+            exclude_symbols=("GME",),
+        ),
+        consent=ConsentMeta(
+            created_at=created.isoformat(),
+            consent_token_sha256="deadbeef",
+            broker="robinhood",
+            account_ref="acct_ref_xyz",
+            expires_at=(created + timedelta(days=30)).isoformat(),
+        ),
+    )
+
+
+def _write_mandate(live_runtime: Path, mandate: Mandate) -> None:
+    broker = live_runtime / "live" / "robinhood"
+    broker.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": mandate.schema_version,
+        "hard_caps": {
+            "account_funding_usd": mandate.hard_caps.account_funding_usd,
+            "max_order_notional_usd": mandate.hard_caps.max_order_notional_usd,
+            "max_total_exposure_usd": mandate.hard_caps.max_total_exposure_usd,
+            "max_leverage": mandate.hard_caps.max_leverage,
+            "allowed_instruments": [i.value for i in mandate.hard_caps.allowed_instruments],
+            "max_trades_per_day": mandate.hard_caps.max_trades_per_day,
+        },
+        "universe": {
+            "asset_classes": [a.value for a in mandate.universe.asset_classes],
+            "min_market_cap_usd": mandate.universe.min_market_cap_usd,
+            "min_avg_daily_volume_usd": mandate.universe.min_avg_daily_volume_usd,
+            "exclude_symbols": list(mandate.universe.exclude_symbols),
+        },
+        "consent": {
+            "created_at": mandate.consent.created_at,
+            "consent_token_sha256": mandate.consent.consent_token_sha256,
+            "broker": mandate.consent.broker,
+            "account_ref": mandate.consent.account_ref,
+            "expires_at": mandate.consent.expires_at,
+        },
+    }
+    (broker / "mandate.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _guard(adapter: _MockAdapter) -> LiveOrderGuardTool:
+    return LiveOrderGuardTool(
+        adapter, _spec(), broker="robinhood", session_id="s1"
+    )
+
+
+def _make_context(**overrides: Any) -> AdvisoryContext:
+    base: dict[str, Any] = {
+        "symbol": "AAPL",
+        "side": "buy",
+        "notional_usd": 100.0,
+        "account_equity": 5000.0,
+        "account_drawdown": 0.0,
+        "open_position_count": 0,
+        "total_exposure_usd": 0.0,
+        "funding_usd": 5000.0,
+    }
+    base.update(overrides)
+    return AdvisoryContext(**base)
+
+
+# --------------------------------------------------------------------------- #
+# 1. Verdict enum                                                              #
+# --------------------------------------------------------------------------- #
+
+
+def test_verdict_enum_members() -> None:
+    assert len(Verdict) == 4
+    assert Verdict.APPROVE.value == "approve"
+    assert Verdict.APPROVE_WITH_CONCERNS.value == "approve_with_concerns"
+    assert Verdict.REJECT.value == "reject"
+    assert Verdict.REVIEW_UNAVAILABLE.value == "review_unavailable"
+
+
+# --------------------------------------------------------------------------- #
+# 2. AdvisoryContext frozen                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_advisory_context_frozen() -> None:
+    ctx = _make_context()
+    with pytest.raises((FrozenInstanceError, AttributeError)):
+        ctx.symbol = "MSFT"  # type: ignore[misc]
+
+
+# --------------------------------------------------------------------------- #
+# 3. AdvisoryResult auto-timestamp                                             #
+# --------------------------------------------------------------------------- #
+
+
+def test_advisory_result_auto_timestamp() -> None:
+    result = AdvisoryResult(verdict=Verdict.APPROVE)
+    assert result.created_at != ""
+    parsed = datetime.fromisoformat(result.created_at)
+    assert parsed.tzinfo is not None
+
+
+# --------------------------------------------------------------------------- #
+# 4. MockAdvisory default approve                                              #
+# --------------------------------------------------------------------------- #
+
+
+def test_mock_advisory_default_approve() -> None:
+    mock = MockAdvisory()
+    ctx = _make_context()
+    result = mock.review(ctx)
+    assert result.verdict == Verdict.APPROVE
+    assert result.concerns == ()
+    assert result.provider == "mock"
+    assert len(mock.call_history) == 1
+
+
+# --------------------------------------------------------------------------- #
+# 5. MockAdvisory configurable verdict                                         #
+# --------------------------------------------------------------------------- #
+
+
+def test_mock_advisory_configurable_verdict() -> None:
+    mock = MockAdvisory(
+        verdict=Verdict.REJECT,
+        concerns=("drawdown > 20%", "concentration risk"),
+        summary="order rejected",
+        confidence=0.9,
+    )
+    ctx = _make_context()
+    result = mock.review(ctx)
+    assert result.verdict == Verdict.REJECT
+    assert result.concerns == ("drawdown > 20%", "concentration risk")
+    assert result.summary == "order rejected"
+    assert result.confidence == 0.9
+
+
+# --------------------------------------------------------------------------- #
+# 6. MockAdvisory raise_on_review                                              #
+# --------------------------------------------------------------------------- #
+
+
+def test_mock_advisory_raise_on_review() -> None:
+    mock = MockAdvisory(raise_on_review=True)
+    ctx = _make_context()
+    with pytest.raises(RuntimeError, match="mock advisory failure"):
+        mock.review(ctx)
+    assert len(mock.call_history) == 1
+
+
+# --------------------------------------------------------------------------- #
+# 7. Orchestrator catches exception → REVIEW_UNAVAILABLE                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_orchestrator_catches_exception() -> None:
+    failing = MockAdvisory(raise_on_review=True, provider_id="failing")
+    healthy = MockAdvisory(verdict=Verdict.APPROVE, provider_id="healthy")
+    orchestrator = AdvisoryOrchestrator([failing, healthy])
+    ctx = _make_context()
+
+    aggregated = orchestrator.review(ctx)
+
+    assert isinstance(aggregated, AggregatedVerdict)
+    assert len(aggregated.results) == 2
+    assert aggregated.results[0].verdict == Verdict.REVIEW_UNAVAILABLE
+    assert aggregated.results[1].verdict == Verdict.APPROVE
+    assert aggregated.verdict == Verdict.REVIEW_UNAVAILABLE
+
+
+# --------------------------------------------------------------------------- #
+# 8. Gate advisory disabled by default                                         #
+# --------------------------------------------------------------------------- #
+
+
+def test_gate_advisory_disabled_by_default(
+    live_runtime: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("VIBE_TRADING_ENABLE_ADVISORY", raising=False)
+    _write_mandate(live_runtime, _mandate())
+    adapter = _MockAdapter()
+    guard = _guard(adapter)
+
+    out = json.loads(
+        guard.execute(
+            symbol="AAPL", side="buy", instrument_type="equity", notional_usd=100.0
+        )
+    )
+
+    assert out.get("status") == "ok"
+    live_action = out.get("live_action")
+    assert live_action is not None
+    gate_decision = live_action["gate_decision"]
+    assert gate_decision["advisory"] is None
+    assert "advisory" not in gate_decision["checked_limits"]
+
+
+# --------------------------------------------------------------------------- #
+# 9. Gate advisory enabled with mock provider                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_gate_advisory_enabled_with_mock_provider(
+    live_runtime: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("VIBE_TRADING_ENABLE_ADVISORY", "1")
+
+    mock_provider = MockAdvisory(
+        verdict=Verdict.APPROVE_WITH_CONCERNS,
+        concerns=("high concentration",),
+        summary="proceed with caution",
+        provider_id="test_mock",
+    )
+
+    original_init = AdvisoryOrchestrator.__init__
+
+    def _patched_init(self: AdvisoryOrchestrator, providers: list) -> None:
+        original_init(self, [mock_provider])
+
+    monkeypatch.setattr(AdvisoryOrchestrator, "__init__", _patched_init)
+
+    _write_mandate(live_runtime, _mandate())
+    adapter = _MockAdapter()
+    guard = _guard(adapter)
+
+    out = json.loads(
+        guard.execute(
+            symbol="AAPL", side="buy", instrument_type="equity", notional_usd=100.0
+        )
+    )
+
+    assert out.get("status") == "ok"
+    assert len(adapter.order_calls) == 1
+
+    live_action = out.get("live_action")
+    assert live_action is not None
+    gate_decision = live_action["gate_decision"]
+    assert "advisory" in gate_decision["checked_limits"]
+
+    advisory = gate_decision["advisory"]
+    assert advisory is not None
+    assert advisory["verdict"] == "approve_with_concerns"
+    assert "high concentration" in advisory["concerns"]
+    assert len(advisory["results"]) == 1
+    assert advisory["results"][0]["provider"] == "test_mock"

--- a/agent/tests/test_advisory.py
+++ b/agent/tests/test_advisory.py
@@ -22,6 +22,8 @@ from src.live.advisory import (
     AdvisoryResult,
     AggregatedVerdict,
     Verdict,
+    clear_advisory_providers,
+    register_advisory_provider,
 )
 from src.live.advisory.mock import MockAdvisory
 from src.live.mandate.model import (
@@ -153,7 +155,7 @@ def _make_context(**overrides: Any) -> AdvisoryContext:
         "side": "buy",
         "notional_usd": 100.0,
         "account_equity": 5000.0,
-        "account_drawdown": 0.0,
+        "utilization_ratio": 0.0,
         "open_position_count": 0,
         "total_exposure_usd": 0.0,
         "funding_usd": 5000.0,
@@ -310,34 +312,31 @@ def test_gate_advisory_enabled_with_mock_provider(
         provider_id="test_mock",
     )
 
-    original_init = AdvisoryOrchestrator.__init__
+    register_advisory_provider(mock_provider)
+    try:
+        _write_mandate(live_runtime, _mandate())
+        adapter = _MockAdapter()
+        guard = _guard(adapter)
 
-    def _patched_init(self: AdvisoryOrchestrator, providers: list) -> None:
-        original_init(self, [mock_provider])
-
-    monkeypatch.setattr(AdvisoryOrchestrator, "__init__", _patched_init)
-
-    _write_mandate(live_runtime, _mandate())
-    adapter = _MockAdapter()
-    guard = _guard(adapter)
-
-    out = json.loads(
-        guard.execute(
-            symbol="AAPL", side="buy", instrument_type="equity", notional_usd=100.0
+        out = json.loads(
+            guard.execute(
+                symbol="AAPL", side="buy", instrument_type="equity", notional_usd=100.0
+            )
         )
-    )
 
-    assert out.get("status") == "ok"
-    assert len(adapter.order_calls) == 1
+        assert out.get("status") == "ok"
+        assert len(adapter.order_calls) == 1
 
-    live_action = out.get("live_action")
-    assert live_action is not None
-    gate_decision = live_action["gate_decision"]
-    assert "advisory" in gate_decision["checked_limits"]
+        live_action = out.get("live_action")
+        assert live_action is not None
+        gate_decision = live_action["gate_decision"]
+        assert "advisory" in gate_decision["checked_limits"]
 
-    advisory = gate_decision["advisory"]
-    assert advisory is not None
-    assert advisory["verdict"] == "approve_with_concerns"
-    assert "high concentration" in advisory["concerns"]
-    assert len(advisory["results"]) == 1
-    assert advisory["results"][0]["provider"] == "test_mock"
+        advisory = gate_decision["advisory"]
+        assert advisory is not None
+        assert advisory["verdict"] == "approve_with_concerns"
+        assert "high concentration" in advisory["concerns"]
+        assert len(advisory["results"]) == 1
+        assert advisory["results"][0]["provider"] == "test_mock"
+    finally:
+        clear_advisory_providers()


### PR DESCRIPTION
## Summary

- Add broker-agnostic `PreTradeAdvisoryInterface` for external risk-assessment services to provide observational pre-trade opinions (e.g. invinoveritas `/review`)
- Add `MockAdvisory` with configurable verdict, delay, exception injection, and call-history recording for test suites
- Wire advisory layer into `LiveOrderGuardTool._allow()` behind opt-in env var `VIBE_TRADING_ENABLE_ADVISORY` — purely observational, never blocks order execution
- Add 9 unit tests covering interface contract, mock behavior, orchestrator fail-open, and gate integration (disabled + enabled paths)

## Why

The existing mandate gate answers **"is this allowed?"** (structural compliance: universe, notional, leverage, daily cap, kill switch). Issue #317 identified a missing layer above the mandate: a capital-scale-aware verdict on whether *this specific order, right now* is sound given the current account state — answering **"is this wise?"**.

Per the community discussion, @warren618 requested:

> *"The clean first step would be a broker-agnostic advisory interface with tests/mocks, kept separate from the broker-specific mandate enforcement path"*

This PR delivers exactly that first step. The `InvinoveritasAdvisory` HTTP implementation is a follow-up PR by @babyblueviper1.

Closes #317

## Changes

- **`agent/src/live/advisory/__init__.py`** (new, 242 LOC): `Verdict` enum (APPROVE / APPROVE_WITH_CONCERNS / REJECT / REVIEW_UNAVAILABLE), `AdvisoryContext` frozen dataclass (8 fields: symbol, side, notional_usd, account_equity, account_drawdown, open_position_count, total_exposure_usd, funding_usd), `AdvisoryResult` frozen dataclass with auto-filled UTC timestamp, `PreTradeAdvisoryInterface` ABC (provider_id + review()), `AdvisoryOrchestrator` (sequential execution, fail-open exception handling, worst-case aggregation), `AggregatedVerdict` with `all_concerns` property.
- **`agent/src/live/advisory/mock.py`** (new, 88 LOC): `MockAdvisory` implementing `PreTradeAdvisoryInterface` — configurable verdict, optional delay, forced exception, call-history recording. No network dependencies.
- **`agent/src/live/order_guard.py`** (modified, +113/-4): Add `_advisory_review()` method to `LiveOrderGuardTool` that builds `AdvisoryContext` from intent/positions/balance/mandate, calls the orchestrator, and returns a verdict dict. Wire into `_allow()` before broker forward. Env-var `VIBE_TRADING_ENABLE_ADVISORY` gates activation (default off). Advisory verdict embedded in `gate_decision["advisory"]` for audit visibility. Fail-open: any exception → REVIEW_UNAVAILABLE, order proceeds unchanged. `_allow()` signature extended with `positions`/`balance` kwargs threaded from `execute()`.
- **`agent/tests/test_advisory.py`** (new, 343 LOC): 9 unit tests following existing `_MockAdapter` / `live_runtime` fixture patterns from `test_mandate_enforcement.py` and `test_killswitch_blocks_orders.py`.

## Test Plan

### Automated tests

- [x] New advisory tests (`conda run -n legonanobot python -m pytest tests/test_advisory.py -v` → **9 passed** in 5.61s)
- [x] Existing mandate + killswitch tests (`conda run -n legonanobot python -m pytest tests/test_mandate_enforcement.py tests/test_killswitch_blocks_orders.py -q` → **23 passed**, zero regressions)
- [x] Ruff lint clean (`ruff check agent/src/live/advisory/ agent/tests/test_advisory.py` → 0 errors)

### Unit test breakdown (9 tests, no network required)

| # | Test | Coverage |
|---|------|----------|
| 1 | `test_verdict_enum_members` | Verdict has exactly 4 members with expected string values |
| 2 | `test_advisory_context_frozen` | AdvisoryContext is frozen (setattr raises FrozenInstanceError) |
| 3 | `test_advisory_result_auto_timestamp` | AdvisoryResult auto-fills created_at with UTC ISO |
| 4 | `test_mock_advisory_default_approve` | MockAdvisory() returns APPROVE with empty concerns |
| 5 | `test_mock_advisory_configurable_verdict` | MockAdvisory(verdict=REJECT, concerns=(...)) returns REJECT with concerns |
| 6 | `test_mock_advisory_raise_on_review` | MockAdvisory(raise_on_review=True) raises RuntimeError |
| 7 | `test_orchestrator_catches_exception` | Orchestrator with raising mock → REVIEW_UNAVAILABLE, does not propagate |
| 8 | `test_gate_advisory_disabled_by_default` | LiveOrderGuardTool with no env var: no advisory in gate_decision |
| 9 | `test_gate_advisory_enabled_with_mock_provider` | VIBE_TRADING_ENABLE_ADVISORY=1 + mock provider: verdict embedded in gate_decision["advisory"], order still proceeds |

## Design decisions

1. **Advisory is purely observational** — per community consensus, advisory verdicts are logged and surfaced to the agent but **never block order execution**. The mandate gate's fail-closed semantics are unchanged.
2. **Fail-open** — any provider exception is caught by the orchestrator and converted to `REVIEW_UNAVAILABLE`. An advisory failure must never affect execution.
3. **Default off** — controlled by `VIBE_TRADING_ENABLE_ADVISORY` environment variable. When unset or falsy, the advisory layer is a complete no-op (zero overhead).
4. **Audit integration** — advisory verdict is embedded in the existing `gate_decision["advisory"]` field. No new `LiveActionKind` or audit schema changes.
5. **Broker-agnostic context** — `AdvisoryContext` decouples providers from broker-specific payload shapes. The gate builds the context from the same `positions`/`balance` reads that `check_mandate` already consumes — no additional broker calls.
6. **Zero providers by default** — the orchestrator ships with no providers configured.

## invinoveritas contract mapping

For the future `InvinoveritasAdvisory` implementer (@babyblueviper1):

### Input: `AdvisoryContext` → `/review` request

| AdvisoryContext field | invinoveritas artifact field |
|---|---|
| `symbol` | `coin` |
| `side` | `direction` |
| `notional_usd` | `size_usd` |
| *(not in context)* | `leverage` (needs mandate or order-level data) |
| *(not in context)* | `entry_price` (needs live quote) |
| *(not in context)* | `confidence` / `regime` / `reasoning` (signal-level, not order-level) |

### Output: `/review` response → `AdvisoryResult`

| invinoveritas response field | AdvisoryResult field |
|---|---|
| `verdict` | `verdict` (direct: `approve` → `APPROVE`, etc.) |
| `confidence` | `confidence` |
| `summary` | `summary` |
| `issues[]` | `concerns` (tuple) |
| `proof.id` | `detail["proof_id"]` |

## Known limitations

1. **SDK gate path not covered** — `sdk_order_gate.py` (Tiger/Alpaca/OKX/Binance/Futu/Dhan/Shoonya connectors) has its own `_allow()` that does not receive advisory integration. MCP/Robinhood path first, SDK connectors in a follow-up.
2. **`account_drawdown` approximation** — uses `mandate.hard_caps.account_funding_usd` as a proxy for peak equity. The `InvinoveritasAdvisory` implementer should pass actual peak equity from the broker's account read when available.

## Future recommendations

- **Next PR: `InvinoveritasAdvisory`** — HTTP client for `POST https://api.babyblueviper.com/review` with timeout (8s), 402 handling, signed proof verification (@babyblueviper1)
- **Future: `LocalRulesAdvisory`** — pure-local rule engine (drawdown guard, concentration check). Zero network, zero cost.
- **Future: `MCPAdvisory`** — generic adapter using existing `MCPServerAdapter` infrastructure
- **Future: SDK gate integration** — extend advisory to `sdk_order_gate.py` for direct-SDK connectors
- **Future: Multi-provider config** — JSON/YAML provider registry with aggregation policy
- **Future: Advisory blocking** — opt-in `VIBE_TRADING_ADVISORY_BLOCKING=true` with distinct `advisory_hold` decision type

## Checklist

- [x] No changes to `check_mandate()`, `BreachEvent`, or mandate enforcement logic
- [x] No changes to broker connectors, trading profiles, or MCP server
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Advisory layer is purely observational — never blocks or alters order execution
- [x] Default off via `VIBE_TRADING_ENABLE_ADVISORY` env var
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] All commits carry `Signed-off-by:` DCO trailer
- [ ] Documentation updated (if user-facing change)