### PR TITLE
fix(frontend): proxy /channels through Vite dev server

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,6 +8,7 @@ const PROXY_PATHS = [
   "/swarm/runs",
   "/settings/llm",
   "/settings/data-sources",
+  "/channels",
   "/mandate",
   "/live",
   "/upload",


### PR DESCRIPTION
## Summary

The Settings page (`frontend/src/pages/Settings.tsx`) loads three endpoints together in a single `Promise.all`:

```ts
Promise.all([api.getLLMSettings(), api.getDataSourceSettings(), api.getChannelStatus()])
```

`getChannelStatus()` requests `/channels/status`, but `/channels` is **not** in the Vite dev proxy `PROXY_PATHS` (`frontend/vite.config.ts`). In `npm run dev`, that request therefore falls through to the SPA `index.html` fallback and returns HTML instead of JSON. Parsing fails with:

```
Unexpected token '<', "<!doctype "... is not valid JSON
```

Because all three requests share one `Promise.all`, the entire Settings page renders **"Settings are unavailable"** — not just the channels section.

## Fix

Add `/channels` to `PROXY_PATHS` so every `/channels/*` route (`status`, `start`, `stop`, `pairing/command`) reaches the backend in local dev.

```diff
   "/settings/llm",
   "/settings/data-sources",
+  "/channels",
   "/mandate",
```

## Why it surfaced now

The IM channel runtime + Settings UI shipped recently (#341, #343). The backend already serves `/channels/status` as JSON (verified locally — returns `{"running":false,...}` with HTTP 200); only the dev proxy list was missed.

## Scope / impact

- **Local dev only.** Production/Docker is unaffected because the frontend proxies to the backend container there, not through the Vite dev server.
- No backend changes; one line in `vite.config.ts`.

## Testing

- Repro: `vibe-trading dev` → open `http://localhost:5899/settings` → "Settings are unavailable" with the JSON parse error.
- After fix (restart dev server so Vite reloads its config): Settings page loads LLM, data-source, and channel status cleanly.
- `curl http://127.0.0.1:8899/channels/status` returns valid JSON (200), confirming the backend route is correct and only the proxy was missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)