### PR TITLE
fix(trading): treat zero quantity/notional as unset in trading_place_order

### DIFF
--- a/agent/src/tools/trading_connector_tool.py
+++ b/agent/src/tools/trading_connector_tool.py
@@ -342,14 +342,19 @@ class TradingPlaceOrderTool(BaseTool):
 
     def execute(self, **kwargs: Any) -> str:
         """Place an order via the connector profile."""
+        # LLMs frequently populate BOTH sizing fields, leaving the unused one at
+        # 0; a zero size is never valid, so treat it as absent to preserve the
+        # "exactly one of quantity/notional" contract.
+        quantity = _num_or_none(kwargs.get("quantity")) or None
+        notional = _num_or_none(kwargs.get("notional")) or None
         try:
             return _json_result(
                 place_order(
                     str(kwargs["symbol"]),
                     _connection(kwargs.get("connection")),
                     side=str(kwargs.get("side") or ""),
-                    quantity=_num_or_none(kwargs.get("quantity")),
-                    notional=_num_or_none(kwargs.get("notional")),
+                    quantity=quantity,
+                    notional=notional,
                     order_type=str(kwargs.get("order_type") or "market"),
                     limit_price=_num_or_none(kwargs.get("limit_price")),
                     time_in_force=str(kwargs.get("time_in_force") or "day"),

--- a/agent/tests/test_trading_connections.py
+++ b/agent/tests/test_trading_connections.py
@@ -9,7 +9,7 @@ import pytest
 
 from src.trading import profiles, service
 from src.tools import build_registry
-from src.tools.trading_connector_tool import TradingSelectConnectionTool
+from src.tools.trading_connector_tool import TradingPlaceOrderTool, TradingSelectConnectionTool
 
 pytestmark = pytest.mark.unit
 
@@ -80,6 +80,45 @@ def test_select_connection_tool_returns_canonical_profile_id(
     assert payload["status"] == "ok"
     assert payload["selected_profile"] == "ibkr-paper-local"
     assert profiles.load_selected_profile_id() == "ibkr-paper-local"
+
+
+def test_place_order_tool_treats_zero_unused_sizing_field_as_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """LLM-filled zero quantity/notional fields must not violate sizing XOR."""
+    calls: list[dict] = []
+
+    def fake_place_order(symbol, connection, **kwargs):  # noqa: ANN001
+        calls.append({"symbol": symbol, "connection": connection, **kwargs})
+        return {"status": "ok", "echo": kwargs}
+
+    monkeypatch.setattr("src.tools.trading_connector_tool.place_order", fake_place_order)
+
+    quantity_result = json.loads(
+        TradingPlaceOrderTool().execute(
+            symbol="NVDA",
+            connection="alpaca-paper-trade",
+            side="buy",
+            quantity=2,
+            notional=0,
+        )
+    )
+    notional_result = json.loads(
+        TradingPlaceOrderTool().execute(
+            symbol="NVDA",
+            connection="alpaca-paper-trade",
+            side="buy",
+            quantity=0,
+            notional=50,
+        )
+    )
+
+    assert quantity_result["status"] == "ok"
+    assert notional_result["status"] == "ok"
+    assert calls[0]["quantity"] == 2.0
+    assert calls[0]["notional"] is None
+    assert calls[1]["quantity"] is None
+    assert calls[1]["notional"] == 50.0
 
 
 def test_live_broker_mcp_wrappers_are_hidden_from_agent_registry(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Problem

The `trading_place_order` agent tool can never place a **share-quantity** order. Every attempt is rejected by the connector layer with:

```
provide exactly one of quantity or notional
```

## Root cause

The tool schema exposes both `quantity` and `notional`, and LLMs routinely populate **both** fields — filling the unused one with `0`. The wrapper converts sizing via `_num_or_none`:

```python
def _num_or_none(value):
    if value in (None, ""):
        return None
    return float(value)
```

`_num_or_none(0)` returns `0.0` (not `None`), so both `quantity` and `notional` reach `place_order` as non-`None`. `place_order`'s `has_qty == has_notional` guard then fails the request before it ever reaches the broker.

## Reproduction

Ask the agent to place any quantity-based order on a paper connector, e.g. *"place a paper market buy for 2 shares of NVDA on alpaca-paper-trade"*. The model emits `quantity=2, notional=0` and the order is rejected. After the fix, the same request places successfully (verified end-to-end against an Alpaca paper account: order `ACCEPTED`).

## Fix

A zero order size is never valid, so coerce a `0` quantity/notional to `None` in `trading_place_order.execute()`. This preserves the "exactly one of quantity/notional" contract regardless of which field the model over-fills, and doesn't change behavior for correctly-formed calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)