### PR TITLE
feat(live): add InvinoveritasAdvisory /review provider (#317 follow-up to #328)

### DIFF
--- a/agent/src/live/advisory/invinoveritas.py
+++ b/agent/src/live/advisory/invinoveritas.py
@@ -1,0 +1,224 @@
+"""invinoveritas ``/review`` advisory provider.
+
+:class:`InvinoveritasAdvisory` calls the public invinoveritas ``/review``
+endpoint — the verification layer for autonomous agents — to obtain an
+*independent*, capital-scale-aware pre-trade verdict on a proposed order, and
+returns it as an observational :class:`~src.live.advisory.AdvisoryResult`.
+
+Two properties make this more than a second rule engine:
+
+* **Independent.** The verdict comes from a party that is *not* the agent
+  placing the order, so "is this wise?" is not graded by the same optimist that
+  produced the order. ``/review`` with ``artifact_type="trade"`` triggers the
+  capital-scale-aware risk-manager review (account equity, exposure, drawdown,
+  position count).
+* **Recomputable.** With ``sign=True`` (the default), ``/review`` returns a
+  portable signed proof that any third party can verify against invinoveritas's
+  published key via ``/verify-proof``, *without trusting this runtime*. The
+  proof and its ``verify_url`` are carried in
+  :attr:`AdvisoryResult.detail` so the gate's audit record
+  (``gate_decision["advisory"]``) stays independently checkable after the fact.
+
+Consistent with the advisory contract, every failure path **fails open**: a
+missing credit/payment, a timeout, a network error, a non-2xx response, or an
+unparseable body all resolve to :attr:`Verdict.REVIEW_UNAVAILABLE`, so an
+advisory outage never blocks order execution.
+
+Example::
+
+    from src.live.advisory import register_advisory_provider
+    from src.live.advisory.invinoveritas import InvinoveritasAdvisory
+
+    register_advisory_provider(InvinoveritasAdvisory(api_key="ivk_..."))
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import httpx
+
+from src.live.advisory import (
+    AdvisoryContext,
+    AdvisoryResult,
+    PreTradeAdvisoryInterface,
+    Verdict,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = "https://api.babyblueviper.com"
+DEFAULT_TIMEOUT_S = 8.0
+
+# Map the /review verdict vocabulary onto the local advisory Verdict enum.
+# /review can return "revise" (a soft "tighten this before shipping"); it is a
+# concern, not a hard reject, so it maps to APPROVE_WITH_CONCERNS.
+_VERDICT_MAP: dict[str, Verdict] = {
+    "approve": Verdict.APPROVE,
+    "approve_with_concerns": Verdict.APPROVE_WITH_CONCERNS,
+    "revise": Verdict.APPROVE_WITH_CONCERNS,
+    "reject": Verdict.REJECT,
+}
+
+
+class InvinoveritasAdvisory(PreTradeAdvisoryInterface):
+    """Pre-trade advisory provider backed by invinoveritas ``/review``.
+
+    Args:
+        api_key: Optional bearer token for a funded invinoveritas account. When
+            omitted, the call falls back to the ``INVINOVERITAS_API_KEY``
+            environment variable. ``/review`` is a paid endpoint; without usable
+            credit the call resolves to :attr:`Verdict.REVIEW_UNAVAILABLE`
+            (fail-open) rather than raising.
+        base_url: API base URL (defaults to the public deployment, or the
+            ``INVINOVERITAS_BASE_URL`` environment variable).
+        timeout_s: Per-request timeout in seconds. On timeout the provider fails
+            open to :attr:`Verdict.REVIEW_UNAVAILABLE`.
+        sign: Request a portable signed proof on each verdict (default
+            ``True``). The proof is stored in :attr:`AdvisoryResult.detail`.
+        client: Optional pre-constructed :class:`httpx.Client` (primarily for
+            tests / connection reuse). When omitted, a client is created per
+            call and closed afterwards.
+        provider_id: Identifier stamped onto every result.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout_s: float = DEFAULT_TIMEOUT_S,
+        sign: bool = True,
+        client: httpx.Client | None = None,
+        provider_id: str = "invinoveritas",
+    ) -> None:
+        self._api_key = api_key or os.getenv("INVINOVERITAS_API_KEY")
+        self._base_url = (base_url or os.getenv("INVINOVERITAS_BASE_URL") or DEFAULT_BASE_URL).rstrip("/")
+        self._timeout_s = timeout_s
+        self._sign = sign
+        self._client = client
+        self._provider_id = provider_id
+
+    @property
+    def provider_id(self) -> str:
+        """Unique identifier for this advisory provider."""
+        return self._provider_id
+
+    def review(self, context: AdvisoryContext) -> AdvisoryResult:
+        """Obtain an independent ``/review`` verdict for *context*.
+
+        Args:
+            context: Normalized pre-trade context.
+
+        Returns:
+            An :class:`AdvisoryResult`. Any failure (no credit, timeout, network
+            error, non-2xx response, or unparseable body) resolves to
+            :attr:`Verdict.REVIEW_UNAVAILABLE` so the order is never blocked.
+        """
+        payload = {
+            "artifact": self._build_artifact(context),
+            "artifact_type": "trade",
+            "context": self._build_context(context)[:4000],
+            "concerns": (
+                "capital-scale soundness, over-concentration, drawdown sensitivity, position sizing"
+            ),
+            "sign": self._sign,
+        }
+        headers = {"Content-Type": "application/json"}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+
+        try:
+            response = self._post(payload, headers)
+        except httpx.TimeoutException:
+            return self._unavailable("/review timed out")
+        except httpx.HTTPError as exc:
+            return self._unavailable(f"/review request error: {type(exc).__name__}")
+
+        if response.status_code == 402:
+            # Payment required: no usable credit/payment. Observational → fail open.
+            return self._unavailable("/review requires payment (configure a funded api_key)")
+        if response.status_code != 200:
+            return self._unavailable(f"/review returned HTTP {response.status_code}")
+
+        try:
+            body = response.json()
+        except ValueError:
+            return self._unavailable("/review returned an unparseable body")
+
+        return self._to_result(body)
+
+    # -- internals -----------------------------------------------------------
+
+    def _post(self, payload: dict[str, Any], headers: dict[str, str]) -> httpx.Response:
+        """POST *payload* to ``/review``, reusing an injected client if present."""
+        url = f"{self._base_url}/review"
+        if self._client is not None:
+            return self._client.post(url, json=payload, headers=headers, timeout=self._timeout_s)
+        with httpx.Client(timeout=self._timeout_s) as client:
+            return client.post(url, json=payload, headers=headers)
+
+    def _to_result(self, body: dict[str, Any]) -> AdvisoryResult:
+        """Translate a ``/review`` response body into an :class:`AdvisoryResult`."""
+        raw_verdict = str(body.get("verdict") or "").lower()
+        verdict = _VERDICT_MAP.get(raw_verdict)
+        if verdict is None:
+            # Unknown/absent verdict — do not guess; surface as unavailable.
+            return self._unavailable(f"/review returned an unrecognized verdict: {raw_verdict!r}")
+
+        issues = body.get("issues") or []
+        concerns = tuple(
+            f"[{(issue.get('severity') or '?')}] {issue.get('title') or issue.get('detail') or ''}".strip()
+            for issue in issues
+            if isinstance(issue, dict)
+        )
+        proof = body.get("proof") or {}
+        detail: dict[str, Any] = {
+            "review_verdict": raw_verdict,
+            "issues": issues,
+        }
+        if proof:
+            detail["proof"] = proof
+            verify_url = proof.get("verify_url")
+            if verify_url:
+                detail["verify_url"] = verify_url
+
+        confidence = body.get("confidence")
+        return AdvisoryResult(
+            verdict=verdict,
+            confidence=float(confidence) if isinstance(confidence, (int, float)) else None,
+            summary=str(body.get("summary") or ""),
+            concerns=concerns,
+            provider=self._provider_id,
+            detail=detail,
+        )
+
+    def _unavailable(self, summary: str) -> AdvisoryResult:
+        """Build a fail-open :attr:`Verdict.REVIEW_UNAVAILABLE` result."""
+        logger.warning("invinoveritas advisory unavailable: %s", summary)
+        return AdvisoryResult(
+            verdict=Verdict.REVIEW_UNAVAILABLE,
+            summary=summary,
+            provider=self._provider_id,
+        )
+
+    @staticmethod
+    def _build_artifact(context: AdvisoryContext) -> str:
+        """Render the proposed order as the artifact under review."""
+        return (
+            f"Proposed order: {context.side.upper()} {context.symbol} "
+            f"for ${context.notional_usd:,.2f} notional."
+        )
+
+    @staticmethod
+    def _build_context(context: AdvisoryContext) -> str:
+        """Render the account state that makes the verdict capital-scale-aware."""
+        return (
+            f"Account equity ${context.account_equity:,.2f}; "
+            f"committed funding ${context.funding_usd:,.2f}; "
+            f"funding utilization {context.utilization_ratio:.0%}; "
+            f"{context.open_position_count} open position(s); "
+            f"total open exposure ${context.total_exposure_usd:,.2f}. "
+            "Is this specific order sound right now given the account state and scale?"
+        )

--- a/agent/src/live/advisory/invinoveritas.py
+++ b/agent/src/live/advisory/invinoveritas.py
@@ -52,6 +52,12 @@ logger = logging.getLogger(__name__)
 DEFAULT_BASE_URL = "https://api.babyblueviper.com"
 DEFAULT_TIMEOUT_S = 8.0
 
+# The fixed question appended to the rendered account state. Kept as a module
+# constant so the request contract lives in one place (and is assertable in tests).
+_CONTEXT_QUESTION = (
+    "Is this specific order sound right now given the account state and scale?"
+)
+
 # Map the /review verdict vocabulary onto the local advisory Verdict enum.
 # /review can return "revise" (a soft "tighten this before shipping"); it is a
 # concern, not a hard reject, so it maps to APPROVE_WITH_CONCERNS.
@@ -95,6 +101,12 @@ class InvinoveritasAdvisory(PreTradeAdvisoryInterface):
     ) -> None:
         self._api_key = api_key or os.getenv("INVINOVERITAS_API_KEY")
         self._base_url = (base_url or os.getenv("INVINOVERITAS_BASE_URL") or DEFAULT_BASE_URL).rstrip("/")
+        if self._api_key and not self._base_url.startswith("https://"):
+            # A non-HTTPS base_url would transmit the bearer api_key in cleartext.
+            logger.warning(
+                "invinoveritas base_url is not HTTPS (%s); the api_key would be sent in cleartext",
+                self._base_url,
+            )
         self._timeout_s = timeout_s
         self._sign = sign
         self._client = client
@@ -220,5 +232,5 @@ class InvinoveritasAdvisory(PreTradeAdvisoryInterface):
             f"funding utilization {context.utilization_ratio:.0%}; "
             f"{context.open_position_count} open position(s); "
             f"total open exposure ${context.total_exposure_usd:,.2f}. "
-            "Is this specific order sound right now given the account state and scale?"
+            f"{_CONTEXT_QUESTION}"
         )

--- a/agent/tests/test_invinoveritas_advisory.py
+++ b/agent/tests/test_invinoveritas_advisory.py
@@ -175,3 +175,39 @@ def test_orchestrator_worst_case_with_invinoveritas_reject() -> None:
     aggregated = orchestrator.review(_context())
     assert aggregated.verdict is Verdict.REJECT
     assert len(aggregated.results) == 2
+
+
+def test_no_api_key_sends_no_auth_header(monkeypatch: Any) -> None:
+    """With no api_key and no env var, no Authorization header is sent (no secret leaks)."""
+    monkeypatch.delenv("INVINOVERITAS_API_KEY", raising=False)
+    captured: list[httpx.Request] = []
+    provider = _provider(_json_handler({"verdict": "approve"}, capture=captured))
+    provider.review(_context())
+    assert len(captured) == 1
+    assert "authorization" not in {k.lower() for k in captured[0].headers}
+
+
+def test_non_json_body_fails_open() -> None:
+    """A 200 with an unparseable body must fail open (ValueError path), never block."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"<html>not json</html>")
+
+    provider = _provider(handler)
+    result = provider.review(_context())
+    assert result.verdict is Verdict.REVIEW_UNAVAILABLE
+    assert "unparseable" in result.summary.lower()
+
+
+def test_env_var_fallback_for_key_and_base_url(monkeypatch: Any) -> None:
+    """api_key and base_url fall back to env vars when not passed explicitly."""
+    monkeypatch.setenv("INVINOVERITAS_API_KEY", "ivk_env_key")
+    monkeypatch.setenv("INVINOVERITAS_BASE_URL", "https://review.example.test")
+    captured: list[httpx.Request] = []
+    # No api_key / base_url passed → constructor must read the env.
+    provider = _provider(_json_handler({"verdict": "approve"}, capture=captured))
+    provider.review(_context())
+    assert len(captured) == 1
+    request = captured[0]
+    assert request.headers["Authorization"] == "Bearer ivk_env_key"
+    assert request.url.host == "review.example.test"

--- a/agent/tests/test_invinoveritas_advisory.py
+++ b/agent/tests/test_invinoveritas_advisory.py
@@ -1,0 +1,177 @@
+"""Tests for the invinoveritas /review advisory provider (#317 follow-up).
+
+All tests are offline: an :class:`httpx.MockTransport` stands in for the network
+so the provider's request shape and response mapping are exercised without any
+live call. Covers verdict mapping, the fail-open contract (402 / non-2xx /
+timeout / unknown verdict), proof passthrough, auth header, the request
+contract sent to /review, and orchestrator aggregation.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable
+
+import httpx
+
+from src.live.advisory import (
+    AdvisoryContext,
+    AdvisoryOrchestrator,
+    Verdict,
+)
+from src.live.advisory.invinoveritas import InvinoveritasAdvisory
+
+
+def _context(**overrides: Any) -> AdvisoryContext:
+    base: dict[str, Any] = {
+        "symbol": "AAPL",
+        "side": "buy",
+        "notional_usd": 750.0,
+        "account_equity": 5000.0,
+        "utilization_ratio": 0.15,
+        "open_position_count": 2,
+        "total_exposure_usd": 1800.0,
+        "funding_usd": 5000.0,
+    }
+    base.update(overrides)
+    return AdvisoryContext(**base)
+
+
+def _provider(
+    handler: Callable[[httpx.Request], httpx.Response],
+    **kwargs: Any,
+) -> InvinoveritasAdvisory:
+    """Build a provider whose HTTP calls are served by *handler* (no network)."""
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    return InvinoveritasAdvisory(client=client, **kwargs)
+
+
+def _json_handler(
+    body: dict[str, Any],
+    status_code: int = 200,
+    capture: list[httpx.Request] | None = None,
+) -> Callable[[httpx.Request], httpx.Response]:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if capture is not None:
+            capture.append(request)
+        return httpx.Response(status_code, json=body)
+
+    return handler
+
+
+def test_provider_id_default() -> None:
+    provider = InvinoveritasAdvisory()
+    assert provider.provider_id == "invinoveritas"
+
+
+def test_approve_maps_to_approve() -> None:
+    provider = _provider(_json_handler({"verdict": "approve", "summary": "looks fine"}))
+    result = provider.review(_context())
+    assert result.verdict is Verdict.APPROVE
+    assert result.provider == "invinoveritas"
+    assert result.summary == "looks fine"
+
+
+def test_reject_maps_and_carries_concerns() -> None:
+    body = {
+        "verdict": "reject",
+        "confidence": 0.9,
+        "summary": "over-sized for this account",
+        "issues": [
+            {"severity": "high", "title": "notional exceeds prudent fraction of equity"},
+            {"severity": "medium", "title": "concentration in a single name"},
+        ],
+    }
+    provider = _provider(_json_handler(body))
+    result = provider.review(_context())
+    assert result.verdict is Verdict.REJECT
+    assert result.confidence == 0.9
+    assert result.concerns == (
+        "[high] notional exceeds prudent fraction of equity",
+        "[medium] concentration in a single name",
+    )
+
+
+def test_revise_is_soft_concern_not_reject() -> None:
+    provider = _provider(_json_handler({"verdict": "revise", "summary": "tighten the size"}))
+    result = provider.review(_context())
+    assert result.verdict is Verdict.APPROVE_WITH_CONCERNS
+
+
+def test_approve_with_concerns_maps() -> None:
+    provider = _provider(_json_handler({"verdict": "approve_with_concerns"}))
+    result = provider.review(_context())
+    assert result.verdict is Verdict.APPROVE_WITH_CONCERNS
+
+
+def test_payment_required_fails_open() -> None:
+    provider = _provider(_json_handler({"error": "payment required"}, status_code=402))
+    result = provider.review(_context())
+    assert result.verdict is Verdict.REVIEW_UNAVAILABLE
+    assert "payment" in result.summary.lower()
+
+
+def test_server_error_fails_open() -> None:
+    provider = _provider(_json_handler({"error": "boom"}, status_code=500))
+    result = provider.review(_context())
+    assert result.verdict is Verdict.REVIEW_UNAVAILABLE
+    assert "500" in result.summary
+
+
+def test_timeout_fails_open() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("slow", request=request)
+
+    provider = _provider(handler)
+    result = provider.review(_context())
+    assert result.verdict is Verdict.REVIEW_UNAVAILABLE
+    assert "timed out" in result.summary
+
+
+def test_unknown_verdict_fails_open() -> None:
+    provider = _provider(_json_handler({"verdict": "maybe"}))
+    result = provider.review(_context())
+    assert result.verdict is Verdict.REVIEW_UNAVAILABLE
+
+
+def test_proof_passthrough_into_detail() -> None:
+    body = {
+        "verdict": "approve",
+        "proof": {"verify_url": "https://api.babyblueviper.com/verify-proof?id=abc", "sig": "deadbeef"},
+    }
+    provider = _provider(_json_handler(body))
+    result = provider.review(_context())
+    assert result.detail["proof"]["sig"] == "deadbeef"
+    assert result.detail["verify_url"] == "https://api.babyblueviper.com/verify-proof?id=abc"
+
+
+def test_request_contract_sent_to_review() -> None:
+    captured: list[httpx.Request] = []
+    provider = _provider(
+        _json_handler({"verdict": "approve"}, capture=captured),
+        api_key="ivk_test_key",
+    )
+    provider.review(_context(symbol="BTC-USDT", side="sell", notional_usd=1234.5))
+
+    assert len(captured) == 1
+    request = captured[0]
+    assert request.url.path == "/review"
+    assert request.headers["Authorization"] == "Bearer ivk_test_key"
+    sent = json.loads(request.content)
+    assert sent["artifact_type"] == "trade"
+    assert sent["sign"] is True
+    assert "BTC-USDT" in sent["artifact"]
+    assert "SELL" in sent["artifact"]
+    # Account state must reach the reviewer so the verdict is capital-scale-aware.
+    assert "equity" in sent["context"].lower()
+    assert len(sent["context"]) <= 4000
+
+
+def test_orchestrator_worst_case_with_invinoveritas_reject() -> None:
+    from src.live.advisory.mock import MockAdvisory
+
+    invino = _provider(_json_handler({"verdict": "reject", "summary": "no"}))
+    orchestrator = AdvisoryOrchestrator([MockAdvisory(verdict=Verdict.APPROVE), invino])
+    aggregated = orchestrator.review(_context())
+    assert aggregated.verdict is Verdict.REJECT
+    assert len(aggregated.results) == 2


### PR DESCRIPTION
## Summary

Follow-up to the merged advisory interface (#328): add `InvinoveritasAdvisory`, the first concrete `PreTradeAdvisoryInterface` implementation, backed by the invinoveritas [`/review`](https://api.babyblueviper.com) endpoint. As anticipated in #328 ("the `InvinoveritasAdvisory` HTTP implementation is a follow-up PR"), this wires a real external risk reviewer into the observational advisory slot without touching the mandate enforcement path.

Closes the implementation half of #317.

## What it does

`InvinoveritasAdvisory.review(context)` builds a `trade` artifact from the broker-agnostic `AdvisoryContext` and calls `/review` with `artifact_type="trade"` — which triggers invinoveritas's capital-scale-aware risk-manager review (account equity, exposure, drawdown, position count). The response verdict is mapped onto the local `Verdict` enum:

| `/review` verdict | local `Verdict` |
|---|---|
| `approve` | `APPROVE` |
| `approve_with_concerns` | `APPROVE_WITH_CONCERNS` |
| `revise` | `APPROVE_WITH_CONCERNS` (soft concern, not a hard reject) |
| `reject` | `REJECT` |
| anything else / absent | `REVIEW_UNAVAILABLE` (never guess a verdict) |

Two properties beyond a local rule engine:

- **Independent** — the verdict comes from a party that is *not* the agent placing the order, so "is this wise?" is not graded by the same component that produced the order.
- **Recomputable** — with `sign=True` (default), `/review` returns a portable signed proof. It is stored in `AdvisoryResult.detail` (`proof` + `verify_url`) so the existing `gate_decision["advisory"]` audit record stays independently verifiable after the fact, against a published key, without trusting this runtime.

## Respects the existing contract

- **Observational only** — returns an `AdvisoryResult`; the mandate gate remains the sole allow/deny authority. No execution-path or audit-schema changes.
- **Fail-open** — no credit (HTTP 402), timeout, network error, non-2xx, or unparseable/unknown verdict all resolve to `REVIEW_UNAVAILABLE`. An advisory outage never blocks an order. (`AdvisoryOrchestrator` already converts raised exceptions too; this provider additionally returns informative fail-open summaries so the audit trail distinguishes "payment required" from "timeout" from "provider error".)
- **No new dependency** — uses `httpx` (already in `pyproject.toml`). The `httpx.Client` is injectable for tests/reuse.
- **Config** — `api_key` / `base_url` via constructor args or `INVINOVERITAS_API_KEY` / `INVINOVERITAS_BASE_URL` env vars.

Registration is unchanged from #328:

```python
from src.live.advisory import register_advisory_provider
from src.live.advisory.invinoveritas import InvinoveritasAdvisory

register_advisory_provider(InvinoveritasAdvisory(api_key="ivk_..."))
```

## Tests

`agent/tests/test_invinoveritas_advisory.py` — **12 tests, fully offline** via `httpx.MockTransport` (no network):

- verdict mapping (approve / reject+concerns / revise→soft / approve_with_concerns)
- fail-open paths: 402, HTTP 500, read timeout, unknown verdict
- proof + `verify_url` passthrough into `detail`
- request contract sent to `/review` (`artifact_type="trade"`, `sign=true`, bearer auth header, account state present in context, context ≤ 4000 chars)
- orchestrator worst-case aggregation with an invinoveritas `reject`

```
$ PYTHONPATH=agent pytest agent/tests/test_invinoveritas_advisory.py -q
12 passed

$ PYTHONPATH=agent pytest agent/tests/test_advisory.py agent/tests/test_invinoveritas_advisory.py -q
23 passed        # no regression on the #328 advisory suite

$ ruff check agent/src/live/advisory/invinoveritas.py agent/tests/test_invinoveritas_advisory.py
All checks passed!
```

I ran the new + existing advisory suites and ruff locally; I was not able to run the full repo suite under your `conda run -n legonanobot` environment, so CI is the source of truth there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)