### PR TITLE
fix: align Robinhood MCP and env startup

### DIFF
--- a/agent/api_server.py
+++ b/agent/api_server.py
@@ -2631,13 +2631,12 @@ def _live_action_frame_from_tool_result(event: Any) -> Optional[str]:
 def _fetch_broker_ceilings(broker: str) -> Optional[Dict[str, Any]]:
     """Best-effort fetch of broker-side account ceilings for the commit re-check.
 
-    Reads the broker's ``get_account`` tool and derives an authoritative ceiling
-    snapshot (buying power / funding) so the commit-time fit check binds to the
-    venue's real limits rather than an agent-proposed number. Returns ``None`` on
-    any failure (channel not configured, tool error, fields not recognized) so
-    the caller falls back to the proposal's own snapshot — a commit is never
-    blocked on a broker read. The exact Robinhood field names are finalized
-    post-access (L6); we probe the common ones.
+    Reads the broker's mapped account/portfolio tool and derives an authoritative
+    ceiling snapshot (buying power / funding) so the commit-time fit check binds
+    to the venue's real limits rather than an agent-proposed number. Returns
+    ``None`` on any failure (channel not configured, tool error, fields not
+    recognized) so the caller falls back to the proposal's own snapshot — a
+    commit is never blocked on a broker read.
 
     Args:
         broker: The live-broker key.
@@ -2650,7 +2649,10 @@ def _fetch_broker_ceilings(broker: str) -> Optional[Dict[str, Any]]:
     except LiveRunnerUnavailable:
         return None
     try:
-        result = adapter.call_tool("get_account", {})
+        from src.trading.service import runner_tool_name
+
+        account_tool = runner_tool_name(broker, "account") or "get_account"
+        result = adapter.call_tool(account_tool, {})
     except Exception:  # pragma: no cover - status/commit must never raise here
         logger.debug("broker ceiling fetch failed for %s", broker, exc_info=True)
         return None

--- a/agent/cli/main.py
+++ b/agent/cli/main.py
@@ -2,8 +2,8 @@
 
 Responsibilities:
 
-1. Detect whether ``~/.vibe-trading/.env`` exists; if missing, run the
-   onboarding wizard (:mod:`cli.onboard`) before doing anything else.
+1. Detect whether any provider `.env` candidate exists; if all are missing, run
+   the onboarding wizard (:mod:`cli.onboard`) before doing anything else.
 2. Render the startup banner (:mod:`cli.intro`) on interactive entry.
 3. For interactive entry (no subcommand, or ``chat``) drive the REPL
    built on :mod:`cli.input`, :mod:`cli.completer`,
@@ -84,7 +84,10 @@ def _register_live_slash_commands() -> None:
 
 _register_live_slash_commands()
 
+_AGENT_DIR = Path(__file__).resolve().parents[1]
 _ENV_PATH = Path.home() / ".vibe-trading" / ".env"
+_PROJECT_ENV_PATH = _AGENT_DIR / ".env"
+_CWD_ENV_PATH = Path.cwd() / ".env"
 # Best-effort fallbacks used only when the probe genuinely fails (missing
 # dependency, broken install). The numbers track the actual bundled counts
 # so a probe failure still shows a plausible banner rather than "0 loaded".
@@ -108,10 +111,15 @@ def _probe_model_name() -> str:
     name = os.environ.get("LANGCHAIN_MODEL_NAME") or os.environ.get("OPENAI_MODEL")
     if name:
         return name
+    env_path = _first_existing_env_path()
+    if env_path is None:
+        return "unset (use /model to pick one)"
     try:
-        text = _ENV_PATH.read_text(encoding="utf-8")
+        text = env_path.read_text(encoding="utf-8")
         for line in text.splitlines():
             if line.startswith("LANGCHAIN_MODEL_NAME="):
+                return line.split("=", 1)[1].strip()
+            if line.startswith("OPENAI_MODEL="):
                 return line.split("=", 1)[1].strip()
     except OSError:
         pass
@@ -244,13 +252,13 @@ def _is_supported_chat_invocation(argv: Sequence[str]) -> bool:
 
 
 def _maybe_run_onboarding() -> bool:
-    """Run the first-launch wizard when ``.env`` is missing.
+    """Run the first-launch wizard when every provider ``.env`` candidate is missing.
 
     Returns:
         ``True`` if startup should proceed, ``False`` if the user cancelled
         the wizard cleanly.
     """
-    if _ENV_PATH.exists():
+    if _first_existing_env_path() is not None:
         return True
     console = get_console()
     written = run_onboarding(console=console)
@@ -264,6 +272,19 @@ def _maybe_run_onboarding() -> bool:
     except Exception:  # noqa: BLE001 — legacy will load again later
         pass
     return True
+
+
+def _env_candidates() -> tuple[Path, ...]:
+    """Return provider `.env` candidates in the same order as ``src.providers.llm``."""
+    return (_ENV_PATH, _PROJECT_ENV_PATH, _CWD_ENV_PATH)
+
+
+def _first_existing_env_path() -> Path | None:
+    """Return the first configured `.env` candidate that exists, if any."""
+    for path in _env_candidates():
+        if path.exists():
+            return path
+    return None
 
 
 def _show_banner() -> None:

--- a/agent/src/config/schema.py
+++ b/agent/src/config/schema.py
@@ -204,14 +204,16 @@ ROBINHOOD_MCP_SERVER_SEED: dict[str, object] = {
     # READ tool names (``src.trading.connectors.robinhood.classification.ROBINHOOD_TOOL_CLASS``).
     # These MUST match the curated map's READ entries: a name here that the map
     # does not classify READ would resolve UNKNOWN -> gated -> refused, silently
-    # hiding the real read tool. Canonical READ catalog: get_account,
-    # get_positions, get_quotes, list_orders. WRITE (place_order, cancel_order)
-    # is never seeded — the user adds those by hand once a mandate exists.
+    # hiding the real read tool. Canonical READ catalog: get_accounts,
+    # get_portfolio, get_equity_positions, get_equity_quotes, get_equity_orders.
+    # WRITE (place_equity_order, cancel_equity_order) is never seeded — the user
+    # adds those by hand once a mandate exists.
     "enabled_tools": [
-        "get_account",
-        "get_positions",
-        "get_quotes",
-        "list_orders",
+        "get_accounts",
+        "get_portfolio",
+        "get_equity_positions",
+        "get_equity_quotes",
+        "get_equity_orders",
     ],
 }
 

--- a/agent/src/live/order_guard.py
+++ b/agent/src/live/order_guard.py
@@ -25,10 +25,10 @@ returned tool_result carries that redacted record under the frozen
 ``"live_action"`` key so the api_server SSE relay can emit a ``live.action``
 event without touching the agent loop.
 
-When the order is sized by ``quantity``, the gate derives a live quote (broker
-``get_quotes`` READ tool first, then the data loaders) and enforces the LARGER of
-the explicit notional and ``quantity`` × price — fail-closed DENY when no quote
-is obtainable — so the notional/exposure/leverage caps stay enforceable.
+When the order is sized by ``quantity``, the gate derives a live quote (the
+broker-specific quote READ tool first, then the data loaders) and enforces the
+LARGER of the explicit notional and ``quantity`` × price — fail-closed DENY when
+no quote is obtainable — so the notional/exposure/leverage caps stay enforceable.
 
 ``repeatable = False`` mirrors the no-retry stance in
 ``MCPServerAdapter._call_tool`` — a live order must never be silently re-issued.
@@ -249,8 +249,8 @@ class LiveOrderGuardTool(MCPRemoteTool):
     def _quote_price(self, intent: OrderIntent) -> float | None:
         """Return a live USD price for the intent's symbol, fail-closed.
 
-        Prefers the broker's READ quote tool (``get_quotes``) so the price is
-        the broker's own; falls back to Vibe-Trading's data loaders
+        Prefers the broker's mapped READ quote tool so the price is the broker's
+        own; falls back to Vibe-Trading's data loaders
         (:func:`src.live.enforcement.last_price_usd`, standard auto-fallback)
         when the broker quote is unavailable. Returns ``None`` when no source
         yields a usable price.
@@ -276,8 +276,8 @@ class LiveOrderGuardTool(MCPRemoteTool):
     def _broker_quote_price(self, symbol: str) -> float | None:
         """Read a USD price for ``symbol`` from the broker's quote tool.
 
-        Calls the ungated read path (never the guard) for ``get_quotes`` with the
-        symbol argument and parses a price from the common envelope shapes.
+        Calls the ungated read path (never the guard) for the mapped quote tool
+        with the symbol argument and parses a price from the common envelope shapes.
         Returns ``None`` on any error envelope, missing field, or unparseable
         value — the caller then falls back to the data loaders.
 

--- a/agent/src/trading/connectors/robinhood/classification.py
+++ b/agent/src/trading/connectors/robinhood/classification.py
@@ -3,17 +3,18 @@
 Tier 2 of the classification ladder (:mod:`src.live.classification`): an
 explicit, version-controlled map keyed by the broker's remote tool name. Map
 entries are authoritative and override Tier-1 ``annotations`` when they
-disagree (a deceptive ``readOnlyHint=True`` on ``place_order`` cannot demote a
+disagree (a deceptive ``readOnlyHint=True`` on ``place_equity_order`` cannot demote a
 curated WRITE). A tool absent from this map and not annotated read-only is
 UNKNOWN and treated as WRITE (fail-closed).
 
 This map is the FROZEN canonical Robinhood catalog (SPEC §7.5):
-``READ = {get_account, get_positions, get_quotes, list_orders}`` and
-``WRITE = {place_order, cancel_order}``. Any tool the broker reports that is not
-in this map and not annotated read-only resolves to UNKNOWN → treated as WRITE
-(fail-closed), so an unrecognized new broker tool can never slip through as a
-plain read. Adding a tool here is a localized edit to this one dict plus the
-classification test parametrize list.
+``READ = {get_accounts, get_portfolio, get_equity_positions,
+get_equity_quotes, get_equity_orders}`` and
+``WRITE = {place_equity_order, cancel_equity_order}``. Any tool the broker
+reports that is not in this map and not annotated read-only resolves to UNKNOWN
+→ treated as WRITE (fail-closed), so an unrecognized new broker tool can never
+slip through as a plain read. Adding a tool here is a localized edit to this one
+dict plus the classification test parametrize list.
 """
 
 from __future__ import annotations
@@ -23,11 +24,12 @@ from src.live.classification import ToolClass
 #: Frozen canonical Robinhood read/write catalog.
 ROBINHOOD_TOOL_CLASS: dict[str, ToolClass] = {
     # READ
-    "get_account": ToolClass.READ,
-    "get_positions": ToolClass.READ,
-    "get_quotes": ToolClass.READ,
-    "list_orders": ToolClass.READ,
+    "get_accounts": ToolClass.READ,
+    "get_portfolio": ToolClass.READ,
+    "get_equity_positions": ToolClass.READ,
+    "get_equity_quotes": ToolClass.READ,
+    "get_equity_orders": ToolClass.READ,
     # WRITE
-    "place_order": ToolClass.WRITE,
-    "cancel_order": ToolClass.WRITE,
+    "place_equity_order": ToolClass.WRITE,
+    "cancel_equity_order": ToolClass.WRITE,
 }

--- a/agent/src/trading/connectors/robinhood/extractor.py
+++ b/agent/src/trading/connectors/robinhood/extractor.py
@@ -1,18 +1,19 @@
 """Robinhood order-intent extractor (SPEC.md Mandate Enforcement §4).
 
-Maps Robinhood's ``place_order`` tool kwargs to the normalized
+Maps Robinhood's ``place_equity_order`` tool kwargs to the normalized
 :class:`~src.live.enforcement.OrderIntent`. Pinned against the frozen Robinhood
-catalog: the only order-placing WRITE tool is ``place_order`` (``cancel_order``
-is a WRITE but not an *order placement* — it carries no notional/quantity to
-enforce, so it is not an order-intent tool here).
+catalog: the only order-placing WRITE tool is ``place_equity_order``
+(``cancel_equity_order`` is a WRITE but not an *order placement* — it carries no
+notional/quantity to enforce, so it is not an order-intent tool here).
 
-``place_order`` is sized by ``symbol`` + ``side`` plus exactly one (or, defended
-against, both) of ``notional_usd`` / ``quantity`` (``dollar_amount`` accepted as
-a notional alias). The extractor maps these concrete fields and returns ``None``
-(→ DENY) on anything missing or ambiguous — it never guesses, so the gate
-defaults to the safe state. Unknown extra keys are ignored. When both a notional
-and a quantity are present the extractor surfaces BOTH; the gate reconciles them
-to the larger enforced notional (closing the notional+quantity bypass).
+``place_equity_order`` is sized by ``symbol`` + ``side`` plus exactly one (or,
+defended against, both) of ``notional_usd`` / ``quantity`` (``dollar_amount``
+accepted as a notional alias). The extractor maps these concrete fields and
+returns ``None`` (→ DENY) on anything missing or ambiguous — it never guesses,
+so the gate defaults to the safe state. Unknown extra keys are ignored. When
+both a notional and a quantity are present the extractor surfaces BOTH; the gate
+reconciles them to the larger enforced notional (closing the notional+quantity
+bypass).
 """
 
 from __future__ import annotations
@@ -21,9 +22,9 @@ from src.live.enforcement import OrderIntent
 from src.live.mandate.model import InstrumentType
 
 #: Remote tool names this extractor recognizes as order placements. Frozen to
-#: the canonical catalog: ``place_order`` is the sole order-placing WRITE tool
-#: (``cancel_order`` carries no order intent to size).
-_ORDER_TOOLS = frozenset({"place_order"})
+#: the canonical catalog: ``place_equity_order`` is the sole order-placing WRITE
+#: tool (``cancel_equity_order`` carries no order intent to size).
+_ORDER_TOOLS = frozenset({"place_equity_order"})
 
 #: Accepted side spellings → normalized ``"buy"`` / ``"sell"``.
 _SIDE_ALIASES = {
@@ -56,7 +57,7 @@ _QUANTITY_KEYS = ("quantity", "qty", "shares", "units")
 
 
 def extract_order_intent(remote_name: str, kwargs: dict) -> OrderIntent | None:
-    """Parse Robinhood ``place_order`` kwargs into a normalized :class:`OrderIntent`.
+    """Parse Robinhood ``place_equity_order`` kwargs into a normalized :class:`OrderIntent`.
 
     Returns ``None`` (→ DENY) whenever the tool is not a recognized order tool,
     a required field is absent, or a field is ambiguous/invalid. Never guesses;
@@ -64,7 +65,7 @@ def extract_order_intent(remote_name: str, kwargs: dict) -> OrderIntent | None:
 
     Args:
         remote_name: The broker's un-prefixed remote tool name (e.g.
-            ``"place_order"``).
+            ``"place_equity_order"``).
         kwargs: Raw tool-call arguments the agent passed to the order tool.
 
     Returns:

--- a/agent/src/trading/connectors/robinhood/mcp.py
+++ b/agent/src/trading/connectors/robinhood/mcp.py
@@ -5,19 +5,19 @@ from __future__ import annotations
 from typing import Any
 
 _REMOTE_TOOL_NAMES = {
-    "account": "get_account",
-    "positions": "get_positions",
-    "orders": "list_orders",
-    "quote": "get_quotes",
+    "account": "get_portfolio",
+    "positions": "get_equity_positions",
+    "orders": "get_equity_orders",
+    "quote": "get_equity_quotes",
 }
 
 _RUNNER_TOOL_NAMES = {
-    "account": "get_account",
-    "positions": "get_positions",
-    "orders": "list_orders",
-    "quote": "get_quotes",
-    "submit_order": "place_order",
-    "cancel_order": "cancel_order",
+    "account": "get_portfolio",
+    "positions": "get_equity_positions",
+    "orders": "get_equity_orders",
+    "quote": "get_equity_quotes",
+    "submit_order": "place_equity_order",
+    "cancel_order": "cancel_equity_order",
 }
 
 

--- a/agent/tests/test_advisory.py
+++ b/agent/tests/test_advisory.py
@@ -55,9 +55,9 @@ class _MockAdapter:
     def call_tool(
         self, remote_name: str, arguments: dict, *, local_name: str | None = None
     ) -> dict:
-        if remote_name in ("get_positions", "list_positions"):
+        if remote_name == "get_equity_positions":
             return {"positions": self._positions, "status": "ok"}
-        if remote_name in ("get_account", "get_balance", "get_buying_power"):
+        if remote_name == "get_portfolio":
             return {"equity": self._balance, "status": "ok"}
         self.order_calls.append({"remote": remote_name, "arguments": arguments})
         return {"status": "ok", "order_id": "rh_test_1", "state": "accepted"}
@@ -66,8 +66,8 @@ class _MockAdapter:
 def _spec() -> MCPRemoteToolSpec:
     return MCPRemoteToolSpec(
         server_name="robinhood",
-        remote_name="place_order",
-        local_name="mcp_robinhood_place_order",
+        remote_name="place_equity_order",
+        local_name="mcp_robinhood_place_equity_order",
         description="Place an order.",
         parameters={
             "type": "object",

--- a/agent/tests/test_agent_config.py
+++ b/agent/tests/test_agent_config.py
@@ -368,7 +368,7 @@ def test_robinhood_wildcard_validation_names_safe_seed_and_config_path() -> None
     assert ROBINHOOD_AGENT_CONFIG_PATH in message
     assert '"mcpServers"' in message
     assert '"enabledTools"' in message
-    assert '"get_account"' in message
+    assert '"get_portfolio"' in message
     assert "No live channel configured" not in message
 
 
@@ -424,7 +424,7 @@ def test_live_authorize_wildcard_robinhood_config_prints_safe_seed(
     assert 'Robinhood MCP config uses enabledTools: ["*"]' in out
     assert "safe read-only Robinhood seed" in out
     assert ROBINHOOD_AGENT_CONFIG_PATH in out
-    assert '"get_account"' in out
+    assert '"get_portfolio"' in out
     assert "No live channel configured" not in out
 
 
@@ -451,7 +451,7 @@ def test_mcp_robinhood_wildcard_zero_tools_warning_names_safe_allowlist(
     assert tools == []
     assert "wildcard enabledTools" in caplog.text
     assert "safe read-only allowlist" in caplog.text
-    assert "get_account" in caplog.text
+    assert "get_portfolio" in caplog.text
     assert ROBINHOOD_AGENT_CONFIG_PATH in caplog.text
 
 

--- a/agent/tests/test_api_live_runtime.py
+++ b/agent/tests/test_api_live_runtime.py
@@ -397,7 +397,7 @@ def test_live_action_relay_builds_frame_from_guard_result(tmp_path: Path, monkey
         event_type="tool_result",
         session_id="s1",
         data={
-            "tool": "mcp_robinhood_place_order",
+            "tool": "mcp_robinhood_place_equity_order",
             "status": "ok",
             "preview": json.dumps({"status": "ok", "live_action": {"audit_id": audit_id}})[:200],
         },
@@ -427,7 +427,7 @@ def test_live_action_relay_ignores_non_live_results(tmp_path: Path, monkeypatch)
 def test_fetch_broker_ceilings_derives_from_account(tmp_path, monkeypatch) -> None:
     class _StubAdapter:
         def call_tool(self, name, args):
-            assert name == "get_account"
+            assert name == "get_portfolio"
             return {"status": "ok", "result": {"buying_power": 4200.0}}
 
     monkeypatch.setattr(api_server, "_live_broker_adapter", lambda broker: _StubAdapter())

--- a/agent/tests/test_classification.py
+++ b/agent/tests/test_classification.py
@@ -30,16 +30,16 @@ def test_absent_read_only_hint_is_not_read() -> None:
 def test_tier2_curated_map_classifies_known_tools() -> None:
     """Curated map drives classification for known names."""
     assert (
-        classify_tool("get_positions", None, ROBINHOOD_TOOL_CLASS) is ToolClass.READ
+        classify_tool("get_equity_positions", None, ROBINHOOD_TOOL_CLASS) is ToolClass.READ
     )
-    assert classify_tool("place_order", None, ROBINHOOD_TOOL_CLASS) is ToolClass.WRITE
+    assert classify_tool("place_equity_order", None, ROBINHOOD_TOOL_CLASS) is ToolClass.WRITE
 
 
 def test_deceptive_read_only_hint_cannot_demote_curated_write() -> None:
-    """A lying readOnlyHint=True on place_order stays WRITE — the map wins."""
+    """A lying readOnlyHint=True on place_equity_order stays WRITE — the map wins."""
     deceptive = ToolAnnotations(readOnlyHint=True)
     assert (
-        classify_tool("place_order", deceptive, ROBINHOOD_TOOL_CLASS)
+        classify_tool("place_equity_order", deceptive, ROBINHOOD_TOOL_CLASS)
         is ToolClass.WRITE
     )
 
@@ -62,7 +62,7 @@ def test_tier3_default_deny_unknown_and_unannotated() -> None:
 def test_map_read_pin_not_overridden_by_absent_annotation() -> None:
     """A curated READ wins even when annotations are present but silent."""
     ann = ToolAnnotations(title="quotes", readOnlyHint=None)
-    assert classify_tool("get_quotes", ann, ROBINHOOD_TOOL_CLASS) is ToolClass.READ
+    assert classify_tool("get_equity_quotes", ann, ROBINHOOD_TOOL_CLASS) is ToolClass.READ
 
 
 def test_ibkr_sparse_map_pins_known_order_names_write() -> None:

--- a/agent/tests/test_cli_interactive.py
+++ b/agent/tests/test_cli_interactive.py
@@ -12,6 +12,8 @@ Covers:
 
 from __future__ import annotations
 
+import importlib
+from pathlib import Path
 import time
 from types import SimpleNamespace
 from typing import Any
@@ -175,6 +177,52 @@ class TestMainRouting:
         monkeypatch.setattr("sys.stdout.isatty", lambda: True)
         for argv in (["chat", "extra"], ["chat", "foo", "bar"]):
             assert _is_interactive_invocation(argv) is False, argv
+
+    def test_onboarding_skips_when_project_env_exists(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Interactive startup must accept the provider loader's project-local `.env`."""
+        cli_main = importlib.import_module("cli.main")
+
+        home_env = tmp_path / "home" / ".vibe-trading" / ".env"
+        project_env = tmp_path / "agent" / ".env"
+        cwd_env = tmp_path / "cwd" / ".env"
+        project_env.parent.mkdir(parents=True)
+        project_env.write_text("LANGCHAIN_PROVIDER=openai-codex\n", encoding="utf-8")
+
+        monkeypatch.setattr(cli_main, "_ENV_PATH", home_env)
+        monkeypatch.setattr(cli_main, "_PROJECT_ENV_PATH", project_env, raising=False)
+        monkeypatch.setattr(cli_main, "_CWD_ENV_PATH", cwd_env, raising=False)
+
+        def fail_onboarding(*args, **kwargs):  # noqa: ANN001
+            raise AssertionError("onboarding should not run when agent/.env exists")
+
+        monkeypatch.setattr(cli_main, "run_onboarding", fail_onboarding)
+
+        assert cli_main._maybe_run_onboarding() is True
+
+    def test_probe_model_name_reads_project_env_candidate(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The startup banner should show the same project-local model the loader uses."""
+        cli_main = importlib.import_module("cli.main")
+
+        home_env = tmp_path / "home" / ".vibe-trading" / ".env"
+        project_env = tmp_path / "agent" / ".env"
+        cwd_env = tmp_path / "cwd" / ".env"
+        project_env.parent.mkdir(parents=True)
+        project_env.write_text(
+            "LANGCHAIN_MODEL_NAME=openai-codex/gpt-5.3-codex\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.delenv("LANGCHAIN_MODEL_NAME", raising=False)
+        monkeypatch.delenv("OPENAI_MODEL", raising=False)
+        monkeypatch.setattr(cli_main, "_ENV_PATH", home_env)
+        monkeypatch.setattr(cli_main, "_PROJECT_ENV_PATH", project_env, raising=False)
+        monkeypatch.setattr(cli_main, "_CWD_ENV_PATH", cwd_env, raising=False)
+
+        assert cli_main._probe_model_name() == "openai-codex/gpt-5.3-codex"
 
 
 # ---------------------------------------------------------------------------

--- a/agent/tests/test_cli_live.py
+++ b/agent/tests/test_cli_live.py
@@ -359,7 +359,7 @@ class TestLiveAuthorize:
                 "type": "streamableHttp",
                 "url": "https://agent.robinhood.com/mcp/trading",
                 "auth": {"type": "oauth", "scopes": ["trading.read"]},
-                "enabledTools": ["get_account"],
+                "enabledTools": ["get_portfolio"],
             }
         )
         with patch("cli._legacy._live_server_config", return_value=cfg), patch(
@@ -384,7 +384,7 @@ class TestLiveAuthorize:
                 "type": "streamableHttp",
                 "url": "https://agent.robinhood.com/mcp/trading",
                 "auth": {"type": "oauth", "scopes": ["trading.read"]},
-                "enabledTools": ["get_account"],
+                "enabledTools": ["get_portfolio"],
                 "toolTimeout": 600,
                 "initTimeout": 600,
             }
@@ -411,7 +411,7 @@ class TestLiveAuthorize:
                 "type": "streamableHttp",
                 "url": "https://agent.robinhood.com/mcp/trading",
                 "auth": {"type": "oauth", "scopes": ["trading.read"]},
-                "enabledTools": ["get_account"],
+                "enabledTools": ["get_portfolio"],
             }
         )
         with patch("cli._legacy._live_server_config", return_value=cfg), patch(

--- a/agent/tests/test_default_deny_unknown_robinhood_tool.py
+++ b/agent/tests/test_default_deny_unknown_robinhood_tool.py
@@ -36,10 +36,10 @@ from src.tools.mcp import MCPRemoteTool, build_mcp_tool_wrappers
 pytestmark = pytest.mark.unit
 
 # Tool names exercising every tier of the ladder.
-_READ_TOOL = "get_positions"  # curated READ
-_WRITE_TOOL = "place_order"  # curated WRITE
+_READ_TOOL = "get_equity_positions"  # curated READ
+_WRITE_TOOL = "place_equity_order"  # curated WRITE
 _UNKNOWN_TOOL = "place_bracket_order"  # absent from map + annotations=None
-_DECEPTIVE_TOOL = "cancel_order"  # curated WRITE but lies readOnlyHint=True
+_DECEPTIVE_TOOL = "cancel_equity_order"  # curated WRITE but lies readOnlyHint=True
 
 assert _READ_TOOL in ROBINHOOD_TOOL_CLASS and ROBINHOOD_TOOL_CLASS[_READ_TOOL] is ToolClass.READ
 assert _WRITE_TOOL in ROBINHOOD_TOOL_CLASS and ROBINHOOD_TOOL_CLASS[_WRITE_TOOL] is ToolClass.WRITE

--- a/agent/tests/test_enforcement_l6.py
+++ b/agent/tests/test_enforcement_l6.py
@@ -3,9 +3,9 @@
 Covers:
 
 * The frozen canonical Robinhood read/write catalog.
-* The extractor's finalized ``place_order`` field mapping (symbol/side/size,
+* The extractor's finalized ``place_equity_order`` field mapping (symbol/side/size,
   unknown keys ignored, ambiguity → ``None``).
-* Quantity-only quote derivation: broker ``get_quotes`` preferred, data-loader
+* Quantity-only quote derivation: broker ``get_equity_quotes`` preferred, data-loader
   fallback, fail-closed DENY when no quote is obtainable. Never hits the network
   (the loader path is stubbed).
 """
@@ -37,8 +37,14 @@ from src.tools.mcp import MCPRemoteToolSpec
 # C1 / L6 — frozen canonical catalog                                          #
 # --------------------------------------------------------------------------- #
 
-_CANONICAL_READ = {"get_account", "get_positions", "get_quotes", "list_orders"}
-_CANONICAL_WRITE = {"place_order", "cancel_order"}
+_CANONICAL_READ = {
+    "get_accounts",
+    "get_portfolio",
+    "get_equity_positions",
+    "get_equity_quotes",
+    "get_equity_orders",
+}
+_CANONICAL_WRITE = {"place_equity_order", "cancel_equity_order"}
 
 
 def test_catalog_is_exactly_the_canonical_set() -> None:
@@ -57,7 +63,7 @@ def test_catalog_is_exactly_the_canonical_set() -> None:
 
 def test_extractor_maps_notional_order() -> None:
     intent = extract_order_intent(
-        "place_order",
+        "place_equity_order",
         {"symbol": "aapl", "side": "buy", "instrument_type": "stock", "notional_usd": 250.0},
     )
     assert intent is not None
@@ -70,7 +76,7 @@ def test_extractor_maps_notional_order() -> None:
 
 def test_extractor_maps_quantity_and_dollar_amount_alias() -> None:
     intent = extract_order_intent(
-        "place_order",
+        "place_equity_order",
         {"ticker": "NVDA", "action": "sell", "type": "equity", "quantity": 3, "dollar_amount": 600},
     )
     assert intent is not None
@@ -83,7 +89,7 @@ def test_extractor_maps_quantity_and_dollar_amount_alias() -> None:
 
 def test_extractor_ignores_unknown_extra_keys() -> None:
     intent = extract_order_intent(
-        "place_order",
+        "place_equity_order",
         {
             "symbol": "MSFT", "side": "buy", "instrument_type": "equity",
             "quantity": 1, "time_in_force": "gtc", "client_tag": "x", "extended_hours": True,
@@ -95,17 +101,17 @@ def test_extractor_ignores_unknown_extra_keys() -> None:
 
 
 def test_extractor_rejects_non_order_tool() -> None:
-    assert extract_order_intent("cancel_order", {"order_id": "x"}) is None
-    assert extract_order_intent("get_quotes", {"symbol": "AAPL"}) is None
+    assert extract_order_intent("cancel_equity_order", {"order_id": "x"}) is None
+    assert extract_order_intent("get_equity_quotes", {"symbol": "AAPL"}) is None
 
 
 def test_extractor_rejects_missing_or_ambiguous_fields() -> None:
     # Missing side.
-    assert extract_order_intent("place_order", {"symbol": "AAPL", "instrument_type": "equity", "notional_usd": 10}) is None
+    assert extract_order_intent("place_equity_order", {"symbol": "AAPL", "instrument_type": "equity", "notional_usd": 10}) is None
     # Unknown instrument.
-    assert extract_order_intent("place_order", {"symbol": "AAPL", "side": "buy", "instrument_type": "warrant", "notional_usd": 10}) is None
+    assert extract_order_intent("place_equity_order", {"symbol": "AAPL", "side": "buy", "instrument_type": "warrant", "notional_usd": 10}) is None
     # No size at all.
-    assert extract_order_intent("place_order", {"symbol": "AAPL", "side": "buy", "instrument_type": "equity"}) is None
+    assert extract_order_intent("place_equity_order", {"symbol": "AAPL", "side": "buy", "instrument_type": "equity"}) is None
 
 
 # --------------------------------------------------------------------------- #
@@ -122,8 +128,8 @@ def live_runtime(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 def _spec() -> MCPRemoteToolSpec:
     return MCPRemoteToolSpec(
         server_name="robinhood",
-        remote_name="place_order",
-        local_name="mcp_robinhood_place_order",
+        remote_name="place_equity_order",
+        local_name="mcp_robinhood_place_equity_order",
         description="Place an order.",
         parameters={"type": "object", "properties": {}, "additionalProperties": True},
     )
@@ -161,7 +167,7 @@ def _write_mandate(live_runtime: Path, *, max_order_notional_usd: float = 750.0)
 
 
 class _BrokerQuoteAdapter:
-    """Adapter whose ``get_quotes`` returns a price; loader path is never needed."""
+    """Adapter whose ``get_equity_quotes`` returns a price; loader path is never needed."""
 
     def __init__(self, *, price: float) -> None:
         self.server_name = "robinhood"
@@ -170,11 +176,11 @@ class _BrokerQuoteAdapter:
         self.quote_calls = 0
 
     def call_tool(self, remote_name: str, arguments: dict, *, local_name: str | None = None) -> dict:
-        if remote_name == "get_positions":
+        if remote_name == "get_equity_positions":
             return {"positions": [], "status": "ok"}
-        if remote_name == "get_account":
+        if remote_name == "get_portfolio":
             return {"equity": 100000.0, "status": "ok"}
-        if remote_name == "get_quotes":
+        if remote_name == "get_equity_quotes":
             self.quote_calls += 1
             return {"status": "ok", "results": [{"symbol": arguments.get("symbol"), "last_price": self._price}]}
         self.order_calls.append({"remote": remote_name, "arguments": arguments})
@@ -182,18 +188,18 @@ class _BrokerQuoteAdapter:
 
 
 class _NoBrokerQuoteAdapter:
-    """Adapter whose ``get_quotes`` errors — forces the data-loader fallback."""
+    """Adapter whose ``get_equity_quotes`` errors — forces the data-loader fallback."""
 
     def __init__(self) -> None:
         self.server_name = "robinhood"
         self.order_calls: list[dict[str, Any]] = []
 
     def call_tool(self, remote_name: str, arguments: dict, *, local_name: str | None = None) -> dict:
-        if remote_name == "get_positions":
+        if remote_name == "get_equity_positions":
             return {"positions": [], "status": "ok"}
-        if remote_name == "get_account":
+        if remote_name == "get_portfolio":
             return {"equity": 100000.0, "status": "ok"}
-        if remote_name == "get_quotes":
+        if remote_name == "get_equity_quotes":
             return {"status": "error", "error": "quotes unavailable"}
         self.order_calls.append({"remote": remote_name, "arguments": arguments})
         return {"status": "ok", "order_id": "rh_q", "state": "accepted"}

--- a/agent/tests/test_killswitch_blocks_orders.py
+++ b/agent/tests/test_killswitch_blocks_orders.py
@@ -42,9 +42,9 @@ class _MockAdapter:
 
     def call_tool(self, remote_name: str, arguments: dict, *, local_name: str | None = None) -> dict:
         self.calls.append(remote_name)
-        if remote_name in ("get_positions", "list_positions"):
+        if remote_name == "get_equity_positions":
             return {"positions": [], "status": "ok"}
-        if remote_name in ("get_account", "get_balance", "get_buying_power"):
+        if remote_name == "get_portfolio":
             return {"equity": 5000.0, "status": "ok"}
         return {"status": "ok", "order_id": "rh_x", "state": "accepted"}
 
@@ -52,8 +52,8 @@ class _MockAdapter:
 def _order_spec() -> MCPRemoteToolSpec:
     return MCPRemoteToolSpec(
         server_name="robinhood",
-        remote_name="place_order",
-        local_name="mcp_robinhood_place_order",
+        remote_name="place_equity_order",
+        local_name="mcp_robinhood_place_equity_order",
         description="Place an order.",
         parameters={"type": "object", "properties": {}, "additionalProperties": True},
     )
@@ -62,8 +62,8 @@ def _order_spec() -> MCPRemoteToolSpec:
 def _read_spec() -> MCPRemoteToolSpec:
     return MCPRemoteToolSpec(
         server_name="robinhood",
-        remote_name="get_positions",
-        local_name="mcp_robinhood_get_positions",
+        remote_name="get_equity_positions",
+        local_name="mcp_robinhood_get_equity_positions",
         description="Read positions.",
         parameters={"type": "object", "properties": {}, "additionalProperties": True},
     )
@@ -139,4 +139,4 @@ def test_read_tools_unaffected_by_halt(live_runtime: Path) -> None:
 
     payload = json.loads(read_tool.execute())
     assert payload["status"] == "ok"
-    assert adapter.calls == ["get_positions"]
+    assert adapter.calls == ["get_equity_positions"]

--- a/agent/tests/test_mandate_enforcement.py
+++ b/agent/tests/test_mandate_enforcement.py
@@ -61,9 +61,9 @@ class _MockAdapter:
 
     def call_tool(self, remote_name: str, arguments: dict, *, local_name: str | None = None) -> dict:
         self.call_records.append({"remote": remote_name, "arguments": arguments})
-        if remote_name in ("get_positions", "list_positions"):
+        if remote_name == "get_equity_positions":
             return {"positions": self._positions, "status": "ok"}
-        if remote_name in ("get_account", "get_balance", "get_buying_power"):
+        if remote_name == "get_portfolio":
             return {"equity": self._balance, "status": "ok"}
         # The order placement itself (super().execute forwards here).
         self.order_calls.append({"remote": remote_name, "arguments": arguments})
@@ -73,8 +73,8 @@ class _MockAdapter:
 def _spec() -> MCPRemoteToolSpec:
     return MCPRemoteToolSpec(
         server_name="robinhood",
-        remote_name="place_order",
-        local_name="mcp_robinhood_place_order",
+        remote_name="place_equity_order",
+        local_name="mcp_robinhood_place_equity_order",
         description="Place an order.",
         parameters={
             "type": "object",
@@ -174,7 +174,7 @@ def _check(intent: OrderIntent, mandate: Mandate, *, positions=None, daily_count
         positions if positions is not None else [],
         {"equity": 5000.0},
         broker="robinhood",
-        remote_tool="place_order",
+        remote_tool="place_equity_order",
         daily_count=daily_count,
     )
 
@@ -357,9 +357,9 @@ class _FailingForwardAdapter:
         self.order_calls: list[dict[str, Any]] = []
 
     def call_tool(self, remote_name: str, arguments: dict, *, local_name: str | None = None) -> dict:
-        if remote_name == "get_positions":
+        if remote_name == "get_equity_positions":
             return {"positions": [], "status": "ok"}
-        if remote_name == "get_account":
+        if remote_name == "get_portfolio":
             return {"equity": 5000.0, "status": "ok"}
         # The order placement fails at the broker.
         self.order_calls.append({"remote": remote_name, "arguments": arguments})
@@ -427,7 +427,7 @@ def test_successful_forward_consumes_count_and_audits_accepted(live_runtime: Pat
 
 
 class _QuoteAdapter:
-    """Adapter with a working ``get_quotes`` read tool returning a fixed price."""
+    """Adapter with a working ``get_equity_quotes`` read tool returning a fixed price."""
 
     def __init__(self, *, price: float, positions: Any = (), balance: Any = 5000.0) -> None:
         self.server_name = "robinhood"
@@ -438,11 +438,11 @@ class _QuoteAdapter:
         self.quote_calls: list[dict[str, Any]] = []
 
     def call_tool(self, remote_name: str, arguments: dict, *, local_name: str | None = None) -> dict:
-        if remote_name == "get_positions":
+        if remote_name == "get_equity_positions":
             return {"positions": self._positions, "status": "ok"}
-        if remote_name == "get_account":
+        if remote_name == "get_portfolio":
             return {"equity": self._balance, "status": "ok"}
-        if remote_name == "get_quotes":
+        if remote_name == "get_equity_quotes":
             self.quote_calls.append({"arguments": arguments})
             return {"status": "ok", "symbol": arguments.get("symbol"), "price": self._price}
         self.order_calls.append({"remote": remote_name, "arguments": arguments})

--- a/agent/tests/test_oauth_token_cache.py
+++ b/agent/tests/test_oauth_token_cache.py
@@ -179,7 +179,7 @@ def test_token_never_in_audit_payload() -> None:
         session_id="s1",
         outcome="accepted",
         server="robinhood",
-        remote_tool="place_order",
+        remote_tool="place_equity_order",
         broker_request={"symbol": "AAPL", "access_token": _OAUTH_SECRET},
         broker_response={"order_id": "rh_x", "authorization": _OAUTH_SECRET},
     )
@@ -209,8 +209,8 @@ def test_token_not_accepted_from_tool_args_or_variables() -> None:
 
     spec = MCPRemoteToolSpec(
         server_name="robinhood",
-        remote_name="place_order",
-        local_name="mcp_robinhood_place_order",
+        remote_name="place_equity_order",
+        local_name="mcp_robinhood_place_equity_order",
         description="place an order",
         parameters={
             "type": "object",
@@ -282,12 +282,12 @@ def test_cache_expiry_surfaces_reauth_no_silent_stale_call() -> None:
             "type": "streamableHttp",
             "url": "https://agent.robinhood.com/mcp/trading",
             "auth": {"type": "oauth", "scopes": ["trading.read"]},
-            "enabled_tools": ["place_order"],
+            "enabled_tools": ["place_equity_order"],
         }
     )
     adapter = MCPServerAdapter("robinhood", cfg, client_factory=_ExpiredAuthClient)
 
-    result = adapter.call_tool("place_order", {"symbol": "AAPL", "side": "buy"})
+    result = adapter.call_tool("place_equity_order", {"symbol": "AAPL", "side": "buy"})
 
     # Surfaced as an error envelope — never a silent success off a stale token.
     assert result["status"] == "error"

--- a/agent/tests/test_readonly_default.py
+++ b/agent/tests/test_readonly_default.py
@@ -44,8 +44,16 @@ from src.tools.mcp import MCPRemoteTool, build_mcp_tool_wrappers
 
 pytestmark = pytest.mark.unit
 
-# The full Robinhood catalog a mock server would expose (4 READ + 2 WRITE).
-_CATALOG = ("get_account", "get_positions", "get_quotes", "list_orders", "place_order", "cancel_order")
+# The current Robinhood Agentic Trading MCP catalog subset this layer supports.
+_CATALOG = (
+    "get_accounts",
+    "get_portfolio",
+    "get_equity_positions",
+    "get_equity_quotes",
+    "get_equity_orders",
+    "place_equity_order",
+    "cancel_equity_order",
+)
 
 
 class _FakeClient:
@@ -190,8 +198,8 @@ def test_order_tools_absent_with_seed_allowlist() -> None:
     tools = _assemble(list(ROBINHOOD_MCP_SERVER_SEED["enabled_tools"]))
     names = {t._spec.remote_name for t in tools}
     assert names == set(ROBINHOOD_MCP_SERVER_SEED["enabled_tools"])
-    assert "place_order" not in names
-    assert "cancel_order" not in names
+    assert "place_equity_order" not in names
+    assert "cancel_equity_order" not in names
     # Every surviving tool is a plain read-only MCPRemoteTool (no gate).
     assert all(type(t) is MCPRemoteTool and t.is_readonly for t in tools)
     assert not any(isinstance(t, LiveOrderGuardTool) for t in tools)
@@ -202,17 +210,20 @@ def test_order_tools_absent_with_seed_allowlist() -> None:
 
 def test_order_tools_appear_gate_wrapped_when_allowlisted(live_runtime: Path) -> None:
     _commit_mandate(live_runtime)
-    enabled = list(ROBINHOOD_MCP_SERVER_SEED["enabled_tools"]) + ["place_order", "cancel_order"]
+    enabled = list(ROBINHOOD_MCP_SERVER_SEED["enabled_tools"]) + [
+        "place_equity_order",
+        "cancel_equity_order",
+    ]
     tools = _assemble(enabled)
     by_name = {t._spec.remote_name: t for t in tools}
 
-    assert "place_order" in by_name and "cancel_order" in by_name
-    assert isinstance(by_name["place_order"], LiveOrderGuardTool)
-    assert isinstance(by_name["cancel_order"], LiveOrderGuardTool)
-    assert by_name["place_order"].broker == "robinhood"
+    assert "place_equity_order" in by_name and "cancel_equity_order" in by_name
+    assert isinstance(by_name["place_equity_order"], LiveOrderGuardTool)
+    assert isinstance(by_name["cancel_equity_order"], LiveOrderGuardTool)
+    assert by_name["place_equity_order"].broker == "robinhood"
     # Reads stay plain read-only.
-    assert type(by_name["get_account"]) is MCPRemoteTool
-    assert by_name["get_account"].is_readonly is True
+    assert type(by_name["get_portfolio"]) is MCPRemoteTool
+    assert by_name["get_portfolio"].is_readonly is True
 
 
 # --- H8: a Robinhood URL under an aliased key is still a live broker ----------
@@ -230,17 +241,17 @@ def test_aliased_key_with_robinhood_url_is_gated() -> None:
             "type": "streamableHttp",
             "url": "https://agent.robinhood.com/mcp/trading",
             "auth": {"type": "oauth"},
-            "enabled_tools": ["get_positions", "place_order"],
+            "enabled_tools": ["get_equity_positions", "place_equity_order"],
         }
     )
     wrappers = build_mcp_tool_wrappers("rh", cfg, client_factory=_factory)
     gated = wrap_live_broker_tools("rh", wrappers, url=cfg.url)
     by_name = {t._spec.remote_name: t for t in gated}
 
-    assert isinstance(by_name["place_order"], LiveOrderGuardTool)
+    assert isinstance(by_name["place_equity_order"], LiveOrderGuardTool)
     # Broker namespace resolves to the real broker, not the alias.
-    assert by_name["place_order"].broker == "robinhood"
-    assert type(by_name["get_positions"]) is MCPRemoteTool
+    assert by_name["place_equity_order"].broker == "robinhood"
+    assert type(by_name["get_equity_positions"]) is MCPRemoteTool
 
 
 def test_lookalike_host_is_not_a_live_broker() -> None:
@@ -257,16 +268,19 @@ def test_halt_omits_order_tools_at_registration(live_runtime: Path) -> None:
     _commit_mandate(live_runtime)
     trip_halt(by="test", reason="reg-time halt", broker="robinhood")
 
-    enabled = list(ROBINHOOD_MCP_SERVER_SEED["enabled_tools"]) + ["place_order", "cancel_order"]
+    enabled = list(ROBINHOOD_MCP_SERVER_SEED["enabled_tools"]) + [
+        "place_equity_order",
+        "cancel_equity_order",
+    ]
     tools = _assemble(enabled)
     names = {t._spec.remote_name for t in tools}
 
     # Order tools are not even present in the assembled list.
-    assert "place_order" not in names
-    assert "cancel_order" not in names
+    assert "place_equity_order" not in names
+    assert "cancel_equity_order" not in names
     assert not any(isinstance(t, LiveOrderGuardTool) for t in tools)
     # Read tools survive a halt.
-    assert "get_account" in names
+    assert "get_portfolio" in names
     assert all(t.is_readonly for t in tools)
 
 

--- a/agent/tests/test_runtime_flatten.py
+++ b/agent/tests/test_runtime_flatten.py
@@ -171,11 +171,11 @@ def test_every_action_is_audited(live_runtime: Path) -> None:
     kinds = sorted(r["kind"] for r in records)
     assert kinds == ["order_placed", "order_rejected"]
     rejected = next(r for r in records if r["kind"] == "order_rejected")
-    assert rejected["remote_tool"] == "cancel_order"
+    assert rejected["remote_tool"] == "cancel_equity_order"
     assert rejected["outcome"] == "error"
     assert rejected["error"] == "broker rejected o1"
     placed = next(r for r in records if r["kind"] == "order_placed")
-    assert placed["remote_tool"] == "place_order"
+    assert placed["remote_tool"] == "place_equity_order"
     assert placed["outcome"] == "accepted"
     assert placed["server"] == "robinhood"
 

--- a/agent/tests/test_trading_connections.py
+++ b/agent/tests/test_trading_connections.py
@@ -22,7 +22,7 @@ def test_remote_call_requires_enabled_tool(monkeypatch: pytest.MonkeyPatch) -> N
     """Generic remote reads must respect the operator MCP allowlist."""
     server = SimpleNamespace(
         url="https://agent.robinhood.com/mcp/trading",
-        enabled_tools=["get_account"],
+        enabled_tools=["get_portfolio"],
         auth=SimpleNamespace(cache_dir="/tmp/vibe-no-token"),
     )
     monkeypatch.setattr("src.config.loader.load_agent_config", lambda: _agent_config(server))
@@ -38,7 +38,7 @@ def test_remote_call_requires_cached_oauth(monkeypatch: pytest.MonkeyPatch) -> N
     """Generic remote reads must not trigger OAuth from tool/API/MCP paths."""
     server = SimpleNamespace(
         url="https://agent.robinhood.com/mcp/trading",
-        enabled_tools=["get_positions"],
+        enabled_tools=["get_equity_positions"],
         auth=SimpleNamespace(cache_dir="/tmp/vibe-no-token"),
     )
     monkeypatch.setattr("src.config.loader.load_agent_config", lambda: _agent_config(server))
@@ -102,3 +102,45 @@ def test_live_broker_mcp_wrappers_are_hidden_from_agent_registry(monkeypatch: py
 
     assert "trading_positions" in registry.tool_names
     assert not any(name.startswith("mcp_robinhood_") for name in registry.tool_names)
+
+
+def test_robinhood_generic_reads_use_current_agentic_mcp_tool_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for #381: generic reads must not call stale Robinhood tool names."""
+    calls: list[tuple[str, dict]] = []
+    server = SimpleNamespace(
+        url="https://agent.robinhood.com/mcp/trading",
+        enabled_tools=[
+            "get_portfolio",
+            "get_equity_positions",
+            "get_equity_orders",
+            "get_equity_quotes",
+        ],
+        auth=SimpleNamespace(cache_dir="/tmp/vibe-token"),
+    )
+
+    class _Adapter:
+        def __init__(self, server_name, server_config):  # noqa: ANN001
+            assert server_name == "robinhood"
+            assert server_config is server
+
+        def call_tool(self, remote_name, arguments):  # noqa: ANN001
+            calls.append((remote_name, dict(arguments)))
+            return {"status": "ok"}
+
+    monkeypatch.setattr("src.config.loader.load_agent_config", lambda: _agent_config(server))
+    monkeypatch.setattr("src.live.registry.has_cached_oauth_token", lambda *_: True)
+    monkeypatch.setattr("src.tools.mcp.MCPServerAdapter", _Adapter)
+
+    assert service.get_account("robinhood-live-mcp")["status"] == "ok"
+    assert service.get_positions("robinhood-live-mcp")["status"] == "ok"
+    assert service.get_open_orders("robinhood-live-mcp")["status"] == "ok"
+    assert service.get_quote("AAPL", "robinhood-live-mcp")["status"] == "ok"
+
+    assert calls == [
+        ("get_portfolio", {}),
+        ("get_equity_positions", {}),
+        ("get_equity_orders", {}),
+        ("get_equity_quotes", {"symbols": ["AAPL"]}),
+    ]


### PR DESCRIPTION
## Summary
- Align Robinhood Agentic Trading MCP mappings, read/write classification, default read-only seed, order intent extraction, live guard tests, and broker ceiling lookup with the current Robinhood tool names.
- Make interactive CLI startup recognize the same `.env` candidates as the provider loader: `~/.vibe-trading/.env`, `agent/.env`, then `$CWD/.env`.
- Update focused regression coverage for Robinhood live MCP safety paths and project-local env onboarding behavior.

## Verification
- `PYTHONPATH=agent python -m pytest agent/tests/test_readonly_default.py agent/tests/test_classification.py agent/tests/test_enforcement_l6.py agent/tests/test_default_deny_unknown_robinhood_tool.py agent/tests/test_trading_connections.py agent/tests/test_agent_config.py agent/tests/test_api_live_runtime.py agent/tests/test_cli_live.py agent/tests/test_mandate_enforcement.py agent/tests/test_killswitch_blocks_orders.py agent/tests/test_advisory.py agent/tests/test_oauth_token_cache.py agent/tests/test_runtime_flatten.py agent/tests/test_cli_interactive.py agent/tests/test_openai_codex.py agent/tests/test_dotenv_observability.py agent/tests/test_llm.py -q` -> 315 passed, 4 warnings
- `python -m compileall -q agent/api_server.py agent/cli/main.py agent/src/trading/connectors/robinhood/mcp.py agent/src/trading/connectors/robinhood/classification.py agent/src/trading/connectors/robinhood/extractor.py agent/src/config/schema.py agent/tests/test_cli_interactive.py`
- `git diff --check origin/main...HEAD`

Closes #381
Closes #380