### PR TITLE
refactor(api): extract security helpers

### DIFF
--- a/agent/api_server.py
+++ b/agent/api_server.py
@@ -6,31 +6,19 @@ V5: ReAct Agent + async /run + CORS env + SSE tool events.
 
 from __future__ import annotations
 
-import asyncio
-import hmac
-import ipaddress
-import json
 import logging
 import os
 import re
-import signal
-import time
-import csv
-import uuid
-import urllib.parse
-from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException, Query, Request, Security, status
-from fastapi.responses import FileResponse, JSONResponse
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from fastapi import FastAPI, HTTPException, Request, status
+from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 from fastapi.middleware.cors import CORSMiddleware
 from rich.console import Console
 
 from cli._version import __version__ as APP_VERSION
-from src.ui_services import build_run_analysis, load_run_context
 
 # UTF-8 on Windows
 import sys as _sys
@@ -41,13 +29,9 @@ for _s in ("stdout", "stderr"):
 
 RUNS_DIR = Path(__file__).resolve().parent / "runs"
 SESSIONS_DIR = Path(__file__).resolve().parent / "sessions"
-UPLOADS_DIR = Path(__file__).resolve().parent / "uploads"
 AGENT_DIR = Path(__file__).resolve().parent
 ENV_PATH = AGENT_DIR / ".env"
 ENV_EXAMPLE_PATH = AGENT_DIR / ".env.example"
-
-MAX_UPLOAD_SIZE = 50 * 1024 * 1024  # 50 MB
-_UPLOAD_CHUNK_SIZE = 1024 * 1024  # 1 MB
 
 console = Console()
 logger = logging.getLogger(__name__)
@@ -158,88 +142,37 @@ app = FastAPI(
     redoc_url="/redoc"
 )
 
-_DEFAULT_CORS_ORIGINS = [
-    "http://localhost:3000",
-    "http://localhost:5173",
-    "http://localhost:8000",
-    "http://127.0.0.1:3000",
-    "http://127.0.0.1:5173",
-    "http://127.0.0.1:8000",
-]
-
-_DEFAULT_LOOPBACK_HOSTS = frozenset({
-    "localhost",
-    "127.0.0.1",
-    "::1",
-    "[::1]",
-    # Starlette/FastAPI TestClient default host; included so unit tests exercise
-    # the API without having to override Host on every request.
-    "testserver",
-})
-
-
-def _parse_cors_origins(raw: Optional[str]) -> List[str]:
-    """Parse CORS origins and reject credentialed wildcard configuration.
-
-    Args:
-        raw: Comma-separated CORS origins from ``CORS_ORIGINS``. ``None`` or a
-            blank value uses the loopback development defaults.
-
-    Returns:
-        Explicit CORS origins accepted by the API server.
-
-    Raises:
-        RuntimeError: If a wildcard origin is configured while credentials are
-            enabled.
-    """
-    if raw is None or not raw.strip():
-        return list(_DEFAULT_CORS_ORIGINS)
-    origins = [origin.strip() for origin in raw.split(",") if origin.strip()]
-    if "*" in origins:
-        raise RuntimeError(
-            "CORS_ORIGINS='*' is not allowed while credentials are enabled; "
-            "configure explicit Web UI origins instead."
-        )
-    return origins
-
-
-def _parse_extra_loopback_hosts(raw: Optional[str]) -> set[str]:
-    """Return additional trusted Host names for loopback API traffic."""
-    if raw is None or not raw.strip():
-        return set()
-    return {host.strip().lower().rstrip(".") for host in raw.split(",") if host.strip()}
-
-
-_EXTRA_LOOPBACK_HOSTS = _parse_extra_loopback_hosts(os.getenv("API_ALLOWED_HOSTS"))
-
-
-def _host_without_port(host: str) -> str:
-    """Normalize a Host header to a lowercase hostname without a port."""
-    value = host.strip().lower().rstrip(".")
-    if not value:
-        return ""
-    if value.startswith("["):
-        end = value.find("]")
-        if end != -1:
-            return value[: end + 1]
-        return value
-    if value.count(":") == 1:
-        return value.rsplit(":", 1)[0]
-    return value
-
-
-def _is_allowed_loopback_host(host: str) -> bool:
-    """Return whether ``host`` is allowed for loopback-trusted API requests."""
-    normalized = _host_without_port(host)
-    return normalized in _DEFAULT_LOOPBACK_HOSTS or normalized in _EXTRA_LOOPBACK_HOSTS
-
-
-def _is_loopback_bind_host(host: str) -> bool:
-    """Return whether ``host`` resolves to a loopback interface."""
-    try:
-        return ipaddress.ip_address(host).is_loopback
-    except ValueError:
-        return host == "localhost"
+from src.api.security import (  # noqa: F401, E402
+    _API_KEY,
+    _DOCKER_LOOPBACK_ENV,
+    _EXTRA_LOOPBACK_HOSTS,
+    _SAFE_BROWSER_METHODS,
+    _SHELL_TOOLS_ENV,
+    _auth_credential_from_header_or_query,
+    _configured_api_key,
+    _default_gateway_ips,
+    _env_flag_enabled,
+    _env_shell_tools_enabled,
+    _host_without_port,
+    _is_allowed_loopback_host,
+    _is_local_client,
+    _is_loopback_bind_host,
+    _is_loopback_origin,
+    _origin_matches_request_host,
+    _parse_cors_origins,
+    _parse_extra_loopback_hosts,
+    _reject_cross_site_browser_request,
+    _reject_untrusted_loopback_host,
+    _require_shutdown_authorization,
+    _security,
+    _shell_tools_enabled_for_request,
+    _trusted_docker_loopback_ip,
+    _validate_api_auth,
+    require_auth,
+    require_event_stream_auth,
+    require_local_or_auth,
+    require_settings_write_auth,
+)
 
 
 # CORS: override with CORS_ORIGINS (comma-separated explicit origins)
@@ -254,15 +187,7 @@ app.add_middleware(
 )
 
 
-@app.middleware("http")
-async def _reject_untrusted_loopback_host(request: Request, call_next):
-    """Block DNS-rebinding Host headers before loopback auth bypasses run."""
-    if _is_local_client(request) and not _is_allowed_loopback_host(request.headers.get("host", "")):
-        return JSONResponse(
-            status_code=status.HTTP_403_FORBIDDEN,
-            content={"detail": "Untrusted local API host"},
-        )
-    return await call_next(request)
+app.middleware("http")(_reject_untrusted_loopback_host)
 
 
 # ----------------------------------------------------------------------------
@@ -351,302 +276,6 @@ async def _stop_scheduled_research_on_shutdown() -> None:
     """Stop the scheduled research executor on server shutdown."""
     await _stop_channel_runtime()
     await _stop_scheduled_research_executor()
-
-
-# ============================================================================
-# API Key Authentication
-# ============================================================================
-
-_security = HTTPBearer(auto_error=False)
-_API_KEY = os.getenv("API_AUTH_KEY")
-_SHELL_TOOLS_ENV = "VIBE_TRADING_ENABLE_SHELL_TOOLS"
-_DOCKER_LOOPBACK_ENV = "VIBE_TRADING_TRUST_DOCKER_LOOPBACK"
-
-
-def _configured_api_key() -> str:
-    """Return the current API auth key, if configured."""
-    return os.getenv("API_AUTH_KEY") or _API_KEY or ""
-
-
-async def require_auth(
-    request: Request,
-    cred: Optional[HTTPAuthorizationCredentials] = Security(_security),
-) -> None:
-    """Validate Bearer token for sensitive API endpoints.
-
-    Args:
-        request: Incoming HTTP request.
-        cred: HTTP Bearer credentials extracted from the Authorization header.
-
-    Raises:
-        HTTPException: 403 when dev-mode auth is reached from a non-local client.
-        HTTPException: 401 when API_AUTH_KEY is set but the token is missing or wrong.
-    """
-    _validate_api_auth(request=request, cred=cred)
-
-
-async def require_event_stream_auth(
-    request: Request,
-    api_key: Optional[str] = Query(None),
-    cred: Optional[HTTPAuthorizationCredentials] = Security(_security),
-) -> None:
-    """Validate auth for browser EventSource streams.
-
-    Native EventSource cannot send custom Authorization headers, so event
-    stream endpoints may accept the API key from the query string. Normal JSON
-    endpoints must continue to use Bearer auth only.
-
-    Args:
-        request: Incoming HTTP request.
-        api_key: Optional query-string API key for EventSource clients.
-        cred: HTTP Bearer credentials extracted from the Authorization header.
-    """
-    _validate_api_auth(request=request, cred=cred, query_api_key=api_key, allow_query=True)
-
-
-def _auth_credential_from_header_or_query(
-    cred: Optional[HTTPAuthorizationCredentials],
-    query_api_key: Optional[str],
-    *,
-    allow_query: bool,
-) -> str:
-    """Return the supplied API credential from the permitted source."""
-    if cred and cred.credentials:
-        return cred.credentials
-    if allow_query and query_api_key:
-        return query_api_key
-    return ""
-
-
-def _is_loopback_origin(origin: str) -> bool:
-    """Return whether a browser Origin header names a loopback web UI."""
-    try:
-        parsed = urllib.parse.urlsplit(origin)
-    except ValueError:
-        return False
-    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
-        return False
-    host = parsed.hostname.rstrip(".").lower()
-    if host == "localhost":
-        return True
-    try:
-        return ipaddress.ip_address(host).is_loopback
-    except ValueError:
-        return False
-
-
-def _origin_matches_request_host(origin: str, request: Request) -> bool:
-    """Return whether ``origin`` is the same site serving this request."""
-    try:
-        parsed = urllib.parse.urlsplit(origin)
-    except ValueError:
-        return False
-    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
-        return False
-
-    origin_host = parsed.hostname.rstrip(".").lower()
-    origin_port = parsed.port
-    request_host = _host_without_port(request.headers.get("host", ""))
-    if origin_host != request_host:
-        return False
-
-    if origin_port is None:
-        origin_port = 443 if parsed.scheme == "https" else 80
-    request_port = request.url.port
-    if request_port is None:
-        request_port = 443 if request.url.scheme == "https" else 80
-    return origin_port == request_port
-
-
-def _reject_cross_site_browser_request(request: Request) -> None:
-    """Reject unsafe browser requests from untrusted cross-site origins.
-
-    CORS protects response reads, not blind form/fetch side effects. Keep local
-    CLI/curl clients and same-origin browser UI deployments working while
-    refusing browser-originated cross-site POSTs to local control-plane actions
-    such as shutdown.
-    """
-    sec_fetch_site = request.headers.get("sec-fetch-site", "").lower()
-    if sec_fetch_site == "cross-site":
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Cross-site request denied")
-
-    origin = request.headers.get("origin")
-    if origin and not (_is_loopback_origin(origin) or _origin_matches_request_host(origin, request)):
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Cross-site request denied")
-
-
-def _require_shutdown_authorization(
-    *,
-    request: Request,
-    cred: Optional[HTTPAuthorizationCredentials],
-) -> None:
-    """Authorize the local shutdown control-plane action.
-
-    Loopback peer IP alone is not enough for this browser-reachable, destructive
-    action. When API_AUTH_KEY is configured, require the Bearer token even for
-    loopback requests; otherwise preserve local dev-mode shutdown for direct
-    loopback clients while rejecting cross-site browser requests.
-    """
-    _reject_cross_site_browser_request(request)
-    api_key = _configured_api_key()
-    if api_key:
-        token = _auth_credential_from_header_or_query(cred, None, allow_query=False)
-        if not token or not hmac.compare_digest(token, api_key):
-            raise HTTPException(status_code=401, detail="Invalid or missing API key")
-        return
-    if not _is_local_client(request):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="API_AUTH_KEY is required for non-local API access",
-        )
-
-
-_SAFE_BROWSER_METHODS = {"GET", "HEAD", "OPTIONS"}
-
-
-def _validate_api_auth(
-    *,
-    request: Request,
-    cred: Optional[HTTPAuthorizationCredentials],
-    query_api_key: Optional[str] = None,
-    allow_query: bool = False,
-) -> None:
-    """Validate configured auth, preserving loopback-only dev mode."""
-    # CORS protects response reads, not blind side effects. Reject unsafe
-    # browser-originated cross-site requests before honoring loopback dev-mode
-    # trust, otherwise a malicious page can drive local POST/PUT/DELETE routes.
-    if request.method.upper() not in _SAFE_BROWSER_METHODS:
-        _reject_cross_site_browser_request(request)
-
-    # Loopback clients are always trusted, even when API_AUTH_KEY is set.
-    # The key only gates non-local (LAN/remote) access.
-    if _is_local_client(request):
-        return
-
-    api_key = _configured_api_key()
-    if not api_key:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="API_AUTH_KEY is required for non-local API access",
-        )
-
-    token = _auth_credential_from_header_or_query(cred, query_api_key, allow_query=allow_query)
-    if not token or not hmac.compare_digest(token, api_key):
-        raise HTTPException(status_code=401, detail="Invalid or missing API key")
-
-
-def _is_local_client(request: Request) -> bool:
-    """Return whether the request originates from a loopback client."""
-    host = request.client.host if request.client else ""
-    if host in {"localhost", "testclient"}:
-        return True
-    try:
-        ip = ipaddress.ip_address(host)
-    except ValueError:
-        return False
-    if ip.is_loopback:
-        return True
-    return _trusted_docker_loopback_ip(ip)
-
-
-def _env_flag_enabled(name: str) -> bool:
-    """Return whether a boolean environment flag is enabled."""
-    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
-
-
-def _default_gateway_ips() -> set[ipaddress.IPv4Address]:
-    """Return IPv4 default gateway addresses from Linux procfs."""
-    gateways: set[ipaddress.IPv4Address] = set()
-    try:
-        lines = Path("/proc/net/route").read_text(encoding="utf-8").splitlines()
-    except OSError:
-        return gateways
-
-    for line in lines[1:]:
-        fields = line.split()
-        if len(fields) < 3 or fields[1] != "00000000":
-            continue
-        try:
-            raw = int(fields[2], 16).to_bytes(4, byteorder="little")
-            gateways.add(ipaddress.IPv4Address(raw))
-        except ValueError:
-            continue
-    return gateways
-
-
-def _trusted_docker_loopback_ip(ip: ipaddress._BaseAddress) -> bool:
-    """Return whether an IP is the trusted Docker host gateway.
-
-    Docker Desktop presents host requests to a container as the bridge gateway
-    instead of 127.0.0.1. This escape hatch is safe only when the published
-    port is bound to host loopback, so the official compose file enables it
-    together with a 127.0.0.1 port binding.
-    """
-    if not isinstance(ip, ipaddress.IPv4Address):
-        return False
-    if not _env_flag_enabled(_DOCKER_LOOPBACK_ENV):
-        return False
-    return ip in _default_gateway_ips()
-
-
-def _env_shell_tools_enabled() -> bool:
-    """Return whether server-side shell tools are explicitly enabled."""
-    return _env_flag_enabled(_SHELL_TOOLS_ENV)
-
-
-def _shell_tools_enabled_for_request(request: Request) -> bool:
-    """Return whether this API request may expose shell tools to the agent."""
-    # Shell-capable tools execute commands on the host as the API process user.
-    # Do not infer that privilege from peer IP alone: browser DNS rebinding can
-    # make attacker-controlled pages appear as loopback clients. Operators who
-    # intentionally want API-started agents or swarm workers to receive shell
-    # tools must opt in explicitly.
-    return _env_shell_tools_enabled()
-
-
-async def require_local_or_auth(
-    request: Request,
-    cred: Optional[HTTPAuthorizationCredentials] = Security(_security),
-) -> None:
-    """Protect settings access when dev-mode auth is disabled.
-
-    If API_AUTH_KEY is configured, require the bearer token. If not, allow only
-    loopback clients so an API server bound to 0.0.0.0 cannot accept remote
-    credential reads or writes in dev mode.
-    """
-    if _configured_api_key():
-        await require_auth(request, cred)
-        return
-    if not _is_local_client(request):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Settings access requires API_AUTH_KEY or a local loopback client",
-        )
-
-
-async def require_settings_write_auth(
-    request: Request,
-    cred: Optional[HTTPAuthorizationCredentials] = Security(_security),
-) -> None:
-    """Require explicit authorization before changing credential-routing settings.
-
-    Settings writes can redirect stored provider credentials to a different
-    endpoint. When an API key is configured, loopback peer IP alone is not a
-    sufficient user-intent signal because a browser can reach local APIs after
-    DNS rebinding.
-    """
-    api_key = _configured_api_key()
-    if api_key:
-        token = _auth_credential_from_header_or_query(cred, None, allow_query=False)
-        if not token or not hmac.compare_digest(token, api_key):
-            raise HTTPException(status_code=401, detail="Invalid or missing API key")
-        return
-
-    if not _is_local_client(request):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Settings writes require API_AUTH_KEY or a local loopback client",
-        )
 
 
 # ============================================================================
@@ -918,7 +547,7 @@ from src.api.uploads_routes import register_uploads_routes  # noqa: E402
 register_uploads_routes(app)
 
 # Re-export upload constants for test access via ``api_server.*``.
-from src.api.uploads_routes import (  # noqa: E402
+from src.api.uploads_routes import (  # noqa: F401, E402
     MAX_UPLOAD_SIZE,
     UPLOADS_DIR,
     _BLOCKED_UPLOAD_EXT,

--- a/agent/src/api/security.py
+++ b/agent/src/api/security.py
@@ -1,0 +1,414 @@
+"""API authentication and loopback security helpers."""
+
+from __future__ import annotations
+
+import hmac
+import ipaddress
+import os
+import sys
+import urllib.parse
+from pathlib import Path
+from typing import List, Optional
+
+from fastapi import HTTPException, Query, Request, Security, status
+from fastapi.responses import JSONResponse
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+_DEFAULT_CORS_ORIGINS = [
+    "http://localhost:3000",
+    "http://localhost:5173",
+    "http://localhost:8000",
+    "http://127.0.0.1:3000",
+    "http://127.0.0.1:5173",
+    "http://127.0.0.1:8000",
+]
+
+_DEFAULT_LOOPBACK_HOSTS = frozenset({
+    "localhost",
+    "127.0.0.1",
+    "::1",
+    "[::1]",
+    # Starlette/FastAPI TestClient default host; included so unit tests exercise
+    # the API without having to override Host on every request.
+    "testserver",
+})
+
+_security = HTTPBearer(auto_error=False)
+_API_KEY = os.getenv("API_AUTH_KEY")
+_SHELL_TOOLS_ENV = "VIBE_TRADING_ENABLE_SHELL_TOOLS"
+_DOCKER_LOOPBACK_ENV = "VIBE_TRADING_TRUST_DOCKER_LOOPBACK"
+
+
+def _api_server_module():
+    """Return the host ``api_server`` module when it is already imported."""
+    return sys.modules.get("api_server")
+
+
+def _host_attr(name: str, fallback):
+    """Read a compatibility attribute from ``api_server`` when present."""
+    host = _api_server_module()
+    if host is not None and hasattr(host, name):
+        return getattr(host, name)
+    return fallback
+
+
+def _parse_cors_origins(raw: Optional[str]) -> List[str]:
+    """Parse CORS origins and reject credentialed wildcard configuration.
+
+    Args:
+        raw: Comma-separated CORS origins from ``CORS_ORIGINS``. ``None`` or a
+            blank value uses the loopback development defaults.
+
+    Returns:
+        Explicit CORS origins accepted by the API server.
+
+    Raises:
+        RuntimeError: If a wildcard origin is configured while credentials are
+            enabled.
+    """
+    if raw is None or not raw.strip():
+        return list(_DEFAULT_CORS_ORIGINS)
+    origins = [origin.strip() for origin in raw.split(",") if origin.strip()]
+    if "*" in origins:
+        raise RuntimeError(
+            "CORS_ORIGINS='*' is not allowed while credentials are enabled; "
+            "configure explicit Web UI origins instead."
+        )
+    return origins
+
+
+def _parse_extra_loopback_hosts(raw: Optional[str]) -> set[str]:
+    """Return additional trusted Host names for loopback API traffic."""
+    if raw is None or not raw.strip():
+        return set()
+    return {host.strip().lower().rstrip(".") for host in raw.split(",") if host.strip()}
+
+
+_EXTRA_LOOPBACK_HOSTS = _parse_extra_loopback_hosts(os.getenv("API_ALLOWED_HOSTS"))
+
+
+def _host_without_port(host: str) -> str:
+    """Normalize a Host header to a lowercase hostname without a port."""
+    value = host.strip().lower().rstrip(".")
+    if not value:
+        return ""
+    if value.startswith("["):
+        end = value.find("]")
+        if end != -1:
+            return value[: end + 1]
+        return value
+    if value.count(":") == 1:
+        return value.rsplit(":", 1)[0]
+    return value
+
+
+def _is_allowed_loopback_host(host: str) -> bool:
+    """Return whether ``host`` is allowed for loopback-trusted API requests."""
+    normalized = _host_without_port(host)
+    extra_hosts = _host_attr("_EXTRA_LOOPBACK_HOSTS", _EXTRA_LOOPBACK_HOSTS)
+    return normalized in _DEFAULT_LOOPBACK_HOSTS or normalized in extra_hosts
+
+
+def _is_loopback_bind_host(host: str) -> bool:
+    """Return whether ``host`` resolves to a loopback interface."""
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return host == "localhost"
+
+
+async def _reject_untrusted_loopback_host(request: Request, call_next):
+    """Block DNS-rebinding Host headers before loopback auth bypasses run."""
+    if _is_local_client(request) and not _is_allowed_loopback_host(request.headers.get("host", "")):
+        return JSONResponse(
+            status_code=status.HTTP_403_FORBIDDEN,
+            content={"detail": "Untrusted local API host"},
+        )
+    return await call_next(request)
+
+
+def _configured_api_key() -> str:
+    """Return the current API auth key, if configured."""
+    return os.getenv("API_AUTH_KEY") or _host_attr("_API_KEY", _API_KEY) or ""
+
+
+async def require_auth(
+    request: Request,
+    cred: Optional[HTTPAuthorizationCredentials] = Security(_security),
+) -> None:
+    """Validate Bearer token for sensitive API endpoints.
+
+    Args:
+        request: Incoming HTTP request.
+        cred: HTTP Bearer credentials extracted from the Authorization header.
+
+    Raises:
+        HTTPException: 403 when dev-mode auth is reached from a non-local client.
+        HTTPException: 401 when API_AUTH_KEY is set but the token is missing or wrong.
+    """
+    _validate_api_auth(request=request, cred=cred)
+
+
+async def require_event_stream_auth(
+    request: Request,
+    api_key: Optional[str] = Query(None),
+    cred: Optional[HTTPAuthorizationCredentials] = Security(_security),
+) -> None:
+    """Validate auth for browser EventSource streams.
+
+    Native EventSource cannot send custom Authorization headers, so event
+    stream endpoints may accept the API key from the query string. Normal JSON
+    endpoints must continue to use Bearer auth only.
+
+    Args:
+        request: Incoming HTTP request.
+        api_key: Optional query-string API key for EventSource clients.
+        cred: HTTP Bearer credentials extracted from the Authorization header.
+    """
+    _validate_api_auth(request=request, cred=cred, query_api_key=api_key, allow_query=True)
+
+
+def _auth_credential_from_header_or_query(
+    cred: Optional[HTTPAuthorizationCredentials],
+    query_api_key: Optional[str],
+    *,
+    allow_query: bool,
+) -> str:
+    """Return the supplied API credential from the permitted source."""
+    if cred and cred.credentials:
+        return cred.credentials
+    if allow_query and query_api_key:
+        return query_api_key
+    return ""
+
+
+def _is_loopback_origin(origin: str) -> bool:
+    """Return whether a browser Origin header names a loopback web UI."""
+    try:
+        parsed = urllib.parse.urlsplit(origin)
+    except ValueError:
+        return False
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return False
+    host = parsed.hostname.rstrip(".").lower()
+    if host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def _origin_matches_request_host(origin: str, request: Request) -> bool:
+    """Return whether ``origin`` is the same site serving this request."""
+    try:
+        parsed = urllib.parse.urlsplit(origin)
+    except ValueError:
+        return False
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return False
+
+    origin_host = parsed.hostname.rstrip(".").lower()
+    origin_port = parsed.port
+    request_host = _host_without_port(request.headers.get("host", ""))
+    if origin_host != request_host:
+        return False
+
+    if origin_port is None:
+        origin_port = 443 if parsed.scheme == "https" else 80
+    request_port = request.url.port
+    if request_port is None:
+        request_port = 443 if request.url.scheme == "https" else 80
+    return origin_port == request_port
+
+
+def _reject_cross_site_browser_request(request: Request) -> None:
+    """Reject unsafe browser requests from untrusted cross-site origins.
+
+    CORS protects response reads, not blind form/fetch side effects. Keep local
+    CLI/curl clients and same-origin browser UI deployments working while
+    refusing browser-originated cross-site POSTs to local control-plane actions
+    such as shutdown.
+    """
+    sec_fetch_site = request.headers.get("sec-fetch-site", "").lower()
+    if sec_fetch_site == "cross-site":
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Cross-site request denied")
+
+    origin = request.headers.get("origin")
+    if origin and not (_is_loopback_origin(origin) or _origin_matches_request_host(origin, request)):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Cross-site request denied")
+
+
+def _require_shutdown_authorization(
+    *,
+    request: Request,
+    cred: Optional[HTTPAuthorizationCredentials],
+) -> None:
+    """Authorize the local shutdown control-plane action.
+
+    Loopback peer IP alone is not enough for this browser-reachable, destructive
+    action. When API_AUTH_KEY is configured, require the Bearer token even for
+    loopback requests; otherwise preserve local dev-mode shutdown for direct
+    loopback clients while rejecting cross-site browser requests.
+    """
+    _reject_cross_site_browser_request(request)
+    api_key = _configured_api_key()
+    if api_key:
+        token = _auth_credential_from_header_or_query(cred, None, allow_query=False)
+        if not token or not hmac.compare_digest(token, api_key):
+            raise HTTPException(status_code=401, detail="Invalid or missing API key")
+        return
+    if not _is_local_client(request):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="API_AUTH_KEY is required for non-local API access",
+        )
+
+
+_SAFE_BROWSER_METHODS = {"GET", "HEAD", "OPTIONS"}
+
+
+def _validate_api_auth(
+    *,
+    request: Request,
+    cred: Optional[HTTPAuthorizationCredentials],
+    query_api_key: Optional[str] = None,
+    allow_query: bool = False,
+) -> None:
+    """Validate configured auth, preserving loopback-only dev mode."""
+    # CORS protects response reads, not blind side effects. Reject unsafe
+    # browser-originated cross-site requests before honoring loopback dev-mode
+    # trust, otherwise a malicious page can drive local POST/PUT/DELETE routes.
+    if request.method.upper() not in _SAFE_BROWSER_METHODS:
+        _reject_cross_site_browser_request(request)
+
+    # Loopback clients are always trusted, even when API_AUTH_KEY is set.
+    # The key only gates non-local (LAN/remote) access.
+    if _is_local_client(request):
+        return
+
+    api_key = _configured_api_key()
+    if not api_key:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="API_AUTH_KEY is required for non-local API access",
+        )
+
+    token = _auth_credential_from_header_or_query(cred, query_api_key, allow_query=allow_query)
+    if not token or not hmac.compare_digest(token, api_key):
+        raise HTTPException(status_code=401, detail="Invalid or missing API key")
+
+
+def _is_local_client(request: Request) -> bool:
+    """Return whether the request originates from a loopback client."""
+    host = request.client.host if request.client else ""
+    if host in {"localhost", "testclient"}:
+        return True
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    if ip.is_loopback:
+        return True
+    return _trusted_docker_loopback_ip(ip)
+
+
+def _env_flag_enabled(name: str) -> bool:
+    """Return whether a boolean environment flag is enabled."""
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _default_gateway_ips() -> set[ipaddress.IPv4Address]:
+    """Return IPv4 default gateway addresses from Linux procfs."""
+    gateways: set[ipaddress.IPv4Address] = set()
+    try:
+        lines = Path("/proc/net/route").read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return gateways
+
+    for line in lines[1:]:
+        fields = line.split()
+        if len(fields) < 3 or fields[1] != "00000000":
+            continue
+        try:
+            raw = int(fields[2], 16).to_bytes(4, byteorder="little")
+            gateways.add(ipaddress.IPv4Address(raw))
+        except ValueError:
+            continue
+    return gateways
+
+
+def _trusted_docker_loopback_ip(ip: ipaddress._BaseAddress) -> bool:
+    """Return whether an IP is the trusted Docker host gateway.
+
+    Docker Desktop presents host requests to a container as the bridge gateway
+    instead of 127.0.0.1. This escape hatch is safe only when the published
+    port is bound to host loopback, so the official compose file enables it
+    together with a 127.0.0.1 port binding.
+    """
+    if not isinstance(ip, ipaddress.IPv4Address):
+        return False
+    if not _env_flag_enabled(_DOCKER_LOOPBACK_ENV):
+        return False
+    gateway_reader = _host_attr("_default_gateway_ips", _default_gateway_ips)
+    return ip in gateway_reader()
+
+
+def _env_shell_tools_enabled() -> bool:
+    """Return whether server-side shell tools are explicitly enabled."""
+    return _env_flag_enabled(_SHELL_TOOLS_ENV)
+
+
+def _shell_tools_enabled_for_request(request: Request) -> bool:
+    """Return whether this API request may expose shell tools to the agent."""
+    # Shell-capable tools execute commands on the host as the API process user.
+    # Do not infer that privilege from peer IP alone: browser DNS rebinding can
+    # make attacker-controlled pages appear as loopback clients. Operators who
+    # intentionally want API-started agents or swarm workers to receive shell
+    # tools must opt in explicitly.
+    return _env_shell_tools_enabled()
+
+
+async def require_local_or_auth(
+    request: Request,
+    cred: Optional[HTTPAuthorizationCredentials] = Security(_security),
+) -> None:
+    """Protect settings access when dev-mode auth is disabled.
+
+    If API_AUTH_KEY is configured, require the bearer token. If not, allow only
+    loopback clients so an API server bound to 0.0.0.0 cannot accept remote
+    credential reads or writes in dev mode.
+    """
+    if _configured_api_key():
+        await require_auth(request, cred)
+        return
+    if not _is_local_client(request):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Settings access requires API_AUTH_KEY or a local loopback client",
+        )
+
+
+async def require_settings_write_auth(
+    request: Request,
+    cred: Optional[HTTPAuthorizationCredentials] = Security(_security),
+) -> None:
+    """Require explicit authorization before changing credential-routing settings.
+
+    Settings writes can redirect stored provider credentials to a different
+    endpoint. When an API key is configured, loopback peer IP alone is not a
+    sufficient user-intent signal because a browser can reach local APIs after
+    DNS rebinding.
+    """
+    api_key = _configured_api_key()
+    if api_key:
+        token = _auth_credential_from_header_or_query(cred, None, allow_query=False)
+        if not token or not hmac.compare_digest(token, api_key):
+            raise HTTPException(status_code=401, detail="Invalid or missing API key")
+        return
+
+    if not _is_local_client(request):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Settings writes require API_AUTH_KEY or a local loopback client",
+        )

--- a/agent/tests/test_api_security_module.py
+++ b/agent/tests/test_api_security_module.py
@@ -1,0 +1,24 @@
+"""Regression tests for the extracted API security helpers."""
+
+from __future__ import annotations
+
+import api_server
+from src.api import security as api_security
+
+
+def test_api_server_reexports_security_dependencies() -> None:
+    """Keep the public ``api_server.*`` compatibility surface stable."""
+    assert api_server.require_auth is api_security.require_auth
+    assert api_server.require_event_stream_auth is api_security.require_event_stream_auth
+    assert api_server.require_local_or_auth is api_security.require_local_or_auth
+    assert api_server.require_settings_write_auth is api_security.require_settings_write_auth
+    assert api_server._parse_cors_origins is api_security._parse_cors_origins
+    assert api_server._is_loopback_bind_host is api_security._is_loopback_bind_host
+
+
+def test_security_module_honors_api_server_api_key_reexport(monkeypatch) -> None:
+    """Existing tests and consumers monkeypatch ``api_server._API_KEY``."""
+    monkeypatch.delenv("API_AUTH_KEY", raising=False)
+    monkeypatch.setattr(api_server, "_API_KEY", "fallback-secret")
+
+    assert api_security._configured_api_key() == "fallback-secret"


### PR DESCRIPTION
## Summary
- Move API auth, CORS parsing, loopback host checks, DNS-rebinding guard, shutdown authorization, and shell-tool exposure helpers into `src.api.security`.
- Keep `api_server.*` re-exports for existing tests and external compatibility, including monkeypatch-friendly `_API_KEY` and `_default_gateway_ips` behavior.
- Add a focused regression test for the security module extraction.

## Why
This continues the #331 API modularization work without changing route behavior. The main route handlers are already extracted, but the security-critical helpers still lived in `api_server.py`; this gives reviewers a dedicated security module while keeping `api_server.py` as a thinner assembler.

## Scope
- Structural refactor only.
- No route path, auth policy, settings behavior, broker behavior, or data-source behavior changes.
- Does not attempt a full APIRouter conversion.

## Test Plan
- `python3 -m py_compile agent/src/api/security.py agent/api_server.py agent/tests/test_api_security_module.py`
- `git diff --check`
- `uv run --no-project --with ruff ruff check agent/api_server.py agent/src/api/security.py agent/tests/test_api_security_module.py`
- `PYTHONPATH=agent uv run --no-project --with pytest --with fastapi --with pydantic --with rich --with httpx --with python-multipart --with sse-starlette --with pyyaml --with "uvicorn[standard]" python -m pytest agent/tests/test_api_security_module.py agent/tests/test_security_auth_api.py agent/tests/test_serve_bind.py agent/tests/test_spa_deep_link.py -q`
- `PYTHONPATH=agent uv run --no-project --with pytest --with fastapi --with pydantic --with rich --with httpx --with python-multipart --with sse-starlette --with pyyaml --with "uvicorn[standard]" --with fastmcp python -m pytest agent/tests/test_settings_api.py agent/tests/test_upload_api.py agent/tests/test_api_live_runtime.py agent/tests/test_channels_api.py agent/tests/test_goal_api.py -q`

## Risk and Rollback
Low risk: this is a pure move with compatibility re-exports. Rollback is a normal revert of this PR if any import compatibility issue appears.