### PR TITLE
fix(security): block CGNAT/mesh ranges in SSRF guard; close QQ media redirect-to-internal

### DIFF
--- a/agent/src/channels/qq.py
+++ b/agent/src/channels/qq.py
@@ -409,7 +409,20 @@ class QQChannel(BaseChannel):
         if not self._http:
             self._http = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=120))
         try:
-            async with self._http.get(media_ref, allow_redirects=True) as resp:
+            # Do not auto-follow redirects: ``media_ref`` is agent-controlled
+            # (taken from ``msg.media``), and a public URL that 302s to an
+            # internal address (169.254.169.254, 100.64/10, …) would bypass the
+            # pre-flight ``validate_url_target`` check and exfiltrate internal
+            # content as a media attachment. Fail closed on 3xx instead — this
+            # mirrors napcat.py's inbound image download.
+            async with self._http.get(media_ref, allow_redirects=False) as resp:
+                if 300 <= resp.status < 400:
+                    self.logger.warning(
+                        "outbound media download redirect rejected url={} status={}",
+                        media_ref,
+                        resp.status,
+                    )
+                    return None, None
                 if resp.status >= 400:
                     self.logger.warning(
                         "outbound media download failed status={} url={}",

--- a/agent/src/channels/utils.py
+++ b/agent/src/channels/utils.py
@@ -146,11 +146,21 @@ def _is_allowed_loopback_target(
 
 
 def _is_private(addr: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
-    """Check whether *addr* is private, link-local, or loopback."""
-    if addr.is_loopback or addr.is_link_local or addr.is_private:
-        return True
-    # Also block well-known metadata endpoints
-    if isinstance(addr, ipaddress.IPv4Address):
-        return False
-    # IPv6: block unspecified, multicast, unique-local
-    return addr.is_multicast or addr.is_unspecified
+    """Check whether *addr* is non-globally-routable (private/internal/mesh).
+
+    ``addr.is_global`` is False for loopback, link-local, RFC 1918 private,
+    unspecified, reserved, and RFC 6598 shared address space
+    (``100.64.0.0/10`` — the default Tailscale/mesh range). The previous
+    explicit ``is_loopback | is_link_local | is_private`` checks missed the
+    100.64/10 block (``is_private`` is False for it), letting CGNAT/mesh hosts
+    slip past ``validate_url_target`` and be fetched as channel media. Using
+    ``not addr.is_global`` blocks every non-globally-routable range uniformly.
+    Multicast is added explicitly because ``is_global`` is True for multicast
+    addresses (both ``224.0.0.0/4`` and ``ff00::/8``); the old code only caught
+    IPv6 multicast, so this also closes an IPv4-multicast gap and matches
+    ``web_reader_tool._url_allowed``.
+
+    Loopback is still permitted when ``validate_url_target(allow_loopback=True)``
+    is called — that allowance is evaluated before this function runs.
+    """
+    return not addr.is_global or addr.is_multicast

--- a/agent/tests/test_url_target_security.py
+++ b/agent/tests/test_url_target_security.py
@@ -1,0 +1,151 @@
+"""Regression tests for the SSRF URL guard and QQ outbound-media fetch.
+
+Covers two previously-untested gaps:
+
+- ``validate_url_target`` / ``_is_private`` must block non-globally-routable
+  ranges, including RFC 6598 ``100.64.0.0/10`` (CGNAT / the default Tailscale
+  mesh range). ``ipaddress.is_private`` is ``False`` for 100.64/10, so the old
+  ``is_loopback | is_link_local | is_private`` check let those hosts through.
+- QQ's outbound media download must reject HTTP redirects. ``media_ref`` is
+  agent-controlled (it comes from ``msg.media``), so a public URL that 302s to
+  an internal address would otherwise bypass the pre-flight
+  ``validate_url_target`` check and exfiltrate internal content as an
+  attachment. This mirrors napcat.py's inbound image download.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import logging
+
+import pytest
+
+from src.channels import qq as qq_module
+from src.channels.utils import _is_private, validate_url_target
+
+# ─── central SSRF guard ───
+
+
+@pytest.mark.parametrize(
+    "ip",
+    [
+        # RFC 6598 shared address space — the default Tailscale/mesh range.
+        # is_private is False for these, so they slipped through before the fix.
+        "100.64.0.1",
+        "100.100.100.100",
+        "100.127.255.254",
+        # classic private / internal ranges must stay blocked too
+        "10.0.0.1",
+        "172.16.0.1",
+        "192.168.1.1",
+        "127.0.0.1",
+        "169.254.169.254",  # cloud metadata
+        "0.0.0.0",
+        "224.0.0.1",  # multicast
+        # IPv6 non-global
+        "::1",
+        "fe80::1",
+        "fc00::1",
+    ],
+)
+def test_is_private_blocks_non_global_ranges(ip: str) -> None:
+    assert _is_private(ipaddress.ip_address(ip)) is True
+
+
+@pytest.mark.parametrize("ip", ["8.8.8.8", "1.1.1.1", "2606:4700:4700::1111"])
+def test_is_private_allows_global_ranges(ip: str) -> None:
+    assert _is_private(ipaddress.ip_address(ip)) is False
+
+
+@pytest.mark.parametrize("ip", ["100.64.0.1", "100.100.100.100"])
+def test_validate_url_target_blocks_cgnat_ip_literal(ip: str) -> None:
+    # IP-literal host → getaddrinfo is a local parse, so this needs no network.
+    ok, err = validate_url_target(f"http://{ip}/x")
+    assert ok is False
+    assert "private" in err or "internal" in err
+
+
+def test_validate_url_target_allows_public_ip_literal() -> None:
+    ok, _err = validate_url_target("http://8.8.8.8/x")
+    assert ok is True
+
+
+def test_validate_url_target_loopback_only_with_opt_in() -> None:
+    # Default: loopback is blocked even though it is a literal IP.
+    assert validate_url_target("http://127.0.0.1/x")[0] is False
+    # The narrow opt-in still allows literal loopback.
+    assert validate_url_target("http://127.0.0.1/x", allow_loopback=True)[0] is True
+
+
+# ─── QQ outbound-media redirect rejection ───
+
+
+class _FakeResp:
+    def __init__(self, status: int) -> None:
+        self.status = status
+
+    async def __aenter__(self) -> "_FakeResp":
+        return self
+
+    async def __aexit__(self, *_exc: object) -> bool:
+        return False
+
+    async def read(self) -> bytes:
+        return b"internal-content"
+
+
+class _FakeHttp:
+    """Records the ``allow_redirects`` flag and returns a canned response."""
+
+    def __init__(self, status: int) -> None:
+        self.status = status
+        self.allow_redirects: object = "not-called"
+
+    def get(self, url: str, *, allow_redirects: bool = True) -> _FakeResp:
+        self.allow_redirects = allow_redirects
+        return _FakeResp(self.status)
+
+
+def _make_qq_channel(http: _FakeHttp) -> qq_module.QQChannel:
+    # Build a minimal instance without running __init__ (which validates config
+    # and creates a media dir on disk). _read_media_bytes only touches
+    # self._http and self.logger.
+    ch = object.__new__(qq_module.QQChannel)
+    ch._http = http  # type: ignore[attr-defined]
+    # CRITICAL level keeps the (intentionally loguru-style) warning quiet under
+    # a stdlib logger without affecting return-value behavior.
+    log = logging.getLogger("qq-test")
+    log.setLevel(logging.CRITICAL)
+    ch.logger = log  # type: ignore[attr-defined]
+    return ch
+
+
+@pytest.mark.parametrize("status", [301, 302, 303, 307, 308])
+def test_qq_outbound_media_rejects_redirects(status: int) -> None:
+    http = _FakeHttp(status=status)
+    ch = _make_qq_channel(http)
+    # Public IP-literal host → validate_url_target passes without a network call.
+    data, name = asyncio.run(ch._read_media_bytes("http://8.8.8.8/x.png"))
+    assert data is None
+    assert name is None
+    # The fix must not auto-follow redirects.
+    assert http.allow_redirects is False
+
+
+def test_qq_outbound_media_allows_2xx_and_does_not_follow_redirects() -> None:
+    http = _FakeHttp(status=200)
+    ch = _make_qq_channel(http)
+    data, name = asyncio.run(ch._read_media_bytes("http://8.8.8.8/x.png"))
+    assert data == b"internal-content"
+    assert name == "x.png"
+    assert http.allow_redirects is False
+
+
+@pytest.mark.parametrize("status", [400, 404, 500])
+def test_qq_outbound_media_rejects_error_status(status: int) -> None:
+    http = _FakeHttp(status=status)
+    ch = _make_qq_channel(http)
+    data, name = asyncio.run(ch._read_media_bytes("http://8.8.8.8/x.png"))
+    assert data is None
+    assert name is None


### PR DESCRIPTION
## Summary

Two SSRF gaps in the channel media-fetch path, both verified against current `main`.

### 1. Central SSRF IP guard misses RFC 6598 (100.64.0.0/10) — `channels/utils.py`

`_is_private()` (the helper under `validate_url_target`, used by **every** channel: QQ, DingTalk, NapCat, Telegram, and `channelsui`) only checked `is_loopback | is_link_local | is_private`. `ipaddress.is_private` is **`False`** for RFC 6598 shared address space (`100.64.0.0/10`) — the default range used by **Tailscale** and other CGNAT/mesh networks — so those hosts passed validation and were fetched directly as channel media.

```
>>> ipaddress.ip_address("100.64.0.1").is_private
False          # slipped through the old guard
```

**Fix:** `return not addr.is_global or addr.is_multicast`. `is_global` is `False` for every non-globally-routable range (loopback, link-local, RFC 1918, unspecified, reserved, 100.64/10), and multicast is added explicitly because `is_global` is `True` for multicast (`224.0.0.0/4`, `ff00::/8`) — the old code only caught IPv6 multicast, so this also closes an IPv4-multicast gap. This matches the check already used by `web_reader_tool._url_allowed`.

The narrow `allow_loopback=True` opt-in still works — that allowance is evaluated before `_is_private` runs.

### 2. QQ outbound media follows redirects without re-validation — `qq.py`

`_read_media_bytes()` calls `validate_url_target(media_ref)` once, then fetches with `allow_redirects=True`. `media_ref` is **agent-controlled** (it comes from `msg.media`, which is routinely influenced by untrusted external content — web pages via `read_url`, MCP tool output, news). A public URL that returns `302 Location: http://169.254.169.254/latest/meta-data/...` is followed unchecked, and the internal body is read (`await resp.read()`) and uploaded as a media attachment — exfiltrating cloud credentials / internal content.

DingTalk (`follow_redirects=False` + per-hop `validate_resolved_url`) and NapCat (`allow_redirects=False`, reject 3xx) already defend against this; **QQ was the outlier**.

**Fix:** `allow_redirects=False` and fail closed on `3xx`, mirroring NapCat. The separate inbound download at `qq.py:618` fetches a trusted QQ CDN (`multimedia.nt.qq.com`) URL and is intentionally left as-is.

## Test plan

- New `agent/tests/test_url_target_security.py` (29 cases) — the central guard (`validate_url_target` / `_is_private`) previously had **no tests at all**.
  - `100.64.0.0/10` and the rest of the non-global space are blocked; public IPs / IPv6 are allowed; loopback is blocked by default and allowed only via the opt-in.
  - QQ outbound media rejects `301/302/303/307/308`, allows `2xx` (still without following redirects), and rejects `4xx/5xx`.
- Existing `agent/tests/test_web_reader_security.py` still passes (48 total).
- All assertions use IP-literal hosts, so `getaddrinfo` is a local parse — **no network required**.

```
$ python -m pytest tests/test_url_target_security.py tests/test_web_reader_security.py -q
................................................                [100%]
48 passed
```

## Notes / out of scope

- I deliberately did **not** change `web_reader_tool._url_allowed` (also flagged in research as a weaker self-rolled check for hostnames). It forwards to the third-party Jina reader rather than fetching directly, and it is intentionally network-free; routing it through `validate_url_target` (which does DNS resolution) would break `test_read_url_allows_public_http_targets` and add a DNS round-trip to every read. Worth a separate discussion.
- DNS-rebinding (TOCTOU between `validate_url_target`'s `getaddrinfo` and the client's connect) affects all channels and needs a pinned-IP fetch helper — left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)