### PR TITLE
fix(governance): expose _tools passthrough on GovernedToolRegistry

### DIFF
--- a/agent/src/governance/runtime.py
+++ b/agent/src/governance/runtime.py
@@ -38,6 +38,13 @@ class GovernedToolRegistry:
     def tool_names(self) -> list[str]:
         return list(getattr(self.inner, "tool_names", []))
 
+    @property
+    def _tools(self) -> Any:
+        """Preserve the wrapped registry's private tool map for legacy read
+        access (e.g. AgentContext iterates ``registry._tools`` when rendering the
+        system prompt). Read-only passthrough to the inner ToolRegistry."""
+        return getattr(self.inner, "_tools", {})
+
     def get(self, name: str) -> Any:
         return self.inner.get(name)
 

--- a/agent/tests/governance/test_governed_registry.py
+++ b/agent/tests/governance/test_governed_registry.py
@@ -63,6 +63,22 @@ def _cache(risk: RiskLevel, *, surface: ToolSurface = ToolSurface.CLI) -> Manife
     return ManifestCache({"counting": manifest}, surface=surface)
 
 
+def test_tools_property_passthrough_preserves_legacy_surface() -> None:
+    """AgentContext renders the system prompt via ``registry._tools`` (len +
+    .values()); the governance wrapper must preserve that private-map surface
+    by delegating to the inner ToolRegistry."""
+    inner, tool = _registry()
+    governed = GovernedToolRegistry(
+        inner,
+        manifest_cache=_cache(RiskLevel.R0_READ),
+        context=RuntimeContext(surface=ToolSurface.CLI, mode="off"),
+    )
+
+    assert governed._tools is inner._tools
+    assert len(governed._tools) == 1
+    assert list(governed._tools.values()) == [tool]
+
+
 def test_r4_deny_shadow_denies_in_observe() -> None:
     inner, tool = _registry()
     governed = GovernedToolRegistry(


### PR DESCRIPTION
## Summary

- Restore the `_tools` map on `GovernedToolRegistry` so the agent stops crashing in the session runtime.

## Why

Closes #433. After the IRR-AGL governance stack, the registry gets wrapped in `GovernedToolRegistry` before it reaches `AgentContext`, which reads `self.registry._tools` while building the system prompt (`context.py:189`, `:256`). The wrapper doesn't expose `_tools`, so every agent turn in the session runtime dies with `'GovernedToolRegistry' object has no attribute '_tools'`. It's not mode-gated — `govern_registry` wraps the registry even when governance is `off`.

## Changes

- `src/governance/runtime.py`: add a read-only `_tools` property delegating to `self.inner._tools` (the class already documents that it "preserves the existing ToolRegistry surface").
- `tests/governance/test_governed_registry.py`: regression test for the passthrough (exercises `len()` and `.values()` the way `context.py` uses it).

## Test Plan

- [x] Existing tests pass (`pytest agent/tests/governance -q`)
- [x] New test added
- [x] Tested manually — agent replies again in the Web UI session runtime instead of erroring out

## Checklist

- [x] No changes to protected areas — this only touches `src/governance/`
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows CONTRIBUTING.md guidelines
- [ ] Documentation updated (n/a — internal fix, no user-facing surface change)
