### PR TITLE
fix(loaders): align fetch() signature with DataLoaderProtocol in 3 loaders

### DIFF
--- a/agent/backtest/loaders/okx.py
+++ b/agent/backtest/loaders/okx.py
@@ -52,8 +52,9 @@ class DataLoader:
         codes: List[str],
         start_date: str,
         end_date: str,
-        fields: Optional[List[str]] = None,
+        *,
         interval: str = "1D",
+        fields: Optional[List[str]] = None,
     ) -> Dict[str, pd.DataFrame]:
         """Fetch crypto OHLCV via OKX public API.
 

--- a/agent/backtest/loaders/tushare.py
+++ b/agent/backtest/loaders/tushare.py
@@ -69,8 +69,9 @@ class DataLoader:
         codes: List[str],
         start_date: str,
         end_date: str,
-        fields: Optional[List[str]] = None,
+        *,
         interval: str = "1D",
+        fields: Optional[List[str]] = None,
     ) -> Dict[str, pd.DataFrame]:
         """Fetch A-share bars via Tushare API.
 

--- a/agent/backtest/loaders/yfinance_loader.py
+++ b/agent/backtest/loaders/yfinance_loader.py
@@ -229,8 +229,9 @@ class DataLoader:
         codes: List[str],
         start_date: str,
         end_date: str,
-        fields: Optional[List[str]] = None,
+        *,
         interval: str = "1D",
+        fields: Optional[List[str]] = None,
     ) -> Dict[str, pd.DataFrame]:
         """Fetch OHLCV history keyed by the original project symbols.
 


### PR DESCRIPTION
## Summary

Three data loaders (`tushare`, `okx`, `yfinance`) define `fetch()` with `fields` and `interval` as **positional** parameters in the wrong order, violating the `DataLoaderProtocol` contract which declares them **keyword-only** (after `*`).

Closes #436.

## Changes

| File | Before | After |
|------|--------|-------|
| `agent/backtest/loaders/tushare.py:67` | `fetch(self, codes, start, end, fields=None, interval="1D")` | `fetch(self, codes, start, end, *, interval="1D", fields=None)` |
| `agent/backtest/loaders/okx.py:50` | Same | Same |
| `agent/backtest/loaders/yfinance_loader.py:227` | Same | Same |

Two fixes per signature:
1. **Add `*` keyword-only separator** — prevents positional misuse
2. **Reorder `interval` before `fields`** — matches Protocol definition and all 16 other compliant loaders

## Impact

- **Latent bug** — no current caller passes `interval`/`fields` as positional args, so behavior is unchanged
- **Prevents future misuse** — `loader.fetch(codes, start, end, "1D")` would silently pass `"1D"` as `fields` on these 3 loaders but work correctly on the other 16
- **Protocol compliance** — `@runtime_checkable` Protocol check cannot catch parameter-ordering differences; this fix eliminates the divergence at the source

## Testing

- `test_tushare_loader.py`: 55 passed, 4 skipped
- `test_registry.py`: 23 passed
- `test_loader_retry_helpers.py` + `test_ohlc_validation.py` + `test_engine_robustness.py`: 58 passed
- `test_local_loader.py` + `test_mootdx_loader.py` + `test_eastmoney_loader.py` + `test_stooq_loader.py` + `test_futu_loader.py`: 76 passed
- Verified all call sites in `runner.py`, `benchmark.py`, `correlation.py`, `grounding.py`, `market_data.py`, `base.py`, `options_portfolio.py`, `ui_services.py` use keyword arguments only