### PR TITLE
fix(channels): make IM reply timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,6 +683,21 @@ vibe-trading alpha bench --zoo gtja191 --universe csi300 --period 2018-2025 --to
 
 IM channel adapters connect outside chat apps to the same session runtime used by the Web UI and CLI. Configure enabled adapters under `channels` in `~/.vibe-trading/agent.json`; SDK-backed adapters are optional extras, and missing SDKs report recovery hints instead of crashing the runtime.
 
+For long-running channel tasks, tune the central assistant-reply wait budget with `replyTimeoutS` (seconds, default `600`):
+
+```json
+{
+  "channels": {
+    "replyTimeoutS": 1800,
+    "feishu": {
+      "enabled": true
+    }
+  }
+}
+```
+
+This controls how long the shared channel runtime waits for the agent session to produce an assistant message; adapter HTTP/socket timeouts remain adapter-specific.
+
 ```bash
 vibe-trading channels status --local   # inspect config and missing SDK hints without API
 vibe-trading channels status           # query the running API runtime

--- a/agent/api_server.py
+++ b/agent/api_server.py
@@ -861,6 +861,7 @@ def _get_channel_runtime():
         bus=_channel_bus,
         session_service=svc,
         manager=_channel_manager,
+        reply_timeout_s=config["reply_timeout_s"],
     )
     return _channel_runtime
 

--- a/agent/src/channels/registry.py
+++ b/agent/src/channels/registry.py
@@ -12,12 +12,23 @@ from types import ModuleType
 from typing import Any
 from typing import TYPE_CHECKING
 
+from src.config.schema import ChannelsConfig
+
 if TYPE_CHECKING:
     from src.channels.base import BaseChannel
 
 logger = logging.getLogger(__name__)
 
 _INTERNAL = frozenset({"base", "bus", "config", "manager", "pairing", "registry", "runtime", "utils"})
+_LEGACY_GLOBAL_CONFIG_KEYS = frozenset(
+    {"restrictToWorkspace", "restrict_to_workspace", "showReasoning", "show_reasoning"}
+)
+_GLOBAL_CONFIG_KEYS = frozenset(
+    key
+    for name, field in ChannelsConfig.model_fields.items()
+    for key in (name, field.alias)
+    if key
+) | _LEGACY_GLOBAL_CONFIG_KEYS
 
 _INSTALL_HINTS: dict[str, str] = {
     "dingtalk": "pip install 'vibe-trading-ai[dingtalk]'",
@@ -163,6 +174,22 @@ def _config_section(config: Any, name: str) -> Any:
     return getattr(config, name, None)
 
 
+def _configured_channel_names(config: Any) -> set[str]:
+    if isinstance(config, Mapping):
+        return {str(key) for key in config.keys() if str(key) not in _GLOBAL_CONFIG_KEYS}
+    model_dump = getattr(config, "model_dump", None)
+    if callable(model_dump):
+        return _configured_channel_names(model_dump(mode="json", by_alias=False))
+    return {
+        key
+        for key in dir(config)
+        if not key.startswith("_")
+        and key not in _GLOBAL_CONFIG_KEYS
+        and key not in {"model_config", "model_fields"}
+        and not callable(getattr(config, key, None))
+    }
+
+
 def inspect_channels(config: Any | None = None) -> dict[str, dict[str, Any]]:
     """Inspect all built-in channels and annotate configured/enabled state.
 
@@ -174,14 +201,8 @@ def inspect_channels(config: Any | None = None) -> dict[str, dict[str, Any]]:
         Mapping from channel name to JSON-serializable status metadata.
     """
     names = set(discover_channel_names())
-    if isinstance(config, Mapping):
-        names.update(str(key) for key in config.keys())
-    elif config is not None:
-        names.update(
-            key
-            for key in dir(config)
-            if not key.startswith("_") and key not in {"model_config", "model_fields"}
-        )
+    if config is not None:
+        names.update(_configured_channel_names(config))
 
     statuses: dict[str, dict[str, Any]] = {}
     for name in sorted(names):

--- a/agent/src/config/schema.py
+++ b/agent/src/config/schema.py
@@ -439,6 +439,7 @@ class ChannelsConfig(ConfigBase):
     send_progress: bool = True
     send_tool_hints: bool = False
     send_max_retries: int = Field(default=2, ge=1, le=10)
+    reply_timeout_s: float = Field(default=600.0, ge=1.0, le=86400.0)
 
 
 class AgentConfig(ConfigBase):

--- a/agent/tests/test_agent_config.py
+++ b/agent/tests/test_agent_config.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
+from src.channels.config import load_channels_config
 from src.config import (
     AgentConfig,
     MCPServerConfig,
@@ -92,6 +93,38 @@ def test_load_agent_config_accepts_camel_case_json(tmp_path: Path) -> None:
     assert config.mcp_servers["demo"].args == ["demo-server"]
     assert config.mcp_servers["demo"].tool_timeout == 15
     assert config.mcp_servers["demo"].enabled_tools == ["alpha"]
+
+
+def test_load_agent_config_accepts_channel_reply_timeout_aliases(tmp_path: Path) -> None:
+    config_path = tmp_path / "agent.json"
+    config_path.write_text(
+        """
+        {
+          "channels": {
+            "replyTimeoutS": 1800,
+            "sendMaxRetries": 3
+          }
+        }
+        """.strip(),
+        encoding="utf-8",
+    )
+
+    config = load_agent_config(config_path)
+
+    assert config.channels.reply_timeout_s == 1800
+    assert config.channels.send_max_retries == 3
+    assert load_channels_config(config_path)["reply_timeout_s"] == 1800
+
+
+def test_channels_config_accepts_snake_case_reply_timeout() -> None:
+    config = AgentConfig.model_validate({"channels": {"reply_timeout_s": 300}})
+
+    assert config.channels.reply_timeout_s == 300
+
+
+def test_channels_config_rejects_non_positive_reply_timeout() -> None:
+    with pytest.raises(ValidationError):
+        AgentConfig.model_validate({"channels": {"replyTimeoutS": 0}})
 
 
 def test_load_agent_config_supports_yaml(tmp_path: Path) -> None:

--- a/agent/tests/test_channels_api.py
+++ b/agent/tests/test_channels_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from fastapi.testclient import TestClient
@@ -13,24 +14,34 @@ class FakeSessionService:
     """SessionService placeholder for channel status tests."""
 
 
-def _client(tmp_path: Path, monkeypatch) -> TestClient:
+def _client(
+    tmp_path: Path,
+    monkeypatch,
+    *,
+    channels_config: dict[str, object] | None = None,
+) -> TestClient:
     import src.channels.config as channel_config
     import src.channels.pairing.store as pairing_store
+
+    config_path = tmp_path / "agent.json"
+    config_path.write_text(
+        json.dumps({"channels": channels_config or {}}),
+        encoding="utf-8",
+    )
+    config = channel_config.load_channels_config(config_path)
+    config.update(
+        {
+            "websocket": {"enabled": False, "allow_from": ["*"]},
+            "telegram": {"enabled": False},
+            "slack": {"enabled": True},
+        }
+    )
 
     monkeypatch.setattr(api_server, "_channel_runtime", None)
     monkeypatch.setattr(api_server, "_channel_bus", None)
     monkeypatch.setattr(api_server, "_channel_manager", None)
     monkeypatch.setattr(api_server, "_get_session_service", lambda: FakeSessionService())
-    monkeypatch.setattr(
-        channel_config,
-        "load_channels_config",
-        lambda: {
-            "send_max_retries": 1,
-            "websocket": {"enabled": False, "allow_from": ["*"]},
-            "telegram": {"enabled": False},
-            "slack": {"enabled": True},
-        },
-    )
+    monkeypatch.setattr(channel_config, "load_channels_config", lambda: dict(config))
     monkeypatch.setattr(pairing_store, "_store_path", lambda: tmp_path / "pairing.json")
     return TestClient(api_server.app, client=("127.0.0.1", 50000))
 
@@ -47,6 +58,20 @@ def test_channels_status_reports_all_configured_adapters(tmp_path: Path, monkeyp
     assert payload["channels"]["telegram"]["enabled"] is False
     assert payload["channels"]["slack"]["enabled"] is True
     assert "available" in payload["channels"]["slack"]
+    assert "reply_timeout_s" not in payload["channels"]
+    assert "send_max_retries" not in payload["channels"]
+    assert api_server._channel_runtime is not None
+    assert api_server._channel_runtime.config.reply_timeout_s == 600.0
+
+
+def test_channels_runtime_uses_configured_reply_timeout(tmp_path: Path, monkeypatch) -> None:
+    client = _client(tmp_path, monkeypatch, channels_config={"reply_timeout_s": 42})
+
+    response = client.get("/channels/status")
+
+    assert response.status_code == 200
+    assert api_server._channel_runtime is not None
+    assert api_server._channel_runtime.config.reply_timeout_s == 42
 
 
 def test_channels_start_stop_are_controlled_runtime_actions(tmp_path: Path, monkeypatch) -> None:

--- a/agent/tests/test_channels_runtime.py
+++ b/agent/tests/test_channels_runtime.py
@@ -13,6 +13,7 @@ from src.channels.bus.events import InboundMessage, OutboundMessage
 from src.channels.bus.queue import MessageBus
 from src.channels.manager import ChannelManager
 from src.channels.registry import discover_channel_names, inspect_channels
+from src.config.schema import ChannelsConfig
 from src.channelsui.cli_apps_api import normalize_cli_app_mentions
 from src.channelsui.gateway_services import build_gateway_services
 from src.channelsui.mcp_presets_api import normalize_mcp_preset_mentions
@@ -116,11 +117,29 @@ def test_registry_reports_all_built_in_channels_with_dependency_recovery() -> No
     assert all(item["install_hint"].startswith("pip install") for item in missing)
 
 
+def test_registry_ignores_global_channel_settings() -> None:
+    statuses = inspect_channels(
+        ChannelsConfig.model_validate(
+            {
+                "replyTimeoutS": 120,
+                "sendMaxRetries": 1,
+                "telegram": {"enabled": True},
+            }
+        )
+    )
+
+    assert "telegram" in statuses
+    assert "reply_timeout_s" not in statuses
+    assert "send_max_retries" not in statuses
+    assert "model_dump" not in statuses
+
+
 def test_channel_manager_status_includes_every_configured_adapter() -> None:
     bus = MessageBus()
     manager = ChannelManager(
         {
             "send_max_retries": 1,
+            "reply_timeout_s": 600.0,
             "websocket": {"enabled": True, "host": "127.0.0.1", "port": 0, "allow_from": ["*"]},
             "telegram": {"enabled": False},
             "slack": {"enabled": True},
@@ -130,6 +149,8 @@ def test_channel_manager_status_includes_every_configured_adapter() -> None:
 
     status = manager.get_status()
 
+    assert "send_max_retries" not in status
+    assert "reply_timeout_s" not in status
     assert status["websocket"]["loaded"] is True
     assert status["websocket"]["enabled"] is True
     assert status["telegram"]["configured"] is True


### PR DESCRIPTION
## Summary
- Add a validated `channels.replyTimeoutS` setting for the shared IM channel runtime, defaulting to the existing 600-second wait budget.
- Pass the configured timeout into `ChannelRuntime` when the API lazily builds the channel runtime.
- Keep global channel settings out of adapter status output so config keys such as `reply_timeout_s` and `send_max_retries` do not appear as pseudo-channels.
- Document the setting in the README IM channel section.

## Why
Fixes #403.

The runtime already accepts a central assistant-reply timeout, but operators had no documented config path for long-running IM channel tasks. This adds the narrow config plumbing and docs without changing adapter network/socket timeouts.

## Tests
- `PYTHONPATH=agent uv run --no-project --python 3.12 --with pytest --with pydantic --with fastapi --with httpx --with rich --with pyyaml --with python-dotenv --with sse-starlette --with pandas --with numpy --with requests --with jinja2 --with python-multipart --with websockets --with slack-sdk python -m pytest -q agent/tests/test_agent_config.py agent/tests/test_channels_api.py agent/tests/test_channels_runtime.py` -> 51 passed, 2 skipped.
- `python3.12 -m compileall -q agent/src/channels agent/src/config agent/api_server.py` -> passed.
- `git diff --check` -> passed.

## Scope
- In scope: global IM runtime assistant-reply timeout config, runtime wiring, README docs, and fake/local tests.
- Non-goals: per-adapter network timeout controls, UI settings exposure, event-driven runtime waiting, live Feishu/Slack/Telegram smoke tests, LLM or trading-account proof, and any change to the preflight redirect work from #402/#404.