### PR TITLE
fix(security): close post-416 governance and evidence gaps

### DIFF
--- a/agent/cli/_legacy.py
+++ b/agent/cli/_legacy.py
@@ -949,6 +949,10 @@ def _run_agent(
     from src.tools import build_registry
     from src.providers.chat import ChatLLM
     from src.agent.loop import AgentLoop
+    from src.governance.config import get_governance_mode
+    from src.governance.decisions import RuntimeContext
+    from src.governance.manifest import ToolSurface
+    from src.governance.runtime import govern_registry
 
     # Closure-level state for the no-rich path so dots and progress lines
     # don't shoulder-bump each other (M3) and progress prints are throttled
@@ -1088,14 +1092,25 @@ def _run_agent(
         else:
             console.print(f"[yellow]WARNING:[/yellow] {msg}")
 
-    agent = AgentLoop(
-        registry=build_registry(
-            persistent_memory=pm,
-            include_shell_tools=True,
-            agent_config=agent_config,
+    raw_registry = build_registry(
+        persistent_memory=pm,
+        include_shell_tools=True,
+        agent_config=agent_config,
+        session_id=session_id or None,
+        warn_callback=_mcp_warn,
+    )
+    registry = govern_registry(
+        raw_registry,
+        surface=ToolSurface.CLI,
+        context=RuntimeContext(
+            surface=ToolSurface.CLI,
+            mode=get_governance_mode(),
             session_id=session_id or None,
-            warn_callback=_mcp_warn,
         ),
+    )
+
+    agent = AgentLoop(
+        registry=registry,
         llm=ChatLLM(),
         event_callback=on_event,
         max_iterations=max_iter,

--- a/agent/src/agent/loop.py
+++ b/agent/src/agent/loop.py
@@ -447,7 +447,7 @@ def _policy_denied_payload(result: str) -> dict[str, Any] | None:
     """Return a parsed policy-denied payload if a tool result carries one."""
     try:
         data = json.loads(result)
-    except (json.JSONDecodeError, TypeError):
+    except (json.JSONDecodeError, TypeError, ValueError):
         return None
     if isinstance(data, dict) and data.get("error_code") == "policy_denied":
         return data

--- a/agent/src/api/live_routes.py
+++ b/agent/src/api/live_routes.py
@@ -21,6 +21,7 @@ event through the EXISTING session EventBus, so the frontend's already-wired
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import sys as _sys
 import time
@@ -29,6 +30,8 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 from fastapi import Depends, FastAPI, HTTPException, Query
 from pydantic import BaseModel, Field
+
+from src.agent.tools import BaseTool
 
 logger = logging.getLogger(__name__)
 
@@ -174,6 +177,26 @@ class LiveRunnerUnavailable(RuntimeError):
 # ============================================================================
 # Host resolution — shared deps and monkeypatched symbols
 # ============================================================================
+
+
+class _LiveConnectorWriteTool(BaseTool):
+    """Private pseudo-tool that sends one governed live connector write."""
+
+    description = "Governed live connector write"
+    parameters = {"type": "object", "properties": {}, "additionalProperties": True}
+    repeatable = False
+    is_readonly = False
+    live_classification = "WRITE"
+
+    def __init__(self, *, name: str, adapter: Any, remote_tool: str) -> None:
+        self.name = name
+        self._adapter = adapter
+        self._remote_tool = remote_tool
+
+    def execute(self, **kwargs: Any) -> str:
+        result = self._adapter.call_tool(self._remote_tool, dict(kwargs))
+        payload = result if isinstance(result, dict) else {"result": result}
+        return json.dumps(payload, ensure_ascii=False, default=str)
 
 
 def _host() -> Any:
@@ -352,6 +375,83 @@ def _runner_liveness_state(broker: str) -> RunnerLivenessState:
     return RunnerLivenessState(broker=broker, alive=alive, last_tick=tick, last_tick_age_seconds=age)
 
 
+def _call_live_write_tool_governed(
+    *,
+    broker: str,
+    adapter: Any,
+    remote_tool: str,
+    params: Dict[str, Any],
+    operation: str,
+    state_provider: Any | None = None,
+    decision_recorder: Any | None = None,
+    budget_manager: Any | None = None,
+) -> Dict[str, Any]:
+    """Call a live connector write through the standard governance runtime."""
+    from src.agent.tools import ToolRegistry
+    from src.governance.config import get_governance_mode
+    from src.governance.decisions import RuntimeContext
+    from src.governance.discovery import ManifestCache
+    from src.governance.manifest import RiskLevel, ToolManifest, ToolSurface
+    from src.governance.runtime import GovernedToolRegistry, NullGovernanceStateProvider
+    from src.governance.trace_adapter import DecisionRecorder
+
+    tool_name = _live_write_tool_name(broker, operation)
+    tool = _LiveConnectorWriteTool(name=tool_name, adapter=adapter, remote_tool=remote_tool)
+    registry = ToolRegistry()
+    registry.register(tool)
+    manifest = ToolManifest(
+        name=tool_name,
+        surface=ToolSurface.LIVE_CONNECTOR,
+        readonly=False,
+        repeatable=False,
+        risk_level=RiskLevel.R4_TRADE_WRITE,
+        requires_auth=True,
+        requires_consent=True,
+        allowed_modes=["live"],
+        secret_access="broker",
+        timeout_seconds=30,
+        side_effects=["live_trade_write"],
+        live_classification="WRITE",
+    )
+    h = _host()
+    if state_provider is None:
+        factory = getattr(h, "_live_governance_state_provider_factory", None) if h is not None else None
+        if callable(factory):
+            state_provider = factory(broker=broker, operation=operation, params=dict(params))
+    if state_provider is None:
+        state_provider = NullGovernanceStateProvider()
+    if decision_recorder is None and h is not None:
+        decision_recorder = getattr(h, "_live_decision_recorder", None)
+    if decision_recorder is None:
+        decision_recorder = DecisionRecorder()
+    if budget_manager is None and h is not None:
+        budget_manager = getattr(h, "_live_budget_manager", None)
+
+    governed = GovernedToolRegistry(
+        registry,
+        manifest_cache=ManifestCache({tool_name: manifest}, surface=ToolSurface.LIVE_CONNECTOR),
+        context=RuntimeContext(surface=ToolSurface.LIVE_CONNECTOR, mode=get_governance_mode()),
+        decision_recorder=decision_recorder,
+        state_provider=state_provider,
+        budget_manager=budget_manager,
+    )
+    raw_result = governed.execute(tool_name, dict(params))
+    try:
+        decoded = json.loads(raw_result)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return {"status": "ok", "result": raw_result}
+    return decoded if isinstance(decoded, dict) else {"status": "ok", "result": decoded}
+
+
+def _live_write_tool_name(broker: str, operation: str) -> str:
+    return f"live_connector_{_tool_segment(broker)}_{_tool_segment(operation)}"
+
+
+def _tool_segment(value: str) -> str:
+    cleaned = [char.lower() if char.isalnum() else "_" for char in str(value or "unknown")]
+    return "".join(cleaned).strip("_") or "unknown"
+
+
 def _build_live_runner(broker: str) -> Any:
     """Construct a fully-wired ``LiveRunner`` for a broker (SPEC §7.5 R-INT).
 
@@ -400,8 +500,20 @@ def _build_live_runner(broker: str) -> Any:
 
     def _submit(order: Dict[str, Any]) -> Dict[str, Any]:
         if order.get("action") == "cancel":
-            return adapter.call_tool(cancel_order_tool, order)
-        return adapter.call_tool(submit_order_tool, order)
+            return _call_live_write_tool_governed(
+                broker=broker,
+                adapter=adapter,
+                remote_tool=cancel_order_tool,
+                params=order,
+                operation="cancel_order",
+            )
+        return _call_live_write_tool_governed(
+            broker=broker,
+            adapter=adapter,
+            remote_tool=submit_order_tool,
+            params=order,
+            operation="submit_order",
+        )
 
     svc = h._get_session_service()
     session = svc.create_session(title=f"live-runner:{broker}")

--- a/agent/src/api/runs_routes.py
+++ b/agent/src/api/runs_routes.py
@@ -14,6 +14,8 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional
 from fastapi import Depends, FastAPI, HTTPException, Query, status
 from fastapi.responses import JSONResponse
 
+from src.reliability.redaction import redact_secrets
+
 
 # ---------------------------------------------------------------------------
 # Helper functions (module-level; host Pydantic models resolved via sys.modules)
@@ -157,7 +159,7 @@ def _build_response_from_run_dir(
     research_card_path = run_dir / "research_card.json"
     if research_card_path.exists():
         try:
-            response.research_card = json.loads(research_card_path.read_text(encoding="utf-8"))
+            response.research_card = redact_secrets(json.loads(research_card_path.read_text(encoding="utf-8")))
         except (json.JSONDecodeError, OSError):
             pass
 

--- a/agent/src/governance/__init__.py
+++ b/agent/src/governance/__init__.py
@@ -6,14 +6,16 @@ from src.governance.discovery import ManifestCache, discover_tool_manifest
 from src.governance.errors import PolicyDenied
 from src.governance.manifest import RiskLevel, ToolManifest, ToolSurface
 from src.governance.policy_engine import PolicyEngine, PolicyRule
-from src.governance.runtime import GovernedToolRegistry, govern_registry
+from src.governance.runtime import GovernedToolRegistry, GovernanceStateProvider, NullGovernanceStateProvider, govern_registry
 
 __all__ = [
     "BudgetExceeded",
     "BudgetManager",
     "BudgetSnapshot",
     "GovernedToolRegistry",
+    "GovernanceStateProvider",
     "ManifestCache",
+    "NullGovernanceStateProvider",
     "PolicyDecision",
     "PolicyDenied",
     "PolicyEngine",

--- a/agent/src/governance/budget.py
+++ b/agent/src/governance/budget.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+from threading import Lock
 
 from pydantic import BaseModel, Field
 
@@ -41,33 +42,41 @@ class BudgetManager:
 
     def __init__(self, snapshot: BudgetSnapshot | None = None) -> None:
         self.snapshot = snapshot or BudgetSnapshot()
+        self._lock = Lock()
 
     def record_tool_call(self, *, risk_level: RiskLevel) -> None:
-        self._check_runtime()
-        self._increment("tool_calls", "max_tool_calls")
-        if risk_level == RiskLevel.R2_NETWORK:
-            self._increment("network_calls", "max_network_calls")
+        with self._lock:
+            self._check_runtime()
+            self._increment("tool_calls", "max_tool_calls")
+            if risk_level == RiskLevel.R2_NETWORK:
+                self._increment("network_calls", "max_network_calls")
 
     def record_parallel_readonly_call(self) -> None:
-        self._increment("parallel_readonly_calls", "max_parallel_readonly_calls")
+        with self._lock:
+            self._increment("parallel_readonly_calls", "max_parallel_readonly_calls")
 
     def record_bytes_read(self, byte_count: int) -> None:
-        self.snapshot.bytes_read += max(0, int(byte_count))
-        self._check_limit("bytes_read", "max_bytes_read")
+        with self._lock:
+            self.snapshot.bytes_read += max(0, int(byte_count))
+            self._check_limit("bytes_read", "max_bytes_read")
 
     def record_artifact_written(self, byte_count: int = 0) -> None:
-        self._increment("artifacts_written", "max_artifacts_written")
-        self.snapshot.artifact_bytes_written += max(0, int(byte_count))
+        with self._lock:
+            self._increment("artifacts_written", "max_artifacts_written")
+            self.snapshot.artifact_bytes_written += max(0, int(byte_count))
 
     def record_llm_tokens_or_cost(self, amount: float) -> None:
-        self.snapshot.llm_tokens_or_cost += max(0.0, float(amount))
-        self._check_limit("llm_tokens_or_cost", "max_llm_tokens_or_cost")
+        with self._lock:
+            self.snapshot.llm_tokens_or_cost += max(0.0, float(amount))
+            self._check_limit("llm_tokens_or_cost", "max_llm_tokens_or_cost")
 
     def record_backtest_trial(self) -> None:
-        self._increment("backtest_trials", "max_backtest_trials")
+        with self._lock:
+            self._increment("backtest_trials", "max_backtest_trials")
 
     def record_external_mcp_call(self) -> None:
-        self._increment("external_mcp_calls", "max_external_mcp_calls")
+        with self._lock:
+            self._increment("external_mcp_calls", "max_external_mcp_calls")
 
     def _increment(self, field_name: str, limit_name: str) -> None:
         setattr(self.snapshot, field_name, int(getattr(self.snapshot, field_name)) + 1)

--- a/agent/src/governance/decisions.py
+++ b/agent/src/governance/decisions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from datetime import datetime, timezone
 from typing import Any, Literal
 from uuid import uuid4
@@ -28,6 +29,25 @@ class RuntimeContext(BaseModel):
     user_auth_state: dict[str, Any] = Field(default_factory=dict)
     live_state: dict[str, Any] = Field(default_factory=dict)
     budget_state: dict[str, Any] = Field(default_factory=dict)
+    state_authoritative: bool = False
+
+    def with_authoritative_state(
+        self,
+        *,
+        live_state: Mapping[str, Any] | None = None,
+        user_auth_state: Mapping[str, Any] | None = None,
+        budget_state: Mapping[str, Any] | None = None,
+    ) -> "RuntimeContext":
+        """Return a copy with provider-supplied state for policy checks."""
+
+        return self.model_copy(
+            update={
+                "live_state": dict(live_state or {}),
+                "user_auth_state": dict(user_auth_state or {}),
+                "budget_state": dict(budget_state or {}),
+                "state_authoritative": True,
+            }
+        )
 
 
 class ParamAudit(BaseModel):

--- a/agent/src/governance/discovery.py
+++ b/agent/src/governance/discovery.py
@@ -81,11 +81,7 @@ class ManifestCache:
             get_tool = getattr(registry, "get", None)
             tool = get_tool(name) if callable(get_tool) else None
             if tool is not None:
-                manifest = discover_tool_manifest(tool, surface=surface)
-                if manifest.risk_level == RiskLevel.UNCLASSIFIED:
-                    fallback_risk = RiskLevel.R0_READ if manifest.readonly else RiskLevel.R1_WRITE_LOCAL
-                    manifest = manifest.model_copy(update={"risk_level": fallback_risk})
-                manifests[name] = manifest
+                manifests[name] = discover_tool_manifest(tool, surface=surface)
         return cls(manifests, surface=surface)
 
     def get(self, name: str) -> ToolManifest:
@@ -110,9 +106,6 @@ class ManifestCache:
         """Register a manifest for a tool added after cache construction."""
 
         manifest = discover_tool_manifest(tool, surface=self.surface)
-        if manifest.risk_level == RiskLevel.UNCLASSIFIED:
-            fallback_risk = RiskLevel.R0_READ if manifest.readonly else RiskLevel.R1_WRITE_LOCAL
-            manifest = manifest.model_copy(update={"risk_level": fallback_risk})
         self._manifests[manifest.name] = manifest
         return manifest
 

--- a/agent/src/governance/policy_engine.py
+++ b/agent/src/governance/policy_engine.py
@@ -251,6 +251,8 @@ def _decision(
 
 
 def _check_state(context: RuntimeContext, check: str) -> bool:
+    if not context.state_authoritative:
+        return False
     if check in context.live_state:
         return bool(context.live_state[check])
     if check in context.user_auth_state:

--- a/agent/src/governance/runtime.py
+++ b/agent/src/governance/runtime.py
@@ -143,7 +143,43 @@ class GovernedToolRegistry:
                 raise PolicyDenied(decision, shadow=True)
             return self._inner.execute(name, execution_params)
 
-        effective_context = self._build_effective_context()
+        try:
+            effective_context = self._build_effective_context()
+        except Exception as exc:  # noqa: BLE001 - provider failures fail closed before execution
+            audit = build_param_audit(execution_params)
+            action = "deny" if _must_deny_on_policy_exception(manifest, self.context.surface) else "warn"
+            decision = PolicyDecision(
+                tool_name=name,
+                action=action,
+                mode=self.context.mode,
+                reasons=[f"Authoritative governance state provider failed fail-safe: {exc.__class__.__name__}"],
+                rule_id="state_provider_failed",
+                params_hash=audit.params_hash,
+                params_preview=audit.preview,
+            )
+            try:
+                self.decision_recorder.record(decision, manifest=manifest)
+            except Exception as record_exc:  # noqa: BLE001 - audit failure must not open high-risk paths
+                if _must_fail_closed_on_recording_exception(manifest, self.context):
+                    denied = PolicyDecision(
+                        tool_name=name,
+                        action="deny",
+                        mode=self.context.mode,
+                        reasons=[f"Policy decision recording failed fail-safe: {record_exc.__class__.__name__}"],
+                        rule_id="trace_record_failed",
+                        params_hash=audit.params_hash,
+                        params_preview=audit.preview,
+                    )
+                    raise PolicyDenied(denied, shadow=manifest.risk_level in HIGH_RISK_DENY) from record_exc
+                raise
+            if decision.action == "deny":
+                self.decision_recorder.record_denied(
+                    decision,
+                    trace_status="skipped" if manifest.risk_level in HIGH_RISK_DENY else "denied",
+                    shadow=manifest.risk_level in HIGH_RISK_DENY,
+                )
+                raise PolicyDenied(decision, shadow=manifest.risk_level in HIGH_RISK_DENY) from exc
+            effective_context = self.context
         policy_params = _copy_params(execution_params)
         try:
             decision = self.policy.evaluate(name=name, params=policy_params, manifest=manifest, context=effective_context)

--- a/agent/src/governance/runtime.py
+++ b/agent/src/governance/runtime.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Mapping
+from copy import deepcopy
+from typing import Any, Protocol
 
+from src.governance.budget import BudgetExceeded, BudgetManager
 from src.governance.config import get_governance_mode
 from src.governance.decisions import PolicyDecision, RuntimeContext, build_param_audit
 from src.governance.discovery import ManifestCache
@@ -14,6 +17,58 @@ from src.governance.trace_adapter import DecisionRecorder
 
 
 HIGH_RISK_DENY = {RiskLevel.R4_TRADE_WRITE, RiskLevel.R5_SHELL}
+
+
+class GovernanceStateProvider(Protocol):
+    """Authoritative runtime state source for policy checks."""
+
+    def get_live_state(self, context: RuntimeContext) -> Mapping[str, Any]:
+        ...
+
+    def get_user_auth_state(self, context: RuntimeContext) -> Mapping[str, Any]:
+        ...
+
+    def get_budget_state(self, context: RuntimeContext) -> Mapping[str, Any]:
+        ...
+
+
+class NullGovernanceStateProvider:
+    """Fail-closed provider used when no authoritative state source is wired."""
+
+    def get_live_state(self, context: RuntimeContext) -> Mapping[str, Any]:
+        del context
+        return {}
+
+    def get_user_auth_state(self, context: RuntimeContext) -> Mapping[str, Any]:
+        del context
+        return {}
+
+    def get_budget_state(self, context: RuntimeContext) -> Mapping[str, Any]:
+        del context
+        return {}
+
+
+class GovernedToolProxy:
+    """Metadata proxy that routes execution back through governance."""
+
+    __slots__ = ("_registry", "_name", "__raw_tool")
+
+    def __init__(self, registry: "GovernedToolRegistry", name: str, raw_tool: Any) -> None:
+        self._registry = registry
+        self._name = name
+        self.__raw_tool = raw_tool
+
+    def execute(self, **params: Any) -> str:
+        return self._registry.execute(self._name, params)
+
+    @property
+    def __class__(self) -> type:
+        return self.__raw_tool.__class__
+
+    def __getattr__(self, attr: str) -> Any:
+        if attr == "execute" or (attr.startswith("_") and attr != "_spec"):
+            raise AttributeError(attr)
+        return getattr(self.__raw_tool, attr)
 
 
 class GovernedToolRegistry:
@@ -27,31 +82,38 @@ class GovernedToolRegistry:
         policy: PolicyEngine | None = None,
         context: RuntimeContext | None = None,
         decision_recorder: DecisionRecorder | None = None,
+        state_provider: GovernanceStateProvider | None = None,
+        budget_manager: BudgetManager | None = None,
     ) -> None:
-        self.inner = inner
+        self._inner = inner
         self.manifest_cache = manifest_cache
         self.policy = policy or PolicyEngine()
         self.context = context or RuntimeContext(surface=manifest_cache.surface, mode=get_governance_mode())
         self.decision_recorder = decision_recorder or DecisionRecorder()
+        self._state_provider = state_provider or NullGovernanceStateProvider()
+        self._budget_manager = budget_manager
 
     @property
     def tool_names(self) -> list[str]:
-        return list(getattr(self.inner, "tool_names", []))
+        return list(getattr(self._inner, "tool_names", []))
 
     def get(self, name: str) -> Any:
-        return self.inner.get(name)
+        raw_tool = self._inner.get(name)
+        if raw_tool is None:
+            return None
+        return GovernedToolProxy(self, name, raw_tool)
 
     def register(self, tool: Any) -> None:
         """Delegate dynamic tool registration while keeping manifests in sync."""
 
-        register = getattr(self.inner, "register", None)
+        register = getattr(self._inner, "register", None)
         if not callable(register):
             raise AttributeError("wrapped registry does not support register")
         register(tool)
         self.manifest_cache.register(tool)
 
     def get_definitions(self) -> list[dict[str, Any]]:
-        return self.inner.get_definitions()
+        return self._inner.get_definitions()
 
     def set_trace_writer(self, trace_writer: Any | None) -> None:
         self.decision_recorder.set_trace_writer(trace_writer)
@@ -59,28 +121,63 @@ class GovernedToolRegistry:
     def execute(self, name: str, params: dict[str, Any]) -> str:
         """Evaluate policy, then delegate to the wrapped ToolRegistry if allowed."""
 
-        if self.context.mode == "off":
-            return self.inner.execute(name, params)
-
         manifest = self.manifest_cache.get(name)
+        execution_params = _copy_params(params)
+        if self.context.mode == "off":
+            if manifest.risk_level in HIGH_RISK_DENY:
+                audit = build_param_audit(execution_params)
+                decision = PolicyDecision(
+                    tool_name=name,
+                    action="deny",
+                    mode=self.context.mode,
+                    reasons=["High-risk tools cannot bypass governance in off mode"],
+                    rule_id="governance_off_high_risk",
+                    params_hash=audit.params_hash,
+                    params_preview=audit.preview,
+                )
+                try:
+                    self.decision_recorder.record(decision, manifest=manifest)
+                    self.decision_recorder.record_denied(decision, trace_status="skipped", shadow=True)
+                except Exception:
+                    pass
+                raise PolicyDenied(decision, shadow=True)
+            return self._inner.execute(name, execution_params)
+
+        effective_context = self._build_effective_context()
+        policy_params = _copy_params(execution_params)
         try:
-            decision = self.policy.evaluate(name=name, params=params, manifest=manifest, context=self.context)
+            decision = self.policy.evaluate(name=name, params=policy_params, manifest=manifest, context=effective_context)
         except Exception as exc:  # noqa: BLE001 - wrapper must also fail safe
-            audit = build_param_audit(params)
-            action = "deny" if _must_deny_on_policy_exception(manifest, self.context.surface) else "warn"
+            audit = build_param_audit(execution_params)
+            action = "deny" if _must_deny_on_policy_exception(manifest, effective_context.surface) else "warn"
             decision = PolicyDecision(
                 tool_name=name,
                 action=action,
-                mode=self.context.mode,
+                mode=effective_context.mode,
                 reasons=[f"Policy evaluation failed fail-safe: {exc.__class__.__name__}"],
                 rule_id="policy_exception",
                 params_hash=audit.params_hash,
                 params_preview=audit.preview,
             )
-        self.decision_recorder.record(decision, manifest=manifest)
+        try:
+            self.decision_recorder.record(decision, manifest=manifest)
+        except Exception as exc:  # noqa: BLE001 - audit failure must not open high-risk paths
+            if _must_fail_closed_on_recording_exception(manifest, effective_context):
+                audit = build_param_audit(execution_params)
+                denied = PolicyDecision(
+                    tool_name=name,
+                    action="deny",
+                    mode=effective_context.mode,
+                    reasons=[f"Policy decision recording failed fail-safe: {exc.__class__.__name__}"],
+                    rule_id="trace_record_failed",
+                    params_hash=audit.params_hash,
+                    params_preview=audit.preview,
+                )
+                raise PolicyDenied(denied, shadow=manifest.risk_level in HIGH_RISK_DENY) from exc
+            raise
 
         if decision.action == "deny":
-            if self.context.mode == "enforce":
+            if effective_context.mode == "enforce":
                 self.decision_recorder.record_denied(decision, trace_status="denied", shadow=False)
                 raise PolicyDenied(decision, shadow=False)
             if manifest.risk_level in HIGH_RISK_DENY:
@@ -88,13 +185,41 @@ class GovernedToolRegistry:
                 raise PolicyDenied(decision, shadow=True)
             # Low/medium risk observe/warn records the deny as a warning and continues.
 
-        return self.inner.execute(name, params)
+        if effective_context.mode == "warn" and decision.action in {"deny", "warn"}:
+            self.decision_recorder.record_warning(decision)
+
+        if self._budget_manager is not None:
+            try:
+                self._budget_manager.record_tool_call(risk_level=manifest.risk_level)
+            except BudgetExceeded as exc:
+                audit = build_param_audit(execution_params)
+                decision = PolicyDecision(
+                    tool_name=name,
+                    action="deny",
+                    mode=effective_context.mode,
+                    reasons=[f"Governance budget exceeded: {exc}"],
+                    rule_id="budget_exceeded",
+                    params_hash=audit.params_hash,
+                    params_preview=audit.preview,
+                )
+                self.decision_recorder.record(decision, manifest=manifest)
+                self.decision_recorder.record_denied(decision, trace_status="denied", shadow=False)
+                raise PolicyDenied(decision, shadow=False) from exc
+
+        return self._inner.execute(name, execution_params)
 
     def __contains__(self, name: str) -> bool:
-        return name in getattr(self.inner, "tool_names", [])
+        return name in getattr(self._inner, "tool_names", [])
 
     def __len__(self) -> int:
-        return len(getattr(self.inner, "tool_names", []))
+        return len(getattr(self._inner, "tool_names", []))
+
+    def _build_effective_context(self) -> RuntimeContext:
+        return self.context.with_authoritative_state(
+            live_state=self._state_provider.get_live_state(self.context),
+            user_auth_state=self._state_provider.get_user_auth_state(self.context),
+            budget_state=self._state_provider.get_budget_state(self.context),
+        )
 
 
 def govern_registry(
@@ -104,6 +229,8 @@ def govern_registry(
     mode: str | None = None,
     context: RuntimeContext | None = None,
     decision_recorder: DecisionRecorder | None = None,
+    state_provider: GovernanceStateProvider | None = None,
+    budget_manager: BudgetManager | None = None,
 ) -> GovernedToolRegistry:
     """Wrap an existing registry with the governance runtime."""
 
@@ -113,6 +240,8 @@ def govern_registry(
         manifest_cache=ManifestCache.from_registry(registry, surface=surface),
         context=runtime_context,
         decision_recorder=decision_recorder,
+        state_provider=state_provider,
+        budget_manager=budget_manager,
     )
 
 
@@ -127,3 +256,15 @@ def _must_deny_on_policy_exception(manifest: Any, surface: ToolSurface) -> bool:
         ToolSurface.LIVE_CONNECTOR,
         ToolSurface.CHANNEL_BOT,
     }
+
+
+def _must_fail_closed_on_recording_exception(manifest: Any, context: RuntimeContext) -> bool:
+    return _must_deny_on_policy_exception(manifest, context.surface)
+
+
+def _copy_params(params: dict[str, Any]) -> dict[str, Any]:
+    try:
+        copied = deepcopy(params)
+    except Exception:  # noqa: BLE001 - exotic objects still get a mapping boundary
+        copied = dict(params)
+    return copied

--- a/agent/src/governance/trace_adapter.py
+++ b/agent/src/governance/trace_adapter.py
@@ -41,3 +41,16 @@ class DecisionRecorder:
         self.records.append(record)
         if self.trace_writer is not None and hasattr(self.trace_writer, "write"):
             self.trace_writer.write(record)
+
+    def record_warning(self, decision: PolicyDecision, *, trace_status: str = "warned") -> None:
+        record = {
+            "type": "policy_warning",
+            "status": trace_status,
+            "decision_id": decision.decision_id,
+            "tool_name": decision.tool_name,
+            "rule_id": decision.rule_id,
+            "reasons": list(decision.reasons),
+        }
+        self.records.append(record)
+        if self.trace_writer is not None and hasattr(self.trace_writer, "write"):
+            self.trace_writer.write(record)

--- a/agent/src/reliability/data/circuit_breaker.py
+++ b/agent/src/reliability/data/circuit_breaker.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 import sqlite3
 import time
 from dataclasses import dataclass
@@ -65,11 +67,48 @@ class CircuitBreaker:
 
     def record_failure(self, source: str, error: BaseException) -> None:
         """Record a source failure and open if threshold is reached."""
-        snapshot = self.snapshot(source)
-        failures = snapshot.consecutive_failures + 1
-        state = "OPEN" if failures >= self.failure_threshold else snapshot.state
-        opened_at = time.time() if state == "OPEN" else (snapshot.opened_at.timestamp() if snapshot.opened_at else None)
-        self._upsert_state(source, state, failures, type(error).__name__, opened_at)
+        with self._connect() as conn:
+            try:
+                conn.execute("BEGIN IMMEDIATE")
+                row = conn.execute(
+                    """
+                    SELECT state, consecutive_failures, opened_at, last_error_class
+                    FROM circuit_state
+                    WHERE source = ?
+                    """,
+                    (source,),
+                ).fetchone()
+                if row is None:
+                    previous_state = "CLOSED"
+                    failures = 1
+                    previous_opened_at = None
+                else:
+                    previous_state = str(row[0])
+                    failures = int(row[1]) + 1
+                    previous_opened_at = row[2]
+
+                state = previous_state
+                opened_at = previous_opened_at
+                if failures >= self.failure_threshold:
+                    state = "OPEN"
+                    opened_at = (
+                        float(previous_opened_at)
+                        if previous_state == "OPEN" and previous_opened_at is not None
+                        else time.time()
+                    )
+
+                self._write_state(
+                    conn,
+                    source,
+                    state,
+                    failures,
+                    type(error).__name__,
+                    opened_at,
+                )
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                raise
 
     def snapshot(self, source: str) -> CircuitBreakerSnapshot:
         """Return a source state snapshot."""
@@ -114,11 +153,16 @@ class CircuitBreaker:
                 )
                 """
             )
+            conn.commit()
 
-    def _connect(self) -> sqlite3.Connection:
+    @contextmanager
+    def _connect(self) -> Iterator[sqlite3.Connection]:
         conn = sqlite3.connect(str(self.path), timeout=30.0)
-        conn.execute("PRAGMA busy_timeout=30000")
-        return conn
+        try:
+            conn.execute("PRAGMA busy_timeout=30000")
+            yield conn
+        finally:
+            conn.close()
 
     def _upsert_state(
         self,
@@ -129,18 +173,34 @@ class CircuitBreaker:
         opened_at: float | None,
     ) -> None:
         with self._connect() as conn:
-            conn.execute(
-                """
-                INSERT INTO circuit_state (source, state, consecutive_failures, opened_at, last_error_class)
-                VALUES (?, ?, ?, ?, ?)
-                ON CONFLICT(source) DO UPDATE SET
-                    state = excluded.state,
-                    consecutive_failures = excluded.consecutive_failures,
-                    opened_at = excluded.opened_at,
-                    last_error_class = excluded.last_error_class
-                """,
-                (source, state, failures, opened_at, error_class),
-            )
+            try:
+                self._write_state(conn, source, state, failures, error_class, opened_at)
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                raise
+
+    @staticmethod
+    def _write_state(
+        conn: sqlite3.Connection,
+        source: str,
+        state: str,
+        failures: int,
+        error_class: str | None,
+        opened_at: float | None,
+    ) -> None:
+        conn.execute(
+            """
+            INSERT INTO circuit_state (source, state, consecutive_failures, opened_at, last_error_class)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(source) DO UPDATE SET
+                state = excluded.state,
+                consecutive_failures = excluded.consecutive_failures,
+                opened_at = excluded.opened_at,
+                last_error_class = excluded.last_error_class
+            """,
+            (source, state, failures, opened_at, error_class),
+        )
 
 
 def _from_epoch(value: float | None) -> datetime | None:

--- a/agent/src/reliability/redaction.py
+++ b/agent/src/reliability/redaction.py
@@ -25,7 +25,15 @@ _SECRET_KEY_FRAGMENTS = (
 )
 
 _BEARER_RE = re.compile(r"^\s*bearer\s+[A-Za-z0-9._~+/=-]{16,}\s*$", re.IGNORECASE)
-_KEY_PREFIX_RE = re.compile(r"^\s*(sk|rk|pk|ghp|gho|ghu|github_pat)-[A-Za-z0-9_\-]{20,}\s*$", re.IGNORECASE)
+_INLINE_BEARER_RE = re.compile(
+    r"\bauthorization\s*:\s*bearer\s+[^\s,;]+|\bbearer\s+[A-Za-z0-9._~+/=-]{8,}",
+    re.IGNORECASE,
+)
+_ENV_ASSIGNMENT_SECRET_RE = re.compile(
+    r"\b[A-Z0-9_]*(?:SECRET|TOKEN|API_KEY|ACCESS_KEY|PRIVATE_KEY)[A-Z0-9_]*\s*=\s*[^\s,;]+",
+    re.IGNORECASE,
+)
+_KEY_PREFIX_RE = re.compile(r"^\s*(sk|rk|pk|ghp|gho|ghu|github_pat)-[A-Za-z0-9_\-]{8,}\s*$", re.IGNORECASE)
 _LONG_RANDOM_RE = re.compile(r"^(?=.*[A-Z])(?=.*[a-z])(?=.*\d)[A-Za-z0-9_\-+/=]{40,}$")
 
 
@@ -55,4 +63,10 @@ def _key_is_secret_like(key: str) -> bool:
 
 
 def _value_is_secret_like(value: str) -> bool:
-    return bool(_BEARER_RE.match(value) or _KEY_PREFIX_RE.match(value) or _LONG_RANDOM_RE.match(value))
+    return bool(
+        _BEARER_RE.match(value)
+        or _INLINE_BEARER_RE.search(value)
+        or _ENV_ASSIGNMENT_SECRET_RE.search(value)
+        or _KEY_PREFIX_RE.match(value)
+        or _LONG_RANDOM_RE.match(value)
+    )

--- a/agent/src/research_card/api.py
+++ b/agent/src/research_card/api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import sqlite3
 from pathlib import Path
 from typing import Any, Awaitable, Callable
@@ -19,6 +20,7 @@ from src.tools import build_registry
 
 RESEARCH_API_SCHEMA_VERSION = "1.0.0"
 AuthDep = Callable[..., Awaitable[Any] | Any]
+logger = logging.getLogger(__name__)
 
 
 def register_research_card_routes(app: FastAPI, require_auth: AuthDep | None = None) -> None:
@@ -156,7 +158,11 @@ def _read_payload(record: dict[str, Any]) -> Any:
     try:
         path.relative_to(root)
     except ValueError as exc:
-        raise HTTPException(status_code=500, detail="artifact path escapes artifact root") from exc
+        logger.warning(
+            "artifact path escapes artifact root; artifact_id=%s",
+            record.get("artifact_id", "<unknown>"),
+        )
+        raise HTTPException(status_code=404, detail="artifact payload missing") from exc
     try:
         raw = path.read_text(encoding="utf-8")
     except OSError as exc:

--- a/agent/src/tools/__init__.py
+++ b/agent/src/tools/__init__.py
@@ -55,7 +55,7 @@ def _discover_subclasses() -> list[type[BaseTool]]:
     queue = deque(BaseTool.__subclasses__())
     while queue:
         cls = queue.popleft()
-        if cls.name:
+        if cls.name and cls.__module__.startswith("src.tools."):
             classes.append(cls)
         queue.extend(cls.__subclasses__())
 
@@ -75,6 +75,12 @@ def build_registry(
     _mcp_server_tool_name_segments: Mapping[str, str] | None = None,
 ) -> ToolRegistry:
     """Build the tool registry via auto-discovery, optionally enriched with MCP tools.
+
+    This is a raw registry factory. Production execution entry points that run
+    user- or agent-selected tools must wrap the returned registry with
+    ``govern_registry`` before handing it to ``AgentLoop`` or calling
+    ``execute``. Keep this helper raw for schema generation, inventory, tests,
+    and low-level assembly.
 
     Local tools are discovered and registered first. When ``agent_config``
     provides one or more MCP server definitions, remote tools are appended
@@ -247,6 +253,11 @@ def build_registry(
 
 def build_filtered_registry(tool_names: list[str], *, include_shell_tools: bool = False) -> ToolRegistry:
     """Build a ToolRegistry with only specified tools.
+
+    This is a raw local-only helper for tests, schema/inventory, and legacy
+    assembly paths. Production execution entry points must prefer a governed
+    builder such as :func:`build_swarm_registry` or explicitly wrap the result
+    with ``govern_registry`` before executing tools.
 
     Local-tools-only filtered builder. Swarm workers should call
     :func:`build_swarm_registry` instead so they can opt into remote MCP

--- a/agent/tests/governance/test_governance_redteam_boundary.py
+++ b/agent/tests/governance/test_governance_redteam_boundary.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import json
+import threading
+import time
+from typing import Any
+
+import pytest
+
+from src.agent.tools import BaseTool, ToolRegistry
+from src.governance.budget import BudgetManager, BudgetSnapshot
+from src.governance.decisions import RuntimeContext
+from src.governance.discovery import ManifestCache
+from src.governance.errors import PolicyDenied
+from src.governance.manifest import RiskLevel, ToolManifest, ToolSurface
+from src.governance.policy_engine import PolicyEngine, PolicyRule
+from src.governance.runtime import GovernedToolRegistry
+from src.governance.trace_adapter import DecisionRecorder
+
+
+class _ProbeTool(BaseTool):
+    name = "redteam_probe"
+    description = "redteam probe"
+    parameters = {"type": "object", "properties": {}}
+    repeatable = True
+    is_readonly = False
+
+    def __init__(self, *, delay_seconds: float = 0.0) -> None:
+        self.calls = 0
+        self.last_kwargs: dict[str, Any] = {}
+        self._delay_seconds = delay_seconds
+        self._lock = threading.Lock()
+
+    def execute(self, **kwargs: Any) -> str:
+        if self._delay_seconds:
+            time.sleep(self._delay_seconds)
+        with self._lock:
+            self.calls += 1
+            self.last_kwargs = dict(kwargs)
+            calls = self.calls
+        return json.dumps({"status": "ok", "calls": calls})
+
+
+class _FailingRecorder(DecisionRecorder):
+    def record(self, decision, *, manifest=None) -> None:
+        del decision, manifest
+        raise RuntimeError("trace unavailable")
+
+
+def _manifest(risk: RiskLevel, *, surface: ToolSurface = ToolSurface.CLI) -> ToolManifest:
+    return ToolManifest(
+        name="redteam_probe",
+        surface=surface,
+        readonly=risk == RiskLevel.R0_READ,
+        repeatable=True,
+        risk_level=risk,
+        requires_auth=False,
+        requires_consent=risk == RiskLevel.R4_TRADE_WRITE,
+        allowed_modes=["research", "paper", "advisory", "live"],
+        secret_access="none",
+        timeout_seconds=30,
+        side_effects=["redteam"],
+    )
+
+
+def _registry(tool: _ProbeTool | None = None) -> tuple[ToolRegistry, _ProbeTool]:
+    tool = tool or _ProbeTool()
+    inner = ToolRegistry()
+    inner.register(tool)
+    return inner, tool
+
+
+def _governed(
+    *,
+    risk: RiskLevel,
+    context: RuntimeContext,
+    tool: _ProbeTool | None = None,
+    policy: PolicyEngine | None = None,
+    recorder: DecisionRecorder | None = None,
+    budget_manager: BudgetManager | None = None,
+) -> tuple[GovernedToolRegistry, _ProbeTool]:
+    inner, tool = _registry(tool)
+    governed = GovernedToolRegistry(
+        inner,
+        manifest_cache=ManifestCache({"redteam_probe": _manifest(risk, surface=context.surface)}, surface=context.surface),
+        context=context,
+        policy=policy,
+        decision_recorder=recorder,
+        budget_manager=budget_manager,
+    )
+    return governed, tool
+
+
+def test_proxy_public_surface_does_not_expose_raw_tool_escape_hatch() -> None:
+    governed, _tool = _governed(
+        risk=RiskLevel.R4_TRADE_WRITE,
+        context=RuntimeContext(surface=ToolSurface.CLI, mode="observe"),
+    )
+
+    proxy = governed.get("redteam_probe")
+
+    assert not hasattr(proxy, "__dict__")
+    assert not hasattr(proxy, "_raw_tool")
+    assert getattr(proxy, "execute").__self__ is proxy
+    with pytest.raises(PolicyDenied):
+        proxy.execute(symbol="BTC", side="BUY")
+
+
+def test_governance_off_cannot_downgrade_high_risk_execution() -> None:
+    governed, tool = _governed(
+        risk=RiskLevel.R5_SHELL,
+        context=RuntimeContext(surface=ToolSurface.REMOTE_API, mode="off"),
+    )
+
+    with pytest.raises(PolicyDenied):
+        governed.execute("redteam_probe", {})
+
+    assert tool.calls == 0
+
+
+def test_governance_off_preserves_low_risk_legacy_execution() -> None:
+    governed, tool = _governed(
+        risk=RiskLevel.R0_READ,
+        context=RuntimeContext(surface=ToolSurface.MCP_STDIO, mode="off"),
+    )
+
+    result = json.loads(governed.execute("redteam_probe", {}))
+
+    assert result["status"] == "ok"
+    assert tool.calls == 1
+
+
+def test_policy_predicate_cannot_mutate_raw_execution_params() -> None:
+    def mutate_params(**kwargs: Any) -> bool:
+        kwargs["params"]["nested"]["risk"] = "mutated"
+        kwargs["params"]["injected_after_policy"] = True
+        return False
+
+    policy = PolicyEngine(
+        rules=[
+            PolicyRule(
+                priority=1,
+                rule_id="mutating-predicate",
+                description="mutates params and does not match",
+                action="allow",
+                predicate=mutate_params,
+            ),
+            PolicyRule(priority=2, rule_id="allow", description="allow", action="allow"),
+        ]
+    )
+    governed, tool = _governed(
+        risk=RiskLevel.R0_READ,
+        context=RuntimeContext(surface=ToolSurface.MCP_STDIO, mode="enforce"),
+        policy=policy,
+    )
+    params = {"nested": {"risk": "original"}}
+
+    governed.execute("redteam_probe", params)
+
+    assert params == {"nested": {"risk": "original"}}
+    assert tool.last_kwargs == {"nested": {"risk": "original"}}
+
+
+def test_low_risk_trace_failure_is_explicit_and_does_not_execute() -> None:
+    governed, tool = _governed(
+        risk=RiskLevel.R1_WRITE_LOCAL,
+        context=RuntimeContext(surface=ToolSurface.CLI, mode="observe"),
+        recorder=_FailingRecorder(),
+    )
+
+    with pytest.raises(RuntimeError, match="trace unavailable"):
+        governed.execute("redteam_probe", {})
+
+    assert tool.calls == 0
+
+
+def test_concurrent_budget_attack_cannot_exceed_limit() -> None:
+    budget = BudgetManager(BudgetSnapshot(max_tool_calls=1))
+    tool = _ProbeTool(delay_seconds=0.01)
+    governed, tool = _governed(
+        risk=RiskLevel.R1_WRITE_LOCAL,
+        context=RuntimeContext(surface=ToolSurface.CLI, mode="observe"),
+        tool=tool,
+        budget_manager=budget,
+    )
+    barrier = threading.Barrier(12)
+    results: list[str] = []
+    errors: list[BaseException] = []
+    lock = threading.Lock()
+
+    def call_tool() -> None:
+        try:
+            barrier.wait(timeout=5)
+            result = governed.execute("redteam_probe", {})
+            with lock:
+                results.append(result)
+        except BaseException as exc:  # noqa: BLE001 - test captures thread failures
+            with lock:
+                errors.append(exc)
+
+    threads = [threading.Thread(target=call_tool) for _ in range(12)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert tool.calls == 1
+    assert len(results) == 1
+    assert sum(isinstance(exc, PolicyDenied) for exc in errors) == 11

--- a/agent/tests/governance/test_governed_registry.py
+++ b/agent/tests/governance/test_governed_registry.py
@@ -5,7 +5,9 @@ import json
 import pytest
 
 from src.agent.tools import BaseTool, ToolRegistry
+from src.governance.budget import BudgetManager, BudgetSnapshot
 from src.governance.decisions import RuntimeContext
+from src.governance.decisions import build_param_audit
 from src.governance.discovery import ManifestCache
 from src.governance.errors import PolicyDenied
 from src.governance.manifest import RiskLevel, ToolManifest, ToolSurface
@@ -22,21 +24,29 @@ class _CountingTool(BaseTool):
 
     def __init__(self) -> None:
         self.calls = 0
+        self.last_kwargs = {}
 
     def execute(self, **kwargs):
         self.calls += 1
+        self.last_kwargs = dict(kwargs)
         return json.dumps({"status": "ok", "calls": self.calls})
 
 
-class _ReadTool(BaseTool):
-    name = "new_read"
-    description = "new read"
+class _RemoteReadTool:
+    name = "mcp_counting"
+    description = "remote counting"
     parameters = {"type": "object", "properties": {}}
     repeatable = True
     is_readonly = True
 
     def execute(self, **kwargs):
-        return json.dumps({"status": "ok"})
+        return json.dumps({"status": "ok", "remote": True})
+
+
+class _FailingRecorder(DecisionRecorder):
+    def record(self, decision, *, manifest=None) -> None:
+        del decision, manifest
+        raise RuntimeError("trace unavailable")
 
 
 def _registry(tool: _CountingTool | None = None) -> tuple[ToolRegistry, _CountingTool]:
@@ -79,6 +89,36 @@ def test_r4_deny_shadow_denies_in_observe() -> None:
     assert tool.calls == 0
 
 
+def test_get_execute_routes_through_governance() -> None:
+    inner, tool = _registry()
+    governed = GovernedToolRegistry(
+        inner,
+        manifest_cache=_cache(RiskLevel.R4_TRADE_WRITE),
+        context=RuntimeContext(surface=ToolSurface.CLI, mode="observe"),
+    )
+
+    tool_proxy = governed.get("counting")
+
+    with pytest.raises(PolicyDenied) as raised:
+        tool_proxy.execute()
+
+    assert raised.value.shadow is True
+    assert tool.calls == 0
+
+
+def test_governed_registry_does_not_expose_public_inner_registry() -> None:
+    inner, _tool = _registry()
+    governed = GovernedToolRegistry(
+        inner,
+        manifest_cache=_cache(RiskLevel.R4_TRADE_WRITE),
+        context=RuntimeContext(surface=ToolSurface.CLI, mode="observe"),
+    )
+
+    assert not hasattr(governed, "inner")
+    with pytest.raises(AttributeError):
+        getattr(governed, "inner")
+
+
 def test_r5_deny_shadow_denies_in_warn() -> None:
     inner, tool = _registry()
     governed = GovernedToolRegistry(
@@ -108,6 +148,44 @@ def test_policy_denied_does_not_call_inner_execute() -> None:
     assert tool.calls == 0
 
 
+def test_budget_exceeded_denies_before_inner_execute() -> None:
+    inner, tool = _registry()
+    budget = BudgetManager(BudgetSnapshot(max_tool_calls=0))
+    recorder = DecisionRecorder()
+    governed = GovernedToolRegistry(
+        inner,
+        manifest_cache=_cache(RiskLevel.R1_WRITE_LOCAL),
+        context=RuntimeContext(surface=ToolSurface.CLI, mode="observe"),
+        decision_recorder=recorder,
+        budget_manager=budget,
+    )
+
+    with pytest.raises(PolicyDenied) as raised:
+        governed.execute("counting", {})
+
+    assert raised.value.decision.rule_id == "budget_exceeded"
+    assert tool.calls == 0
+    assert budget.snapshot.tool_calls == 1
+    assert recorder.decisions[-1].rule_id == "budget_exceeded"
+
+
+def test_trace_write_failure_denies_high_risk_before_inner_execute() -> None:
+    inner, tool = _registry()
+    governed = GovernedToolRegistry(
+        inner,
+        manifest_cache=_cache(RiskLevel.R4_TRADE_WRITE),
+        context=RuntimeContext(surface=ToolSurface.CLI, mode="observe"),
+        decision_recorder=_FailingRecorder(),
+    )
+
+    with pytest.raises(PolicyDenied) as raised:
+        governed.execute("counting", {})
+
+    assert raised.value.decision.rule_id == "trace_record_failed"
+    assert raised.value.shadow is True
+    assert tool.calls == 0
+
+
 def test_low_risk_deny_observe_continues_with_warning() -> None:
     inner, tool = _registry()
     recorder = DecisionRecorder()
@@ -123,6 +201,23 @@ def test_low_risk_deny_observe_continues_with_warning() -> None:
     assert result["status"] == "ok"
     assert tool.calls == 1
     assert recorder.decisions[-1].action == "deny"
+
+
+def test_warn_mode_records_visible_warning_when_continuing() -> None:
+    inner, tool = _registry()
+    recorder = DecisionRecorder()
+    governed = GovernedToolRegistry(
+        inner,
+        manifest_cache=_cache(RiskLevel.R1_WRITE_LOCAL),
+        context=RuntimeContext(surface=ToolSurface.CLI, mode="warn"),
+        decision_recorder=recorder,
+    )
+
+    result = json.loads(governed.execute("counting", {}))
+
+    assert result["status"] == "ok"
+    assert tool.calls == 1
+    assert any(record["type"] == "policy_warning" for record in recorder.records)
 
 
 def test_policy_decision_goes_to_trace() -> None:
@@ -144,12 +239,29 @@ def test_policy_decision_goes_to_trace() -> None:
     assert "secret" not in json.dumps(record, ensure_ascii=False)
 
 
-def test_mode_off_delegates_directly() -> None:
+def test_policy_hash_matches_actual_executed_params() -> None:
+    inner, tool = _registry()
+    recorder = DecisionRecorder()
+    governed = GovernedToolRegistry(
+        inner,
+        manifest_cache=_cache(RiskLevel.R1_WRITE_LOCAL),
+        context=RuntimeContext(surface=ToolSurface.CLI, mode="observe"),
+        decision_recorder=recorder,
+    )
+    params = {"symbol": "AAPL", "api_key": "secret"}
+
+    governed.execute("counting", params)
+
+    assert tool.last_kwargs == params
+    assert recorder.decisions[-1].params_hash == build_param_audit(tool.last_kwargs).params_hash
+
+
+def test_mode_off_delegates_low_risk_directly() -> None:
     inner, tool = _registry()
     governed = GovernedToolRegistry(
         inner,
-        manifest_cache=_cache(RiskLevel.R5_SHELL, surface=ToolSurface.REMOTE_API),
-        context=RuntimeContext(surface=ToolSurface.REMOTE_API, mode="off"),
+        manifest_cache=_cache(RiskLevel.R0_READ, surface=ToolSurface.MCP_STDIO),
+        context=RuntimeContext(surface=ToolSurface.MCP_STDIO, mode="off"),
     )
 
     result = json.loads(governed.execute("counting", {}))
@@ -158,16 +270,20 @@ def test_mode_off_delegates_directly() -> None:
     assert tool.calls == 1
 
 
-def test_register_delegates_to_inner_registry_and_updates_manifest_cache() -> None:
+def test_register_preserves_tool_registry_surface_and_manifest() -> None:
     inner = ToolRegistry()
     governed = GovernedToolRegistry(
         inner,
-        manifest_cache=ManifestCache({}, surface=ToolSurface.MCP_STDIO),
-        context=RuntimeContext(surface=ToolSurface.MCP_STDIO, mode="enforce"),
+        manifest_cache=ManifestCache({}, surface=ToolSurface.SWARM),
+        context=RuntimeContext(surface=ToolSurface.SWARM, mode="observe"),
     )
 
-    governed.register(_ReadTool())
+    governed.register(_RemoteReadTool())
 
-    assert "new_read" in governed.tool_names
-    assert governed.manifest_cache.get("new_read").risk_level == RiskLevel.R0_READ
-    assert json.loads(governed.execute("new_read", {})) == {"status": "ok"}
+    assert "mcp_counting" in governed
+    proxy = governed.get("mcp_counting")
+    assert proxy is not inner.get("mcp_counting")
+    assert isinstance(proxy, _RemoteReadTool)
+    assert proxy.name == "mcp_counting"
+    assert proxy.description == "remote counting"
+    assert governed.manifest_cache.get("mcp_counting").risk_level == RiskLevel.R2_NETWORK

--- a/agent/tests/governance/test_live_connector_route_governance.py
+++ b/agent/tests/governance/test_live_connector_route_governance.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+import pytest
+
+from src.api import live_routes
+from src.governance.budget import BudgetManager, BudgetSnapshot
+from src.governance.decisions import RuntimeContext, build_param_audit
+from src.governance.errors import PolicyDenied
+
+
+class _FakeAdapter:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def call_tool(self, remote_tool: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        payload = dict(arguments)
+        self.calls.append({"remote_tool": remote_tool, "arguments": payload})
+        return {"status": "ok", "remote_tool": remote_tool, "arguments": payload}
+
+
+class _AllowLiveWriteProvider:
+    def get_live_state(self, context: RuntimeContext) -> dict[str, bool]:
+        del context
+        return {
+            "mandate_active": True,
+            "kill_switch_clear": True,
+            "live_order_guard": True,
+        }
+
+    def get_user_auth_state(self, context: RuntimeContext) -> dict[str, bool]:
+        del context
+        return {"explicit_user_consent": True}
+
+    def get_budget_state(self, context: RuntimeContext) -> dict[str, bool]:
+        del context
+        return {"connector_profile_selected": True}
+
+
+class _CaptureRecorder:
+    def __init__(self) -> None:
+        self.decisions: list[Any] = []
+        self.denied: list[Any] = []
+        self.warnings: list[Any] = []
+
+    def record(self, decision: Any, *, manifest: Any = None) -> None:
+        del manifest
+        self.decisions.append(decision)
+
+    def record_denied(self, decision: Any, *, trace_status: str, shadow: bool) -> None:
+        self.denied.append((decision, trace_status, shadow))
+
+    def record_warning(self, decision: Any) -> None:
+        self.warnings.append(decision)
+
+
+class _FailingRecorder(_CaptureRecorder):
+    def record(self, decision: Any, *, manifest: Any = None) -> None:
+        del decision, manifest
+        raise RuntimeError("trace unavailable")
+
+
+class _FailingStateProvider:
+    def get_live_state(self, context: RuntimeContext) -> dict[str, bool]:
+        del context
+        raise RuntimeError("state backend unavailable")
+
+    def get_user_auth_state(self, context: RuntimeContext) -> dict[str, bool]:
+        del context
+        return {"explicit_user_consent": True}
+
+    def get_budget_state(self, context: RuntimeContext) -> dict[str, bool]:
+        del context
+        return {"connector_profile_selected": True}
+
+
+def _call_live_write(
+    *,
+    params: dict[str, Any] | None = None,
+    operation: str = "submit_order",
+    state_provider: Any = None,
+    recorder: Any = None,
+    budget_manager: BudgetManager | None = None,
+) -> tuple[dict[str, Any], _FakeAdapter, Any]:
+    adapter = _FakeAdapter()
+    recorder = recorder or _CaptureRecorder()
+    result = live_routes._call_live_write_tool_governed(
+        broker="robinhood",
+        adapter=adapter,
+        remote_tool=f"remote_{operation}",
+        params=params or {"symbol": "AAPL", "side": "buy", "qty": 1},
+        operation=operation,
+        state_provider=state_provider,
+        decision_recorder=recorder,
+        budget_manager=budget_manager,
+    )
+    return result, adapter, recorder
+
+
+def test_live_submit_without_authoritative_state_denies_before_adapter_call() -> None:
+    adapter = _FakeAdapter()
+
+    with pytest.raises(PolicyDenied) as exc_info:
+        live_routes._call_live_write_tool_governed(
+            broker="robinhood",
+            adapter=adapter,
+            remote_tool="remote_submit_order",
+            params={"symbol": "AAPL", "side": "buy", "qty": 1},
+            operation="submit_order",
+            decision_recorder=_CaptureRecorder(),
+        )
+
+    assert exc_info.value.decision.rule_id == "P40"
+    assert adapter.calls == []
+
+
+def test_live_cancel_without_authoritative_state_denies_before_adapter_call() -> None:
+    adapter = _FakeAdapter()
+
+    with pytest.raises(PolicyDenied) as exc_info:
+        live_routes._call_live_write_tool_governed(
+            broker="robinhood",
+            adapter=adapter,
+            remote_tool="remote_cancel_order",
+            params={"action": "cancel", "order_id": "ord_123"},
+            operation="cancel_order",
+            decision_recorder=_CaptureRecorder(),
+        )
+
+    assert exc_info.value.decision.rule_id == "P40"
+    assert adapter.calls == []
+
+
+def test_live_write_ignores_forged_state_in_adapter_params() -> None:
+    adapter = _FakeAdapter()
+    forged_params = {
+        "symbol": "AAPL",
+        "side": "buy",
+        "qty": 1,
+        "live_state": {
+            "mandate_active": True,
+            "kill_switch_clear": True,
+            "live_order_guard": True,
+        },
+        "user_auth_state": {"explicit_user_consent": True},
+        "budget_state": {"connector_profile_selected": True},
+    }
+
+    with pytest.raises(PolicyDenied) as exc_info:
+        live_routes._call_live_write_tool_governed(
+            broker="robinhood",
+            adapter=adapter,
+            remote_tool="remote_submit_order",
+            params=forged_params,
+            operation="submit_order",
+            decision_recorder=_CaptureRecorder(),
+        )
+
+    assert exc_info.value.decision.rule_id == "P40"
+    assert adapter.calls == []
+
+
+def test_live_write_with_authoritative_provider_reaches_adapter_once() -> None:
+    params = {"symbol": "AAPL", "side": "buy", "qty": 1}
+
+    result, adapter, _recorder = _call_live_write(
+        params=params,
+        state_provider=_AllowLiveWriteProvider(),
+    )
+
+    assert result["status"] == "ok"
+    assert adapter.calls == [{"remote_tool": "remote_submit_order", "arguments": params}]
+
+
+def test_live_write_trace_failure_denies_before_adapter_call() -> None:
+    adapter = _FakeAdapter()
+
+    with pytest.raises(PolicyDenied) as exc_info:
+        live_routes._call_live_write_tool_governed(
+            broker="robinhood",
+            adapter=adapter,
+            remote_tool="remote_submit_order",
+            params={"symbol": "AAPL", "side": "buy", "qty": 1},
+            operation="submit_order",
+            state_provider=_AllowLiveWriteProvider(),
+            decision_recorder=_FailingRecorder(),
+        )
+
+    assert exc_info.value.decision.rule_id == "trace_record_failed"
+    assert adapter.calls == []
+
+
+def test_live_write_state_provider_failure_denies_before_adapter_call() -> None:
+    adapter = _FakeAdapter()
+
+    with pytest.raises(PolicyDenied) as exc_info:
+        live_routes._call_live_write_tool_governed(
+            broker="robinhood",
+            adapter=adapter,
+            remote_tool="remote_submit_order",
+            params={"symbol": "AAPL", "side": "buy", "qty": 1},
+            operation="submit_order",
+            state_provider=_FailingStateProvider(),
+            decision_recorder=_CaptureRecorder(),
+        )
+
+    assert exc_info.value.decision.rule_id == "state_provider_failed"
+    assert adapter.calls == []
+
+
+def test_live_write_budget_denial_happens_before_adapter_call() -> None:
+    adapter = _FakeAdapter()
+    recorder = _CaptureRecorder()
+
+    with pytest.raises(PolicyDenied) as exc_info:
+        live_routes._call_live_write_tool_governed(
+            broker="robinhood",
+            adapter=adapter,
+            remote_tool="remote_submit_order",
+            params={"symbol": "AAPL", "side": "buy", "qty": 1},
+            operation="submit_order",
+            state_provider=_AllowLiveWriteProvider(),
+            decision_recorder=recorder,
+            budget_manager=BudgetManager(BudgetSnapshot(max_tool_calls=0)),
+        )
+
+    assert exc_info.value.decision.rule_id == "budget_exceeded"
+    assert adapter.calls == []
+
+
+def test_live_write_decision_hash_matches_adapter_arguments() -> None:
+    params = {"symbol": "AAPL", "side": "buy", "qty": 1}
+
+    _result, adapter, recorder = _call_live_write(
+        params=params,
+        state_provider=_AllowLiveWriteProvider(),
+    )
+
+    audit = build_param_audit(adapter.calls[0]["arguments"])
+    assert recorder.decisions[0].params_hash == audit.params_hash
+    assert recorder.decisions[0].params_preview == audit.preview
+
+
+def test_build_live_runner_submit_path_uses_governed_boundary_only() -> None:
+    source = inspect.getsource(live_routes._build_live_runner)
+    submit_start = source.index("def _submit")
+    submit_end = source.index("svc = ", submit_start)
+    submit_block = source[submit_start:submit_end]
+
+    assert "_call_live_write_tool_governed" in submit_block
+    assert "adapter.call_tool" not in submit_block
+    assert "adapter.call_tool(remote_tool, {})" in source

--- a/agent/tests/governance/test_manifest_discovery.py
+++ b/agent/tests/governance/test_manifest_discovery.py
@@ -31,7 +31,18 @@ def test_manifest_contains_all_phase0_inventory_tools() -> None:
     inventory_names = {row["name"] for row in inventory}
     manifest_names = {cache.get(name).name for name in inventory_names}
     assert manifest_names == inventory_names
-    assert all(cache.get(name).risk_level != RiskLevel.UNCLASSIFIED for name in inventory_names)
+    unclassified = [
+        name
+        for name in sorted(inventory_names)
+        if cache.get(name).risk_level.value == RiskLevel.UNCLASSIFIED.value
+    ]
+    assert unclassified == []
+
+
+def test_registry_discovery_ignores_test_module_tool_subclasses() -> None:
+    registry = build_registry(include_shell_tools=True, interactive=False)
+
+    assert "sample_read" not in registry.tool_names
 
 
 def test_bash_is_r5_shell() -> None:
@@ -58,6 +69,27 @@ def test_unknown_new_tool_is_unclassified() -> None:
 
     manifest = discover_tool_manifest(NewTool(), surface=ToolSurface.CLI)
 
+    assert manifest.risk_level == RiskLevel.UNCLASSIFIED
+
+
+def test_unknown_readonly_registered_tool_stays_unclassified() -> None:
+    class UnknownReadonlyTool(BaseTool):
+        name = "unknown_readonly_tool"
+        description = "claims readonly but has no reviewed namespace"
+        parameters = {"type": "object", "properties": {}}
+        is_readonly = True
+
+        def execute(self, **kwargs):
+            return "{}"
+
+    inner = ToolRegistry()
+    cache = ManifestCache({}, surface=ToolSurface.CLI)
+    governed = GovernedToolRegistry(inner, manifest_cache=cache)
+
+    governed.register(UnknownReadonlyTool())
+
+    manifest = cache.get("unknown_readonly_tool")
+    assert manifest.readonly is True
     assert manifest.risk_level == RiskLevel.UNCLASSIFIED
 
 

--- a/agent/tests/governance/test_route_governance_coverage.py
+++ b/agent/tests/governance/test_route_governance_coverage.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import importlib
+import inspect
+import types
+from unittest.mock import patch
+
+from src.agent.tools import ToolRegistry
+from src.governance.manifest import ToolSurface
+from src.governance.runtime import GovernedToolRegistry
+from src.tools import build_filtered_registry, build_registry, build_swarm_registry
+
+
+def test_raw_registry_factories_remain_non_execution_helpers() -> None:
+    registry = build_registry(interactive=False)
+    filtered = build_filtered_registry([], include_shell_tools=False)
+
+    assert isinstance(registry, ToolRegistry)
+    assert isinstance(filtered, ToolRegistry)
+    assert not isinstance(registry, GovernedToolRegistry)
+    assert not isinstance(filtered, GovernedToolRegistry)
+
+
+def test_swarm_worker_factory_returns_governed_registry() -> None:
+    registry = build_swarm_registry(["read_file"])
+
+    assert isinstance(registry, GovernedToolRegistry)
+    assert registry.context.surface == ToolSurface.SWARM
+
+
+def test_mcp_server_tool_execution_registry_is_governed() -> None:
+    mcp_server = importlib.import_module("mcp_server")
+    raw = ToolRegistry()
+
+    old_registry = mcp_server._registry
+    old_include_shell_tools = mcp_server._include_shell_tools
+    old_surface = mcp_server._governance_surface
+    try:
+        mcp_server._registry = None
+        mcp_server._include_shell_tools = False
+        mcp_server._governance_surface = "mcp_sse"
+        with patch("src.tools.build_registry", return_value=raw):
+            registry = mcp_server._get_registry()
+    finally:
+        mcp_server._registry = old_registry
+        mcp_server._include_shell_tools = old_include_shell_tools
+        mcp_server._governance_surface = old_surface
+
+    assert isinstance(registry, GovernedToolRegistry)
+    assert registry.context.surface == ToolSurface.MCP_SSE
+
+
+def test_session_service_agent_route_wraps_registry_after_build() -> None:
+    from src.session.service import SessionService
+
+    source = inspect.getsource(SessionService._run_with_agent)
+    build_idx = source.find("build_registry(")
+    govern_idx = source.find("govern_registry(")
+
+    assert build_idx != -1
+    assert govern_idx != -1
+    assert govern_idx > build_idx
+
+
+def test_cli_agent_route_wraps_registry_before_agent_loop() -> None:
+    legacy = importlib.import_module("cli._legacy")
+    captured: dict[str, object] = {}
+
+    class _StubAgentLoop:
+        def __init__(self, *, registry, llm, event_callback, max_iterations, persistent_memory) -> None:
+            del llm, event_callback, max_iterations, persistent_memory
+            captured["registry"] = registry
+            self.memory = types.SimpleNamespace(run_dir=None)
+
+        def cancel(self) -> None:
+            captured["cancelled"] = True
+
+        def run(self, **kwargs):
+            captured["run_kwargs"] = kwargs
+            return {"content": "ok"}
+
+    with patch("src.tools.build_registry", return_value=ToolRegistry()), patch(
+        "src.agent.loop.AgentLoop", _StubAgentLoop
+    ), patch("src.providers.chat.ChatLLM", lambda *args, **kwargs: object()), patch(
+        "src.memory.persistent.PersistentMemory",
+        lambda *args, **kwargs: types.SimpleNamespace(run_dir=None),
+    ), patch(
+        "src.config.loader.load_agent_config", return_value=types.SimpleNamespace(mcp_servers={})
+    ):
+        legacy._run_agent("hello", stream_output=False, session_id="cli-session")
+
+    registry = captured["registry"]
+    assert isinstance(registry, GovernedToolRegistry)
+    assert registry.context.surface == ToolSurface.CLI
+
+
+def test_scheduled_research_executor_does_not_construct_raw_tool_registry() -> None:
+    from src.scheduled_research.executor import ScheduledResearchExecutor
+
+    source = inspect.getsource(ScheduledResearchExecutor)
+
+    assert "build_registry" not in source
+    assert "build_filtered_registry" not in source
+    assert "registry.execute" not in source

--- a/agent/tests/governance/test_route_governance_coverage.py
+++ b/agent/tests/governance/test_route_governance_coverage.py
@@ -5,6 +5,8 @@ import inspect
 import types
 from unittest.mock import patch
 
+import pytest
+
 from src.agent.tools import ToolRegistry
 from src.governance.manifest import ToolSurface
 from src.governance.runtime import GovernedToolRegistry
@@ -28,7 +30,18 @@ def test_swarm_worker_factory_returns_governed_registry() -> None:
     assert registry.context.surface == ToolSurface.SWARM
 
 
-def test_mcp_server_tool_execution_registry_is_governed() -> None:
+@pytest.mark.parametrize(
+    ("surface_name", "expected_surface"),
+    [
+        ("mcp_stdio", ToolSurface.MCP_STDIO),
+        ("mcp_sse", ToolSurface.MCP_SSE),
+        ("mcp_http", ToolSurface.MCP_HTTP),
+    ],
+)
+def test_mcp_server_tool_execution_registry_variants_are_governed(
+    surface_name: str,
+    expected_surface: ToolSurface,
+) -> None:
     mcp_server = importlib.import_module("mcp_server")
     raw = ToolRegistry()
 
@@ -38,7 +51,7 @@ def test_mcp_server_tool_execution_registry_is_governed() -> None:
     try:
         mcp_server._registry = None
         mcp_server._include_shell_tools = False
-        mcp_server._governance_surface = "mcp_sse"
+        mcp_server._governance_surface = surface_name
         with patch("src.tools.build_registry", return_value=raw):
             registry = mcp_server._get_registry()
     finally:
@@ -47,7 +60,7 @@ def test_mcp_server_tool_execution_registry_is_governed() -> None:
         mcp_server._governance_surface = old_surface
 
     assert isinstance(registry, GovernedToolRegistry)
-    assert registry.context.surface == ToolSurface.MCP_SSE
+    assert registry.context.surface == expected_surface
 
 
 def test_session_service_agent_route_wraps_registry_after_build() -> None:

--- a/agent/tests/governance/test_surface_policies.py
+++ b/agent/tests/governance/test_surface_policies.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from src.agent.tools import BaseTool, ToolRegistry
 from src.governance.decisions import RuntimeContext
 from src.governance.discovery import ManifestCache
+from src.governance.errors import PolicyDenied
 from src.governance.manifest import RiskLevel, ToolManifest, ToolSurface
 from src.governance.policy_engine import PolicyEngine
 from src.governance.runtime import GovernedToolRegistry
@@ -23,6 +26,23 @@ class _LiveGuardStillRunsTool(BaseTool):
     def execute(self, **kwargs):
         self.calls += 1
         return json.dumps({"status": "blocked", "reason": "live guard denied"})
+
+
+class _StaticStateProvider:
+    def __init__(self, *, live_state: dict[str, bool] | None = None) -> None:
+        self.live_state = live_state or {}
+
+    def get_live_state(self, context: RuntimeContext) -> dict[str, bool]:
+        del context
+        return dict(self.live_state)
+
+    def get_user_auth_state(self, context: RuntimeContext) -> dict[str, bool]:
+        del context
+        return {}
+
+    def get_budget_state(self, context: RuntimeContext) -> dict[str, bool]:
+        del context
+        return {}
 
 
 def _manifest(
@@ -101,7 +121,7 @@ def test_swarm_cannot_inject_mcp_url_via_prompt() -> None:
     assert decision.rule_id == "P35"
 
 
-def test_r4_requires_live_guard_but_does_not_replace_it() -> None:
+def test_r4_rejects_forged_runtime_context_live_state() -> None:
     engine = PolicyEngine()
     manifest = _manifest(
         name="trading_place_order",
@@ -125,8 +145,8 @@ def test_r4_requires_live_guard_but_does_not_replace_it() -> None:
             },
         ),
     )
-    assert decision.action == "allow"
-    assert "live_order_guard" in decision.required_checks
+    assert decision.action == "deny"
+    assert decision.rule_id == "P40"
 
     tool = _LiveGuardStillRunsTool()
     inner = ToolRegistry()
@@ -137,6 +157,41 @@ def test_r4_requires_live_guard_but_does_not_replace_it() -> None:
         context=RuntimeContext(
             surface=ToolSurface.LIVE_CONNECTOR,
             mode="enforce",
+            live_state={
+                "mandate_active": True,
+                "kill_switch_clear": True,
+                "explicit_user_consent": True,
+                "live_order_guard": True,
+                "connector_profile_selected": True,
+            },
+        ),
+    )
+
+    with pytest.raises(PolicyDenied):
+        governed.execute("trading_place_order", {"symbol": "AAPL"})
+    assert tool.calls == 0
+
+
+def test_r4_requires_authoritative_provider_but_does_not_replace_live_guard() -> None:
+    manifest = _manifest(
+        name="trading_place_order",
+        surface=ToolSurface.LIVE_CONNECTOR,
+        risk=RiskLevel.R4_TRADE_WRITE,
+        readonly=False,
+    )
+
+    tool = _LiveGuardStillRunsTool()
+    inner = ToolRegistry()
+    inner.register(tool)
+    governed = GovernedToolRegistry(
+        inner,
+        manifest_cache=ManifestCache({"trading_place_order": manifest}, surface=ToolSurface.LIVE_CONNECTOR),
+        context=RuntimeContext(
+            surface=ToolSurface.LIVE_CONNECTOR,
+            mode="enforce",
+            live_state={"mandate_active": False},
+        ),
+        state_provider=_StaticStateProvider(
             live_state={
                 "mandate_active": True,
                 "kill_switch_clear": True,

--- a/agent/tests/reliability/test_circuit_breaker.py
+++ b/agent/tests/reliability/test_circuit_breaker.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from typing import Any
 
+import src.reliability.data.circuit_breaker as circuit_breaker_module
 from src.reliability.data.circuit_breaker import CircuitBreaker
 
 
@@ -35,3 +40,71 @@ def test_circuit_breaker_skip_records_warning(tmp_path: Path) -> None:
     assert decision.allowed is False
     assert decision.warning is not None
     assert decision.warning.code == "DATA_SOURCE_SKIPPED_BY_CIRCUIT"
+
+
+def test_record_failure_is_atomic_for_concurrent_new_source(tmp_path: Path, monkeypatch) -> None:
+    worker_count = 12
+    breaker = CircuitBreaker(
+        tmp_path / "breaker.sqlite",
+        failure_threshold=worker_count,
+        open_seconds=60,
+    )
+    original_snapshot = breaker.snapshot
+    barrier = threading.Barrier(worker_count)
+
+    def stale_snapshot(source: str):
+        snapshot = original_snapshot(source)
+        barrier.wait(timeout=5)
+        return snapshot
+
+    monkeypatch.setattr(breaker, "snapshot", stale_snapshot)
+
+    def fail_once(_index: int) -> None:
+        breaker.record_failure("new_source", RuntimeError("boom"))
+
+    with ThreadPoolExecutor(max_workers=worker_count) as pool:
+        list(pool.map(fail_once, range(worker_count)))
+
+    snapshot = original_snapshot("new_source")
+    assert snapshot.consecutive_failures == worker_count
+    assert snapshot.state == "OPEN"
+
+
+def test_circuit_breaker_connections_close_for_operations(tmp_path: Path, monkeypatch) -> None:
+    real_connect = sqlite3.connect
+    opened: list["_TrackingConnection"] = []
+
+    class _TrackingConnection:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self._conn = real_connect(*args, **kwargs)
+            self.closed = False
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(self._conn, name)
+
+        def __enter__(self) -> "_TrackingConnection":
+            self._conn.__enter__()
+            return self
+
+        def __exit__(self, *args: Any) -> bool | None:
+            return self._conn.__exit__(*args)
+
+        def close(self) -> None:
+            self.closed = True
+            self._conn.close()
+
+    def tracking_connect(*args: Any, **kwargs: Any) -> _TrackingConnection:
+        conn = _TrackingConnection(*args, **kwargs)
+        opened.append(conn)
+        return conn
+
+    monkeypatch.setattr(circuit_breaker_module.sqlite3, "connect", tracking_connect)
+
+    breaker = CircuitBreaker(tmp_path / "breaker.sqlite", failure_threshold=2, open_seconds=0)
+    breaker.record_failure("yahoo", RuntimeError("rate limited"))
+    breaker.before_request("yahoo")
+    breaker.record_success("yahoo")
+    breaker.snapshot("yahoo")
+
+    assert opened
+    assert all(conn.closed for conn in opened)

--- a/agent/tests/research_card/test_research_card_api.py
+++ b/agent/tests/research_card/test_research_card_api.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -112,6 +114,46 @@ def test_research_artifact_and_protocol_read_endpoints(tmp_path: Path, monkeypat
     assert artifact_response.json()["artifact"]["artifact_id"] == record.artifact_id
     assert protocol_response.status_code == 200
     assert protocol_response.json()["protocol_id"] == "proto_api"
+
+
+def test_research_artifact_path_traversal_returns_404_without_leaking_path(
+    tmp_path: Path,
+    monkeypatch,
+    caplog,
+) -> None:
+    client = _client(tmp_path, monkeypatch)
+    store = ArtifactStore(root=tmp_path / "artifacts")
+    record = store.write_json(
+        {"token": "sk-test-secret-abcdefghijklmnopqrstuvwxyz"},
+        artifact_type="research_protocol",
+        generated_by="test",
+        metadata={"protocol_id": "escaped"},
+        schema_version="1.0.0",
+    )
+    assert record is not None
+    escaped = tmp_path / "outside-secret" / "secret-token.json"
+    escaped.parent.mkdir(parents=True)
+    escaped.write_text('{"token":"sk-escaped-secret-abcdefghijklmnopqrstuvwxyz"}', encoding="utf-8")
+    with sqlite3.connect(str(store.index_path)) as conn:
+        conn.execute(
+            "UPDATE artifacts SET path = ? WHERE artifact_id = ?",
+            (str(escaped), record.artifact_id),
+        )
+        conn.commit()
+
+    with caplog.at_level(logging.WARNING):
+        response = client.get(f"/research/artifacts/{record.artifact_id}")
+
+    body = response.text
+    assert response.status_code == 404
+    assert str(escaped) not in body
+    assert "secret-token" not in body
+    assert "sk-escaped-secret" not in body
+    messages = [item.getMessage() for item in caplog.records]
+    assert any("artifact path escapes artifact root" in message for message in messages)
+    assert any(record.artifact_id in message for message in messages)
+    assert all(str(escaped) not in message for message in messages)
+    assert all("secret-token" not in message for message in messages)
 
 
 def test_tool_manifest_api_is_read_only(tmp_path: Path, monkeypatch) -> None:

--- a/agent/tests/research_protocol/test_trial_ledger_concurrency.py
+++ b/agent/tests/research_protocol/test_trial_ledger_concurrency.py
@@ -4,6 +4,7 @@ import sqlite3
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -76,3 +77,89 @@ def test_sqlite_locked_retries(tmp_path: Path) -> None:
 
     assert event.sequence_number == 1
     assert ledger.verify().valid is True
+
+
+def test_trial_ledger_append_closes_success_connection(tmp_path: Path, monkeypatch) -> None:
+    path = tmp_path / "ledger.sqlite"
+    ledger = TrialLedger(path)
+
+    class _Cursor:
+        def fetchone(self) -> None:
+            return None
+
+    class _SuccessConnection:
+        def __init__(self) -> None:
+            self.closed = False
+            self.committed = False
+            self.rolled_back = False
+
+        def execute(self, _sql: str, _params: Any = None) -> _Cursor:
+            return _Cursor()
+
+        def commit(self) -> None:
+            self.committed = True
+
+        def rollback(self) -> None:
+            self.rolled_back = True
+
+        def close(self) -> None:
+            self.closed = True
+
+    conn = _SuccessConnection()
+    monkeypatch.setattr(ledger, "_connect", lambda timeout=30.0: conn)
+
+    event = ledger.append(
+        protocol_hash=GOLDEN_PROTOCOL_HASH,
+        event_type=TrialEventType.TRIAL_STARTED,
+        payload={"trial_id": "success-close"},
+    )
+
+    assert event.sequence_number == 1
+    assert conn.committed is True
+    assert conn.rolled_back is False
+    assert conn.closed is True
+
+
+def test_trial_ledger_append_closes_each_locked_retry_on_terminal_failure(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    path = tmp_path / "ledger.sqlite"
+    ledger = TrialLedger(path, write_retry_count=3, write_retry_delay_ms=0)
+
+    class _LockedConnection:
+        def __init__(self) -> None:
+            self.closed = False
+            self.rolled_back = False
+
+        def execute(self, _sql: str, _params: Any = None) -> None:
+            raise sqlite3.OperationalError("database is locked")
+
+        def rollback(self) -> None:
+            self.rolled_back = True
+
+        def close(self) -> None:
+            self.closed = True
+
+    conns: list[_LockedConnection] = []
+
+    def connect(*, timeout: float = 30.0) -> _LockedConnection:
+        del timeout
+        conn = _LockedConnection()
+        conns.append(conn)
+        return conn
+
+    monkeypatch.setattr(ledger, "_connect", connect)
+    monkeypatch.setattr("src.research_protocol.ledger.time.sleep", lambda _delay: None)
+    monkeypatch.setattr("src.research_protocol.ledger.random.uniform", lambda _low, _high: 0.0)
+
+    with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+        ledger.append(
+            protocol_hash=GOLDEN_PROTOCOL_HASH,
+            event_type=TrialEventType.TRIAL_STARTED,
+            payload={"trial_id": "terminal-locked"},
+        )
+
+    assert len(conns) == 3
+    assert all(conn.rolled_back for conn in conns)
+    assert all(conn.closed for conn in conns)

--- a/agent/tests/security/test_phase6_evidence_research_card_security.py
+++ b/agent/tests/security/test_phase6_evidence_research_card_security.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+import api_server
+
+
+def _client(tmp_path: Path, monkeypatch) -> TestClient:
+    monkeypatch.setattr(api_server, "RUNS_DIR", tmp_path / "runs")
+    return TestClient(api_server.app, client=("127.0.0.1", 50000))
+
+
+def test_run_detail_research_card_payload_redacts_secret_like_values(tmp_path: Path, monkeypatch) -> None:
+    client = _client(tmp_path, monkeypatch)
+    run_dir = tmp_path / "runs" / "run_secret_card"
+    run_dir.mkdir(parents=True)
+    (run_dir / "state.json").write_text(
+        json.dumps({"status": "success", "created_at": "2026-01-01T00:00:00Z"}),
+        encoding="utf-8",
+    )
+    (run_dir / "research_card.json").write_text(
+        json.dumps(
+            {
+                "card_id": "card_secret",
+                "schema_version": "1.0.0",
+                "title": "Secret fixture",
+                "hypothesis": "Authorization: Bearer fixture-token",
+                "benchmark": {"primary": "sk-test-123456"},
+                "cost_model": {"api_key": "sk-test-123456"},
+                "warnings": [
+                    {
+                        "code": "SECRET_FIXTURE",
+                        "message": "AWS_SECRET_ACCESS_KEY=fixture",
+                    }
+                ],
+                "conclusion_level": "exploratory",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    response = client.get("/runs/run_secret_card")
+
+    assert response.status_code == 200
+    raw = response.text
+    assert "fixture-token" not in raw
+    assert "sk-test-123456" not in raw
+    assert "AWS_SECRET_ACCESS_KEY=fixture" not in raw
+    assert "[REDACTED]" in raw

--- a/agent/tests/test_agent_loop_policy_denied_payload.py
+++ b/agent/tests/test_agent_loop_policy_denied_payload.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pytest
+
+from src.agent import loop as agent_loop
+
+
+def test_policy_denied_payload_handles_value_error(monkeypatch) -> None:
+    def raise_value_error(_result: str):
+        raise ValueError("decoder rejected payload")
+
+    monkeypatch.setattr(agent_loop.json, "loads", raise_value_error)
+
+    assert agent_loop._policy_denied_payload("{bad json}") is None
+
+
+def test_policy_denied_payload_does_not_swallow_keyboard_interrupt(monkeypatch) -> None:
+    def raise_keyboard_interrupt(_result: str):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(agent_loop.json, "loads", raise_keyboard_interrupt)
+
+    with pytest.raises(KeyboardInterrupt):
+        agent_loop._policy_denied_payload("{}")
+
+
+def test_policy_denied_payload_does_not_swallow_system_exit(monkeypatch) -> None:
+    def raise_system_exit(_result: str):
+        raise SystemExit(2)
+
+    monkeypatch.setattr(agent_loop.json, "loads", raise_system_exit)
+
+    with pytest.raises(SystemExit):
+        agent_loop._policy_denied_payload("{}")

--- a/frontend/src/components/research/DataProvenancePanel.tsx
+++ b/frontend/src/components/research/DataProvenancePanel.tsx
@@ -1,5 +1,7 @@
 import { Database } from "lucide-react";
 
+import { redactDisplayText } from "./redaction";
+
 export interface DataSourceSummary {
   audit_id?: string;
   source?: string;
@@ -32,10 +34,10 @@ export function DataProvenancePanel({ dataSources = [] }: { dataSources?: DataSo
             <tbody>
               {dataSources.map((source, index) => (
                 <tr key={source.audit_id || index} className="border-b last:border-0">
-                  <td className="py-2 pr-4 font-mono text-xs">{source.source || "unknown"}</td>
-                  <td className="py-2 pr-4 font-mono text-xs">{source.selected_source || "unknown"}</td>
+                  <td className="py-2 pr-4 font-mono text-xs">{redactDisplayText(source.source || "unknown")}</td>
+                  <td className="py-2 pr-4 font-mono text-xs">{redactDisplayText(source.selected_source || "unknown")}</td>
                   <td className="py-2 pr-4 text-xs text-muted-foreground">
-                    {(source.fallback_chain || []).join(" -> ") || "None recorded"}
+                    {(source.fallback_chain || []).map(redactDisplayText).join(" -> ") || "None recorded"}
                   </td>
                   <td className="py-2 text-right tabular-nums">{source.row_count ?? "-"}</td>
                 </tr>

--- a/frontend/src/components/research/PITWarningsPanel.tsx
+++ b/frontend/src/components/research/PITWarningsPanel.tsx
@@ -1,5 +1,7 @@
 import { AlertTriangle } from "lucide-react";
 
+import { redactDisplayText } from "./redaction";
+
 export interface StructuredIssue {
   code: string;
   severity?: string;
@@ -29,8 +31,8 @@ export function PITWarningsPanel({
         <ul className="space-y-2 text-sm">
           {items.map((item) => (
             <li key={`${item.severity || "warning"}-${item.code}`} className="rounded-md border border-amber-500/25 bg-amber-500/5 p-2">
-              <div className="font-mono text-xs font-medium">{item.code}</div>
-              {item.message && <div className="mt-1 text-xs text-muted-foreground">{item.message}</div>}
+              <div className="font-mono text-xs font-medium">{redactDisplayText(item.code)}</div>
+              {item.message && <div className="mt-1 text-xs text-muted-foreground">{redactDisplayText(item.message)}</div>}
             </li>
           ))}
         </ul>

--- a/frontend/src/components/research/PolicyDecisionsPanel.tsx
+++ b/frontend/src/components/research/PolicyDecisionsPanel.tsx
@@ -1,5 +1,7 @@
 import { ShieldCheck } from "lucide-react";
 
+import { redactDisplayText } from "./redaction";
+
 export interface PolicyDecisionSummary {
   decision_id?: string;
   tool_name?: string;
@@ -27,8 +29,8 @@ export function PolicyDecisionsPanel({ decisions = [] }: { decisions?: PolicyDec
         <div className="space-y-1">
           {decisions.map((decision, index) => (
             <div key={decision.decision_id || index} className="flex items-center justify-between gap-3 rounded-md bg-muted/30 px-2 py-1.5 text-xs">
-              <span className="truncate font-mono">{decision.tool_name || "unknown_tool"}</span>
-              <span className="font-mono text-muted-foreground">{decision.rule_id || "no_rule"}</span>
+              <span className="truncate font-mono">{redactDisplayText(decision.tool_name || "unknown_tool")}</span>
+              <span className="font-mono text-muted-foreground">{redactDisplayText(decision.rule_id || "no_rule")}</span>
             </div>
           ))}
         </div>

--- a/frontend/src/components/research/QuantScorecardPanel.tsx
+++ b/frontend/src/components/research/QuantScorecardPanel.tsx
@@ -1,6 +1,7 @@
 import { BarChart3 } from "lucide-react";
 
 import type { StructuredIssue } from "./PITWarningsPanel";
+import { redactDisplayText } from "./redaction";
 
 export interface QuantScorecardSummary {
   scorecard_id?: string;
@@ -27,13 +28,13 @@ export function QuantScorecardPanel({ scorecard }: { scorecard?: QuantScorecardS
         <div className="space-y-3">
           <div className="grid grid-cols-2 gap-2">
             <ScoreStat label="Score" value={formatScore(scorecard.score)} />
-            <ScoreStat label="Conclusion Cap" value={scorecard.conclusion_cap || "unknown"} />
+            <ScoreStat label="Conclusion Cap" value={redactDisplayText(scorecard.conclusion_cap || "unknown")} />
           </div>
           {breakdown.length > 0 && (
             <div className="space-y-1">
               {breakdown.map(([key, value]) => (
                 <div key={key} className="grid grid-cols-[minmax(0,1fr)_4rem] items-center gap-3 text-xs">
-                  <span className="font-mono">{key}</span>
+                  <span className="font-mono">{redactDisplayText(key)}</span>
                   <span className="text-right tabular-nums text-muted-foreground">{formatScore(value)}</span>
                 </div>
               ))}

--- a/frontend/src/components/research/ResearchCardPanel.tsx
+++ b/frontend/src/components/research/ResearchCardPanel.tsx
@@ -4,6 +4,7 @@ import type { QuantScorecardSummary } from "./QuantScorecardPanel";
 import type { DataSourceSummary } from "./DataProvenancePanel";
 import type { PolicyDecisionSummary } from "./PolicyDecisionsPanel";
 import type { StructuredIssue } from "./PITWarningsPanel";
+import { redactDisplayText, redactDisplayValue } from "./redaction";
 
 export interface ResearchCardSummary {
   card_id: string;
@@ -44,8 +45,10 @@ export function ResearchCardPanel({ card }: { card?: ResearchCardSummary | null 
     <section className="rounded-md border bg-card p-4">
       <div className="mb-3 flex flex-wrap items-center gap-2">
         <FileCheck2 className="h-4 w-4 text-muted-foreground" />
-        <h2 className="text-sm font-medium">{card.title || "Research Card"}</h2>
-        <span className="rounded-md bg-muted px-2 py-1 font-mono text-xs">{card.conclusion_level || "exploratory"}</span>
+        <h2 className="text-sm font-medium">{redactDisplayText(card.title || "Research Card")}</h2>
+        <span className="rounded-md bg-muted px-2 py-1 font-mono text-xs">
+          {redactDisplayText(card.conclusion_level || "exploratory")}
+        </span>
         <button
           onClick={() => downloadMarkdown(card)}
           className="ml-auto inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs hover:bg-muted"
@@ -55,7 +58,7 @@ export function ResearchCardPanel({ card }: { card?: ResearchCardSummary | null 
           Export Markdown
         </button>
       </div>
-      {card.hypothesis && <p className="mb-3 text-sm text-muted-foreground">{card.hypothesis}</p>}
+      {card.hypothesis && <p className="mb-3 text-sm text-muted-foreground">{redactDisplayText(card.hypothesis)}</p>}
       <div className="grid gap-2 sm:grid-cols-3">
         <ResearchStat label="Warnings" value={String(warnings.length)} />
         <ResearchStat label="Hard Failures" value={String(hardFailures.length)} tone={hardFailures.length ? "danger" : "normal"} />
@@ -73,8 +76,8 @@ export function ResearchCardPanel({ card }: { card?: ResearchCardSummary | null 
         <div className="mt-3 space-y-2">
           {hardFailures.map((failure) => (
             <div key={failure.code} className="rounded-md border border-red-500/25 bg-red-500/5 p-2 text-sm">
-              <div className="font-mono text-xs font-medium text-danger">{failure.code}</div>
-              {failure.message && <div className="mt-1 text-xs text-muted-foreground">{failure.message}</div>}
+              <div className="font-mono text-xs font-medium text-danger">{redactDisplayText(failure.code)}</div>
+              {failure.message && <div className="mt-1 text-xs text-muted-foreground">{redactDisplayText(failure.message)}</div>}
             </div>
           ))}
         </div>
@@ -94,7 +97,7 @@ function EvidenceBlock({ title, data }: { title: string; data?: Record<string, u
         <div className="space-y-1">
           {entries.slice(0, 4).map(([key, value]) => (
             <div key={key} className="truncate font-mono text-xs">
-              {key}: {formatEvidenceValue(value)}
+              {redactDisplayText(key)}: {formatEvidenceValue(value)}
             </div>
           ))}
         </div>
@@ -128,7 +131,7 @@ function formatEvidenceValue(value: unknown): string {
     return Number.isFinite(value) ? String(value) : "unknown";
   }
   if (typeof value === "string") {
-    return value || "Not recorded";
+    return value ? redactDisplayText(value) : "Not recorded";
   }
   if (typeof value === "boolean") {
     return value ? "true" : "false";
@@ -137,18 +140,18 @@ function formatEvidenceValue(value: unknown): string {
     return value.map(formatEvidenceValue).join(", ");
   }
   if (value && typeof value === "object") {
-    return JSON.stringify(value);
+    return JSON.stringify(redactDisplayValue(value));
   }
   return "Not recorded";
 }
 
 function downloadMarkdown(card: ResearchCardSummary) {
   const lines = [
-    `# Research Card: ${card.title || card.card_id}`,
+    `# Research Card: ${redactDisplayText(card.title || card.card_id)}`,
     "",
-    `- Card ID: \`${card.card_id}\``,
-    `- Schema Version: \`${card.schema_version || "unknown"}\``,
-    `- Conclusion: \`${card.conclusion_level || "exploratory"}\``,
+    `- Card ID: \`${redactDisplayText(card.card_id)}\``,
+    `- Schema Version: \`${redactDisplayText(card.schema_version || "unknown")}\``,
+    `- Conclusion: \`${redactDisplayText(card.conclusion_level || "exploratory")}\``,
     "",
     "## Evidence",
     `- Benchmark: ${formatBenchmark(card.benchmark)}`,
@@ -157,10 +160,10 @@ function downloadMarkdown(card: ResearchCardSummary) {
     ...formatEvidenceLines("OOS", card.oos_results),
     "",
     "## Warnings",
-    ...((card.warnings || []).map((warning) => `- \`${warning.code}\`: ${warning.message || ""}`)),
+    ...((card.warnings || []).map((warning) => `- \`${redactDisplayText(warning.code)}\`: ${warning.message ? redactDisplayText(warning.message) : ""}`)),
     "",
     "## Hard Failures",
-    ...((card.hard_failures || []).map((failure) => `- \`${failure.code}\`: ${failure.message || ""}`)),
+    ...((card.hard_failures || []).map((failure) => `- \`${redactDisplayText(failure.code)}\`: ${failure.message ? redactDisplayText(failure.message) : ""}`)),
     "",
   ];
   const blob = new Blob([lines.join("\n")], { type: "text/markdown;charset=utf-8" });
@@ -177,5 +180,5 @@ function formatEvidenceLines(title: string, data?: Record<string, unknown>): str
   if (entries.length === 0) {
     return [`- ${title}: Not recorded`];
   }
-  return entries.map(([key, value]) => `- ${title} ${key}: ${formatEvidenceValue(value)}`);
+  return entries.map(([key, value]) => `- ${title} ${redactDisplayText(key)}: ${formatEvidenceValue(value)}`);
 }

--- a/frontend/src/components/research/__tests__/ResearchPanels.test.tsx
+++ b/frontend/src/components/research/__tests__/ResearchPanels.test.tsx
@@ -118,4 +118,52 @@ describe("research reliability panels", () => {
     expect(screen.getByText("local_cache")).toBeInTheDocument();
     expect(screen.getByText("local_cache -> vendor")).toBeInTheDocument();
   });
+
+  it("redacts secret-like values before rendering research card evidence", () => {
+    render(
+      <ResearchCardPanel
+        card={{
+          card_id: "card_secret",
+          schema_version: "1.0.0",
+          title: "Secret Fixture",
+          hypothesis: "Authorization: Bearer fixture-token",
+          conclusion_level: "exploratory",
+          cost_model: { api_key: "sk-test-123456", commission_bps: 2 },
+          hard_failures: [{ code: "SECRET_FIXTURE", severity: "hard_failure", message: "AWS_SECRET_ACCESS_KEY=fixture" }],
+          warnings: [],
+        }}
+      />,
+    );
+
+    expect(screen.queryByText(/fixture-token/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/sk-test-123456/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/AWS_SECRET_ACCESS_KEY=fixture/i)).not.toBeInTheDocument();
+    expect(screen.getAllByText("[REDACTED]").length).toBeGreaterThan(0);
+  });
+
+  it("redacts secret-like values in policy, PIT, scorecard, and data provenance panels", () => {
+    render(
+      <>
+        <PolicyDecisionsPanel decisions={[{ decision_id: "pd_1", tool_name: "Authorization: Bearer fixture-token", action: "deny", rule_id: "AWS_SECRET_ACCESS_KEY=fixture" }]} />
+        <PITWarningsPanel warnings={[{ code: "DATA_AVAILABLE_AT_MISSING", severity: "warning", message: "Authorization: Bearer fixture-token" }]} />
+        <QuantScorecardPanel scorecard={{ conclusion_cap: "AWS_SECRET_ACCESS_KEY=fixture", score_breakdown: { "Authorization: Bearer fixture-token": 1 } }} />
+        <DataProvenancePanel dataSources={[{ source: "AWS_SECRET_ACCESS_KEY=fixture", selected_source: "local_cache", fallback_chain: ["Authorization: Bearer fixture-token"] }]} />
+      </>,
+    );
+
+    expect(screen.queryByText(/fixture-token/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/AWS_SECRET_ACCESS_KEY=fixture/i)).not.toBeInTheDocument();
+    expect(screen.getAllByText("[REDACTED]").length).toBeGreaterThan(0);
+  });
+
+  it("renders malicious HTML fixtures as text instead of executable markup", () => {
+    render(
+      <PITWarningsPanel
+        warnings={[{ code: "DATA_AVAILABLE_AT_MISSING", severity: "warning", message: "<script>window.__pwned = true</script>" }]}
+      />,
+    );
+
+    expect(screen.getByText("<script>window.__pwned = true</script>")).toBeInTheDocument();
+    expect((window as unknown as { __pwned?: boolean }).__pwned).toBeUndefined();
+  });
 });

--- a/frontend/src/components/research/redaction.ts
+++ b/frontend/src/components/research/redaction.ts
@@ -1,0 +1,57 @@
+export const REDACTED = "[REDACTED]";
+
+const SECRET_KEY_FRAGMENTS = [
+  "secret",
+  "token",
+  "api_key",
+  "apikey",
+  "password",
+  "credential",
+  "broker",
+  "authorization",
+  "cookie",
+  "session",
+  "private_key",
+  "refresh_token",
+  "access_token",
+];
+
+const BEARER_RE = /^\s*bearer\s+[A-Za-z0-9._~+/=-]{8,}\s*$/i;
+const INLINE_BEARER_RE = /\bauthorization\s*:\s*bearer\s+[^\s,;]+|\bbearer\s+[A-Za-z0-9._~+/=-]{8,}/i;
+const ENV_ASSIGNMENT_SECRET_RE = /\b[A-Z0-9_]*(?:SECRET|TOKEN|API_KEY|ACCESS_KEY|PRIVATE_KEY)[A-Z0-9_]*\s*=\s*[^\s,;]+/i;
+const KEY_PREFIX_RE = /^\s*(sk|rk|pk|ghp|gho|ghu|github_pat)-[A-Za-z0-9_-]{8,}\s*$/i;
+
+export function redactDisplayText(value: string): string {
+  return isSecretLikeText(value) ? REDACTED : value;
+}
+
+export function redactDisplayValue(value: unknown): unknown {
+  if (typeof value === "string") {
+    return redactDisplayText(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map(redactDisplayValue);
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, item]) => {
+        if (isSecretLikeText(key)) {
+          return [REDACTED, REDACTED];
+        }
+        return [key, redactDisplayValue(item)];
+      }),
+    );
+  }
+  return value;
+}
+
+function isSecretLikeText(value: string): boolean {
+  const lowered = value.toLowerCase();
+  return (
+    SECRET_KEY_FRAGMENTS.some((fragment) => lowered.includes(fragment)) ||
+    BEARER_RE.test(value) ||
+    INLINE_BEARER_RE.test(value) ||
+    ENV_ASSIGNMENT_SECRET_RE.test(value) ||
+    KEY_PREFIX_RE.test(value)
+  );
+}


### PR DESCRIPTION
## Summary

This PR is a post-#416 security hardening follow-up. It addresses governance execution-boundary, live-connector, reliability, research-card/evidence, and frontend redaction issues identified in the #416 review, #420, and a local post-merge red-team audit.

The key change is that high-risk tool and live-connector write paths now consistently pass through a governed execution boundary before raw execution. This PR intentionally preserves the stronger governed-proxy + authoritative state-provider design rather than relying on metadata/documentation-only guidance.

## What changed

### Governance execution boundary

- `GovernedToolRegistry.get()` now returns a governed proxy instead of exposing a raw tool.
- `get().execute(...)` routes back through `GovernedToolRegistry.execute()`.
- Public raw-registry access through `.inner` is removed.
- High-risk trace/recorder failures fail closed before raw execution.
- Budget checks run before raw execution.
- Warn mode emits observable `policy_warning` trace records.
- Unknown or self-reported read-only tools are not promoted to safe classifications by fallback behavior.
- Policy decision params hash is kept consistent with executed params.

### P40 / runtime state hardening

- P40 live-write checks now require authoritative `GovernanceStateProvider` state.
- Caller-provided `RuntimeContext.live_state`, `user_auth_state`, and `budget_state` cannot satisfy live-write gates.
- Missing or failing state providers fail closed for live/high-risk writes.

### Live connector governance

- Live submit/cancel write-like paths now pass through a governed pseudo-tool boundary before `adapter.call_tool(...)`.
- Missing provider state, forged state, P40 denial, recorder failure, state-provider failure, and budget exceed all stop before adapter execution.
- Read-only broker/account/position/order reads remain direct and are documented/tested as read-only paths.

### Reliability fixes

- `CircuitBreaker` now closes SQLite connections deterministically.
- `CircuitBreaker.record_failure` is atomic under concurrency.
- TrialLedger retry lifecycle now has regression coverage for closing connections before retry sleep and on terminal failure.

### Research-card / evidence API hardening

- `research_card/api.py` returns `404` plus warning for artifact paths escaping `artifact_root`, instead of returning `500`.
- Escaped filesystem paths are not leaked in responses.
- `/runs/{run_id}` redacts raw `research_card.json` payloads.
- Backend redaction catches inline bearer strings, env-style secrets, and shorter token prefixes.

### Frontend redaction

- Research panels now use shared display/export redaction before rendering sensitive fields.
- Tests cover secret-like fixtures and verify malicious `<script>` content renders as text rather than executable markup.

### Route coverage

- MCP stdio/SSE/HTTP registry construction variants are independently covered.
- CLI startup wraps the raw registry with governance.
- SessionService, swarm, scheduler, and route construction paths are covered by regression tests.

## Issues addressed

### #416 review findings

- B1: `GovernedToolRegistry.get()` raw tool bypass — fixed with tests.
- B2: public `self.inner` raw registry bypass — fixed with tests.
- B3: forgeable `RuntimeContext` state for P40 — fixed with tests.
- C1: bare `except` in policy-denied payload parsing — fixed with tests.
- C2: CircuitBreaker SQLite connection leak — fixed with tests.
- M1: TrialLedger retry connection lifecycle — covered with regression tests.
- M2: research-card path traversal returning 500 — fixed with tests.
- M3: CircuitBreaker TOCTOU race — fixed with tests.

### #420

- Raw `get()` tool bypass — fixed.
- Public inner-registry bypass — fixed.
- Research-card path traversal HTTP status — fixed.
- CircuitBreaker TOCTOU — fixed.
- RuntimeContext state forgeability — fixed.

## Relationship to #422

This PR does not merge #422 directly.

It preserves a stronger governed-proxy design for `get()` and adds authoritative `GovernanceStateProvider` semantics for P40. It also includes equivalent or stronger fixes for the concrete #420 implementation issues, while additionally covering live connector governance, frontend/backend redaction, and broader route-level regression coverage.

## Validation

All final checks passed:

- Governance: 63 passed
- Reliability: 67 passed
- Research protocol: 19 passed
- Research card: 19 passed
- Security regressions: 12 passed
- Phase 6 security: 1 passed
- Agent loop payload: 3 passed
- MCP integration: 13 passed
- Agent/swarm integration: 14 passed
- Live/API selector: 803 passed
- Broad security selector: 1070 passed
- Frontend ResearchPanels: 10 passed
- Frontend api: 13 passed
- Ruff touched backend files: passed

Existing warnings observed: FastAPI/httpx deprecation warnings only.

## Compatibility notes

- `get()` no longer exposes raw executable tool objects through normal public usage. Metadata access is still delegated through the governed proxy.
- Live submit/cancel paths now require the same governed high-risk execution semantics before adapter execution.
- TrialLedger source behavior is unchanged; this PR adds regression coverage for its retry-close lifecycle.

## Remaining follow-ups

No blocking gaps remain based on current static audit and regression tests.

Potential non-blocking follow-ups:

- Deeper OpenAPI snapshot coverage for newly surfaced read-only views.
- Stronger frontend response-schema validation.
- Additional documentation around read-only MCP fallback behavior.
- Cleanup for existing FastAPI/httpx deprecation warnings.