### PR TITLE
refactor(api) [Patch 2/9]: extract system routes to src/api/system_routes.py

### DIFF
--- a/agent/api_server.py
+++ b/agent/api_server.py
@@ -138,13 +138,6 @@ class RunResponse(BaseModel):
     run_logs: Optional[List[Dict[str, Any]]] = Field(None, description="Structured stdout/stderr lines")
 
 
-class HealthResponse(BaseModel):
-    """Health check payload."""
-    status: str = Field(..., description="Service status")
-    service: str = Field(..., description="Service name")
-    timestamp: str = Field(..., description="Server timestamp")
-
-
 class LLMProviderOption(BaseModel):
     """Supported LLM provider metadata for the settings UI."""
 
@@ -1704,16 +1697,6 @@ async def update_data_source_settings(payload: UpdateDataSourceSettingsRequest):
     return _build_data_source_settings_response(_read_env_values(ENV_PATH))
 
 
-@app.get("/health", response_model=HealthResponse)
-async def health_check():
-    """Liveness probe."""
-    return HealthResponse(
-        status="healthy",
-        service="Vibe-Trading API",
-        timestamp=datetime.now().isoformat()
-    )
-
-
 @app.get("/channels/status", dependencies=[Depends(require_auth)])
 async def channels_status():
     """Return IM channel runtime and adapter status."""
@@ -1744,88 +1727,6 @@ async def channels_pairing_command(payload: ChannelPairingCommandRequest):
     return {
         "channel": payload.channel,
         "reply": handle_pairing_command(payload.channel, payload.command),
-    }
-
-
-@app.get("/correlation")
-async def get_correlation_matrix(
-    codes: str = Query(..., description="Comma-separated asset codes, e.g. BTC-USDT,ETH-USDT,SPY"),
-    days: int = Query(90, description="Lookback window in days", ge=7, le=365),
-    method: str = Query("pearson", description="Correlation method: pearson or spearman"),
-):
-    """Compute cross-asset correlation matrix from daily returns.
-
-    Fetches price data for each code via available data loaders,
-    computes pairwise correlation of daily returns over the lookback window.
-    """
-    from backtest.correlation import compute_correlation_matrix
-
-    code_list = [c.strip() for c in codes.split(",") if c.strip()]
-    if len(code_list) < 2:
-        raise HTTPException(status_code=400, detail="At least 2 asset codes required")
-    if len(code_list) > 20:
-        raise HTTPException(status_code=400, detail="Maximum 20 assets per request")
-    if method not in ("pearson", "spearman"):
-        raise HTTPException(status_code=400, detail="method must be 'pearson' or 'spearman'")
-
-    try:
-        result = compute_correlation_matrix(codes=code_list, days=days, method=method)
-        return result
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
-    except Exception as exc:
-        raise HTTPException(status_code=500, detail=f"Correlation computation failed: {exc}")
-
-
-def _terminate_current_process() -> None:
-    """Stop the current API process after the response has been sent."""
-    time.sleep(0.25)
-    os.kill(os.getpid(), signal.SIGTERM)
-
-
-@app.post("/system/shutdown")
-async def shutdown_local_api(
-    background_tasks: BackgroundTasks,
-    request: Request,
-    cred: Optional[HTTPAuthorizationCredentials] = Security(_security),
-):
-    """Shut down the local API server after explicit local authorization."""
-    _require_shutdown_authorization(request=request, cred=cred)
-    client_host = request.client.host if request.client else ""
-    if client_host not in {"127.0.0.1", "::1", "localhost"}:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Local access only")
-
-    background_tasks.add_task(_terminate_current_process)
-    return {
-        "status": "shutting-down",
-        "service": "Vibe-Trading API",
-        "timestamp": datetime.now().isoformat(),
-    }
-
-
-@app.get("/skills")
-async def list_skills():
-    """List registered skills (name and description)."""
-    from src.agent.skills import SkillsLoader
-
-    loader = SkillsLoader()
-    return [
-        {
-            "name": s.name,
-            "description": s.description,
-        }
-        for s in loader.skills
-    ]
-
-
-@app.get("/api")
-async def api_info():
-    """Service metadata."""
-    return {
-        "service": "Vibe-Trading API",
-        "version": APP_VERSION,
-        "docs": "/docs",
-        "health": "/health",
     }
 
 
@@ -2327,6 +2228,17 @@ async def session_events(
             "X-Accel-Buffering": "no",
         },
     )
+
+
+# ============================================================================
+# System routes - defined in src/api/system_routes.py
+# ============================================================================
+
+from src.api.system_routes import register_system_routes  # noqa: E402
+register_system_routes(app)
+
+# Re-export for test monkeypatch compatibility
+from src.api.system_routes import _terminate_current_process  # noqa: F401, E402
 
 
 # ============================================================================

--- a/agent/src/api/system_routes.py
+++ b/agent/src/api/system_routes.py
@@ -1,0 +1,160 @@
+"""System and utility HTTP routes.
+
+Mounted by ``agent/api_server.py`` via ``register_system_routes(app, ...)``.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import time
+from datetime import datetime
+from typing import Optional
+
+from fastapi import BackgroundTasks, FastAPI, HTTPException, Query, Request, Security, status
+from fastapi.security import HTTPAuthorizationCredentials
+from pydantic import BaseModel, Field
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models (defined locally -- NO shared modules, per maintainer rule)
+# ---------------------------------------------------------------------------
+
+class HealthResponse(BaseModel):
+    """Health check payload."""
+    status: str = Field(..., description="Service status")
+    service: str = Field(..., description="Service name")
+    timestamp: str = Field(..., description="Server timestamp")
+
+
+# ---------------------------------------------------------------------------
+# Process termination
+# ---------------------------------------------------------------------------
+
+
+def _terminate_current_process() -> None:
+    """Stop the current API process after the response has been sent."""
+    time.sleep(0.25)
+    os.kill(os.getpid(), signal.SIGTERM)
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+def register_system_routes(
+    app: FastAPI,
+    app_version: str | None = None,
+) -> None:
+    """Mount the system routes onto ``app``.
+
+    Resolves ``_security``, ``_require_shutdown_authorization``, and
+    ``APP_VERSION`` from the host ``api_server`` module via ``sys.modules``
+    when not passed explicitly.
+    """
+    # Resolve host dependencies via sys.modules fallback
+    import sys as _sys
+
+    host = _sys.modules.get("api_server") or _sys.modules.get("agent.api_server")
+
+    if host is None:
+        raise RuntimeError(
+            "register_system_routes: api_server module not in sys.modules; "
+            "ensure api_server is imported before calling this function"
+        )
+
+    _security = host._security
+    _require_shutdown_authorization = host._require_shutdown_authorization
+    _app_version = app_version if app_version is not None else host.APP_VERSION
+
+    def _get_terminate_process():
+        """Late-access _terminate_current_process for test monkeypatch compat."""
+        h = _sys.modules.get("api_server") or _sys.modules.get("agent.api_server")
+        if h is not None:
+            fn = getattr(h, "_terminate_current_process", None)
+            if fn is not None:
+                return fn
+        return _terminate_current_process
+
+    # --- Routes ---
+
+    @app.get("/health", response_model=HealthResponse)
+    async def health_check():
+        """Liveness probe."""
+        return HealthResponse(
+            status="healthy",
+            service="Vibe-Trading API",
+            timestamp=datetime.now().isoformat()
+        )
+
+    @app.get("/correlation")
+    async def get_correlation_matrix(
+        codes: str = Query(..., description="Comma-separated asset codes, e.g. BTC-USDT,ETH-USDT,SPY"),
+        days: int = Query(90, description="Lookback window in days", ge=7, le=365),
+        method: str = Query("pearson", description="Correlation method: pearson or spearman"),
+    ):
+        """Compute cross-asset correlation matrix from daily returns.
+
+        Fetches price data for each code via available data loaders,
+        computes pairwise correlation of daily returns over the lookback window.
+        """
+        from backtest.correlation import compute_correlation_matrix
+
+        code_list = [c.strip() for c in codes.split(",") if c.strip()]
+        if len(code_list) < 2:
+            raise HTTPException(status_code=400, detail="At least 2 asset codes required")
+        if len(code_list) > 20:
+            raise HTTPException(status_code=400, detail="Maximum 20 assets per request")
+        if method not in ("pearson", "spearman"):
+            raise HTTPException(status_code=400, detail="method must be 'pearson' or 'spearman'")
+
+        try:
+            result = compute_correlation_matrix(codes=code_list, days=days, method=method)
+            return result
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+        except Exception as exc:
+            raise HTTPException(status_code=500, detail=f"Correlation computation failed: {exc}")
+
+    @app.post("/system/shutdown")
+    async def shutdown_local_api(
+        background_tasks: BackgroundTasks,
+        request: Request,
+        cred: Optional[HTTPAuthorizationCredentials] = Security(_security),
+    ):
+        """Shut down the local API server after explicit local authorization."""
+        _require_shutdown_authorization(request=request, cred=cred)
+        client_host = request.client.host if request.client else ""
+        if client_host not in {"127.0.0.1", "::1", "localhost"}:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Local access only")
+
+        background_tasks.add_task(_get_terminate_process())
+        return {
+            "status": "shutting-down",
+            "service": "Vibe-Trading API",
+            "timestamp": datetime.now().isoformat(),
+        }
+
+    @app.get("/skills")
+    async def list_skills():
+        """List registered skills (name and description)."""
+        from src.agent.skills import SkillsLoader
+
+        loader = SkillsLoader()
+        return [
+            {
+                "name": s.name,
+                "description": s.description,
+            }
+            for s in loader.skills
+        ]
+
+    @app.get("/api")
+    async def api_info():
+        """Service metadata."""
+        return {
+            "service": "Vibe-Trading API",
+            "version": _app_version,
+            "docs": "/docs",
+            "health": "/health",
+        }


### PR DESCRIPTION
## Summary

- Extract 5 system routes from `agent/api_server.py` into `agent/src/api/system_routes.py`
- `system_routes.py` is self-contained — defines `HealthResponse` locally, resolves `_security` and `_require_shutdown_authorization` from host `api_server` via `sys.modules` fallback
- Re-export `_terminate_current_process` back to `api_server` to preserve existing test monkeypatch compatibility

## Why

Part of the API modularisation roadmap (#331). Follows the self-contained route-module pattern established by #375. Each route module is independently extractable, has no shared scaffolding, and gives an immediate measurable reduction in the monolithic `api_server.py`.

Refs #331
Refs #375

## Changes

- New file `agent/src/api/system_routes.py`: 5 routes (health, correlation, shutdown, skills, api-info) + `_terminate_current_process` helper
- `api_server.py`: remove the 5 route definitions, add registration call + re-export
- No shared infrastructure imports (no `deps.py`, `models.py`, `helpers.py`)
- `Security(_security)` DI pattern preserved exactly for `/system/shutdown`
- Net reduction verified: `api_server.py` shrinks from 3,552 to 3,471 lines

## Test Plan

- [x] Existing tests pass
- [ ] New tests added (not applicable — structural refactor, behaviour unchanged)
- [ ] Tested manually (not applicable)

```bash
PYTHONPATH=agent pytest agent/tests/test_security_auth_api.py agent/tests/test_spa_deep_link.py -q
# 65 passed
python -m compileall -q agent/api_server.py agent/src/api/system_routes.py
git diff --check
```

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Documentation updated (not applicable — internal refactor)

---

## Overall Project Plan

This PR is **Patch 2 of 9** in the API modularisation series (issue #331). The goal is to decompose the 3,552-line `api_server.py` into 9 self-contained route modules under `src/api/`, leaving only app factory, Pydantic models, auth dependencies, and shared helpers (~1,200 lines).

| Patch | Module | Routes | Lines | Status |
|-------|--------|--------|-------|--------|
| **1/9** | uploads_routes.py | 2 | ~103 | ✅ **Merged** — [#375](https://github.com/HKUDS/Vibe-Trading/pull/375) |
| **2/9** | system_routes.py | 5 | ~81 | 🔵 This PR — [#378](https://github.com/HKUDS/Vibe-Trading/pull/378) |
| **3/9** | channels_routes.py | 4 | ~22 | 📝 Draft — [#379](https://github.com/HKUDS/Vibe-Trading/pull/379) (depends on #378) |
| **4/9** | settings_routes.py | 4 | ~230 | Pending |
| **5/9** | runs_routes.py | 4 | ~300 | Pending |
| **6/9** | scheduled_routes.py | 3 | ~160 | Pending |
| **7/9** | swarm_routes.py | 7 | ~240 | Pending |
| **8/9** | sessions_routes.py | 14 | ~400 | Pending |
| **9/9** | live_routes.py + cleanup | 7+0 | ~630 | Pending |

Each patch follows the [#375](https://github.com/HKUDS/Vibe-Trading/pull/375) pattern: self-contained route module, `sys.modules` fallback for auth, route-level constants/models, re-exports for test monkeypatch compat, zero behaviour change, zero test modifications.