### PR TITLE
feat(providers): add "Kimi for Coding" subscription plan as a distinct provider

### DIFF
--- a/agent/.env.example
+++ b/agent/.env.example
@@ -56,11 +56,19 @@ OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 # ZHIPU_API_KEY=xxx
 # ZHIPU_BASE_URL=https://open.bigmodel.cn/api/paas/v4
 
-# --- Moonshot / Kimi ---
+# --- Moonshot / Kimi (open platform, pay-as-you-go) ---
 # LANGCHAIN_PROVIDER=moonshot
 # LANGCHAIN_MODEL_NAME=kimi-k2.6
 # MOONSHOT_API_KEY=sk-xxx
 # MOONSHOT_BASE_URL=https://api.moonshot.ai/v1
+
+# --- Kimi for Coding (subscription plan; NOT the open platform above) ---
+# Create the key in the Kimi Code console (kimi.com/code/docs). A coding-plan
+# key is rejected by api.moonshot.ai and vice-versa. temperature is forced to 1.
+# LANGCHAIN_PROVIDER=kimi-coding
+# LANGCHAIN_MODEL_NAME=kimi-for-coding
+# KIMI_CODING_API_KEY=sk-kimi-xxx
+# KIMI_CODING_BASE_URL=https://api.kimi.com/coding/v1
 
 # --- MiniMax ---
 # LANGCHAIN_PROVIDER=minimax

--- a/agent/src/providers/capabilities.py
+++ b/agent/src/providers/capabilities.py
@@ -70,6 +70,20 @@ _MOONSHOT_CAPABILITIES = ProviderCapabilities(
     default_headers={"User-Agent": _KIMI_USER_AGENT},
 )
 
+# Kimi for Coding subscription plan (kimi.com/code/docs). Same wire behaviour as
+# the Moonshot open platform, but a different endpoint (api.kimi.com/coding/v1),
+# a stable `kimi-for-coding` model id, and its own key namespace so both surfaces
+# can be configured side by side.
+_KIMI_CODING_CAPABILITIES = ProviderCapabilities(
+    "kimi-coding",
+    "KIMI_CODING_API_KEY",
+    "KIMI_CODING_BASE_URL",
+    capture_reasoning=True,
+    send_reasoning_content=True,
+    normalize_assistant_content=True,
+    default_headers={"User-Agent": _KIMI_USER_AGENT},
+)
+
 _ZHIPU_CAPABILITIES = ProviderCapabilities("zhipu", "ZHIPU_API_KEY", "ZHIPU_BASE_URL")
 
 _OPENAI_CODEX_CAPABILITIES = ProviderCapabilities("openai-codex", None, "OPENAI_CODEX_BASE_URL")
@@ -104,6 +118,7 @@ _PROVIDERS: dict[str, ProviderCapabilities] = {
     "glm": _ZHIPU_CAPABILITIES,
     "moonshot": _MOONSHOT_CAPABILITIES,
     "kimi": _MOONSHOT_CAPABILITIES,
+    "kimi-coding": _KIMI_CODING_CAPABILITIES,
     "minimax": ProviderCapabilities("minimax", "MINIMAX_API_KEY", "MINIMAX_BASE_URL"),
     "mimo": ProviderCapabilities("mimo", "MIMO_API_KEY", "MIMO_BASE_URL"),
     "zai": ProviderCapabilities("zai", "ZAI_API_KEY", "ZAI_BASE_URL"),

--- a/agent/src/providers/llm.py
+++ b/agent/src/providers/llm.py
@@ -615,9 +615,10 @@ def build_llm(*, model_name: Optional[str] = None, callbacks: Any = None) -> Any
     # default 0.0 is used to avoid an API validation error.
     if provider == "minimax" and temperature <= 0.0:
         temperature = 0.01
-    # Moonshot kimi-k2.x reasoning models reject any temperature other than 1
+    # Kimi reasoning models (kimi-k2.x open platform, kimi-for-coding plan)
+    # reject any temperature other than 1
     # ("invalid temperature: only 1 is allowed for this model").
-    if caps.name == "moonshot" and name.lower().startswith("kimi-k2") and temperature != 1.0:
+    if caps.name in {"moonshot", "kimi-coding"} and name.lower().startswith(("kimi-k2", "kimi-for-coding")) and temperature != 1.0:
         logger.info("Forcing temperature=1.0 for %s (provider requirement)", name)
         temperature = 1.0
     # Optional reasoning activation for relays requiring opt-in (e.g. OpenRouter).
@@ -634,7 +635,7 @@ def build_llm(*, model_name: Optional[str] = None, callbacks: Any = None) -> Any
     }
     if caps.default_headers:
         headers = dict(caps.default_headers)
-        if caps.name == "moonshot":
+        if caps.name in {"moonshot", "kimi-coding"}:
             custom_ua = os.getenv("MOONSHOT_USER_AGENT", "").strip()
             if custom_ua:
                 headers["User-Agent"] = custom_ua

--- a/agent/src/providers/llm_providers.json
+++ b/agent/src/providers/llm_providers.json
@@ -101,6 +101,15 @@
     "api_key_required": true
   },
   {
+    "name": "kimi-coding",
+    "label": "Kimi for Coding (subscription plan)",
+    "api_key_env": "KIMI_CODING_API_KEY",
+    "base_url_env": "KIMI_CODING_BASE_URL",
+    "default_model": "kimi-for-coding",
+    "default_base_url": "https://api.kimi.com/coding/v1",
+    "api_key_required": true
+  },
+  {
     "name": "minimax",
     "label": "MiniMax",
     "api_key_env": "MINIMAX_API_KEY",

--- a/agent/tests/test_llm.py
+++ b/agent/tests/test_llm.py
@@ -275,3 +275,83 @@ class TestReasoningEffortPassthrough:
         })
         assert captured["extra_body"]["reasoning"]["effort"] == "high"
 
+
+class TestKimiCodingProvider:
+    """Kimi for Coding subscription plan is a distinct provider that reuses the
+    Moonshot wire behaviour but ships its own endpoint, model id and key namespace."""
+
+    def test_capabilities_use_own_env_namespace(self) -> None:
+        caps = get_provider_capabilities("kimi-coding")
+        assert caps.name == "kimi-coding"
+        assert (caps.api_key_env, caps.base_url_env) == (
+            "KIMI_CODING_API_KEY",
+            "KIMI_CODING_BASE_URL",
+        )
+
+    def test_reuses_moonshot_wire_behaviour(self) -> None:
+        """Reasoning capture + Kimi User-Agent must match the Moonshot record."""
+        kimi = get_provider_capabilities("kimi-coding")
+        moonshot = get_provider_capabilities("moonshot")
+        assert kimi.capture_reasoning is True
+        assert kimi.send_reasoning_content is True
+        assert kimi.normalize_assistant_content is True
+        assert kimi.default_headers.get("User-Agent") == moonshot.default_headers.get(
+            "User-Agent"
+        )
+
+    def test_provider_env_names(self) -> None:
+        assert provider_env_names("kimi-coding") == (
+            "KIMI_CODING_API_KEY",
+            "KIMI_CODING_BASE_URL",
+        )
+
+    def test_env_mapping_to_openai_vars(self) -> None:
+        import src.providers.llm as llm_mod
+        llm_mod._dotenv_loaded = True
+
+        clean = {
+            k: v
+            for k, v in os.environ.items()
+            if not k.startswith(("OPENAI_", "LANGCHAIN_", "KIMI_CODING_", "MOONSHOT_"))
+        }
+        clean.update({
+            "LANGCHAIN_PROVIDER": "kimi-coding",
+            "KIMI_CODING_API_KEY": "sk-kimi-test",
+            "KIMI_CODING_BASE_URL": "https://api.kimi.com/coding/v1",
+        })
+        with patch.dict(os.environ, clean, clear=True):
+            _sync_provider_env()
+            assert os.environ.get("OPENAI_API_KEY") == "sk-kimi-test"
+            assert os.environ.get("OPENAI_API_BASE") == "https://api.kimi.com/coding/v1"
+
+    def _build_and_capture(self, temperature: str) -> dict:
+        import src.providers.llm as llm_mod
+        llm_mod._dotenv_loaded = True
+
+        captured: dict = {}
+
+        class _FakeChatOpenAI:
+            def __init__(self, **kwargs: object) -> None:
+                captured.update(kwargs)
+
+        env = {
+            "LANGCHAIN_PROVIDER": "kimi-coding",
+            "KIMI_CODING_API_KEY": "sk-kimi-test",
+            "KIMI_CODING_BASE_URL": "https://api.kimi.com/coding/v1",
+            "LANGCHAIN_MODEL_NAME": "kimi-for-coding",
+            "LANGCHAIN_TEMPERATURE": temperature,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with patch.object(llm_mod, "ChatOpenAIWithReasoning", _FakeChatOpenAI):
+                build_llm()
+        return captured
+
+    def test_kimi_for_coding_temperature_forced_to_one(self) -> None:
+        """kimi-for-coding rejects any temperature != 1; build_llm must force it."""
+        captured = self._build_and_capture("0.0")
+        assert float(captured["temperature"]) == 1.0
+
+    def test_sets_kimi_user_agent_header(self) -> None:
+        captured = self._build_and_capture("1.0")
+        assert captured["default_headers"]["User-Agent"].startswith("Vibe-Trading/")
+


### PR DESCRIPTION
### Summary

Adds a dedicated `kimi-coding` provider for Moonshot's **Kimi for Coding** subscription plan, as approved in #432.

Kimi ships two non-interchangeable API surfaces — the open platform (`api.moonshot.ai/v1`) and Kimi for Coding (`api.kimi.com/coding/v1`); a key issued for one is rejected by the other. Today coding-plan users have to hand-edit the model id and base URL every time they switch providers, and any dropdown change resets it. This adds `kimi-coding` as a first-class provider so both surfaces can be configured side by side, while leaving `moonshot` untouched.

### What's in it

- **New provider `kimi-coding`** (`capabilities.py`) — reuses the Moonshot wire behaviour (reasoning capture, `send_reasoning_content`, Kimi `User-Agent`) but with its own key namespace `KIMI_CODING_API_KEY` / `KIMI_CODING_BASE_URL`, endpoint `https://api.kimi.com/coding/v1`, and stable model id `kimi-for-coding`.
- **`temperature=1` guard extended** (`llm.py`) — the "only 1 is allowed" constraint now covers `kimi-coding` + the `kimi-for-coding` model, alongside the existing `moonshot` / `kimi-k2.x` case. The custom `User-Agent` override path is extended the same way.
- **Settings dropdown entry** (`llm_providers.json`) — `"Kimi for Coding (subscription plan)"`, which `settings_routes._load_llm_providers()` serves to the Settings UI.
- **`.env.example`** — a documented `Kimi for Coding` block, explicitly noting the key is not interchangeable with the open platform.
- **Tests** (`tests/test_llm.py::TestKimiCodingProvider`) — 6 unit tests covering the env namespace, wire-behaviour parity with `moonshot`, `_sync_provider_env` mapping, the forced `temperature=1`, and the `User-Agent` header.

### Notes

- `moonshot` / `kimi` behaviour is unchanged; this is purely additive.
- Rebased onto latest `main` (post the #405/#416 governance revert and the recent refactors); touches only `agent/src/providers/*` + its `.env.example` and tests, no overlap with other in-flight changes. `TestKimiCodingProvider` is green on that tree.

Closes #432.
