### PR TITLE
Fix unsupported Codex OAuth default model in init

### DIFF
--- a/agent/.env.example
+++ b/agent/.env.example
@@ -18,7 +18,7 @@ OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 # Login first: vibe-trading provider login openai-codex
 # Requires a ChatGPT account with Codex access. OAuth tokens are stored by oauth-cli-kit.
 # LANGCHAIN_PROVIDER=openai-codex
-# LANGCHAIN_MODEL_NAME=openai-codex/gpt-5.3-codex
+# LANGCHAIN_MODEL_NAME=openai-codex/gpt-5.4
 # OPENAI_CODEX_BASE_URL=https://chatgpt.com/backend-api/codex/responses
 
 # --- DeepSeek ---

--- a/agent/cli/_legacy.py
+++ b/agent/cli/_legacy.py
@@ -4595,7 +4595,7 @@ _PROVIDER_CHOICES: list[dict[str, str | None]] = [
         "key_env": None,
         "base_env": "OPENAI_CODEX_BASE_URL",
         "base_url": "https://chatgpt.com/backend-api/codex/responses",
-        "model": "openai-codex/gpt-5.3-codex",
+        "model": "openai-codex/gpt-5.4",
         "key_prefix": None,
         "key_placeholder": None,
     },

--- a/agent/cli/onboard.py
+++ b/agent/cli/onboard.py
@@ -61,6 +61,10 @@ PROVIDERS: Final[tuple[Provider, ...]] = (
              "gpt-5.5", "OPENAI_API_KEY", "OPENAI_BASE_URL",
              "https://api.openai.com/v1", "sk-",
              ("gpt-5.5", "gpt-5.5-pro", "gpt-5.5-instant")),
+    Provider("openai-codex", "OpenAI Codex", "ChatGPT OAuth for Codex",
+             "openai-codex/gpt-5.4", None, "OPENAI_CODEX_BASE_URL",
+             "https://chatgpt.com/backend-api/codex/responses", None,
+             ("openai-codex/gpt-5.4", "openai-codex/gpt-5.4-mini")),
     Provider("deepseek", "DeepSeek",
              "cheapest tier — good for batch backtest research",
              "deepseek-v4-pro", "DEEPSEEK_API_KEY", "DEEPSEEK_BASE_URL",
@@ -411,8 +415,18 @@ def run_onboarding(*, console: Console | None = None) -> Path | None:
         provider: Provider = state["provider"]  # type: ignore[assignment]
         if provider.key_env is None:
             cons.print()
-            cons.print(Text("  Ollama runs locally — no API key needed.",
-                             style=Theme.success))
+            if provider.key == "openai-codex":
+                cons.print(Text(
+                    "  OpenAI Codex uses ChatGPT OAuth — no API key needed here.",
+                    style=Theme.success,
+                ))
+                cons.print(Text(
+                    "  After setup, run: vibe-trading provider login openai-codex",
+                    style=Theme.muted,
+                ))
+            else:
+                cons.print(Text("  Ollama runs locally — no API key needed.",
+                                 style=Theme.success))
             return "ok"
         while True:
             key = _prompt_secret(

--- a/agent/src/providers/llm_providers.json
+++ b/agent/src/providers/llm_providers.json
@@ -22,7 +22,7 @@
     "label": "OpenAI Codex (ChatGPT OAuth)",
     "api_key_env": null,
     "base_url_env": "OPENAI_CODEX_BASE_URL",
-    "default_model": "openai-codex/gpt-5.3-codex",
+    "default_model": "openai-codex/gpt-5.4",
     "default_base_url": "https://chatgpt.com/backend-api/codex/responses",
     "api_key_required": false,
     "auth_type": "oauth",

--- a/agent/tests/test_cli_init.py
+++ b/agent/tests/test_cli_init.py
@@ -101,3 +101,26 @@ class TestCliInit:
         assert "LANGCHAIN_MODEL_NAME=qwen2.5:32b" in content
         assert "OPENAI_API_KEY=" not in content
         assert "OPENROUTER_API_KEY=" not in content
+
+    def test_cmd_init_openai_codex_uses_supported_default_and_oauth(self, tmp_path: Path) -> None:
+        env_path = tmp_path / ".env"
+
+        with patch.object(cli, "_INIT_ENV_PATH", env_path), \
+             patch.object(cli.IntPrompt, "ask", return_value=13), \
+             patch.object(
+                 cli.Prompt,
+                 "ask",
+                 side_effect=[
+                     "https://chatgpt.com/backend-api/codex/responses",
+                     "openai-codex/gpt-5.4",
+                     "",
+                 ],
+             ):
+            result = cli.cmd_init()
+
+        assert result == 0
+        content = env_path.read_text(encoding="utf-8")
+        assert "LANGCHAIN_PROVIDER=openai-codex" in content
+        assert "OPENAI_CODEX_BASE_URL=https://chatgpt.com/backend-api/codex/responses" in content
+        assert "LANGCHAIN_MODEL_NAME=openai-codex/gpt-5.4" in content
+        assert "OPENAI_API_KEY=" not in content

--- a/agent/tests/test_cli_interactive.py
+++ b/agent/tests/test_cli_interactive.py
@@ -212,7 +212,7 @@ class TestMainRouting:
         cwd_env = tmp_path / "cwd" / ".env"
         project_env.parent.mkdir(parents=True)
         project_env.write_text(
-            "LANGCHAIN_MODEL_NAME=openai-codex/gpt-5.3-codex\n",
+            "LANGCHAIN_MODEL_NAME=openai-codex/gpt-5.4\n",
             encoding="utf-8",
         )
 
@@ -222,7 +222,7 @@ class TestMainRouting:
         monkeypatch.setattr(cli_main, "_PROJECT_ENV_PATH", project_env, raising=False)
         monkeypatch.setattr(cli_main, "_CWD_ENV_PATH", cwd_env, raising=False)
 
-        assert cli_main._probe_model_name() == "openai-codex/gpt-5.3-codex"
+        assert cli_main._probe_model_name() == "openai-codex/gpt-5.4"
 
 
 # ---------------------------------------------------------------------------

--- a/agent/tests/test_llm_provider_defaults.py
+++ b/agent/tests/test_llm_provider_defaults.py
@@ -12,6 +12,7 @@ from cli.onboard import PROVIDERS as ONBOARD_PROVIDERS
 EXPECTED_PROVIDER_DEFAULTS = {
     "openrouter": "deepseek/deepseek-v4-pro",
     "openai": "gpt-5.5",
+    "openai-codex": "openai-codex/gpt-5.4",
     "deepseek": "deepseek-v4-pro",
     "gemini": "gemini-3.5-flash",
     "groq": "meta-llama/llama-4-maverick-17b-128e-instruct",
@@ -47,6 +48,15 @@ def test_interactive_onboard_openai_defaults_to_available_model() -> None:
     assert provider.default_model != "gpt-5.5-instant"
 
 
+def test_interactive_onboard_codex_defaults_to_supported_model() -> None:
+    provider = next(provider for provider in ONBOARD_PROVIDERS if provider.key == "openai-codex")
+
+    assert provider.default_model == "openai-codex/gpt-5.4"
+    assert provider.key_env is None
+    assert provider.base_env == "OPENAI_CODEX_BASE_URL"
+    assert provider.suggested_models[0] == "openai-codex/gpt-5.4"
+
+
 def test_legacy_cli_provider_choices_match_registry_defaults() -> None:
     legacy_defaults = {
         str(item["provider"]): item["model"]
@@ -65,4 +75,5 @@ def test_interactive_onboard_suggests_current_primary_models() -> None:
 
     assert onboard_defaults["openrouter"] == "deepseek/deepseek-v4-pro"
     assert onboard_defaults["openai"] == "gpt-5.5"
+    assert onboard_defaults["openai-codex"] == "openai-codex/gpt-5.4"
     assert onboard_defaults["deepseek"] == "deepseek-v4-pro"

--- a/agent/tests/test_openai_codex.py
+++ b/agent/tests/test_openai_codex.py
@@ -18,7 +18,7 @@ from src.providers.openai_codex import (
 )
 
 
-DEFAULT_CODEX_MODEL = "openai-codex/gpt-5.3-codex"
+DEFAULT_CODEX_MODEL = "openai-codex/gpt-5.4"
 
 
 def test_provider_default_model_matches_live_codex_account_path() -> None:
@@ -68,8 +68,8 @@ def test_codex_body_strips_provider_prefix_and_converts_tools() -> None:
         stream=True,
     )
 
-    assert _strip_model_prefix(DEFAULT_CODEX_MODEL) == "gpt-5.3-codex"
-    assert body["model"] == "gpt-5.3-codex"
+    assert _strip_model_prefix(DEFAULT_CODEX_MODEL) == "gpt-5.4"
+    assert body["model"] == "gpt-5.4"
     assert body["instructions"] == "You are careful."
     assert body["tools"][0]["name"] == "bash"
     assert body["input"][0]["content"][0]["text"] == "Say hi."


### PR DESCRIPTION
## Summary

Updates the OpenAI Codex OAuth default model from `openai-codex/gpt-5.3-codex` to `openai-codex/gpt-5.4`.

`gpt-5.3-codex` is no longer supported when using Codex with a ChatGPT account, so the previous default caused Codex OAuth runs initialized through Vibe-Trading to fail with:

```text
The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account.
```

## Changes

- Replaces the Codex OAuth default model in provider metadata and legacy init config.
- Updates `.env.example` to use `openai-codex/gpt-5.4`.
- Adds OpenAI Codex to the newer `vibe-trading init` onboarding provider list.
- Shows Codex-specific OAuth guidance in onboarding instead of treating all no-key providers as Ollama.
- Updates/adds regression tests for Codex defaults and init behavior.

## Related Issue

Fixes #445

## Verification

```sh
.venv/bin/python -m pytest \
  agent/tests/test_openai_codex.py \
  agent/tests/test_cli_init.py \
  agent/tests/test_llm_provider_defaults.py \
  agent/tests/test_cli_interactive.py
```

```text
87 passed
```
