### PR TITLE
fix(preflight): avoid following provider probe redirects

### DIFF
--- a/agent/src/preflight.py
+++ b/agent/src/preflight.py
@@ -109,7 +109,7 @@ def _check_llm_provider() -> CheckResult:
         ping_url = base_url.rstrip("/")
         if ping_url.endswith("/v1"):
             ping_url = ping_url[:-3]
-        requests.get(ping_url, timeout=10)
+        requests.get(ping_url, timeout=10, allow_redirects=False)
         return CheckResult(
             name=f"LLM ({provider})",
             status="ready",

--- a/agent/tests/test_preflight.py
+++ b/agent/tests/test_preflight.py
@@ -4,7 +4,75 @@ from __future__ import annotations
 
 import sys
 
+import requests
+
 from src import preflight
+
+
+def _configure_llm_preflight(monkeypatch) -> None:
+    """Install a minimal OpenAI-compatible provider environment for preflight tests."""
+    import src.providers.llm as llm
+
+    monkeypatch.setenv("LANGCHAIN_PROVIDER", "openai")
+    monkeypatch.setenv("LANGCHAIN_MODEL_NAME", "gpt-test")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://example.test/v1")
+    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+    monkeypatch.setattr(llm, "_ensure_dotenv", lambda: None)
+    monkeypatch.setattr(llm, "_sync_provider_env", lambda: None)
+    monkeypatch.setattr(
+        llm,
+        "provider_diagnostics",
+        lambda: {
+            "base_url": "https://example.test/v1",
+            "timeout_seconds": 120,
+            "max_retries": 2,
+            "proxy": {},
+        },
+    )
+
+
+def test_llm_preflight_probe_does_not_follow_redirects(monkeypatch) -> None:
+    """A redirect response still proves the HTTPS provider base is reachable."""
+    _configure_llm_preflight(monkeypatch)
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def fake_get(url: str, **kwargs: object) -> object:
+        calls.append((url, kwargs))
+        response = requests.Response()
+        response.status_code = 307
+        return response
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    result = preflight._check_llm_provider()
+
+    assert result.status == "ready"
+    assert calls == [
+        (
+            "https://example.test",
+            {
+                "timeout": 10,
+                "allow_redirects": False,
+            },
+        )
+    ]
+
+
+def test_llm_preflight_probe_reports_request_errors(monkeypatch) -> None:
+    """Request failures remain critical errors for the LLM provider check."""
+    _configure_llm_preflight(monkeypatch)
+
+    def fake_get(url: str, **kwargs: object) -> object:
+        del url, kwargs
+        raise requests.Timeout("timed out")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    result = preflight._check_llm_provider()
+
+    assert result.status == "error"
+    assert result.critical is True
+    assert "Timeout: timed out" in result.message
 
 
 def test_akshare_check_uses_spec_without_import(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Stop the LLM preflight reachability probe from following redirects from the stripped provider base URL.
- Add focused regression coverage for a 307-style provider response and request-error handling.

## Why
Fixes #402.

The preflight comment says the stripped base URL probe is only meant to test TCP+SSL reachability. A redirect response already proves the HTTPS endpoint responded, so following the redirect can turn a working OpenAI-compatible provider into a false critical startup failure.

## Changes
- Pass `allow_redirects=False` on the LLM preflight `requests.get(...)` reachability probe.
- Add mocked tests for a redirect-style response and unchanged request-error behavior.

## Test Plan
- [x] Existing tests pass: `PYTHONPATH=agent .venv/bin/python -m pytest agent/tests/test_preflight.py -q`
- [x] New tests added for the redirect/preflight path.
- [x] Compile check: `PYTHONPATH=agent .venv/bin/python -m py_compile agent/src/preflight.py agent/tests/test_preflight.py`
- [x] Broader Python suite: `env HOME="$PWD/.cache/test-home" XDG_CACHE_HOME="$PWD/.cache/xdg" MPLCONFIGDIR="$PWD/.cache/matplotlib" PYTHONPATH=agent .venv/bin/python -m pytest --ignore=agent/tests/e2e_backtest --ignore=agent/tests/test_e2e_harness_v2.py --tb=short -q`
- [x] Whitespace check: `git diff --check`

## Scope
- No changes to actual chat/completions provider calls.
- No retry, diagnostics, broker, trading, API server, or UI changes.
- No live provider credentials or real NetMind API calls were used; the regression is mocked.

## Checklist
- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows CONTRIBUTING.md guidelines
- [x] Documentation updated if user-facing change: not applicable; behavior is covered by tests
