### PR TITLE
refactor(api): extract upload routes

### DIFF
--- a/agent/api_server.py
+++ b/agent/api_server.py
@@ -22,7 +22,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException, Query, Request, Security, UploadFile, status
+from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException, Query, Request, Security, status
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, Field
@@ -2330,110 +2330,21 @@ async def session_events(
 
 
 # ============================================================================
-# File Upload
+# Upload routes - defined in src/api/uploads_routes.py
 # ============================================================================
 
-_BLOCKED_UPLOAD_EXT = {
-    # binaries / executables we should never accept
-    ".exe", ".msi", ".bat", ".cmd", ".com", ".scr", ".app", ".dmg",
-    ".so", ".dll", ".dylib",
-    # executable-adjacent source, shell, config, and template files
-    ".py", ".pyw", ".sh", ".bash", ".zsh", ".fish", ".ps1",
-    ".yaml", ".yml", ".j2", ".jinja", ".jinja2", ".template",
-    # archives — don't auto-extract; user can unpack locally
-    ".zip", ".rar", ".7z", ".tar", ".gz", ".tgz", ".bz2", ".xz",
-}
+from src.api.uploads_routes import register_uploads_routes  # noqa: E402
+register_uploads_routes(app)
 
-_BLOCKED_UPLOAD_NAMES = {
-    "dockerfile",
-    "containerfile",
-}
-
-
-_SHADOW_ID_RE = __import__("re").compile(r"^shadow_[0-9a-f]{8}$")
-
-
-@app.get("/shadow-reports/{shadow_id}", dependencies=[Depends(require_auth)])
-async def get_shadow_report(shadow_id: str, format: str = "html"):
-    """Serve a rendered Shadow Account report (HTML by default, PDF if available).
-
-    Reports live under ``~/.vibe-trading/shadow_reports/<shadow_id>.{html,pdf}``.
-    """
-    if not _SHADOW_ID_RE.match(shadow_id):
-        raise HTTPException(status_code=400, detail="invalid shadow_id")
-    if format not in ("html", "pdf"):
-        raise HTTPException(status_code=400, detail="format must be html or pdf")
-
-    reports_dir = Path.home() / ".vibe-trading" / "shadow_reports"
-    path = reports_dir / f"{shadow_id}.{format}"
-    if not path.exists():
-        raise HTTPException(status_code=404, detail=f"Shadow report not found: {shadow_id}.{format}")
-
-    media_type = "text/html; charset=utf-8" if format == "html" else "application/pdf"
-    # Inline so browsers render HTML/PDF directly instead of forcing download.
-    return FileResponse(
-        path,
-        media_type=media_type,
-        headers={"Content-Disposition": f'inline; filename="{shadow_id}.{format}"'},
-    )
-
-
-@app.post("/upload", dependencies=[Depends(require_auth)])
-async def upload_file(file: UploadFile):
-    """Upload any document or data file (max 50MB).
-
-    Accepts most common formats: PDF, Word, Excel, PowerPoint, images,
-    CSV/TSV, plain text, JSON, and TOML. Executables, executable-adjacent
-    source/config/template files, and archives are rejected.
-    """
-    if not file.filename:
-        raise HTTPException(status_code=400, detail="Missing filename")
-    filename = Path(file.filename).name
-    ext = Path(filename).suffix.lower()
-    if ext in _BLOCKED_UPLOAD_EXT or filename.lower() in _BLOCKED_UPLOAD_NAMES:
-        raise HTTPException(
-            status_code=400,
-            detail="This file type is not allowed for upload.",
-        )
-
-    safe_name = f"{uuid.uuid4().hex}{ext}"
-    dest = UPLOADS_DIR / safe_name
-    total_size = 0
-
-    try:
-        UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
-        with dest.open("wb") as handle:
-            while True:
-                chunk = await file.read(_UPLOAD_CHUNK_SIZE)
-                if not chunk:
-                    break
-                total_size += len(chunk)
-                if total_size > MAX_UPLOAD_SIZE:
-                    handle.close()
-                    if dest.exists():
-                        dest.unlink()
-                    raise HTTPException(
-                        status_code=413,
-                        detail=f"File too large (limit {MAX_UPLOAD_SIZE // (1024 * 1024)} MB)",
-                    )
-                handle.write(chunk)
-    except HTTPException:
-        raise
-    except OSError as exc:
-        if dest.exists():
-            dest.unlink()
-        raise HTTPException(
-            status_code=500,
-            detail="Upload failed while storing the file. Please retry or choose a different file.",
-        ) from exc
-    finally:
-        await file.close()
-
-    return {
-        "status": "ok",
-        "file_path": f"uploads/{safe_name}",
-        "filename": filename,
-    }
+# Re-export upload constants for test access via ``api_server.*``.
+from src.api.uploads_routes import (  # noqa: E402
+    MAX_UPLOAD_SIZE,
+    UPLOADS_DIR,
+    _BLOCKED_UPLOAD_EXT,
+    _BLOCKED_UPLOAD_NAMES,
+    _SHADOW_ID_RE,
+    _UPLOAD_CHUNK_SIZE,
+)
 
 
 # ============================================================================

--- a/agent/src/api/uploads_routes.py
+++ b/agent/src/api/uploads_routes.py
@@ -1,0 +1,176 @@
+"""Upload and Shadow Account report HTTP routes.
+
+Mounted by ``agent/api_server.py`` via ``register_uploads_routes(app, ...)``.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+
+from fastapi import Depends, FastAPI, HTTPException, UploadFile
+from fastapi.responses import FileResponse
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+UPLOADS_DIR = Path(__file__).resolve().parent.parent.parent / "uploads"
+MAX_UPLOAD_SIZE = 50 * 1024 * 1024  # 50 MB
+_UPLOAD_CHUNK_SIZE = 1024 * 1024  # 1 MB
+
+_BLOCKED_UPLOAD_EXT = {
+    # binaries / executables we should never accept
+    ".exe", ".msi", ".bat", ".cmd", ".com", ".scr", ".app", ".dmg",
+    ".so", ".dll", ".dylib",
+    # executable-adjacent source, shell, config, and template files
+    ".py", ".pyw", ".sh", ".bash", ".zsh", ".fish", ".ps1",
+    ".yaml", ".yml", ".j2", ".jinja", ".jinja2", ".template",
+    # archives — don't auto-extract; user can unpack locally
+    ".zip", ".rar", ".7z", ".tar", ".gz", ".tgz", ".bz2", ".xz",
+}
+
+_BLOCKED_UPLOAD_NAMES = {
+    "dockerfile",
+    "containerfile",
+}
+
+_SHADOW_ID_RE = re.compile(r"^shadow_[0-9a-f]{8}$")
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+AuthDep = Callable[..., Awaitable[Any] | Any]
+
+
+def register_uploads_routes(
+    app: FastAPI,
+    require_auth: AuthDep | None = None,
+) -> None:
+    """Mount the upload routes onto ``app``.
+
+    Args:
+        app: The host FastAPI app.
+        require_auth: Header-auth dependency for JSON endpoints.
+
+    For backwards compatibility, when the dependency callable is not passed
+    explicitly we resolve it from the host ``api_server`` module via
+    ``sys.modules``. Prefer the explicit form in new call sites.
+    """
+    if require_auth is None:
+        import sys as _sys
+
+        host = _sys.modules.get("api_server") or _sys.modules.get("agent.api_server")
+        if host is None:  # pragma: no cover - only triggers on unusual import setups
+            raise RuntimeError(
+                "register_uploads_routes: api_server module not in sys.modules; "
+                "pass require_auth explicitly"
+            )
+        require_auth = host.require_auth
+
+    # Resolve host attributes at call time so existing tests and operator
+    # overrides like ``monkeypatch.setattr(api_server, "UPLOADS_DIR", ...)`` work.
+    def _host_uploads_dir() -> Path:
+        import sys as _sys
+
+        host = _sys.modules.get("api_server") or _sys.modules.get("agent.api_server")
+        return host.UPLOADS_DIR if host else UPLOADS_DIR
+
+    def _host_max_upload_size() -> int:
+        import sys as _sys
+
+        host = _sys.modules.get("api_server") or _sys.modules.get("agent.api_server")
+        return host.MAX_UPLOAD_SIZE if host else MAX_UPLOAD_SIZE
+
+    def _host_chunk_size() -> int:
+        import sys as _sys
+
+        host = _sys.modules.get("api_server") or _sys.modules.get("agent.api_server")
+        return host._UPLOAD_CHUNK_SIZE if host else _UPLOAD_CHUNK_SIZE
+
+    @app.get("/shadow-reports/{shadow_id}", dependencies=[Depends(require_auth)])
+    async def get_shadow_report(shadow_id: str, format: str = "html"):
+        """Serve a rendered Shadow Account report.
+
+        Reports live under ``~/.vibe-trading/shadow_reports/<shadow_id>.{html,pdf}``.
+        """
+        if not _SHADOW_ID_RE.match(shadow_id):
+            raise HTTPException(status_code=400, detail="invalid shadow_id")
+        if format not in ("html", "pdf"):
+            raise HTTPException(status_code=400, detail="format must be html or pdf")
+
+        reports_dir = Path.home() / ".vibe-trading" / "shadow_reports"
+        path = reports_dir / f"{shadow_id}.{format}"
+        if not path.exists():
+            raise HTTPException(status_code=404, detail=f"Shadow report not found: {shadow_id}.{format}")
+
+        media_type = "text/html; charset=utf-8" if format == "html" else "application/pdf"
+        return FileResponse(
+            path,
+            media_type=media_type,
+            headers={"Content-Disposition": f'inline; filename="{shadow_id}.{format}"'},
+        )
+
+    @app.post("/upload", dependencies=[Depends(require_auth)])
+    async def upload_file(file: UploadFile):
+        """Upload any document or data file (max 50MB).
+
+        Accepts most common formats: PDF, Word, Excel, PowerPoint, images,
+        CSV/TSV, plain text, JSON, and TOML. Executables, executable-adjacent
+        source/config/template files, and archives are rejected.
+        """
+        if not file.filename:
+            raise HTTPException(status_code=400, detail="Missing filename")
+        filename = Path(file.filename).name
+        ext = Path(filename).suffix.lower()
+        if ext in _BLOCKED_UPLOAD_EXT or filename.lower() in _BLOCKED_UPLOAD_NAMES:
+            raise HTTPException(
+                status_code=400,
+                detail="This file type is not allowed for upload.",
+            )
+
+        uploads_dir = _host_uploads_dir()
+        max_size = _host_max_upload_size()
+        chunk_size = _host_chunk_size()
+
+        safe_name = f"{uuid.uuid4().hex}{ext}"
+        dest = uploads_dir / safe_name
+        total_size = 0
+
+        try:
+            uploads_dir.mkdir(parents=True, exist_ok=True)
+            with dest.open("wb") as handle:
+                while True:
+                    chunk = await file.read(chunk_size)
+                    if not chunk:
+                        break
+                    total_size += len(chunk)
+                    if total_size > max_size:
+                        handle.close()
+                        if dest.exists():
+                            dest.unlink()
+                        raise HTTPException(
+                            status_code=413,
+                            detail=f"File too large (limit {max_size // (1024 * 1024)} MB)",
+                        )
+                    handle.write(chunk)
+        except HTTPException:
+            raise
+        except OSError as exc:
+            if dest.exists():
+                dest.unlink()
+            raise HTTPException(
+                status_code=500,
+                detail="Upload failed while storing the file. Please retry or choose a different file.",
+            ) from exc
+        finally:
+            await file.close()
+
+        return {
+            "status": "ok",
+            "file_path": f"uploads/{safe_name}",
+            "filename": filename,
+        }


### PR DESCRIPTION
## Summary

- Extract `POST /upload` and `GET /shadow-reports/{shadow_id}` from `agent/api_server.py` into `agent/src/api/uploads_routes.py`.
- Keep `api_server.*` upload constants re-exported so the existing upload tests and monkeypatch hooks continue to work.
- Narrow the integration from #358 so unused duplicate API scaffolding does not land in `main`.

## Credit

Original route-extraction work from #358 by @shadowinlife. This maintainer integration keeps that usable slice and leaves the broader #331 API modularization issue open for later phases.

Refs #331
Refs #358

## Validation

- `PYTHONPATH=agent pytest agent/tests/test_upload_api.py agent/tests/test_upload_security.py agent/tests/test_security_auth_api.py agent/tests/test_settings_api.py agent/tests/test_spa_deep_link.py agent/tests/test_run_card.py -q` -> 102 passed
- `python -m compileall -q agent/api_server.py agent/src/api/uploads_routes.py`
- `git diff --check`
