### PR TITLE
feat(i18n): default UI language to Chinese (zh-CN)

### DIFF
--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -48,11 +48,10 @@ i18n
       ko: { translation: ko },
       ar: { translation: ar },
     },
-    // Default to English for everyone on first visit; only an explicit toggle
-    // (persisted to localStorage) switches language. After a manual choice
-    // the navigator value can act as a fallback when the saved language is
-    // removed.
-    fallbackLng: "en",
+    // Default to Chinese when no explicit choice is saved and the browser
+    // locale does not match a supported language. An explicit toggle
+    // (persisted to localStorage) always takes precedence.
+    fallbackLng: "zh-CN",
     supportedLngs: SUPPORTED_LANGUAGES.map((l) => l.code),
     // Allow "en-US" → "en", "ja-JP" → "ja", etc.
     nonExplicitSupportedLngs: true,


### PR DESCRIPTION
Switch fallbackLng from en to zh-CN so first-time visitors see the Chinese UI by default. The English toggle (persisted to localStorage) still works. The full zh-CN translation pack already shipped upstream.

## Summary

<!-- What does this PR do? 1-3 bullet points. -->

-

## Why

<!-- What problem does it solve? Link related issues with "Closes #123". -->

## Changes

<!-- List key changes. For new skills/presets, describe what they cover. -->

-

## Test Plan

- [x] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [x] New tests added (if applicable)
- [x] Tested manually (describe below)

## Checklist

- [ ] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [ ] No hardcoded values (API keys, file paths, magic numbers)
- [ ] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] Documentation updated (if user-facing change)
