### PR TITLE
fix(backtest): create artifacts dir before writing validation.json

### DIFF
--- a/agent/backtest/engines/base.py
+++ b/agent/backtest/engines/base.py
@@ -474,8 +474,11 @@ class BaseEngine(ABC):
                 config, equity_series, self.trades, self.initial_capital, bars_per_year,
             )
             m["validation"] = v_results
-            # Write validation.json artifact
+            # Write validation.json artifact. The artifacts dir is normally
+            # created by _write_artifacts() below (step 8), so ensure it exists
+            # here to avoid a FileNotFoundError when run_dir/artifacts is absent.
             v_path = run_dir / "artifacts" / "validation.json"
+            v_path.parent.mkdir(parents=True, exist_ok=True)
             v_path.write_text(json.dumps(v_results, indent=2, ensure_ascii=False), encoding="utf-8")
 
         # 8. Artifacts

--- a/agent/tests/test_engine_robustness.py
+++ b/agent/tests/test_engine_robustness.py
@@ -517,3 +517,62 @@ class TestFullBacktestRobustness:
         engine = ChinaAEngine({"initial_cash": 1_000_000})
         engine._execute_bars(dates, data_map, close_df, target_pos, valid_codes)
         assert len(engine.equity_snapshots) == 20
+
+
+# ---------------------------------------------------------------------------
+# 6. Validation artifact — write must not assume artifacts/ already exists
+# ---------------------------------------------------------------------------
+
+
+class TestValidationArtifactDir:
+    def test_validation_json_written_when_artifacts_dir_absent(
+        self, tmp_path: Path
+    ) -> None:
+        """Enabling validation must not crash when run_dir/artifacts is absent.
+
+        The validation.json write (step 7) runs before _write_artifacts()
+        (step 8) creates run_dir/artifacts, so the write must create the
+        directory itself. Regression test for the FileNotFoundError hit when
+        run_dir has no pre-created artifacts/ (e.g. a swarm agent workspace).
+        """
+        dates = pd.bdate_range("2024-04-01", periods=3)
+        bars = pd.DataFrame(
+            {
+                "open": [10.0, 11.0, 12.0],
+                "high": [10.5, 11.5, 12.5],
+                "low": [9.5, 10.5, 11.5],
+                "close": [10.2, 11.2, 12.2],
+                "volume": [1000, 1100, 1200],
+            },
+            index=dates,
+        )
+
+        class FakeLoader:
+            def fetch(self, *args, **kwargs):
+                return {"000001.SZ": bars.copy()}
+
+        class SignalEngine:
+            def generate(self, data_map):
+                return {"000001.SZ": pd.Series(1.0, index=data_map["000001.SZ"].index)}
+
+        run_dir = tmp_path / "run"
+        run_dir.mkdir()
+        assert not (run_dir / "artifacts").exists()
+
+        engine = ChinaAEngine({"initial_cash": 1_000_000})
+        metrics = engine.run_backtest(
+            {
+                "codes": ["000001.SZ"],
+                "start_date": "2024-04-01",
+                "end_date": "2024-04-30",
+                "source": "tushare",
+                "initial_cash": 1_000_000,
+                "validation": {"bootstrap": {"n_bootstrap": 20, "seed": 1}},
+            },
+            FakeLoader(),
+            SignalEngine(),
+            run_dir,
+        )
+
+        assert "validation" in metrics
+        assert (run_dir / "artifacts" / "validation.json").exists()


### PR DESCRIPTION
## What

When `config["validation"]` is set, `BaseEngine.run_backtest()` writes `run_dir/artifacts/validation.json` (step 7) **before** `_write_artifacts()` creates `run_dir/artifacts` (step 8). If that directory doesn't already exist, the write raises `FileNotFoundError` and aborts the backtest.

This surfaced when running an `investment_committee` swarm — the `portfolio_manager` sub-agent's `run_dir` has no pre-created `artifacts/`, so its validation-enabled backtest crashed (the swarm was fault-tolerant and still finished, but the PM's backtest artifact was lost).

## Fix

Ensure the parent directory exists immediately before the write:

```python
v_path = run_dir / "artifacts" / "validation.json"
v_path.parent.mkdir(parents=True, exist_ok=True)
v_path.write_text(...)
```

One line + a short explanatory comment. The bug is not platform-specific.

## Test

Adds `TestValidationArtifactDir` to `tests/test_engine_robustness.py`: runs a backtest with validation enabled against a `run_dir` that has no pre-created `artifacts/`, and asserts `validation.json` is written.

- With the fix: **passes**.
- Reverting only the fix: **fails** with the exact `FileNotFoundError`.
- Full `tests/test_engine_robustness.py`: **32 passed**.

Fixes #427
