### PR TITLE
fix(i18n): fix zh-CN language switching and LanguageSwitcher display

### DIFF
--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -337,11 +337,15 @@ function LanguageSwitcher() {
     };
   }, [open]);
 
-  // i18n.language may be a regional variant like "ja-JP" even though only
-  // "ja" is in SUPPORTED_LANGUAGES (nonExplicitSupportedLngs resolves the
-  // resources but keeps the full code). The i18n.languages array contains
-  // both the detected and resolved codes, so we match against any entry.
+  // i18n.language (singular) is the primary active language. We try an exact
+  // match first against SUPPORTED_LANGUAGES. If that fails (e.g. a regional
+  // variant like "ja-JP"), we fall back to i18n.languages (plural) which
+  // includes both the detected and resolved codes. NOTE: i18n.languages
+  // always contains the fallback language ("en"), so it must NOT be the
+  // primary match — otherwise "en" being first in SUPPORTED_LANGUAGES
+  // would always win and the switcher would never show any other language.
   const current =
+    SUPPORTED_LANGUAGES.find((l) => l.code === i18n.language) ??
     SUPPORTED_LANGUAGES.find((l) => i18n.languages?.includes(l.code)) ??
     SUPPORTED_LANGUAGES[0];
 

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -54,8 +54,9 @@ i18n
     // removed.
     fallbackLng: "en",
     supportedLngs: SUPPORTED_LANGUAGES.map((l) => l.code),
-    // Allow "en-US" → "en", "ja-JP" → "ja", etc.
-    nonExplicitSupportedLngs: true,
+    // NOTE: Intentionally NOT using nonExplicitSupportedLngs — it strips
+    // region codes from compound language keys like "zh-CN" which causes
+    // isSupportedCode to reject them ("zh-CN" → "zh", not in supportedLngs).
     interpolation: { escapeValue: false },
     detection: {
       // In browsers the navigator.language gives the user's browser locale,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -12,7 +12,8 @@ const PROXY_PATHS = [
   "/live",
   "/upload",
   "/shadow-reports",
-];
+  "/channels",
+]
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");


### PR DESCRIPTION
## Summary

Fixes zh-CN (Chinese) language switching that was silently falling back to English, fixes the LanguageSwitcher always displaying "English" regardless of the active language, and fixes Settings page JSON parse error caused by missing Vite proxy rule.

## Why

Three separate i18n bugs combined to make the Chinese UI non-functional:

1. `nonExplicitSupportedLngs: true` in i18next config causes `isSupportedCode()` to strip region codes (`zh-CN` → `zh`) before checking `supportedLngs`. Since `"zh"` is not in the supported list, `changeLanguage("zh-CN")` is rejected and falls back to English. Other languages (`ja`, `ko`, `ar`) are unaffected because they are simple two-letter codes.

2. `LanguageSwitcher` used `i18n.languages` (plural) to detect the current language. This array always includes the fallback `"en"`, and since `"en"` is first in `SUPPORTED_LANGUAGES`, `.find()` always matched English regardless of the active language.

3. Settings page calls `/channels/status` via `Promise.all` alongside `/settings/llm` and `/settings/data-sources`. The Vite proxy config was missing `/channels`, so the request fell through to the static file handler which returned `index.html`, causing `Unexpected token "<", "<!doctype..." is not valid JSON`.

## Changes

- `frontend/src/i18n/index.ts`: Removed `nonExplicitSupportedLngs: true` from i18next init config.
- `frontend/vite.config.ts`: Added `"/channels"` to `PROXY_PATHS` array.
- `frontend/src/components/layout/Layout.tsx`: Changed `LanguageSwitcher` current language detection to check `i18n.language` (singular, primary active language) first, then fall back to `i18n.languages` (plural).

## Test Plan

- [x] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [ ] New tests added (if applicable)
- [x] Tested manually (describe below)

Manual testing:
- Verified `npm run build` completes with zero TypeScript errors.
- Verified `changeLanguage("zh-CN")` resolves to `["zh-CN", "en"]` hierarchy (not `["en"]`).
- Verified `LanguageSwitcher` shows correct language label after switching.
- Verified Settings page loads without JSON parse error.

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Documentation updated (if user-facing change)