### PR TITLE
docs: add IRR-AGL reliability RFC and tool inventory

### DIFF
--- a/agent/scripts/dump_tool_inventory.py
+++ b/agent/scripts/dump_tool_inventory.py
@@ -1,0 +1,167 @@
+"""Dump a read-only inventory of registered local tools.
+
+Phase 0 uses this as an audit helper only. It builds the existing registry,
+records metadata, and never calls ``ToolRegistry.execute`` or any tool's
+``execute`` method.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+AGENT_DIR = Path(__file__).resolve().parents[1]
+if str(AGENT_DIR) not in sys.path:
+    sys.path.insert(0, str(AGENT_DIR))
+
+from src.agent.tools import BaseTool  # noqa: E402
+from src.tools import build_registry  # noqa: E402
+
+
+SHELL_TOOL_NAMES = {"bash", "background_run"}
+TRADE_WRITE_TERMS = (
+    "place_order",
+    "cancel_order",
+    "modify_order",
+    "submit_order",
+    "flatten",
+    "trade_write",
+    "order_write",
+)
+TRADE_READ_TERMS = (
+    "account",
+    "balance",
+    "broker",
+    "connector",
+    "order",
+    "position",
+    "portfolio",
+    "trading",
+)
+NETWORK_TERMS = (
+    "market_data",
+    "web_",
+    "url",
+    "news",
+    "sec_",
+    "fred",
+    "iwencai",
+    "dragon_tiger",
+    "northbound",
+    "fund_flow",
+    "financial_statements",
+    "stock_profile",
+)
+LOCAL_WRITE_TERMS = ("write", "edit", "remember", "journal", "save")
+
+
+def _contains_any(value: str, terms: tuple[str, ...]) -> bool:
+    return any(term in value for term in terms)
+
+
+def guess_surface(tool: BaseTool) -> str:
+    """Best-effort surface classification for Phase 0 review."""
+    name = tool.name.lower()
+    module = tool.__class__.__module__.lower()
+    combined = f"{module}.{name}"
+
+    if name in SHELL_TOOL_NAMES:
+        return "local_cli"
+    if ".mcp" in module or tool.__class__.__name__.lower().startswith("mcp"):
+        return "mcp"
+    if "live" in module or "trading_connector" in module or "broker" in combined:
+        return "live_connector"
+    if module.endswith((".read_file_tool", ".write_file_tool", ".edit_file_tool")) or _contains_any(
+        name,
+        ("read_file", "write_file", "edit_file"),
+    ):
+        return "filesystem"
+    if _contains_any(combined, NETWORK_TERMS):
+        return "network_data"
+    return "local_research"
+
+
+def guess_risk(tool: BaseTool) -> str:
+    """Best-effort risk classification aligned with AGENTS.md risk levels."""
+    name = tool.name.lower()
+    module = tool.__class__.__module__.lower()
+    combined = f"{module}.{name}"
+    is_readonly = bool(getattr(tool, "is_readonly", True))
+
+    if name in SHELL_TOOL_NAMES:
+        return "R5_SHELL"
+    if _contains_any(combined, TRADE_WRITE_TERMS) or (
+        not is_readonly and "trading_connector" in module
+    ):
+        return "R4_TRADE_WRITE"
+    if _contains_any(combined, TRADE_READ_TERMS) and "trading" in combined:
+        return "R3_TRADE_READ"
+    if not is_readonly:
+        if _contains_any(combined, LOCAL_WRITE_TERMS):
+            return "R1_WRITE_LOCAL"
+        return "R1_WRITE_LOCAL"
+    if _contains_any(combined, NETWORK_TERMS):
+        return "R2_NETWORK"
+    return "R0_READ"
+
+
+def build_tool_inventory(*, include_shell_tools: bool = True) -> list[dict[str, Any]]:
+    """Return inventory rows for currently available local tools."""
+    registry = build_registry(include_shell_tools=include_shell_tools, interactive=False)
+    rows: list[dict[str, Any]] = []
+    for name in registry.tool_names:
+        tool = registry.get(name)
+        if tool is None:
+            continue
+        rows.append({
+            "name": tool.name,
+            "module": tool.__class__.__module__,
+            "class_name": tool.__class__.__name__,
+            "is_readonly": bool(getattr(tool, "is_readonly", True)),
+            "repeatable": bool(getattr(tool, "repeatable", False)),
+            "surface_guess": guess_surface(tool),
+            "risk_guess": guess_risk(tool),
+        })
+    return sorted(rows, key=lambda row: row["name"])
+
+
+def _format_table(rows: list[dict[str, Any]]) -> str:
+    headers = ["name", "module", "is_readonly", "repeatable", "surface_guess", "risk_guess"]
+    table = [
+        "| " + " | ".join(headers) + " |",
+        "| " + " | ".join("---" for _ in headers) + " |",
+    ]
+    for row in rows:
+        table.append("| " + " | ".join(str(row[column]) for column in headers) + " |")
+    return "\n".join(table)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Dump the Vibe-Trading local tool inventory.")
+    parser.add_argument(
+        "--format",
+        choices=("json", "table"),
+        default="json",
+        help="Output format. Defaults to JSON for machine review.",
+    )
+    parser.add_argument(
+        "--exclude-shell-tools",
+        action="store_true",
+        help="Exclude shell-capable tools from the inventory.",
+    )
+    args = parser.parse_args(argv)
+
+    rows = build_tool_inventory(include_shell_tools=not args.exclude_shell_tools)
+    if args.format == "table":
+        print(_format_table(rows))
+    else:
+        print(json.dumps(rows, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent/tests/reliability/test_environment_contract.py
+++ b/agent/tests/reliability/test_environment_contract.py
@@ -1,0 +1,146 @@
+"""Phase 0.5 readiness checks for the IRR-AGL environment contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+import pydantic
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+INVENTORY_SCRIPT = REPO_ROOT / "agent" / "scripts" / "dump_tool_inventory.py"
+VALID_MODES = {"off", "observe", "warn", "enforce"}
+
+
+def _expand_config_path(raw: str) -> Path:
+    return Path(os.path.expandvars(os.path.expanduser(raw))).resolve(strict=False)
+
+
+def _default_artifact_root() -> Path:
+    return (Path.home() / ".vibe-trading" / "artifacts").resolve(strict=False)
+
+
+def _default_ledger_path() -> Path:
+    return (Path.home() / ".vibe-trading" / "research-ledger" / "ledger.sqlite").resolve(strict=False)
+
+
+def _parse_mode(raw: str | None, *, default: str = "observe") -> str:
+    value = (raw or default).strip().lower()
+    if value not in VALID_MODES:
+        raise ValueError(f"unsupported IRR-AGL mode: {raw!r}")
+    return value
+
+
+def _load_inventory_module():
+    spec = importlib.util.spec_from_file_location("dump_tool_inventory", INVENTORY_SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_pydantic_major_version_is_2() -> None:
+    assert int(pydantic.VERSION.split(".", 1)[0]) == 2
+
+
+def test_scipy_is_importable() -> None:
+    scipy_spec = importlib.util.find_spec("scipy")
+
+    assert scipy_spec is not None
+
+
+def test_default_artifact_root_resolves_under_user_home() -> None:
+    artifact_root = _default_artifact_root()
+
+    artifact_root.relative_to(Path.home().resolve(strict=False))
+    assert artifact_root.name == "artifacts"
+    assert artifact_root.parent.name == ".vibe-trading"
+
+
+def test_artifact_root_override_can_resolve_outside_user_home(tmp_path: Path, monkeypatch) -> None:
+    override = tmp_path / "custom-artifacts"
+    monkeypatch.setenv("VIBE_TRADING_ARTIFACT_ROOT", str(override))
+
+    resolved = _expand_config_path(os.environ["VIBE_TRADING_ARTIFACT_ROOT"])
+
+    assert resolved == override.resolve(strict=False)
+
+
+def test_default_ledger_path_resolves_under_user_home() -> None:
+    ledger_path = _default_ledger_path()
+
+    ledger_path.relative_to(Path.home().resolve(strict=False))
+    assert ledger_path.name == "ledger.sqlite"
+    assert ledger_path.parent.name == "research-ledger"
+    assert ledger_path.parent.parent.name == ".vibe-trading"
+
+
+def test_ledger_path_override_can_resolve_outside_user_home(tmp_path: Path, monkeypatch) -> None:
+    override = tmp_path / "research-ledger" / "ledger.sqlite"
+    monkeypatch.setenv("VIBE_TRADING_RESEARCH_LEDGER_PATH", str(override))
+
+    resolved = _expand_config_path(os.environ["VIBE_TRADING_RESEARCH_LEDGER_PATH"])
+
+    assert resolved == override.resolve(strict=False)
+
+
+def test_platform_path_expansion_smoke(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("VIBE_TRADING_TEST_HOME", str(tmp_path))
+    raw = (
+        r"%VIBE_TRADING_TEST_HOME%\artifacts"
+        if os.name == "nt"
+        else "$VIBE_TRADING_TEST_HOME/artifacts"
+    )
+
+    resolved = _expand_config_path(raw)
+
+    assert resolved == (tmp_path / "artifacts").resolve(strict=False)
+
+
+def test_reliability_and_governance_feature_modes_accept_baseline_values() -> None:
+    for env_name in ("VIBE_TRADING_RELIABILITY_MODE", "VIBE_TRADING_GOVERNANCE_MODE"):
+        for mode in ("off", "observe", "warn", "enforce"):
+            assert _parse_mode(mode) == mode
+            assert _parse_mode(mode.upper()) == mode
+
+
+def test_current_cli_package_is_discoverable() -> None:
+    cli_spec = importlib.util.find_spec("cli")
+    cli_main_spec = importlib.util.find_spec("cli.main")
+
+    assert cli_spec is not None
+    assert cli_main_spec is not None
+
+
+def test_dump_tool_inventory_output_has_stable_required_fields() -> None:
+    module = _load_inventory_module()
+
+    rows = module.build_tool_inventory()
+
+    assert rows
+    assert [row["name"] for row in rows] == sorted(row["name"] for row in rows)
+
+    required_fields = {
+        "name",
+        "module",
+        "class_name",
+        "is_readonly",
+        "repeatable",
+        "surface_guess",
+        "risk_guess",
+    }
+    allowed_risks = {"R0_READ", "R1_WRITE_LOCAL", "R2_NETWORK", "R3_TRADE_READ", "R4_TRADE_WRITE", "R5_SHELL"}
+    allowed_surfaces = {"filesystem", "live_connector", "local_cli", "local_research", "mcp", "network_data"}
+
+    for row in rows:
+        assert required_fields <= row.keys()
+        assert isinstance(row["name"], str) and row["name"]
+        assert isinstance(row["module"], str) and row["module"]
+        assert isinstance(row["class_name"], str) and row["class_name"]
+        assert isinstance(row["is_readonly"], bool)
+        assert isinstance(row["repeatable"], bool)
+        assert row["surface_guess"] in allowed_surfaces
+        assert row["risk_guess"] in allowed_risks

--- a/agent/tests/test_tool_inventory_smoke.py
+++ b/agent/tests/test_tool_inventory_smoke.py
@@ -1,0 +1,57 @@
+"""Smoke tests for the Phase 0 tool inventory script."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "dump_tool_inventory.py"
+
+
+def _load_inventory_module():
+    spec = importlib.util.spec_from_file_location("dump_tool_inventory", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_tool_inventory_rows_include_required_governance_fields() -> None:
+    module = _load_inventory_module()
+
+    rows = module.build_tool_inventory()
+
+    assert rows
+    names = [row["name"] for row in rows]
+    assert names == sorted(names)
+    assert len(names) == len(set(names))
+
+    required_fields = {
+        "name",
+        "module",
+        "is_readonly",
+        "repeatable",
+        "surface_guess",
+        "risk_guess",
+    }
+    for row in rows:
+        assert required_fields <= row.keys()
+        assert isinstance(row["name"], str) and row["name"]
+        assert isinstance(row["module"], str) and row["module"]
+        assert isinstance(row["is_readonly"], bool)
+        assert isinstance(row["repeatable"], bool)
+        assert isinstance(row["surface_guess"], str) and row["surface_guess"]
+        assert isinstance(row["risk_guess"], str) and row["risk_guess"]
+
+
+def test_shell_tools_are_inventory_only_and_marked_r5() -> None:
+    module = _load_inventory_module()
+
+    rows = module.build_tool_inventory()
+    by_name = {row["name"]: row for row in rows}
+
+    assert "bash" in by_name
+    assert by_name["bash"]["surface_guess"] == "local_cli"
+    assert by_name["bash"]["risk_guess"] == "R5_SHELL"

--- a/docs/irr-agl-readiness-check.md
+++ b/docs/irr-agl-readiness-check.md
@@ -1,0 +1,102 @@
+# IRR-AGL Phase 0.5 Readiness Check
+
+Date: 2026-07-06
+Branch: `phase/00-readiness-gate`
+Status: Implementation readiness gate
+
+## Scope
+
+Phase 0.5 verifies the local environment and repository contract before Phase 1
+adds the artifact store. This phase intentionally changes no runtime behavior.
+It adds a readiness document and an environment-contract test only.
+
+## Required Preflight
+
+Executed on Windows PowerShell from `D:\Vibe-Trading`:
+
+```powershell
+git status --short
+git branch --show-current
+.\.venv\Scripts\python.exe -c "import pydantic, scipy; print(pydantic.VERSION); print(scipy.__version__)"
+.\.venv\Scripts\python.exe -X utf8 agent/scripts/dump_tool_inventory.py
+.\.venv\Scripts\python.exe -X utf8 -m pytest agent/tests/test_tool_inventory_smoke.py -q
+```
+
+Observed baseline:
+
+- Worktree was clean before Phase 0.5 edits.
+- Current phase branch is `phase/00-readiness-gate`.
+- Pydantic is importable with major version `2`.
+- SciPy is importable.
+- Phase 0 tool inventory emits stable governance fields.
+- Phase 0 inventory smoke tests pass.
+
+## Repository Surfaces Checked
+
+Readiness review covered the required Phase 0.5 surfaces:
+
+- `pyproject.toml`
+- `AGENTS.md`
+- `docs/reliability-governance-rfc.md`
+- `agent/cli/`
+- `agent/src/agent/tools.py`
+- `agent/src/agent/trace.py`
+- `agent/backtest/run_card.py`
+- `agent/backtest/loaders/registry.py`
+- `agent/src/live/`
+- `agent/src/tools/mcp.py`
+- `agent/mcp_server.py`
+- `.github/workflows/test.yml`
+
+Important invariants remain unchanged:
+
+- `BaseTool.execute(**kwargs) -> str`
+- `ToolRegistry.execute(name, params) -> str`
+- `DataLoaderProtocol.fetch(...) -> dict[str, DataFrame]`
+- Explicit `local` data source requests do not fall back to network sources.
+- Live write tools remain gated by mandate, expiry, kill switch, intent parsing,
+  limits, and `LiveOrderGuardTool`.
+- MCP SSE/HTTP shell exposure remains stricter than stdio.
+- Run card JSON continues to use strict JSON output with non-finite values
+  normalized before serialization.
+
+## Environment Contract Baseline
+
+Phase 0.5 records the configuration contract that Phase 1 and Phase 3 will turn
+into runtime modules:
+
+- `VIBE_TRADING_RELIABILITY_MODE` accepts `off`, `observe`, `warn`, `enforce`.
+- `VIBE_TRADING_GOVERNANCE_MODE` accepts `off`, `observe`, `warn`, `enforce`.
+- Default artifact root resolves under `~/.vibe-trading/artifacts`.
+- Default research ledger path resolves under
+  `~/.vibe-trading/research-ledger/ledger.sqlite`.
+- Environment overrides can point those paths elsewhere.
+- Windows-style environment path expansion is covered by a smoke test on
+  Windows, with a POSIX equivalent used on non-Windows CI.
+- The current CLI package is discoverable through the configured Python path.
+
+The parser used in this phase is test-local on purpose. Phase 1 should introduce
+`agent/src/reliability/config.py`; Phase 3 should introduce
+`agent/src/governance/config.py`.
+
+## Acceptance
+
+Targeted checks for this phase:
+
+```powershell
+.\.venv\Scripts\python.exe -X utf8 -m pytest agent/tests/reliability/test_environment_contract.py agent/tests/test_tool_inventory_smoke.py -q
+```
+
+No real LLM, broker, external MCP server, or real external market-data service is
+required.
+
+## Rollback
+
+Rollback is limited to deleting:
+
+- `docs/irr-agl-readiness-check.md`
+- `agent/tests/reliability/test_environment_contract.py`
+
+No database, artifact root, runtime config, live mandate, API response, MCP
+schema, loader, or ToolRegistry rollback is required because Phase 0.5 does not
+change runtime code.

--- a/docs/reliability-governance-rfc.md
+++ b/docs/reliability-governance-rfc.md
@@ -1,0 +1,189 @@
+# IRR-AGL Reliability Governance RFC
+
+Date: 2026-07-05
+Branch: `phase/00-rfc-tool-inventory`
+Status: Phase 0 baseline
+
+## Purpose
+
+This RFC turns the IRR-AGL architecture baseline in `AGENTS.md` into the first
+reviewable implementation checkpoint for Vibe-Trading. Phase 0 does not change
+runtime behavior. It records repository facts, exposes a local tool inventory,
+and defines the minimum guardrails for later reliability, governance, protocol,
+scorecard, eval, and Research Card work.
+
+The core principle is unchanged: improve the existing system through wrappers,
+adapters, audit extensions, and read-only surfaces. Do not replace the current
+Agent loop, `BaseTool`, `ToolRegistry`, loader registry, backtest engines, MCP
+transport, live mandate, kill switch, or `LiveOrderGuardTool`.
+
+## Phase 0 Scope
+
+Phase 0 adds only three review artifacts:
+
+- `docs/reliability-governance-rfc.md`: this RFC.
+- `agent/scripts/dump_tool_inventory.py`: a read-only local inventory script.
+- `agent/tests/test_tool_inventory_smoke.py`: smoke tests for the inventory
+  contract.
+
+The inventory script builds the existing local registry and records metadata.
+It never calls `ToolRegistry.execute()` and never calls a tool's `execute()`
+method.
+
+## Non-Goals
+
+Phase 0 does not implement:
+
+- `ArtifactStore`.
+- `AuditedDataLoader`.
+- `PITChecker`.
+- `GovernedToolRegistry`.
+- `PolicyEngine`.
+- `BudgetManager`.
+- `ResearchProtocol`.
+- `TrialLedger`.
+- `QuantReliabilityScorecard`.
+- `ResearchCard`.
+- UI or API panels.
+- Any live trading, shell execution, MCP remote discovery, scheduler, swarm, or
+  externally reachable server behavior.
+
+Those capabilities belong to later `phase/*` branches and must remain
+feature-flagged, independently testable, and mergeable through
+`integration/irr-agl`.
+
+## Repository Facts To Preserve
+
+The following public interfaces remain unchanged:
+
+```python
+BaseTool.execute(**kwargs) -> str
+ToolRegistry.execute(name, params) -> str
+DataLoaderProtocol.fetch(
+    codes,
+    start_date,
+    end_date,
+    interval="1D",
+    fields=None,
+) -> dict[str, DataFrame]
+```
+
+The following safety boundaries remain authoritative:
+
+- Shell-capable tools stay behind explicit opt-in.
+- File tools stay constrained by existing path allowlists.
+- URL/media readers keep SSRF protections.
+- Generated backtest subprocesses do not inherit LLM, broker, or live secrets.
+- `local:` data sources must not silently fall back to network sources.
+- Live orders remain gated by mandate, kill switch, broker classification, and
+  `LiveOrderGuardTool`.
+- `commit_mandate()` remains outside the agent tool registry.
+
+## Tool Inventory Contract
+
+The Phase 0 inventory emits one row per currently available local tool with
+these fields:
+
+```text
+name
+module
+class_name
+is_readonly
+repeatable
+surface_guess
+risk_guess
+```
+
+Current local inventory summary on this branch:
+
+| Dimension | Count |
+|---|---:|
+| Total tools | 70 |
+| `surface_guess=filesystem` | 3 |
+| `surface_guess=live_connector` | 10 |
+| `surface_guess=local_cli` | 2 |
+| `surface_guess=local_research` | 45 |
+| `surface_guess=network_data` | 10 |
+| `risk_guess=R0_READ` | 26 |
+| `risk_guess=R1_WRITE_LOCAL` | 21 |
+| `risk_guess=R2_NETWORK` | 10 |
+| `risk_guess=R3_TRADE_READ` | 8 |
+| `risk_guess=R4_TRADE_WRITE` | 3 |
+| `risk_guess=R5_SHELL` | 2 |
+
+The `surface_guess` and `risk_guess` fields are intentionally heuristic in
+Phase 0. They are an audit aid, not an enforcement source. Phase 3 owns the
+authoritative `ToolManifest`, policy priority model, fail-safe behavior, and
+R4/R5 shadow-deny enforcement.
+
+## Initial Risk Mapping
+
+The Phase 0 script maps tools into the IRR-AGL risk vocabulary:
+
+| Risk | Meaning In Phase 0 |
+|---|---|
+| `R0_READ` | Local read-only research or analysis tool |
+| `R1_WRITE_LOCAL` | Local write or state-mutating tool |
+| `R2_NETWORK` | Read-only tool that may depend on network or external data |
+| `R3_TRADE_READ` | Live connector account, order, position, quote, or history read |
+| `R4_TRADE_WRITE` | Live connector order placement, cancellation, selection, or mutation |
+| `R5_SHELL` | Shell-capable or background command execution tool |
+
+Unknown or ambiguous tools must not be assumed safe in later phases. Phase 3
+must either classify them explicitly or mark them `UNCLASSIFIED` for policy
+review.
+
+## Acceptance
+
+Phase 0 is accepted when these commands pass:
+
+```powershell
+.\.venv\Scripts\python.exe -X utf8 agent/scripts/dump_tool_inventory.py
+.\.venv\Scripts\python.exe -X utf8 -m pytest agent/tests/test_tool_inventory_smoke.py -q
+```
+
+The script may also render a Markdown table for review:
+
+```powershell
+.\.venv\Scripts\python.exe -X utf8 agent/scripts/dump_tool_inventory.py --format table
+```
+
+## Review Focus
+
+Reviewers should verify:
+
+- No existing registry, loader, live safety, API, UI, or README quickstart
+  behavior changed.
+- Inventory rows include the required governance fields.
+- Shell-capable tools are visible in inventory and marked `R5_SHELL`.
+- The script does not execute tools.
+- The script does not require real LLM, broker, data-provider, MCP, or network
+  access.
+- The RFC does not claim later phases are implemented.
+
+## Rollback
+
+Rollback is limited to deleting the three Phase 0 artifacts:
+
+```text
+docs/reliability-governance-rfc.md
+agent/scripts/dump_tool_inventory.py
+agent/tests/test_tool_inventory_smoke.py
+```
+
+No database migration, feature flag migration, runtime config change, artifact
+store cleanup, or UI/API rollback is required because Phase 0 has no runtime
+behavior change.
+
+## Next Branches
+
+After Phase 0 is reviewed and merged into `integration/irr-agl`, start the next
+implementation branch from `integration/irr-agl`:
+
+```text
+phase/01-artifact-store
+```
+
+Phase 1 should implement only the artifact and trace-extension foundation
+described in `AGENTS.md`. It must not start Data/PIT enforcement, tool policy
+enforcement, Research Protocol, Quant Scorecard, or Research Card UI work.


### PR DESCRIPTION
## Summary

This PR adds an initial reliability/governance RFC and a read-only tool inventory script.

The goal is to document the current tool surface and establish a small, reviewable baseline for future reliability and governance improvements.

This PR intentionally keeps the scope narrow: it does not change runtime behavior, wrap tools, modify data loaders, alter MCP schemas, or touch live trading behavior.

## Motivation

Vibe-Trading already has a broad execution surface across local tools, MCP, API, backtesting, scheduled research, swarm workers, and live trading safety components.

Before adding any reliability or governance behavior, this PR introduces a lightweight RFC and a tool inventory script so that future changes can be reviewed against the existing tool surface and safety boundaries.

## Scope

This PR adds:

- `docs/reliability-governance-rfc.md`
- `docs/irr-agl-readiness-check.md`
- `agent/scripts/dump_tool_inventory.py`
- tool inventory smoke tests
- readiness / environment contract tests

The inventory script is read-only and reports tool metadata such as:

- tool name
- module
- readonly / repeatable metadata
- surface/risk guesses where available

## Non-goals

This PR does **not**:

- change `BaseTool`
- change `ToolRegistry`
- change tool execution behavior
- intercept or deny any tool call
- change data loader behavior
- change `local:` data source behavior
- change MCP tool schemas
- change API behavior
- change live trading safety behavior
- add new runtime dependencies
- introduce external network I/O into tests

## Compatibility and safety

This is intended to be a documentation and inventory-only baseline.

It should not affect:

- README quickstart flows
- existing tool registry behavior
- existing loader behavior
- existing backtest behavior
- existing live mandate / kill switch / order guard behavior

## Tests

Targeted tests:

```powershell
.\.venv\Scripts\python.exe -m pytest agent/tests/test_tool_inventory_smoke.py agent/tests/reliability/test_environment_contract.py -q --tb=short