### PR TITLE
fix(frontend): make channel settings robust against API failures and proxy channel requests

### DIFF
--- a/frontend/src/__tests__/viteProxy.test.ts
+++ b/frontend/src/__tests__/viteProxy.test.ts
@@ -1,0 +1,17 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("Vite API proxy config", () => {
+  const configPath = path.resolve(__dirname, "../../vite.config.ts");
+  const config = fs.readFileSync(configPath, "utf8");
+
+  it("proxies channel runtime endpoints", () => {
+    expect(config).toContain('"/channels"');
+  });
+
+  it("proxies settings endpoints", () => {
+    expect(config).toContain('"/settings/llm"');
+    expect(config).toContain('"/settings/data-sources"');
+  });
+});

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "../api";
+
+async function loadApiModule() {
+  vi.resetModules();
+  return import("../api");
+}
+
+describe("api request helper", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn(() => ""),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it("rejects non-JSON responses with a descriptive error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("<!doctype html><html><body>SPA</body></html>", {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        }),
+      ),
+    );
+
+    const { api } = await loadApiModule();
+
+    await expect(api.getChannelStatus()).rejects.toMatchObject({
+      name: "ApiError",
+      status: 200,
+      message: expect.stringContaining("Expected JSON from /channels/status, got text/html"),
+    } satisfies Partial<ApiError>);
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -47,7 +47,18 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
     throw await errorFromResponse(res);
   }
   const text = await res.text();
-  return text ? JSON.parse(text) : ({} as T);
+  if (!text) return {} as T;
+
+  const contentType = res.headers.get("content-type") || "";
+  if (!contentType.includes("application/json")) {
+    const preview = text.slice(0, 80).replace(/\s+/g, " ");
+    throw new ApiError(
+      `Expected JSON from ${path}, got ${contentType || "unknown content type"}: ${preview}`,
+      res.status,
+    );
+  }
+
+  return JSON.parse(text) as T;
 }
 
 export interface UploadResult {

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -53,30 +53,56 @@ export function Settings() {
 
   useEffect(() => {
     let alive = true;
-    Promise.all([api.getLLMSettings(), api.getDataSourceSettings(), api.getChannelStatus()])
-      .then(([llmData, dataSourceData, channelData]) => {
+
+    Promise.allSettled([
+      api.getLLMSettings(),
+      api.getDataSourceSettings(),
+      api.getChannelStatus(),
+    ])
+      .then(([llmResult, dataSourceResult, channelResult]) => {
         if (!alive) return;
-        setSettings(llmData);
-        setForm(toForm(llmData));
-        setDataSettings(dataSourceData);
-        setChannelStatus(channelData);
-        setSettingsLoadError(null);
-      })
-      .catch((error) => {
-        const message = error instanceof Error ? error.message : "Unknown error";
-        setSettingsLoadError(message);
-        if (isAuthRequiredError(error)) {
-          toast.error(message);
+
+        if (llmResult.status === "fulfilled") {
+          setSettings(llmResult.value);
+          setForm(toForm(llmResult.value));
         } else {
-          toast.error(`Failed to load LLM settings: ${message}`);
-          toast.error(`Failed to load data source settings: ${message}`);
+          const message = llmResult.reason instanceof Error ? llmResult.reason.message : "Unknown error";
+          setSettingsLoadError(message);
+          if (isAuthRequiredError(llmResult.reason)) {
+            toast.error(message);
+          } else {
+            toast.error(`Failed to load LLM settings: ${message}`);
+          }
+        }
+
+        if (dataSourceResult.status === "fulfilled") {
+          setDataSettings(dataSourceResult.value);
+        } else {
+          const message = dataSourceResult.reason instanceof Error ? dataSourceResult.reason.message : "Unknown error";
+          setSettingsLoadError(message);
+          if (isAuthRequiredError(dataSourceResult.reason)) {
+            toast.error(message);
+          } else {
+            toast.error(`Failed to load data source settings: ${message}`);
+          }
+        }
+
+        if (channelResult.status === "fulfilled") {
+          setChannelStatus(channelResult.value);
+        } else {
+          const message = channelResult.reason instanceof Error ? channelResult.reason.message : "Unknown error";
+          toast.error(`${t("settings.channels.refreshFailed")}: ${message}`);
+          setChannelStatus(null);
         }
       })
       .finally(() => {
         if (alive) setLoading(false);
       });
-    return () => { alive = false; };
-  }, []);
+
+    return () => {
+      alive = false;
+    };
+  }, [t]);
 
   const refreshChannelStatus = async () => {
     setChannelRefreshing(true);
@@ -211,7 +237,7 @@ export function Settings() {
     </form>
   );
 
-  if (loading || !form || !settings || !dataSettings || !channelStatus) {
+  if (loading || !form || !settings || !dataSettings) {
     return (
       <div className="mx-auto max-w-5xl space-y-6 p-6">
         <div className="space-y-2">
@@ -247,11 +273,121 @@ export function Settings() {
   const tushareStatus = dataSettings.tushare_token_configured
     ? "Configured"
     : "Leave blank to keep the current token";
-  const channelRows = Object.entries(channelStatus.channels ?? {}).sort(([a], [b]) => a.localeCompare(b));
+  const channelRows = channelStatus
+    ? Object.entries(channelStatus.channels ?? {}).sort(([a], [b]) => a.localeCompare(b))
+    : [];
   const channelEnabledCount = channelRows.filter(([, item]) => item.enabled).length;
   const channelLoadedCount = channelRows.filter(([, item]) => item.loaded).length;
   const channelUnavailableCount = channelRows.filter(([, item]) => item.available === false).length;
   const channelBusy = channelRefreshing || channelAction !== null;
+
+  const channelsSection = (
+    <section className="rounded-lg border bg-card p-5 shadow-sm">
+      <div className="mb-5 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <MessageSquareMore className="h-4 w-4 text-primary" />
+            <h2 className="text-base font-semibold">{t("settings.channels.title")}</h2>
+          </div>
+          <p className="max-w-3xl text-sm text-muted-foreground">{t("settings.channels.description")}</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={refreshChannelStatus}
+            disabled={channelBusy}
+            className="inline-flex items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm text-muted-foreground transition hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {channelRefreshing ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+            {t("settings.channels.refresh")}
+          </button>
+          <button
+            type="button"
+            onClick={() => setChannelsRunning("start")}
+            disabled={channelBusy || !channelStatus}
+            className="inline-flex items-center justify-center gap-2 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {channelAction === "start" ? <Loader2 className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}
+            {t("settings.channels.start")}
+          </button>
+          <button
+            type="button"
+            onClick={() => setChannelsRunning("stop")}
+            disabled={channelBusy || !channelStatus}
+            className="inline-flex items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm text-muted-foreground transition hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {channelAction === "stop" ? <Loader2 className="h-4 w-4 animate-spin" /> : <Square className="h-4 w-4" />}
+            {t("settings.channels.stop")}
+          </button>
+        </div>
+      </div>
+
+      {channelStatus ? (
+        <>
+          <div className="mb-4 grid gap-3 md:grid-cols-4">
+            <div className="rounded-md border bg-muted/20 px-3 py-2">
+              <div className="text-xs text-muted-foreground">{t("settings.channels.runtime")}</div>
+              <div className="text-sm font-medium">{channelStatus.running ? t("settings.channels.running") : t("settings.channels.stopped")}</div>
+            </div>
+            <div className="rounded-md border bg-muted/20 px-3 py-2">
+              <div className="text-xs text-muted-foreground">{t("settings.channels.enabled")}</div>
+              <div className="text-sm font-medium">{channelEnabledCount}</div>
+            </div>
+            <div className="rounded-md border bg-muted/20 px-3 py-2">
+              <div className="text-xs text-muted-foreground">{t("settings.channels.loaded")}</div>
+              <div className="text-sm font-medium">{channelLoadedCount}</div>
+            </div>
+            <div className="rounded-md border bg-muted/20 px-3 py-2">
+              <div className="text-xs text-muted-foreground">{t("settings.channels.unavailable")}</div>
+              <div className="text-sm font-medium">{channelUnavailableCount}</div>
+            </div>
+          </div>
+
+          <div className="overflow-hidden rounded-md border">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/40 text-xs text-muted-foreground">
+                <tr>
+                  <th className="px-3 py-2 text-left font-medium">{t("settings.channels.channel")}</th>
+                  <th className="px-3 py-2 text-left font-medium">{t("settings.channels.state")}</th>
+                  <th className="px-3 py-2 text-left font-medium">{t("settings.channels.recovery")}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {channelRows.map(([name, item]) => (
+                  <tr key={name} className="border-t">
+                    <td className="px-3 py-2 align-top">
+                      <div className="font-medium">{item.display_name || name}</div>
+                      <div className="text-xs text-muted-foreground">{name}</div>
+                    </td>
+                    <td className="px-3 py-2 align-top">
+                      <div className="flex flex-wrap gap-1.5">
+                        <span className={`rounded-full px-2 py-0.5 text-xs ${item.enabled ? "bg-primary/10 text-primary" : "bg-muted text-muted-foreground"}`}>
+                          {item.enabled ? t("settings.channels.enabled") : t("settings.channels.disabled")}
+                        </span>
+                        <span className={`rounded-full px-2 py-0.5 text-xs ${item.loaded ? "bg-success/10 text-success" : "bg-muted text-muted-foreground"}`}>
+                          {item.loaded ? t("settings.channels.loaded") : t("settings.channels.notLoaded")}
+                        </span>
+                        <span className={`rounded-full px-2 py-0.5 text-xs ${item.running ? "bg-success/10 text-success" : "bg-muted text-muted-foreground"}`}>
+                          {item.running ? t("settings.channels.running") : t("settings.channels.stopped")}
+                        </span>
+                      </div>
+                    </td>
+                    <td className="max-w-md px-3 py-2 align-top text-xs text-muted-foreground">
+                      {item.install_hint || item.error || t("settings.channels.noRecovery")}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      ) : (
+        <div className="rounded-md border bg-muted/20 px-4 py-6 text-center text-sm text-muted-foreground">
+          {t("settings.channels.refreshFailed")}
+        </div>
+      )}
+    </section>
+  );
 
   return (
     <div className="mx-auto max-w-5xl space-y-6 p-6">
@@ -262,103 +398,7 @@ export function Settings() {
 
       {localApiAccessSection}
 
-      <section className="rounded-lg border bg-card p-5 shadow-sm">
-        <div className="mb-5 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-          <div className="space-y-1">
-            <div className="flex items-center gap-2">
-              <MessageSquareMore className="h-4 w-4 text-primary" />
-              <h2 className="text-base font-semibold">{t("settings.channels.title")}</h2>
-            </div>
-            <p className="max-w-3xl text-sm text-muted-foreground">{t("settings.channels.description")}</p>
-          </div>
-          <div className="flex flex-wrap gap-2">
-            <button
-              type="button"
-              onClick={refreshChannelStatus}
-              disabled={channelBusy}
-              className="inline-flex items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm text-muted-foreground transition hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              {channelRefreshing ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
-              {t("settings.channels.refresh")}
-            </button>
-            <button
-              type="button"
-              onClick={() => setChannelsRunning("start")}
-              disabled={channelBusy}
-              className="inline-flex items-center justify-center gap-2 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              {channelAction === "start" ? <Loader2 className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}
-              {t("settings.channels.start")}
-            </button>
-            <button
-              type="button"
-              onClick={() => setChannelsRunning("stop")}
-              disabled={channelBusy}
-              className="inline-flex items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm text-muted-foreground transition hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              {channelAction === "stop" ? <Loader2 className="h-4 w-4 animate-spin" /> : <Square className="h-4 w-4" />}
-              {t("settings.channels.stop")}
-            </button>
-          </div>
-        </div>
-
-        <div className="mb-4 grid gap-3 md:grid-cols-4">
-          <div className="rounded-md border bg-muted/20 px-3 py-2">
-            <div className="text-xs text-muted-foreground">{t("settings.channels.runtime")}</div>
-            <div className="text-sm font-medium">{channelStatus.running ? t("settings.channels.running") : t("settings.channels.stopped")}</div>
-          </div>
-          <div className="rounded-md border bg-muted/20 px-3 py-2">
-            <div className="text-xs text-muted-foreground">{t("settings.channels.enabled")}</div>
-            <div className="text-sm font-medium">{channelEnabledCount}</div>
-          </div>
-          <div className="rounded-md border bg-muted/20 px-3 py-2">
-            <div className="text-xs text-muted-foreground">{t("settings.channels.loaded")}</div>
-            <div className="text-sm font-medium">{channelLoadedCount}</div>
-          </div>
-          <div className="rounded-md border bg-muted/20 px-3 py-2">
-            <div className="text-xs text-muted-foreground">{t("settings.channels.unavailable")}</div>
-            <div className="text-sm font-medium">{channelUnavailableCount}</div>
-          </div>
-        </div>
-
-        <div className="overflow-hidden rounded-md border">
-          <table className="w-full text-sm">
-            <thead className="bg-muted/40 text-xs text-muted-foreground">
-              <tr>
-                <th className="px-3 py-2 text-left font-medium">{t("settings.channels.channel")}</th>
-                <th className="px-3 py-2 text-left font-medium">{t("settings.channels.state")}</th>
-                <th className="px-3 py-2 text-left font-medium">{t("settings.channels.recovery")}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {channelRows.map(([name, item]) => (
-                <tr key={name} className="border-t">
-                  <td className="px-3 py-2 align-top">
-                    <div className="font-medium">{item.display_name || name}</div>
-                    <div className="text-xs text-muted-foreground">{name}</div>
-                  </td>
-                  <td className="px-3 py-2 align-top">
-                    <div className="flex flex-wrap gap-1.5">
-                      <span className={`rounded-full px-2 py-0.5 text-xs ${item.enabled ? "bg-primary/10 text-primary" : "bg-muted text-muted-foreground"}`}>
-                        {item.enabled ? t("settings.channels.enabled") : t("settings.channels.disabled")}
-                      </span>
-                      <span className={`rounded-full px-2 py-0.5 text-xs ${item.loaded ? "bg-success/10 text-success" : "bg-muted text-muted-foreground"}`}>
-                        {item.loaded ? t("settings.channels.loaded") : t("settings.channels.notLoaded")}
-                      </span>
-                      <span className={`rounded-full px-2 py-0.5 text-xs ${item.running ? "bg-success/10 text-success" : "bg-muted text-muted-foreground"}`}>
-                        {item.running ? t("settings.channels.running") : t("settings.channels.stopped")}
-                      </span>
-                    </div>
-                  </td>
-                  <td className="max-w-md px-3 py-2 align-top text-xs text-muted-foreground">
-                    {item.install_hint || item.error || t("settings.channels.noRecovery")}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </section>
+      {channelsSection}
 
       <div className="space-y-2">
         <h2 className="text-lg font-semibold tracking-tight">{"LLM Settings"}</h2>

--- a/frontend/src/pages/__tests__/SettingsChannels.test.tsx
+++ b/frontend/src/pages/__tests__/SettingsChannels.test.tsx
@@ -128,4 +128,18 @@ describe("Settings IM channels panel", () => {
 
     await waitFor(() => expect(apiMock.startChannels).toHaveBeenCalledTimes(1));
   });
+
+  it("still renders LLM and data source settings when channel status fails", async () => {
+    apiMock.getChannelStatus.mockRejectedValue(
+      new Error('Expected JSON from /channels/status, got text/html: <!doctype html>'),
+    );
+
+    render(<Settings />);
+
+    expect(await screen.findByText("LLM Settings")).toBeInTheDocument();
+    expect(screen.getByText("Data Source Settings")).toBeInTheDocument();
+    expect(screen.getByText("IM Channels")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Refresh" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Start channels" })).toBeDisabled();
+  });
 });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,6 +8,7 @@ const PROXY_PATHS = [
   "/swarm/runs",
   "/settings/llm",
   "/settings/data-sources",
+  "/channels",
   "/mandate",
   "/live",
   "/upload",


### PR DESCRIPTION
## Goal
    Make the frontend channel settings page robust against API failures and proxy channel requests in Vite.

    ## Affected Areas
    - `frontend/vite.config.ts` (Proxy settings)
    - `frontend/src/pages/Settings.tsx` (Resilience during page-load)
    - `frontend/src/lib/api.ts` (Diagnostics on API response)
    - `frontend/src/__tests__/` (Regression tests)

    ## Out of Scope
    Backend changes, live broker connectivity, or mandate enforcement changes.

    ## Test Plan
    Ran regression tests including `viteProxy.test.ts`, `api.test.ts`, and `SettingsChannels.test.tsx`. All 6 related tests pass.

    ## Risk Notes
    No live trading, secret, or broker risks. This is entirely contained to frontend UI handling and dev server proxy routing. 

    ## Rollback Path
    A standard `git revert` of this PR is safe.