### PR TITLE
refactor(api): extract shared infrastructure + uploads routes into src/api/

### DIFF
--- a/agent/api_server.py
+++ b/agent/api_server.py
@@ -2322,110 +2322,19 @@ async def session_events(
 
 
 # ============================================================================
-# File Upload
+# Upload routes — defined in src/api/uploads_routes.py
 # ============================================================================
 
-_BLOCKED_UPLOAD_EXT = {
-    # binaries / executables we should never accept
-    ".exe", ".msi", ".bat", ".cmd", ".com", ".scr", ".app", ".dmg",
-    ".so", ".dll", ".dylib",
-    # executable-adjacent source, shell, config, and template files
-    ".py", ".pyw", ".sh", ".bash", ".zsh", ".fish", ".ps1",
-    ".yaml", ".yml", ".j2", ".jinja", ".jinja2", ".template",
-    # archives — don't auto-extract; user can unpack locally
-    ".zip", ".rar", ".7z", ".tar", ".gz", ".tgz", ".bz2", ".xz",
-}
+from src.api.uploads_routes import register_uploads_routes  # noqa: E402
+register_uploads_routes(app)
 
-_BLOCKED_UPLOAD_NAMES = {
-    "dockerfile",
-    "containerfile",
-}
-
-
-_SHADOW_ID_RE = __import__("re").compile(r"^shadow_[0-9a-f]{8}$")
-
-
-@app.get("/shadow-reports/{shadow_id}", dependencies=[Depends(require_auth)])
-async def get_shadow_report(shadow_id: str, format: str = "html"):
-    """Serve a rendered Shadow Account report (HTML by default, PDF if available).
-
-    Reports live under ``~/.vibe-trading/shadow_reports/<shadow_id>.{html,pdf}``.
-    """
-    if not _SHADOW_ID_RE.match(shadow_id):
-        raise HTTPException(status_code=400, detail="invalid shadow_id")
-    if format not in ("html", "pdf"):
-        raise HTTPException(status_code=400, detail="format must be html or pdf")
-
-    reports_dir = Path.home() / ".vibe-trading" / "shadow_reports"
-    path = reports_dir / f"{shadow_id}.{format}"
-    if not path.exists():
-        raise HTTPException(status_code=404, detail=f"Shadow report not found: {shadow_id}.{format}")
-
-    media_type = "text/html; charset=utf-8" if format == "html" else "application/pdf"
-    # Inline so browsers render HTML/PDF directly instead of forcing download.
-    return FileResponse(
-        path,
-        media_type=media_type,
-        headers={"Content-Disposition": f'inline; filename="{shadow_id}.{format}"'},
-    )
-
-
-@app.post("/upload", dependencies=[Depends(require_auth)])
-async def upload_file(file: UploadFile):
-    """Upload any document or data file (max 50MB).
-
-    Accepts most common formats: PDF, Word, Excel, PowerPoint, images,
-    CSV/TSV, plain text, JSON, and TOML. Executables, executable-adjacent
-    source/config/template files, and archives are rejected.
-    """
-    if not file.filename:
-        raise HTTPException(status_code=400, detail="Missing filename")
-    filename = Path(file.filename).name
-    ext = Path(filename).suffix.lower()
-    if ext in _BLOCKED_UPLOAD_EXT or filename.lower() in _BLOCKED_UPLOAD_NAMES:
-        raise HTTPException(
-            status_code=400,
-            detail="This file type is not allowed for upload.",
-        )
-
-    safe_name = f"{uuid.uuid4().hex}{ext}"
-    dest = UPLOADS_DIR / safe_name
-    total_size = 0
-
-    try:
-        UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
-        with dest.open("wb") as handle:
-            while True:
-                chunk = await file.read(_UPLOAD_CHUNK_SIZE)
-                if not chunk:
-                    break
-                total_size += len(chunk)
-                if total_size > MAX_UPLOAD_SIZE:
-                    handle.close()
-                    if dest.exists():
-                        dest.unlink()
-                    raise HTTPException(
-                        status_code=413,
-                        detail=f"File too large (limit {MAX_UPLOAD_SIZE // (1024 * 1024)} MB)",
-                    )
-                handle.write(chunk)
-    except HTTPException:
-        raise
-    except OSError as exc:
-        if dest.exists():
-            dest.unlink()
-        raise HTTPException(
-            status_code=500,
-            detail="Upload failed while storing the file. Please retry or choose a different file.",
-        ) from exc
-    finally:
-        await file.close()
-
-    return {
-        "status": "ok",
-        "file_path": f"uploads/{safe_name}",
-        "filename": filename,
-    }
+# Re-export upload constants for test access via ``api_server.*``
+from src.api.uploads_routes import (  # noqa: E402
+    _BLOCKED_UPLOAD_EXT,
+    _BLOCKED_UPLOAD_NAMES,
+    _SHADOW_ID_RE,
+)
+from src.api.helpers import UPLOADS_DIR, MAX_UPLOAD_SIZE, _UPLOAD_CHUNK_SIZE  # noqa: E402
 
 
 # ============================================================================

--- a/agent/src/api/deps.py
+++ b/agent/src/api/deps.py
@@ -1,0 +1,393 @@
+"""Auth dependencies and security helpers for the Vibe-Trading API server.
+
+Extracted verbatim from ``api_server.py`` (PR-0 of the api_server refactor).
+This is a LEAF module — it imports only from stdlib + FastAPI.
+"""
+
+from __future__ import annotations
+
+import hmac
+import ipaddress
+import os
+import urllib.parse
+from pathlib import Path
+from typing import Optional
+
+from fastapi import HTTPException, Query, Request, Security, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+
+# ============================================================================
+# Constants
+# ============================================================================
+
+_DEFAULT_CORS_ORIGINS = [
+    "http://localhost:3000",
+    "http://localhost:5173",
+    "http://localhost:8000",
+    "http://127.0.0.1:3000",
+    "http://127.0.0.1:5173",
+    "http://127.0.0.1:8000",
+]
+
+_DEFAULT_LOOPBACK_HOSTS = frozenset({
+    "localhost",
+    "127.0.0.1",
+    "::1",
+    "[::1]",
+    # Starlette/FastAPI TestClient default host; included so unit tests exercise
+    # the API without having to override Host on every request.
+    "testserver",
+})
+
+
+def _parse_cors_origins(raw: Optional[str]) -> list[str]:
+    """Parse CORS origins and reject credentialed wildcard configuration.
+
+    Args:
+        raw: Comma-separated CORS origins from ``CORS_ORIGINS``. ``None`` or a
+            blank value uses the loopback development defaults.
+
+    Returns:
+        Explicit CORS origins accepted by the API server.
+
+    Raises:
+        RuntimeError: If a wildcard origin is configured while credentials are
+            enabled.
+    """
+    if raw is None or not raw.strip():
+        return list(_DEFAULT_CORS_ORIGINS)
+    origins = [origin.strip() for origin in raw.split(",") if origin.strip()]
+    if "*" in origins:
+        raise RuntimeError(
+            "CORS_ORIGINS='*' is not allowed while credentials are enabled; "
+            "configure explicit Web UI origins instead."
+        )
+    return origins
+
+
+def _parse_extra_loopback_hosts(raw: Optional[str]) -> set[str]:
+    """Return additional trusted Host names for loopback API traffic."""
+    if raw is None or not raw.strip():
+        return set()
+    return {host.strip().lower().rstrip(".") for host in raw.split(",") if host.strip()}
+
+
+_EXTRA_LOOPBACK_HOSTS = _parse_extra_loopback_hosts(os.getenv("API_ALLOWED_HOSTS"))
+
+
+def _host_without_port(host: str) -> str:
+    """Normalize a Host header to a lowercase hostname without a port."""
+    value = host.strip().lower().rstrip(".")
+    if not value:
+        return ""
+    if value.startswith("["):
+        end = value.find("]")
+        if end != -1:
+            return value[: end + 1]
+        return value
+    if value.count(":") == 1:
+        return value.rsplit(":", 1)[0]
+    return value
+
+
+def _is_allowed_loopback_host(host: str) -> bool:
+    """Return whether ``host`` is allowed for loopback-trusted API requests."""
+    normalized = _host_without_port(host)
+    return normalized in _DEFAULT_LOOPBACK_HOSTS or normalized in _EXTRA_LOOPBACK_HOSTS
+
+
+# ============================================================================
+# API Key Authentication
+# ============================================================================
+
+_security = HTTPBearer(auto_error=False)
+_API_KEY = os.getenv("API_AUTH_KEY")
+_SHELL_TOOLS_ENV = "VIBE_TRADING_ENABLE_SHELL_TOOLS"
+_DOCKER_LOOPBACK_ENV = "VIBE_TRADING_TRUST_DOCKER_LOOPBACK"
+
+
+def _configured_api_key() -> str:
+    """Return the current API auth key, if configured."""
+    return os.getenv("API_AUTH_KEY") or _API_KEY or ""
+
+
+async def require_auth(
+    request: Request,
+    cred: Optional[HTTPAuthorizationCredentials] = Security(_security),
+) -> None:
+    """Validate Bearer token for sensitive API endpoints.
+
+    Args:
+        request: Incoming HTTP request.
+        cred: HTTP Bearer credentials extracted from the Authorization header.
+
+    Raises:
+        HTTPException: 403 when dev-mode auth is reached from a non-local client.
+        HTTPException: 401 when API_AUTH_KEY is set but the token is missing or wrong.
+    """
+    _validate_api_auth(request=request, cred=cred)
+
+
+async def require_event_stream_auth(
+    request: Request,
+    api_key: Optional[str] = Query(None),
+    cred: Optional[HTTPAuthorizationCredentials] = Security(_security),
+) -> None:
+    """Validate auth for browser EventSource streams.
+
+    Native EventSource cannot send custom Authorization headers, so event
+    stream endpoints may accept the API key from the query string. Normal JSON
+    endpoints must continue to use Bearer auth only.
+
+    Args:
+        request: Incoming HTTP request.
+        api_key: Optional query-string API key for EventSource clients.
+        cred: HTTP Bearer credentials extracted from the Authorization header.
+    """
+    _validate_api_auth(request=request, cred=cred, query_api_key=api_key, allow_query=True)
+
+
+def _auth_credential_from_header_or_query(
+    cred: Optional[HTTPAuthorizationCredentials],
+    query_api_key: Optional[str],
+    *,
+    allow_query: bool,
+) -> str:
+    """Return the supplied API credential from the permitted source."""
+    if cred and cred.credentials:
+        return cred.credentials
+    if allow_query and query_api_key:
+        return query_api_key
+    return ""
+
+
+def _is_loopback_origin(origin: str) -> bool:
+    """Return whether a browser Origin header names a loopback web UI."""
+    try:
+        parsed = urllib.parse.urlsplit(origin)
+    except ValueError:
+        return False
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return False
+    host = parsed.hostname.rstrip(".").lower()
+    if host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def _origin_matches_request_host(origin: str, request: Request) -> bool:
+    """Return whether ``origin`` is the same site serving this request."""
+    try:
+        parsed = urllib.parse.urlsplit(origin)
+    except ValueError:
+        return False
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return False
+
+    origin_host = parsed.hostname.rstrip(".").lower()
+    origin_port = parsed.port
+    request_host = _host_without_port(request.headers.get("host", ""))
+    if origin_host != request_host:
+        return False
+
+    if origin_port is None:
+        origin_port = 443 if parsed.scheme == "https" else 80
+    request_port = request.url.port
+    if request_port is None:
+        request_port = 443 if request.url.scheme == "https" else 80
+    return origin_port == request_port
+
+
+def _reject_cross_site_browser_request(request: Request) -> None:
+    """Reject unsafe browser requests from untrusted cross-site origins.
+
+    CORS protects response reads, not blind form/fetch side effects. Keep local
+    CLI/curl clients and same-origin browser UI deployments working while
+    refusing browser-originated cross-site POSTs to local control-plane actions
+    such as shutdown.
+    """
+    sec_fetch_site = request.headers.get("sec-fetch-site", "").lower()
+    if sec_fetch_site == "cross-site":
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Cross-site request denied")
+
+    origin = request.headers.get("origin")
+    if origin and not (_is_loopback_origin(origin) or _origin_matches_request_host(origin, request)):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Cross-site request denied")
+
+
+def _require_shutdown_authorization(
+    *,
+    request: Request,
+    cred: Optional[HTTPAuthorizationCredentials],
+) -> None:
+    """Authorize the local shutdown control-plane action.
+
+    Loopback peer IP alone is not enough for this browser-reachable, destructive
+    action. When API_AUTH_KEY is configured, require the Bearer token even for
+    loopback requests; otherwise preserve local dev-mode shutdown for direct
+    loopback clients while rejecting cross-site browser requests.
+    """
+    _reject_cross_site_browser_request(request)
+    api_key = _configured_api_key()
+    if api_key:
+        token = _auth_credential_from_header_or_query(cred, None, allow_query=False)
+        if not token or not hmac.compare_digest(token, api_key):
+            raise HTTPException(status_code=401, detail="Invalid or missing API key")
+        return
+    if not _is_local_client(request):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="API_AUTH_KEY is required for non-local API access",
+        )
+
+
+_SAFE_BROWSER_METHODS = {"GET", "HEAD", "OPTIONS"}
+
+
+def _validate_api_auth(
+    *,
+    request: Request,
+    cred: Optional[HTTPAuthorizationCredentials],
+    query_api_key: Optional[str] = None,
+    allow_query: bool = False,
+) -> None:
+    """Validate configured auth, preserving loopback-only dev mode."""
+    # CORS protects response reads, not blind side effects. Reject unsafe
+    # browser-originated cross-site requests before honoring loopback dev-mode
+    # trust, otherwise a malicious page can drive local POST/PUT/DELETE routes.
+    if request.method.upper() not in _SAFE_BROWSER_METHODS:
+        _reject_cross_site_browser_request(request)
+
+    # Loopback clients are always trusted, even when API_AUTH_KEY is set.
+    # The key only gates non-local (LAN/remote) access.
+    if _is_local_client(request):
+        return
+
+    api_key = _configured_api_key()
+    if not api_key:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="API_AUTH_KEY is required for non-local API access",
+        )
+
+    token = _auth_credential_from_header_or_query(cred, query_api_key, allow_query=allow_query)
+    if not token or not hmac.compare_digest(token, api_key):
+        raise HTTPException(status_code=401, detail="Invalid or missing API key")
+
+
+def _is_local_client(request: Request) -> bool:
+    """Return whether the request originates from a loopback client."""
+    host = request.client.host if request.client else ""
+    if host in {"localhost", "testclient"}:
+        return True
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    if ip.is_loopback:
+        return True
+    return _trusted_docker_loopback_ip(ip)
+
+
+def _env_flag_enabled(name: str) -> bool:
+    """Return whether a boolean environment flag is enabled."""
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _default_gateway_ips() -> set[ipaddress.IPv4Address]:
+    """Return IPv4 default gateway addresses from Linux procfs."""
+    gateways: set[ipaddress.IPv4Address] = set()
+    try:
+        lines = Path("/proc/net/route").read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return gateways
+
+    for line in lines[1:]:
+        fields = line.split()
+        if len(fields) < 3 or fields[1] != "00000000":
+            continue
+        try:
+            raw = int(fields[2], 16).to_bytes(4, byteorder="little")
+            gateways.add(ipaddress.IPv4Address(raw))
+        except ValueError:
+            continue
+    return gateways
+
+
+def _trusted_docker_loopback_ip(ip: ipaddress._BaseAddress) -> bool:
+    """Return whether an IP is the trusted Docker host gateway.
+
+    Docker Desktop presents host requests to a container as the bridge gateway
+    instead of 127.0.0.1. This escape hatch is safe only when the published
+    port is bound to host loopback, so the official compose file enables it
+    together with a 127.0.0.1 port binding.
+    """
+    if not isinstance(ip, ipaddress.IPv4Address):
+        return False
+    if not _env_flag_enabled(_DOCKER_LOOPBACK_ENV):
+        return False
+    return ip in _default_gateway_ips()
+
+
+def _env_shell_tools_enabled() -> bool:
+    """Return whether server-side shell tools are explicitly enabled."""
+    return _env_flag_enabled(_SHELL_TOOLS_ENV)
+
+
+def _shell_tools_enabled_for_request(request: Request) -> bool:
+    """Return whether this API request may expose shell tools to the agent."""
+    # Shell-capable tools execute commands on the host as the API process user.
+    # Do not infer that privilege from peer IP alone: browser DNS rebinding can
+    # make attacker-controlled pages appear as loopback clients. Operators who
+    # intentionally want API-started agents or swarm workers to receive shell
+    # tools must opt in explicitly.
+    return _env_shell_tools_enabled()
+
+
+async def require_local_or_auth(
+    request: Request,
+    cred: Optional[HTTPAuthorizationCredentials] = Security(_security),
+) -> None:
+    """Protect settings access when dev-mode auth is disabled.
+
+    If API_AUTH_KEY is configured, require the bearer token. If not, allow only
+    loopback clients so an API server bound to 0.0.0.0 cannot accept remote
+    credential reads or writes in dev mode.
+    """
+    if _configured_api_key():
+        await require_auth(request, cred)
+        return
+    if not _is_local_client(request):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Settings access requires API_AUTH_KEY or a local loopback client",
+        )
+
+
+async def require_settings_write_auth(
+    request: Request,
+    cred: Optional[HTTPAuthorizationCredentials] = Security(_security),
+) -> None:
+    """Require explicit authorization before changing credential-routing settings.
+
+    Settings writes can redirect stored provider credentials to a different
+    endpoint. When an API key is configured, loopback peer IP alone is not a
+    sufficient user-intent signal because a browser can reach local APIs after
+    DNS rebinding.
+    """
+    api_key = _configured_api_key()
+    if api_key:
+        token = _auth_credential_from_header_or_query(cred, None, allow_query=False)
+        if not token or not hmac.compare_digest(token, api_key):
+            raise HTTPException(status_code=401, detail="Invalid or missing API key")
+        return
+
+    if not _is_local_client(request):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Settings writes require API_AUTH_KEY or a local loopback client",
+        )

--- a/agent/src/api/helpers.py
+++ b/agent/src/api/helpers.py
@@ -1,0 +1,401 @@
+from __future__ import annotations
+
+import csv
+import json
+import logging
+import os
+import re
+import signal
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from fastapi import HTTPException, status
+
+from src.api.models import Artifact, BacktestMetrics, RAGSelection, RunResponse
+
+logger = logging.getLogger(__name__)
+
+# ============================================================================
+# Path constants
+# ============================================================================
+
+RUNS_DIR = Path(__file__).resolve().parent.parent.parent / "runs"
+SESSIONS_DIR = Path(__file__).resolve().parent.parent.parent / "sessions"
+UPLOADS_DIR = Path(__file__).resolve().parent.parent.parent / "uploads"
+AGENT_DIR = Path(__file__).resolve().parent.parent.parent
+ENV_PATH = AGENT_DIR / ".env"
+ENV_EXAMPLE_PATH = AGENT_DIR / ".env.example"
+MAX_UPLOAD_SIZE = 50 * 1024 * 1024  # 50 MB
+_UPLOAD_CHUNK_SIZE = 1024 * 1024  # 1 MB
+_FRONTEND_DIST = Path(__file__).resolve().parent.parent.parent.parent / "frontend" / "dist"
+
+# ============================================================================
+# SPA fallback constants
+# ============================================================================
+
+# Patterns are written narrowly so the SPA shell only shadows paths that
+# actually correspond to frontend pages. In particular ``/runs/{id}`` is
+# the RunDetail page, but ``/runs/{id}/code`` and ``/runs/{id}/pine`` are
+# API-only endpoints with no SPA route — using a broad ``/runs/`` prefix
+# here would incorrectly hijack those when the browser sets ``Accept:
+# text/html`` (e.g. a user pasting the URL into the address bar).
+
+_SPA_HTML_EXACT_PATHS: frozenset[str] = frozenset({"/correlation"})
+# Each regex matches a complete request path. Trailing slash optional.
+_SPA_HTML_PATH_REGEX: tuple[re.Pattern[str], ...] = (
+    # ``/runs/{run_id}`` — RunDetail page. Excludes ``/runs/{id}/code``,
+    # ``/runs/{id}/pine`` (API only) and ``/runs`` (collection endpoint).
+    re.compile(r"^/runs/[^/]+/?$"),
+)
+
+
+def _is_spa_html_route(path: str) -> bool:
+    """Return True when ``path`` corresponds to a frontend SPA page that
+    shadows an API endpoint and should fall back to ``index.html`` on
+    browser navigation."""
+    if path in _SPA_HTML_EXACT_PATHS:
+        return True
+    return any(pattern.match(path) for pattern in _SPA_HTML_PATH_REGEX)
+
+
+# ============================================================================
+# Settings / env helpers
+# ============================================================================
+
+
+def _ensure_agent_env_file() -> Path:
+    """Ensure the project-local agent/.env exists."""
+    if not ENV_PATH.exists():
+        ENV_PATH.write_text("# Created by Vibe-Trading Web UI settings.\n", encoding="utf-8")
+    return ENV_PATH
+
+
+def _strip_env_value(value: str) -> str:
+    """Remove basic dotenv quotes and inline comments."""
+    value = value.strip()
+    if " #" in value:
+        value = value.split(" #", 1)[0].rstrip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        value = value[1:-1]
+    return value.strip()
+
+
+def _read_env_values(path: Path) -> Dict[str, str]:
+    """Read active KEY=value entries from a dotenv file."""
+    values: Dict[str, str] = {}
+    if not path.exists():
+        return values
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if key:
+            values[key] = _strip_env_value(value)
+    return values
+
+
+def _read_settings_env_values() -> Dict[str, str]:
+    """Read settings without creating agent/.env.
+
+    Prefer the user's active agent/.env. If it does not exist yet, fall back to
+    agent/.env.example for display defaults only.
+    """
+    if ENV_PATH.exists():
+        return _read_env_values(ENV_PATH)
+    if ENV_EXAMPLE_PATH.exists():
+        return _read_env_values(ENV_EXAMPLE_PATH)
+    return {}
+
+
+def _project_relative_path(path: Path) -> str:
+    """Return a project-relative display path without leaking an absolute path."""
+    try:
+        return path.resolve().relative_to(AGENT_DIR.parent.resolve()).as_posix()
+    except ValueError:
+        return path.name
+
+
+def _format_env_value(value: str) -> str:
+    """Format a dotenv value without allowing multiline injection."""
+    if "\n" in value or "\r" in value:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Environment values cannot contain newlines")
+    value = value.strip()
+    if not value:
+        return ""
+    if any(ch.isspace() for ch in value) or "#" in value:
+        return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+    return value
+
+
+def _write_env_values(path: Path, updates: Dict[str, str]) -> None:
+    """Upsert active dotenv values while preserving comments and ordering."""
+    _ensure_agent_env_file()
+    lines = path.read_text(encoding="utf-8").splitlines()
+    seen: set[str] = set()
+    for index, raw in enumerate(lines):
+        stripped = raw.lstrip()
+        is_comment = stripped.startswith("#")
+        candidate = stripped[1:].lstrip() if is_comment else stripped
+        if "=" not in candidate:
+            continue
+        key = candidate.split("=", 1)[0].strip()
+        if key in updates and key not in seen:
+            lines[index] = f"{key}={_format_env_value(updates[key])}"
+            seen.add(key)
+    missing = [key for key in updates if key not in seen]
+    if missing:
+        if lines and lines[-1].strip():
+            lines.append("")
+        lines.append("# Updated from Web UI")
+        for key in missing:
+            lines.append(f"{key}={_format_env_value(updates[key])}")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _is_configured_secret(value: str, placeholders: set[str]) -> bool:
+    """Return True when a secret is set and not a documented placeholder."""
+    normalized = value.strip().strip('"').strip("'")
+    if not normalized:
+        return False
+    return normalized.lower() not in {placeholder.lower() for placeholder in placeholders}
+
+
+def _coerce_float(value: str, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_int(value: str, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+# ============================================================================
+# Run-response helpers
+# ============================================================================
+
+
+def _load_json_file(path: Path) -> Optional[Dict[str, Any]]:
+    """Load JSON from disk if present."""
+    try:
+        if path.exists():
+            return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        pass
+    return None
+
+
+def _load_csv_to_dict(path: Path, limit: Optional[int] = None) -> List[Dict[str, Any]]:
+    """Load CSV rows into a list of dictionaries."""
+    try:
+        if not path.exists():
+            return []
+        with path.open("r", encoding="utf-8", newline="") as handle:
+            rows = [dict(row) for row in csv.DictReader(handle)]
+        if limit is not None:
+            rows = rows[:limit]
+        return rows
+    except Exception:
+        return []
+
+
+def _build_response_from_run_dir(
+    run_dir: Path,
+    elapsed: float,
+    *,
+    include_analysis: bool = False,
+    chart_symbol: Optional[str] = None,
+    chart_payload: str = "full",
+    chart_symbols_out: Optional[List[str]] = None,
+) -> RunResponse:
+    """Build a run response from a persisted run directory."""
+    run_id = run_dir.name
+
+    response = RunResponse(
+        status="unknown",
+        run_id=run_id,
+        elapsed_seconds=elapsed,
+        run_directory=str(run_dir),
+    )
+
+    state_data = _load_json_file(run_dir / "state.json")
+    if state_data:
+        state_status = str(state_data.get("status") or "").lower()
+        if state_status == "success":
+            response.status = "success"
+        elif state_status == "failed":
+            response.status = "failed"
+            response.reason = state_data.get("reason", "")
+        else:
+            response.status = state_status or "unknown"
+    else:
+        response.status = "unknown"
+
+    planner_path = run_dir / "planner_output.json"
+    response.planner_output = _load_json_file(planner_path)
+
+    design_path = run_dir / "design_spec.json"
+    response.strategy_spec = _load_json_file(design_path)
+
+    rag_path = run_dir / "rag_metadata.json"
+    rag_data = _load_json_file(rag_path)
+    if rag_data:
+        response.rag_selection = RAGSelection(
+            selected_api=rag_data.get("selected_api") or rag_data.get("api_code", ""),
+            selected_name=rag_data.get("selected_name") or rag_data.get("api_name", ""),
+            selected_score=float(rag_data.get("selected_score") or rag_data.get("score", 0.0)),
+        )
+
+    metrics_path = run_dir / "artifacts" / "metrics.csv"
+    if metrics_path.exists():
+        metrics_dict_list = _load_csv_to_dict(metrics_path, limit=1)
+        if metrics_dict_list:
+            row = metrics_dict_list[0]
+            try:
+                # Pass ALL CSV columns to BacktestMetrics (extra="allow")
+                parsed: dict = {}
+                for k, v in row.items():
+                    if not k or not v:
+                        continue
+                    try:
+                        parsed[k] = int(float(v)) if k == "trade_count" or k == "max_consecutive_loss" else float(v)
+                    except (ValueError, TypeError):
+                        continue
+                if "final_value" in parsed:
+                    response.metrics = BacktestMetrics(**parsed)
+            except (ValueError, TypeError):
+                pass
+
+
+    artifacts_dir = run_dir / "artifacts"
+    if artifacts_dir.exists():
+        for file_path in artifacts_dir.iterdir():
+            if file_path.is_file():
+                file_type = file_path.suffix.lstrip(".")
+                response.artifacts.append(
+                    Artifact(
+                        name=file_path.name,
+                        path=str(file_path),
+                        type=file_type if file_type else "unknown",
+                        size=file_path.stat().st_size,
+                        exists=True,
+                    )
+                )
+
+    equity_path = run_dir / "artifacts" / "equity.csv"
+    if equity_path.exists():
+        response.artifacts_equity_csv = _load_csv_to_dict(equity_path)
+
+    metrics_csv_path = run_dir / "artifacts" / "metrics.csv"
+    if metrics_csv_path.exists():
+        response.artifacts_metrics_csv = _load_csv_to_dict(metrics_csv_path)
+
+    run_card_path = run_dir / "run_card.json"
+    if run_card_path.exists():
+        try:
+            response.run_card = json.loads(run_card_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    llm_usage_path = run_dir / "llm_usage.json"
+    if llm_usage_path.exists():
+        try:
+            response.llm_usage = json.loads(llm_usage_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    trades_path = run_dir / "artifacts" / "trades.csv"
+    if trades_path.exists():
+        response.artifacts_trades_csv = _load_csv_to_dict(trades_path)
+
+    validation_path = run_dir / "artifacts" / "validation.json"
+    if validation_path.exists():
+        try:
+            response.validation = json.loads(validation_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    if response.artifacts_equity_csv:
+        filtered_equity = []
+        for row in response.artifacts_equity_csv[:1000]:
+            filtered_row: Dict[str, Any] = {}
+            if "timestamp" in row:
+                filtered_row["time"] = row["timestamp"]
+            if "equity" in row:
+                filtered_row["equity"] = row["equity"]
+            if "drawdown" in row:
+                filtered_row["drawdown"] = row["drawdown"]
+            filtered_equity.append(filtered_row)
+        response.equity_curve = filtered_equity
+
+    if response.artifacts_trades_csv:
+        response.trade_log = response.artifacts_trades_csv[:500]
+
+    if include_analysis:
+        from src.ui_services import build_run_analysis
+
+        analysis = build_run_analysis(
+            run_dir,
+        symbols=[chart_symbol] if chart_symbol else None,
+        include_payload=chart_payload != "summary" or bool(chart_symbol),
+        include_symbol_list=chart_symbols_out is not None,
+    )
+        if chart_symbols_out is not None:
+            chart_symbols_out.extend(analysis.get("chart_symbols") or [])
+        response.run_stage = analysis.get("run_stage")
+        response.run_context = analysis.get("run_context")
+        response.price_series = analysis.get("price_series")
+        response.indicator_series = analysis.get("indicator_series")
+        response.trade_markers = analysis.get("trade_markers")
+        response.run_logs = analysis.get("run_logs")
+
+    return response
+
+
+def _run_response_payload(response: RunResponse) -> Dict[str, Any]:
+    """Return a JSON-ready payload for opt-in run response variants."""
+    return response.model_dump(mode="json")
+
+
+# ============================================================================
+# Path-parameter validation
+# ============================================================================
+
+# ``run_id`` and ``session_id`` flow directly into filesystem paths
+# (``RUNS_DIR / run_id`` etc.). Restrict to a safe character class so that
+# values like ``..`` or ``foo/../bar`` cannot escape the parent directory.
+_SAFE_PATH_PARAM_RE = __import__("re").compile(r"^[A-Za-z0-9_-]{1,128}$")
+
+
+def _validate_path_param(value: str, kind: str) -> None:
+    """Reject path parameters that could escape the parent directory.
+
+    Args:
+        value: User-supplied path-parameter value.
+        kind: Parameter name, used in the error detail.
+
+    Raises:
+        HTTPException: 400 when ``value`` does not match the safe character
+            class, mirroring the existing ``_SHADOW_ID_RE`` check.
+    """
+    if not _SAFE_PATH_PARAM_RE.fullmatch(value or ""):
+        raise HTTPException(status_code=400, detail=f"invalid {kind}")
+
+
+# ============================================================================
+# Process termination
+# ============================================================================
+
+
+def _terminate_current_process() -> None:
+    """Stop the current API process after the response has been sent."""
+    time.sleep(0.25)
+    os.kill(os.getpid(), signal.SIGTERM)

--- a/agent/src/api/live_relay.py
+++ b/agent/src/api/live_relay.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from src.api.state import _get_session_service
+
+logger = logging.getLogger(__name__)
+
+# ============================================================================
+# Live-channel SSE relay helpers
+# ============================================================================
+
+# These are the privileged SURFACE actions of the live-trading channel
+# (live-trading SPEC, Consent §1/§3/§4). None is an agent tool:
+#   - POST /mandate/commit  -> the single mandate writer (commit_mandate)
+#   - POST /live/halt       -> trip the kill switch (P5 trip_halt)
+#   - POST /live/resume     -> clear the kill switch (P5 clear_halt)
+# Each best-effort relays a mandate.committed / live.halted / live.action event
+# through the EXISTING session EventBus, so the frontend's already-wired
+# /sessions/{id}/events SSE stream reflects the state change. No new bus.
+
+
+def _emit_live_event(session_id: Optional[str], event_type: str, data: Dict[str, Any]) -> None:
+    """Best-effort relay of a live-channel event through the existing bus.
+
+    The event flows out the existing ``/sessions/{session_id}/events`` SSE
+    stream. Notifications never gate autonomy (SPEC Consent §5): a relay failure
+    or a missing session is swallowed — the state change already happened on disk.
+
+    Args:
+        session_id: Target session, or ``None`` to skip relay.
+        event_type: SSE event name (``mandate.committed`` / ``live.halted`` /
+            ``live.resumed`` / ``live.action``).
+        data: JSON-serializable event payload.
+    """
+    if not session_id:
+        return
+    try:
+        svc = _get_session_service()
+        if svc and svc.get_session(session_id):
+            svc.event_bus.emit(session_id, event_type, data)
+    except Exception:  # pragma: no cover - relay is non-blocking by contract
+        logger.debug("live event relay failed for %s/%s", session_id, event_type, exc_info=True)
+
+
+# ---- C1: propose_mandate_profiles tool_result -> mandate.proposal SSE frame ----
+#
+# The agent surfaces a proposal by calling the read-only ``propose_mandate_profiles``
+# tool whose tool_result JSON body is ``{"type":"mandate.proposal", ...}`` (SPEC
+# Consent §1). The CLI / frontend listen for a TOP-LEVEL ``mandate.proposal`` SSE
+# event. ``src/agent/loop.py`` only emits a truncated ``tool_result`` event
+# (``preview = result[:200]``) and is PROTECTED — we do NOT edit it. Instead this
+# open-file SSE seam (TASKS "Remaining integration items" #1, the recommended
+# wiring) detects the propose tool's tool_result on the stream, recovers the
+# ``proposal_id`` from the preview, reloads the FULL persisted proposal from the
+# proposal store (written by the tool before it returned), and emits the
+# ``mandate.proposal`` frame. No protected touch.
+
+_PROPOSAL_TOOL_NAME = "propose_mandate_profiles"
+_PROPOSAL_ID_RE = re.compile(r'"proposal_id"\s*:\s*"(mp_[0-9a-f]{32})"')
+
+
+def _load_full_proposal(proposal_id: str) -> Optional[Dict[str, Any]]:
+    """Reload a persisted ``mandate.proposal`` payload by id, broker-agnostic.
+
+    The propose tool persists the full proposal under
+    ``<runtime_root>/live/<broker>/proposals/<proposal_id>.json`` before
+    returning. The SSE ``tool_result`` preview is too short to carry the full
+    body, so the relay reloads it from disk. The broker segment is unknown from
+    the preview alone, so every broker's proposals directory is searched.
+
+    Args:
+        proposal_id: The ``mp_...`` id parsed from the tool_result preview.
+
+    Returns:
+        The full proposal dict, or ``None`` when not found / unreadable.
+    """
+    try:
+        from src.live.paths import live_root
+
+        for proposal_path in live_root().glob(f"*/proposals/{proposal_id}.json"):
+            try:
+                data = json.loads(proposal_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if isinstance(data, dict) and data.get("type") == "mandate.proposal":
+                return data
+    except Exception:  # pragma: no cover - relay must never break the stream
+        logger.debug("mandate.proposal reload failed for %s", proposal_id, exc_info=True)
+    return None
+
+
+def _mandate_proposal_frame_from_tool_result(event: Any) -> Optional[str]:
+    """Build a ``mandate.proposal`` SSE frame from a propose-tool tool_result.
+
+    Args:
+        event: An ``SSEEvent`` flowing through the session stream.
+
+    Returns:
+        A ready-to-yield SSE text frame for the ``mandate.proposal`` event, or
+        ``None`` when ``event`` is not a successful propose-tool result or the
+        proposal cannot be recovered.
+    """
+    data = getattr(event, "data", None)
+    if getattr(event, "event_type", None) != "tool_result" or not isinstance(data, dict):
+        return None
+    if data.get("tool") != _PROPOSAL_TOOL_NAME or data.get("status") != "ok":
+        return None
+    match = _PROPOSAL_ID_RE.search(str(data.get("preview") or ""))
+    if not match:
+        return None
+    proposal = _load_full_proposal(match.group(1))
+    if proposal is None:
+        return None
+
+    from src.session.events import SSEEvent
+
+    frame = SSEEvent(
+        event_type="mandate.proposal",
+        data=proposal,
+        session_id=getattr(event, "session_id", "") or "",
+    )
+    return frame.to_sse()
+
+
+_LIVE_ACTION_ID_RE = re.compile(r'"audit_id"\s*:\s*"(la_[0-9a-zA-Z]+)"')
+
+
+def _load_live_action_record(audit_id: str) -> Optional[Dict[str, Any]]:
+    """Reload a redacted live-action record from the ledger by ``audit_id``.
+
+    The order guard embeds its (already-redacted) audit record under the
+    ``live_action`` key of its tool_result, but the SSE ``tool_result`` preview
+    is truncated to ~200 chars, so the full record is reloaded from the
+    append-only ledger at ``<runtime_root>/live/audit.jsonl``.
+
+    Args:
+        audit_id: The ``la_...`` id parsed from the tool_result preview.
+
+    Returns:
+        The full redacted live-action record, or ``None`` when not found.
+    """
+    try:
+        from src.live.paths import live_root
+
+        ledger = live_root() / "audit.jsonl"
+        if not ledger.exists():
+            return None
+        for line in reversed(ledger.read_text(encoding="utf-8").splitlines()):
+            if audit_id not in line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(record, dict) and record.get("audit_id") == audit_id:
+                return record
+    except Exception:  # pragma: no cover - relay must never break the stream
+        logger.debug("live.action reload failed for %s", audit_id, exc_info=True)
+    return None
+
+
+def _live_action_frame_from_tool_result(event: Any) -> Optional[str]:
+    """Build a ``live.action`` SSE frame from an order-guard tool_result.
+
+    The order guard stamps a ``live_action`` audit record onto its tool_result
+    (and the ledger) for every live order placed/rejected. The interactive agent
+    loop only emits a truncated ``tool_result`` event and is PROTECTED, so this
+    open-file relay surfaces the live action as a top-level ``live.action`` event
+    for the timeline — without touching ``src/agent/loop.py``. (Autonomous-runner
+    actions already emit ``live.action`` natively via the runner's event bus.)
+
+    Args:
+        event: An ``SSEEvent`` flowing through the session stream.
+
+    Returns:
+        A ready-to-yield ``live.action`` SSE frame, or ``None`` when the event is
+        not an order-guard result carrying a recoverable live-action record.
+    """
+    data = getattr(event, "data", None)
+    if getattr(event, "event_type", None) != "tool_result" or not isinstance(data, dict):
+        return None
+    preview = str(data.get("preview") or "")
+    if '"live_action"' not in preview:
+        return None
+    match = _LIVE_ACTION_ID_RE.search(preview)
+    if not match:
+        return None
+    record = _load_live_action_record(match.group(1))
+    if record is None:
+        return None
+
+    from src.session.events import SSEEvent
+
+    frame = SSEEvent(
+        event_type="live.action",
+        data=record,
+        session_id=getattr(event, "session_id", "") or "",
+    )
+    return frame.to_sse()

--- a/agent/src/api/models.py
+++ b/agent/src/api/models.py
@@ -1,0 +1,461 @@
+"""Pydantic models for the Vibe-Trading API server.
+
+Extracted verbatim from ``api_server.py`` (PR-0 of the api_server refactor).
+This is a LEAF module — it imports only from stdlib + Pydantic.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+# ============================================================================
+# Pydantic Models
+# ============================================================================
+
+class Artifact(BaseModel):
+    """Artifact file metadata."""
+    name: str = Field(..., description="File name")
+    path: str = Field(..., description="File path")
+    type: str = Field(..., description="File type: csv, json, txt, etc.")
+    size: int = Field(..., description="Size in bytes")
+    exists: bool = Field(..., description="Whether the file exists")
+
+
+class BacktestMetrics(BaseModel):
+    """Backtest summary metrics."""
+    model_config = {"extra": "allow"}
+
+    final_value: float = Field(..., description="Ending portfolio value")
+    total_return: float = Field(..., description="Total return")
+    annual_return: float = Field(..., description="Annualized return")
+    max_drawdown: float = Field(..., description="Max drawdown")
+    sharpe: float = Field(..., description="Sharpe ratio")
+    win_rate: float = Field(..., description="Win rate")
+    trade_count: int = Field(..., description="Number of trades")
+
+
+
+class RAGSelection(BaseModel):
+    """RAG routing result."""
+    selected_api: str = Field(..., description="Selected API code")
+    selected_name: str = Field(..., description="Selected API name")
+    selected_score: float = Field(..., description="Match score")
+
+
+class RunInfo(BaseModel):
+    """Compact run row for list views."""
+    run_id: str
+    status: str
+    created_at: str
+    prompt: Optional[str] = None
+    total_return: Optional[float] = None
+    sharpe: Optional[float] = None
+    codes: List[str] = Field(default_factory=list)
+    start_date: Optional[str] = None
+    end_date: Optional[str] = None
+
+
+class RunResponse(BaseModel):
+    """API response payload for a single run."""
+
+    status: str = Field(..., description="Run status: success, failed, aborted")
+    run_id: str = Field(..., description="Run identifier")
+    elapsed_seconds: float = Field(..., description="Execution time in seconds")
+    reason: Optional[str] = Field(None, description="Failure reason when available")
+
+    planner_output: Optional[Dict[str, Any]] = Field(None, description="Planner output")
+    strategy_spec: Optional[Dict[str, Any]] = Field(None, description="Strategy specification")
+    rag_selection: Optional[RAGSelection] = Field(None, description="Selected RAG metadata")
+
+    metrics: Optional[BacktestMetrics] = Field(None, description="Backtest metrics")
+    artifacts: List[Artifact] = Field(default_factory=list, description="Run artifacts")
+    run_card: Optional[Dict[str, Any]] = Field(None, description="Trust Layer run card payload")
+    llm_usage: Optional[Dict[str, Any]] = Field(None, description="Provider-reported AgentLoop usage summary")
+
+    equity_curve: Optional[List[Dict[str, Any]]] = Field(None, description="Equity preview")
+    trade_log: Optional[List[Dict[str, Any]]] = Field(None, description="Trade preview")
+
+    artifacts_equity_csv: Optional[List[Dict[str, Any]]] = Field(None, description="Full equity rows")
+    artifacts_metrics_csv: Optional[List[Dict[str, Any]]] = Field(None, description="Full metrics rows")
+    artifacts_trades_csv: Optional[List[Dict[str, Any]]] = Field(None, description="Full trade rows")
+    validation: Optional[Dict[str, Any]] = Field(None, description="Statistical validation results")
+
+    run_directory: str = Field(..., description="Run directory path")
+    run_stage: Optional[str] = Field(None, description="UI-facing run stage")
+    run_context: Optional[Dict[str, Any]] = Field(None, description="Normalized request context")
+    price_series: Optional[Dict[str, List[Dict[str, Any]]]] = Field(None, description="Grouped OHLC series")
+    indicator_series: Optional[Dict[str, Dict[str, List[Dict[str, Any]]]]] = Field(
+        None,
+        description="Grouped indicator overlays",
+    )
+    trade_markers: Optional[List[Dict[str, Any]]] = Field(None, description="Trade markers for charts")
+    run_logs: Optional[List[Dict[str, Any]]] = Field(None, description="Structured stdout/stderr lines")
+
+
+class HealthResponse(BaseModel):
+    """Health check payload."""
+    status: str = Field(..., description="Service status")
+    service: str = Field(..., description="Service name")
+    timestamp: str = Field(..., description="Server timestamp")
+
+
+class LLMProviderOption(BaseModel):
+    """Supported LLM provider metadata for the settings UI."""
+
+    name: str
+    label: str
+    api_key_env: Optional[str] = None
+    base_url_env: str
+    default_model: str
+    default_base_url: str
+    api_key_required: bool = True
+    auth_type: str = "api_key"
+    login_command: Optional[str] = None
+
+
+class LLMSettingsResponse(BaseModel):
+    """Current LLM runtime settings."""
+
+    provider: str
+    model_name: str
+    base_url: str
+    api_key_env: Optional[str] = None
+    api_key_configured: bool
+    api_key_hint: Optional[str] = None
+    api_key_required: bool
+    temperature: float
+    timeout_seconds: int
+    max_retries: int
+    reasoning_effort: str
+    sse_timeout_seconds: int
+    env_path: str
+    providers: List[LLMProviderOption]
+
+
+class UpdateLLMSettingsRequest(BaseModel):
+    """Update LLM settings persisted to agent/.env."""
+
+    provider: str = Field(..., min_length=1)
+    model_name: str = Field(..., min_length=1)
+    base_url: Optional[str] = None
+    api_key: Optional[str] = None
+    clear_api_key: bool = False
+    temperature: float = 0.0
+    timeout_seconds: int = Field(120, ge=1, le=3600)
+    max_retries: int = Field(2, ge=0, le=20)
+    reasoning_effort: Optional[str] = None
+
+
+class DataSourceSettingsResponse(BaseModel):
+    """Current data source credential settings."""
+
+    tushare_token_configured: bool
+    tushare_token_hint: Optional[str] = None
+    baostock_supported: bool
+    baostock_installed: bool
+    baostock_message: str
+    env_path: str
+
+
+class UpdateDataSourceSettingsRequest(BaseModel):
+    """Update project-local data source credentials."""
+
+    tushare_token: Optional[str] = None
+    clear_tushare_token: bool = False
+
+
+# ---- V4 Session Models ----
+
+class CreateSessionRequest(BaseModel):
+    """Create session request body."""
+    title: str = Field("", description="Session title")
+    config: Optional[Dict[str, Any]] = Field(None, description="Session config")
+
+
+class SessionResponse(BaseModel):
+    """Session record."""
+    session_id: str
+    title: str
+    status: str
+    created_at: str
+    updated_at: str
+    last_attempt_id: Optional[str] = None
+
+
+class SendMessageRequest(BaseModel):
+    """Send chat message: natural-language strategy description."""
+    content: str = Field(..., description="Natural language strategy description", min_length=1, max_length=5000)
+
+
+class MessageResponse(BaseModel):
+    """Stored chat message."""
+    message_id: str
+    session_id: str
+    role: str
+    content: str
+    created_at: str
+    linked_attempt_id: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+
+
+class CreateGoalRequest(BaseModel):
+    """Create or replace a finance research goal."""
+
+    objective: str = Field(..., min_length=1, max_length=5000)
+    criteria: List[str] = Field(default_factory=list)
+    ui_summary: str = ""
+    protocol: str = "thesis_review"
+    risk_tier: str = "research_general"
+    token_budget: Optional[int] = Field(None, ge=1)
+    turn_budget: Optional[int] = Field(None, ge=1)
+    time_budget_seconds: Optional[int] = Field(None, ge=1)
+
+
+class UpdateGoalRequest(BaseModel):
+    """Edit mutable finance research goal fields."""
+
+    goal_id: str = Field(..., min_length=1)
+    expected_goal_id: str = Field(..., min_length=1)
+    objective: Optional[str] = Field(None, min_length=1, max_length=5000)
+    ui_summary: Optional[str] = Field(None, max_length=500)
+
+
+class AddGoalEvidenceRequest(BaseModel):
+    """Append evidence to a finance research goal."""
+
+    goal_id: str = Field(..., min_length=1)
+    expected_goal_id: str = Field(..., min_length=1)
+    text: str = Field(..., min_length=1, max_length=10000)
+    criterion_id: Optional[str] = None
+    claim_id: Optional[str] = None
+    evidence_type: str = "evidence"
+    tool_call_id: Optional[str] = None
+    run_id: Optional[str] = None
+    source_provider: Optional[str] = None
+    source_type: Optional[str] = None
+    source_uri: Optional[str] = None
+    symbol_universe: List[str] = Field(default_factory=list)
+    benchmark: List[str] = Field(default_factory=list)
+    timeframe: Optional[str] = None
+    method: Optional[str] = None
+    assumptions: Dict[str, Any] = Field(default_factory=dict)
+    artifact_path: Optional[str] = None
+    artifact_hash: Optional[str] = None
+    data_as_of: Optional[str] = None
+    confidence: Optional[str] = None
+    caveat: Optional[str] = None
+    contradicts_claim_ids: List[str] = Field(default_factory=list)
+
+
+class GoalSnapshotResponse(BaseModel):
+    """Finance research goal snapshot."""
+
+    goal: Dict[str, Any]
+    claims: List[Dict[str, Any]]
+    criteria: List[Dict[str, Any]]
+    evidence: List[Dict[str, Any]]
+    evidence_count: int = 0
+
+
+class AddGoalEvidenceResponse(BaseModel):
+    """Response after appending goal evidence."""
+
+    evidence: Dict[str, Any]
+    snapshot: GoalSnapshotResponse
+
+
+class GoalAuditRowRequest(BaseModel):
+    """One criterion row for goal status audits."""
+
+    criterion_id: str = Field(..., min_length=1)
+    result: str = Field(..., min_length=1)
+    evidence_ids: List[str] = Field(default_factory=list)
+    notes: str = ""
+
+
+class UpdateGoalStatusRequest(BaseModel):
+    """Update a finance research goal status."""
+
+    goal_id: str = Field(..., min_length=1)
+    expected_goal_id: str = Field(..., min_length=1)
+    status: str = Field(..., min_length=1)
+    audit: List[GoalAuditRowRequest] = Field(default_factory=list)
+    recap: Optional[str] = None
+
+
+class UpdateGoalStatusResponse(BaseModel):
+    """Response after changing a goal status."""
+
+    goal: Dict[str, Any]
+    snapshot: GoalSnapshotResponse
+
+
+class UpdateGoalResponse(BaseModel):
+    """Response after editing a goal."""
+
+    goal: Dict[str, Any]
+    snapshot: GoalSnapshotResponse
+
+
+# ---- Live trading channel: consent commit + kill switch ----
+
+
+class CommitMandateRequest(BaseModel):
+    """Surface-originated mandate commit (Consent §1 / §3).
+
+    This is the ONLY write path that activates a live-trading mandate. It is a
+    privileged HTTP action the user surface sends on an explicit click/keypress
+    — NOT a tool the agent model can call. ``consent_ack`` MUST be ``true``.
+    """
+
+    broker: str = Field(..., min_length=1, max_length=64)
+    proposal_id: str = Field(..., pattern=r"^mp_[0-9a-f]{32}$")
+    selected_ordinal: int = Field(..., ge=1, le=10)
+    adjustments: Optional[Dict[str, Any]] = None
+    consent_ack: bool = Field(..., description="Explicit affirmative; must be true")
+    session_id: Optional[str] = None
+    account_ref: str = Field("", max_length=128)
+    lifetime_days: int = Field(30, ge=1, le=365)
+
+
+class LiveHaltRequest(BaseModel):
+    """Trip or clear the live kill switch (Consent §4).
+
+    Tripping/clearing is a privileged surface action, never an agent tool. When
+    ``broker`` is omitted the GLOBAL switch is used (halts every broker).
+    """
+
+    broker: Optional[str] = Field(None, max_length=64)
+    reason: str = Field("user requested halt", max_length=500)
+    session_id: Optional[str] = None
+
+
+class LiveAuthorizeRequest(BaseModel):
+    """Kick off (or describe) the OAuth bootstrap for a live broker (C2).
+
+    Vibe-Trading never holds funds and never operates a venue, so the OAuth
+    bootstrap runs through the broker's own user-authorized device flow on the
+    client (CLI / desktop MCP), not a server-side redirect. This endpoint is the
+    web on-ramp: it tells a Web UI user exactly how to discover/start the flow.
+    """
+
+    broker: str = Field(..., min_length=1, max_length=64)
+
+
+class LiveRunnerControlRequest(BaseModel):
+    """Start or stop the persistent live runner for one broker (SPEC §7.5).
+
+    The runner wakes on schedule/market events and trades autonomously inside a
+    committed mandate. Starting it is a privileged surface action, never an
+    agent tool. A committed, unexpired mandate must already exist.
+    """
+
+    broker: str = Field(..., min_length=1, max_length=64)
+    session_id: Optional[str] = None
+
+
+class BrokerAuthState(BaseModel):
+    """Per-broker authorization snapshot for ``GET /live/status``."""
+
+    broker: str
+    oauth_token_present: bool = Field(..., description="Whether an OAuth token cache exists")
+    is_live_broker: bool = Field(..., description="Whether this key is a recognized live broker")
+
+
+class MandateLimits(BaseModel):
+    """Flattened active-mandate limits surfaced to the UI (Mandate layer a/b)."""
+
+    max_order_notional_usd: float
+    max_total_exposure_usd: float
+    max_leverage: float
+    max_trades_per_day: int
+    allowed_instruments: List[str]
+    account_funding_usd: float
+
+
+class ActiveMandateState(BaseModel):
+    """Active-mandate snapshot with the expiry countdown (SPEC §9 dec. 2)."""
+
+    broker: str
+    account_ref: str
+    created_at: str
+    expires_at: str
+    expires_in_seconds: Optional[int] = Field(
+        None, description="Seconds until expiry; negative when already expired"
+    )
+    expired: bool
+    limits: MandateLimits
+
+
+class RunnerLivenessState(BaseModel):
+    """Runner liveness snapshot via the §7.5 liveness contract."""
+
+    broker: str
+    alive: bool
+    last_tick: Optional[float] = Field(None, description="Unix epoch of last heartbeat tick")
+    last_tick_age_seconds: Optional[float] = None
+
+
+class LiveBrokerStatus(BaseModel):
+    """Combined live-channel status for a single broker."""
+
+    auth: BrokerAuthState
+    mandate: Optional[ActiveMandateState] = None
+    runner: RunnerLivenessState
+    halted: bool = Field(..., description="Per-broker OR global kill switch is tripped")
+
+
+class LiveStatusResponse(BaseModel):
+    """Top-level live-channel status (C2)."""
+
+    global_halted: bool = Field(..., description="Whether the GLOBAL kill switch is tripped")
+    brokers: List[LiveBrokerStatus]
+
+
+class ChannelPairingCommandRequest(BaseModel):
+    """Pairing command executed through the IM control surface."""
+
+    channel: str = Field(..., min_length=1, max_length=64)
+    command: str = Field("list", max_length=500)
+
+
+# ---- Models defined later in api_server.py ----
+
+
+class UpdateSessionRequest(BaseModel):
+    """Session update fields."""
+    title: Optional[str] = None
+
+
+class LiveRunnerUnavailable(RuntimeError):
+    """Raised when a live runner cannot be wired (broker not configured/authorized).
+
+    Distinct from a programming error so the start endpoint can map it to a 503
+    rather than a 500: the runtime is fine, the broker channel just isn't ready.
+    """
+
+
+class CreateScheduledRunRequest(BaseModel):
+    """Request body for POST /scheduled-runs."""
+
+    id: Optional[str] = Field(None, description="Job id; auto-generated UUID when omitted")
+    prompt: str = Field(..., min_length=1, description="Research prompt or backtest description")
+    schedule: str = Field(..., min_length=1, description="Interval-ms or 5-field cron expression")
+    next_run_at: Optional[int] = Field(None, description="Epoch-ms for next run; defaults to now")
+    config: Dict[str, Any] = Field(default_factory=dict, description="Optional backtest parameters")
+
+
+class ScheduledRunResponse(BaseModel):
+    """API response for a single scheduled job."""
+
+    id: str
+    prompt: str
+    schedule: str
+    next_run_at: int
+    status: str
+    created_at: int
+    config: Dict[str, Any] = Field(default_factory=dict)

--- a/agent/src/api/models.py
+++ b/agent/src/api/models.py
@@ -6,7 +6,6 @@ This is a LEAF module — it imports only from stdlib + Pydantic.
 
 from __future__ import annotations
 
-from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field

--- a/agent/src/api/state.py
+++ b/agent/src/api/state.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+from fastapi import HTTPException
+
+from src.api.helpers import RUNS_DIR, SESSIONS_DIR
+
+logger = logging.getLogger(__name__)
+
+# ============================================================================
+# Module-level singleton variables
+# ============================================================================
+
+_session_service = None
+_goal_store = None
+_channel_runtime = None
+_channel_bus = None
+_channel_manager = None
+_swarm_runtime = None
+_scheduled_research_store: Optional["ScheduledResearchJobStore"] = None
+_scheduled_research_executor: Optional["ScheduledResearchExecutor"] = None
+
+# ============================================================================
+# Scheduled research constants
+# ============================================================================
+
+_SCHEDULED_RESEARCH_SCHEDULER_ENV = "VIBE_TRADING_ENABLE_SCHEDULER"
+_SCHEDULED_RESEARCH_TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+# ============================================================================
+# Session service
+# ============================================================================
+
+
+def _get_session_service():
+    """Lazy-init session service when ENABLE_SESSION_RUNTIME=true."""
+    global _session_service
+    if _session_service is not None:
+        return _session_service
+
+    if os.getenv("ENABLE_SESSION_RUNTIME", "true").lower() != "true":
+        return None
+
+    import asyncio
+    from src.session.store import SessionStore
+    from src.session.events import EventBus
+    from src.session.service import SessionService
+
+    store = SessionStore(base_dir=SESSIONS_DIR)
+    event_bus = EventBus()
+
+    try:
+        loop = asyncio.get_event_loop()
+        event_bus.set_loop(loop)
+    except RuntimeError:
+        pass
+
+    _session_service = SessionService(
+        store=store,
+        event_bus=event_bus,
+        runs_dir=RUNS_DIR,
+    )
+    return _session_service
+
+
+# ============================================================================
+# Channel runtime
+# ============================================================================
+
+
+def _get_channel_runtime():
+    """Lazy-init IM channel runtime without starting platform adapters."""
+    global _channel_runtime, _channel_bus, _channel_manager
+    if _channel_runtime is not None:
+        return _channel_runtime
+
+    from src.channels.bus.queue import MessageBus
+    from src.channels.config import load_channels_config
+    from src.channels.manager import ChannelManager
+    from src.channels.runtime import ChannelRuntime
+
+    svc = _get_session_service()
+    if not svc:
+        raise HTTPException(status_code=501, detail="Session runtime not enabled")
+
+    _channel_bus = MessageBus()
+    config = load_channels_config()
+    _channel_manager = ChannelManager(config, _channel_bus, session_service=svc)
+    _channel_runtime = ChannelRuntime(
+        bus=_channel_bus,
+        session_service=svc,
+        manager=_channel_manager,
+    )
+    return _channel_runtime
+
+
+async def _start_channel_runtime():
+    """Start the IM channel runtime."""
+    runtime = _get_channel_runtime()
+    await runtime.start(start_manager=True)
+    return runtime
+
+
+async def _stop_channel_runtime() -> None:
+    """Stop the IM channel runtime if it was initialized."""
+    if _channel_runtime is None:
+        return
+    await _channel_runtime.stop()
+
+
+# ============================================================================
+# Goal store
+# ============================================================================
+
+
+def _get_goal_store():
+    """Return the shared finance goal store."""
+    global _goal_store
+    if _goal_store is None:
+        from src.goal import GoalStore
+
+        _goal_store = GoalStore()
+    return _goal_store
+
+
+def _get_existing_session_or_404(session_id: str):
+    svc = _get_session_service()
+    if not svc:
+        raise HTTPException(status_code=501, detail="Session runtime not enabled")
+    session = svc.get_session(session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail=f"Session {session_id} not found")
+    return svc, session
+
+
+# ============================================================================
+# Swarm runtime
+# ============================================================================
+
+
+def _get_swarm_runtime():
+    """Lazy-init SwarmRuntime singleton."""
+    global _swarm_runtime
+    if _swarm_runtime is not None:
+        return _swarm_runtime
+    from src.config import load_swarm_agent_config
+    from src.swarm.store import SwarmStore
+    from src.swarm.runtime import SwarmRuntime
+    swarm_dir = Path(__file__).resolve().parent.parent.parent / ".swarm" / "runs"
+    store = SwarmStore(base_dir=swarm_dir)
+    # Boot-time / operator-trusted: REST API callers cannot influence the
+    # config path. See docs/2026-05-25_swarm_mcp_tools_roadmap.md.
+    agent_config = load_swarm_agent_config()
+    _swarm_runtime = SwarmRuntime(store=store, agent_config=agent_config)
+    return _swarm_runtime
+
+
+# ============================================================================
+# Scheduled research
+# ============================================================================
+
+
+def _get_scheduled_research_store() -> "ScheduledResearchJobStore":
+    """Return the singleton ScheduledResearchJobStore, creating it on first call."""
+    global _scheduled_research_store
+    if _scheduled_research_store is None:
+        from src.scheduled_research.store import ScheduledResearchJobStore
+
+        _scheduled_research_store = ScheduledResearchJobStore()
+    return _scheduled_research_store
+
+
+def _scheduled_research_scheduler_enabled() -> bool:
+    """Return whether scheduled research execution is enabled."""
+    return os.getenv(_SCHEDULED_RESEARCH_SCHEDULER_ENV, "").strip().lower() in _SCHEDULED_RESEARCH_TRUE_VALUES
+
+
+def _get_scheduled_research_executor() -> "ScheduledResearchExecutor":
+    """Return the singleton scheduled research executor."""
+    global _scheduled_research_executor
+    if _scheduled_research_executor is None:
+        from src.scheduled_research.executor import ScheduledResearchExecutor
+
+        _scheduled_research_executor = ScheduledResearchExecutor(
+            _get_scheduled_research_store(),
+            _dispatch_scheduled_research_job,
+            enabled=_scheduled_research_scheduler_enabled(),
+        )
+    return _scheduled_research_executor
+
+
+def _start_scheduled_research_executor() -> None:
+    """Start scheduled research execution when explicitly enabled."""
+    if not _scheduled_research_scheduler_enabled():
+        return
+    _get_scheduled_research_executor().start()
+
+
+async def _stop_scheduled_research_executor() -> None:
+    """Stop scheduled research execution if it was started."""
+    executor = _scheduled_research_executor
+    if executor is not None:
+        await executor.stop()

--- a/agent/src/api/state.py
+++ b/agent/src/api/state.py
@@ -181,6 +181,23 @@ def _scheduled_research_scheduler_enabled() -> bool:
     return os.getenv(_SCHEDULED_RESEARCH_SCHEDULER_ENV, "").strip().lower() in _SCHEDULED_RESEARCH_TRUE_VALUES
 
 
+async def _dispatch_scheduled_research_job(job: "ScheduledResearchJob") -> None:
+    """Enqueue one scheduled research job through the session runtime.
+
+    ``send_message`` queues the agent attempt and returns once accepted; it
+    does not wait for that agent run to reach a terminal status. The executor's
+    ``COMPLETED`` state for this dispatch path means "successfully enqueued."
+    """
+    svc = _get_session_service()
+    if not svc:
+        raise RuntimeError("Session runtime not enabled")
+    # Pass a copy so the session runtime's internal config writes (e.g.
+    # include_shell_tools) do not mutate the persisted scheduled-run config.
+    session = svc.create_session(title=f"scheduled-research:{job.id}", config=dict(job.config))
+    logger.info("dispatching scheduled research job %s via session %s", job.id, session.session_id)
+    await svc.send_message(session.session_id, job.prompt)
+
+
 def _get_scheduled_research_executor() -> "ScheduledResearchExecutor":
     """Return the singleton scheduled research executor."""
     global _scheduled_research_executor

--- a/agent/src/api/uploads_routes.py
+++ b/agent/src/api/uploads_routes.py
@@ -1,0 +1,185 @@
+"""Upload and Shadow Account report HTTP routes.
+
+Mounted by ``agent/api_server.py`` via ``register_uploads_routes(app, ...)``.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import uuid
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+
+from fastapi import Depends, FastAPI, HTTPException, UploadFile
+from fastapi.responses import FileResponse
+
+from src.api.helpers import MAX_UPLOAD_SIZE, UPLOADS_DIR, _UPLOAD_CHUNK_SIZE
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_BLOCKED_UPLOAD_EXT = {
+    # binaries / executables we should never accept
+    ".exe", ".msi", ".bat", ".cmd", ".com", ".scr", ".app", ".dmg",
+    ".so", ".dll", ".dylib",
+    # executable-adjacent source, shell, config, and template files
+    ".py", ".pyw", ".sh", ".bash", ".zsh", ".fish", ".ps1",
+    ".yaml", ".yml", ".j2", ".jinja", ".jinja2", ".template",
+    # archives — don't auto-extract; user can unpack locally
+    ".zip", ".rar", ".7z", ".tar", ".gz", ".tgz", ".bz2", ".xz",
+}
+
+_BLOCKED_UPLOAD_NAMES = {
+    "dockerfile",
+    "containerfile",
+}
+
+_SHADOW_ID_RE = re.compile(r"^shadow_[0-9a-f]{8}$")
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+AuthDep = Callable[..., Awaitable[Any] | Any]
+
+
+def register_uploads_routes(
+    app: FastAPI,
+    require_auth: AuthDep | None = None,
+) -> None:
+    """Mount the upload routes onto ``app``.
+
+    Args:
+        app: The host FastAPI app.
+        require_auth: Header-auth dependency for JSON endpoints.
+
+    For backwards compatibility, when the dependency callable is not passed
+    explicitly we resolve it from the host ``api_server`` module via
+    ``sys.modules``. Prefer the explicit form in new call sites.
+    """
+    if require_auth is None:
+        import sys as _sys
+
+        host = _sys.modules.get("api_server") or _sys.modules.get("agent.api_server")
+        if host is None:  # pragma: no cover — only triggers on weird import setups
+            raise RuntimeError(
+                "register_uploads_routes: api_server module not in sys.modules; "
+                "pass require_auth explicitly"
+            )
+        require_auth = host.require_auth
+
+    # -----------------------------------------------------------------------
+    # Helpers — resolve host-module attributes at call time so that
+    # ``monkeypatch.setattr(api_server, "UPLOADS_DIR", ...)`` works.
+    # -----------------------------------------------------------------------
+
+    def _host_uploads_dir() -> Path:
+        import sys as _sys
+        host = _sys.modules.get("api_server") or _sys.modules.get("agent.api_server")
+        return host.UPLOADS_DIR if host else UPLOADS_DIR
+
+    def _host_max_upload_size() -> int:
+        import sys as _sys
+        host = _sys.modules.get("api_server") or _sys.modules.get("agent.api_server")
+        return host.MAX_UPLOAD_SIZE if host else MAX_UPLOAD_SIZE
+
+    def _host_chunk_size() -> int:
+        import sys as _sys
+        host = _sys.modules.get("api_server") or _sys.modules.get("agent.api_server")
+        return host._UPLOAD_CHUNK_SIZE if host else _UPLOAD_CHUNK_SIZE
+
+    # -----------------------------------------------------------------------
+    # GET /shadow-reports/{shadow_id}
+    # -----------------------------------------------------------------------
+
+    @app.get("/shadow-reports/{shadow_id}", dependencies=[Depends(require_auth)])
+    async def get_shadow_report(shadow_id: str, format: str = "html"):
+        """Serve a rendered Shadow Account report (HTML by default, PDF if available).
+
+        Reports live under ``~/.vibe-trading/shadow_reports/<shadow_id>.{html,pdf}``.
+        """
+        if not _SHADOW_ID_RE.match(shadow_id):
+            raise HTTPException(status_code=400, detail="invalid shadow_id")
+        if format not in ("html", "pdf"):
+            raise HTTPException(status_code=400, detail="format must be html or pdf")
+
+        reports_dir = Path.home() / ".vibe-trading" / "shadow_reports"
+        path = reports_dir / f"{shadow_id}.{format}"
+        if not path.exists():
+            raise HTTPException(status_code=404, detail=f"Shadow report not found: {shadow_id}.{format}")
+
+        media_type = "text/html; charset=utf-8" if format == "html" else "application/pdf"
+        return FileResponse(
+            path,
+            media_type=media_type,
+            headers={"Content-Disposition": f'inline; filename="{shadow_id}.{format}"'},
+        )
+
+    # -----------------------------------------------------------------------
+    # POST /upload
+    # -----------------------------------------------------------------------
+
+    @app.post("/upload", dependencies=[Depends(require_auth)])
+    async def upload_file(file: UploadFile):
+        """Upload any document or data file (max 50MB).
+
+        Accepts most common formats: PDF, Word, Excel, PowerPoint, images,
+        CSV/TSV, plain text, JSON, and TOML. Executables, executable-adjacent
+        source/config/template files, and archives are rejected.
+        """
+        if not file.filename:
+            raise HTTPException(status_code=400, detail="Missing filename")
+        filename = Path(file.filename).name
+        ext = Path(filename).suffix.lower()
+        if ext in _BLOCKED_UPLOAD_EXT or filename.lower() in _BLOCKED_UPLOAD_NAMES:
+            raise HTTPException(
+                status_code=400,
+                detail="This file type is not allowed for upload.",
+            )
+
+        uploads_dir = _host_uploads_dir()
+        max_size = _host_max_upload_size()
+        chunk_size = _host_chunk_size()
+
+        safe_name = f"{uuid.uuid4().hex}{ext}"
+        dest = uploads_dir / safe_name
+        total_size = 0
+
+        try:
+            uploads_dir.mkdir(parents=True, exist_ok=True)
+            with dest.open("wb") as handle:
+                while True:
+                    chunk = await file.read(chunk_size)
+                    if not chunk:
+                        break
+                    total_size += len(chunk)
+                    if total_size > max_size:
+                        handle.close()
+                        if dest.exists():
+                            dest.unlink()
+                        raise HTTPException(
+                            status_code=413,
+                            detail=f"File too large (limit {max_size // (1024 * 1024)} MB)",
+                        )
+                    handle.write(chunk)
+        except HTTPException:
+            raise
+        except OSError as exc:
+            if dest.exists():
+                dest.unlink()
+            raise HTTPException(
+                status_code=500,
+                detail="Upload failed while storing the file. Please retry or choose a different file.",
+            ) from exc
+        finally:
+            await file.close()
+
+        return {
+            "status": "ok",
+            "file_path": f"uploads/{safe_name}",
+            "filename": filename,
+        }


### PR DESCRIPTION
## Summary

- Extract shared infrastructure from `agent/api_server.py` (3,626 lines) into 5 focused modules under `agent/src/api/`: `deps.py`, `models.py`, `helpers.py`, `state.py`, `live_relay.py`
- Extract upload routes (`POST /upload`, `GET /shadow-reports/{shadow_id}`) into `agent/src/api/uploads_routes.py` following the existing `alpha_routes.py` registration pattern
- Reduce `api_server.py` from 3,626 → 3,535 lines (−91 lines) with zero behavior change

## Why

`agent/api_server.py` has grown to 3,626 lines with 50 route decorators — a single module hosting auth, CORS, DNS-rebinding middleware, Pydantic models, session/run/swarm orchestration, live-trading endpoints, upload handling, and the dev launcher. This concentration of unrelated responsibilities makes the file hard to review safely and raises the barrier for new contributors. See #331 for the full analysis.

This is **PR 1 of 5** in an incremental modularization series. Each PR is independently mergeable with green tests.

Closes #331 (partial — shared infrastructure + uploads extraction)

## Changes

### New shared infrastructure modules (additive)

| Module | Lines | Content |
|--------|-------|---------|
| `src/api/deps.py` | 393 | Auth dependencies + security helpers (CORS, DNS-rebinding, loopback detection, CSRF, shell-tools gating) |
| `src/api/models.py` | 461 | All 38 Pydantic models + `LiveRunnerUnavailable` exception |
| `src/api/helpers.py` | 401 | Path constants, env I/O helpers, `_build_response_from_run_dir`, `_validate_path_param`, SPA fallback |
| `src/api/state.py` | 209 | Lazy-init singleton accessors (session service, goal store, swarm/channel/scheduled runtimes) |
| `src/api/live_relay.py` | 204 | SSE relay helpers for live trading events |

### First route extraction: uploads

| Module | Lines | Routes |
|--------|-------|--------|
| `src/api/uploads_routes.py` | 185 | `POST /upload`, `GET /shadow-reports/{shadow_id}` |

### `api_server.py` changes

- Upload route definitions replaced with `register_uploads_routes(app)` call
- Re-exports added for backward-compatible test access

### Design decisions

1. **Function-based registration** (not `APIRouter`) — follows existing `alpha_routes.py` pattern
2. **Per-module Pydantic models** — avoids coupling unrelated groups
3. **SSE relay in `live_relay.py`** — resolves sessions ↔ live circular dependency
4. **Re-exports for test compatibility** — all test-accessed symbols remain importable via `api_server.*`

## Test Plan

- [x] Existing tests pass (`cd agent && pytest tests/test_upload_api.py tests/test_upload_security.py tests/test_security_auth_api.py tests/test_settings_api.py tests/test_spa_deep_link.py tests/test_run_card.py -v` — all pass)
- [x] New tests added (not applicable — pure structural refactor, zero test changes)
- [x] Tested manually: verified all 5 new modules importable without circular imports, all path constants resolve correctly

## Checklist

- [ ] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] Documentation updated (not applicable — internal refactor, no user-facing change)
