### PR TITLE
fix(docker): bind frontend dev port to loopback for consistency with backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     image: node:20
     working_dir: /app
     ports:
-      - "5899:5899"
+      - "127.0.0.1:5899:5899"
     volumes:
       - ./frontend:/app
     environment:


### PR DESCRIPTION
## Summary

- Bind the frontend dev service port to `127.0.0.1:5899:5899` instead of `5899:5899` (all interfaces), matching the backend's existing `127.0.0.1:8899:8899` loopback discipline.

## Why

The optional `frontend` dev service in `docker-compose.yml` published port 5899 on all host interfaces (`0.0.0.0`), while the backend was correctly bound to `127.0.0.1:8899`. On a shared/LAN network, this exposed the Vite dev server — source, module graph, and HMR websocket — to other hosts unnecessarily.

Closes #334

## Changes

- `docker-compose.yml` line 35: `"5899:5899"` → `"127.0.0.1:5899:5899"`

## Test Plan

- [x] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`) — no code changes, compose-only fix
- [x] New tests added (if applicable) — N/A
- [x] Tested manually: verified `docker compose config` renders the loopback-prefixed port correctly

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] Documentation updated (if user-facing change) — the compose file is self-documenting; the `frontend` profile remains opt-in and dev-only