### PR TITLE
fix(api): default bind to 127.0.0.1 and warn on non-loopback without API_AUTH_KEY

### DIFF
--- a/agent/api_server.py
+++ b/agent/api_server.py
@@ -547,6 +547,14 @@ def _is_allowed_loopback_host(host: str) -> bool:
     return normalized in _DEFAULT_LOOPBACK_HOSTS or normalized in _EXTRA_LOOPBACK_HOSTS
 
 
+def _is_loopback_bind_host(host: str) -> bool:
+    """Return whether ``host`` resolves to a loopback interface."""
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return host == "localhost"
+
+
 # CORS: override with CORS_ORIGINS (comma-separated explicit origins)
 _CORS_ORIGINS = _parse_cors_origins(os.getenv("CORS_ORIGINS"))
 
@@ -3493,12 +3501,19 @@ def serve_main(argv: list[str] | None = None) -> int:
 
     parser = argparse.ArgumentParser(description="Vibe-Trading Server")
     parser.add_argument("--port", type=int, default=8000, help="Listen port (default 8000)")
-    parser.add_argument("--host", default="0.0.0.0", help="Bind address")
+    parser.add_argument("--host", default="127.0.0.1", help="Bind address")
     parser.add_argument("--dev", action="store_true", help="Dev mode: spawn Vite on :5173")
     try:
         args = parser.parse_args(argv)
     except SystemExit as exc:
         return int(exc.code) if isinstance(exc.code, int) else 2
+
+    if not _is_loopback_bind_host(args.host) and not _configured_api_key():
+        print(
+            f"[warn] Binding to {args.host} without API_AUTH_KEY set. "
+            f"Remote requests are rejected by the loopback peer-IP check, "
+            f"but consider using --host 127.0.0.1 for local-only access."
+        )
 
     frontend_dist = Path(__file__).resolve().parent.parent / "frontend" / "dist"
     frontend_root = Path(__file__).resolve().parent.parent / "frontend"

--- a/agent/cli/main.py
+++ b/agent/cli/main.py
@@ -1314,7 +1314,7 @@ def _build_typer_app():  # type: ignore[no-untyped-def]
 
     @app.command("serve", help="Start the FastAPI server.")
     def _serve(
-        host: str = typer.Option("0.0.0.0", "--host"),
+        host: str = typer.Option("127.0.0.1", "--host"),
         port: int = typer.Option(8000, "--port"),
         dev: bool = typer.Option(False, "--dev", help="Also boot the Vite dev server."),
     ) -> None:

--- a/agent/tests/test_serve_bind.py
+++ b/agent/tests/test_serve_bind.py
@@ -1,0 +1,111 @@
+"""Tests for the API server bind default and non-loopback warning.
+
+Covers the secure-by-default behavior added for #333:
+  - `_is_loopback_bind_host` classification (IPv4 / IPv6 / hostname / edge)
+  - `serve_main` defaults the bind address to loopback (127.0.0.1)
+  - binding a non-loopback address without API_AUTH_KEY emits a startup warning,
+    while loopback or a configured key stays quiet
+
+Warning assertions match the bind warning's own text rather than the bare
+``[warn]`` prefix, so an unrelated startup warning (e.g. a missing frontend
+build in CI) cannot satisfy or break them.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+import api_server
+
+# Unique substring of the non-loopback bind warning (api_server.py:3513).
+_BIND_WARN = "without API_AUTH_KEY set"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "host, expected",
+    [
+        ("127.0.0.1", True),
+        ("127.0.0.2", True),
+        ("::1", True),
+        ("0:0:0:0:0:0:0:1", True),
+        ("localhost", True),
+        ("0.0.0.0", False),
+        ("::", False),
+        ("192.168.1.5", False),
+        ("", False),
+    ],
+)
+def test_is_loopback_bind_host(host: str, expected: bool) -> None:
+    assert api_server._is_loopback_bind_host(host) is expected
+
+
+def _run_serve(argv: list[str]) -> str | None:
+    """Invoke serve_main with uvicorn stubbed; return the host it bound to.
+
+    The frontend mount / static-file branches are short-circuited because
+    uvicorn.run raises SystemExit before reaching the server loop.
+    """
+    captured: dict[str, object] = {}
+
+    def fake_run(*args: object, **kwargs: object) -> None:
+        captured["host"] = kwargs.get("host") or (args[1] if len(args) > 1 else None)
+        raise SystemExit(0)
+
+    with mock.patch("uvicorn.run", fake_run):
+        try:
+            api_server.serve_main(argv)
+        except SystemExit:
+            pass
+    return captured.get("host")  # type: ignore[return-value]
+
+
+@pytest.mark.unit
+def test_serve_defaults_to_loopback() -> None:
+    assert _run_serve([]) == "127.0.0.1"
+
+
+@pytest.mark.unit
+def test_serve_honors_explicit_host() -> None:
+    assert _run_serve(["--host", "0.0.0.0"]) == "0.0.0.0"
+
+
+@pytest.mark.unit
+def test_non_loopback_without_key_warns(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("API_AUTH_KEY", raising=False)
+    monkeypatch.setattr(api_server, "_API_KEY", None, raising=False)
+
+    _run_serve(["--host", "0.0.0.0"])
+
+    out = capsys.readouterr().out
+    assert _BIND_WARN in out
+
+
+@pytest.mark.unit
+def test_loopback_does_not_warn(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("API_AUTH_KEY", raising=False)
+    monkeypatch.setattr(api_server, "_API_KEY", None, raising=False)
+
+    _run_serve(["--host", "127.0.0.1"])
+
+    out = capsys.readouterr().out
+    assert _BIND_WARN not in out
+
+
+@pytest.mark.unit
+def test_non_loopback_with_key_does_not_warn(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("API_AUTH_KEY", "secret")
+    monkeypatch.setattr(api_server, "_API_KEY", "secret", raising=False)
+
+    _run_serve(["--host", "0.0.0.0"])
+
+    out = capsys.readouterr().out
+    assert _BIND_WARN not in out


### PR DESCRIPTION
## Summary

Default the `--host` bind address from `0.0.0.0` to `127.0.0.1`, and log a startup warning when binding to a non-loopback address without `API_AUTH_KEY` configured.

## Why

The Docker compose already binds to `127.0.0.1:8899:8899`, so loopback-only is the intended secure-by-default posture — but the bare CLI default of `0.0.0.0` did not match. The existing loopback peer-IP and DNS-rebinding checks still reject remote requests, but defense-in-depth argues the bind itself should default to loopback. Binding to all interfaces should be a conscious opt-in, with a warning when done without `API_AUTH_KEY`.

## Changes

- `agent/api_server.py`: `--host` default `"0.0.0.0"` → `"127.0.0.1"`; added `_is_loopback_bind_host()` (`ipaddress.is_loopback` + `"localhost"` fallback); startup warning when binding non-loopback without `API_AUTH_KEY`.
- `agent/cli/main.py`: Typer `serve` command `--host` default also set to `127.0.0.1`, so every serve entry point agrees. The console script and `python -m cli` already bound loopback (they route through the argparse path); this covers the `python -m cli.main` Typer path too.
- `agent/tests/test_serve_bind.py`: new test coverage.

Docker is unaffected: the Dockerfile passes `--host 0.0.0.0` explicitly and compose binds loopback on the host side — neither relies on the default.

I left out one reviewer-style nit — only computing the warning state lazily — because the check is a single comparison at startup, not a hot path.

## Test Plan

- [x] ruff check (changed files) — clean (the 5 F821 in `api_server.py` pre-exist on origin/main; none introduced)
- [x] pytest tests/test_serve_bind.py — 14 passed (`_is_loopback_bind_host` truth table incl. IPv6/hostname/edge, loopback default, warning only on non-loopback without a key)
- [x] pytest (full, excl e2e) — passes, zero failures

## Checklist

- [x] No changes to protected areas without prior discussion
- [x] No hardcoded values
- [x] Code follows CONTRIBUTING.md guidelines
- [x] Documentation updated (if user-facing change) — n/a, default/behavior change

Refs #333