### PR TITLE
Fix CLI first chat input at resume prompt

### DIFF
--- a/agent/cli/main.py
+++ b/agent/cli/main.py
@@ -457,7 +457,9 @@ def _maybe_resume_last_session(console: Any) -> Optional[Dict[str, Any]]:
 
     Returns:
         A dict ``{"session_id": str, "history": list[dict], "title": str}``
-        when the user opts to resume, otherwise ``None`` (new session).
+        when the user opts to resume, ``{"pending_input": str}`` when the
+        user typed a first chat turn into the prompt, otherwise ``None`` (new
+        session).
     """
     try:
         store = _session_store()
@@ -474,11 +476,14 @@ def _maybe_resume_last_session(console: Any) -> Optional[Dict[str, Any]]:
         f"[dim]Resume last session ({title})? (r)esume / (n)ew (default: new)[/dim]"
     )
     try:
-        choice = input("> ").strip().lower()
+        raw_choice = input("> ").strip()
     except (EOFError, KeyboardInterrupt):
         return None
-    if choice not in {"r", "resume", "y", "yes"}:
+    choice = raw_choice.lower()
+    if choice in {"", "n", "new", "no"}:
         return None
+    if choice not in {"r", "resume", "y", "yes"}:
+        return {"pending_input": raw_choice}
 
     return {
         "session_id": last.session_id,
@@ -1095,6 +1100,7 @@ def _interactive_loop(max_iter: int, resume_session_id: Optional[str] = None) ->
     # the prompt appear only after the user presses Enter.
 
     ctx = InteractiveContext(max_iter=max_iter)
+    pending_input: Optional[str] = None
 
     if resume_session_id:
         # Resume a specific session by ID (``vibe-trading resume <session-id>``).
@@ -1116,11 +1122,14 @@ def _interactive_loop(max_iter: int, resume_session_id: Optional[str] = None) ->
         # Offer to resume the most recent session. Audit item 8.
         resume = _maybe_resume_last_session(console)
         if resume is not None:
-            ctx.session_id = resume["session_id"]
-            ctx.history = list(resume["history"])
-            console.print(
-                f"[dim]Resumed session: {resume['title']} ({len(ctx.history)} prior turns)[/dim]"
-            )
+            if "pending_input" in resume:
+                pending_input = str(resume["pending_input"])
+            else:
+                ctx.session_id = resume["session_id"]
+                ctx.history = list(resume["history"])
+                console.print(
+                    f"[dim]Resumed session: {resume['title']} ({len(ctx.history)} prior turns)[/dim]"
+                )
 
     # Build the prompt session once so history + completer persist.
     try:
@@ -1139,27 +1148,31 @@ def _interactive_loop(max_iter: int, resume_session_id: Optional[str] = None) ->
     session = make_session()
 
     while True:
-        _print_recap_if_needed(console, ctx)
-        try:
-            user_input = get_user_input(session=session)
-        except KeyboardInterrupt:
-            # Should not reach here — the keybinding raises EOFError instead.
-            continue
-        except EOFError:
-            # Two interpretations: Ctrl+D (always exit), or Ctrl+C on an
-            # empty line (show hint, exit on second press).
-            #
-            # ``ctrl_c_within_window`` reads a press-time decision cached
-            # by the keybinding: True iff the gap between the *previous*
-            # Ctrl+C press and *this* one is < 2 s. First press → False
-            # (no prior press) → we print the hint and continue. Second
-            # press inside the window → True → we break.
-            if ctrl_c_within_window(session, window_sec=2.0):
-                break
-            console.print(
-                "[dim]Press Ctrl+C again within 2s, Ctrl+D, or type /quit to exit[/dim]"
-            )
-            continue
+        if pending_input is not None:
+            user_input = pending_input
+            pending_input = None
+        else:
+            _print_recap_if_needed(console, ctx)
+            try:
+                user_input = get_user_input(session=session)
+            except KeyboardInterrupt:
+                # Should not reach here — the keybinding raises EOFError instead.
+                continue
+            except EOFError:
+                # Two interpretations: Ctrl+D (always exit), or Ctrl+C on an
+                # empty line (show hint, exit on second press).
+                #
+                # ``ctrl_c_within_window`` reads a press-time decision cached
+                # by the keybinding: True iff the gap between the *previous*
+                # Ctrl+C press and *this* one is < 2 s. First press → False
+                # (no prior press) → we print the hint and continue. Second
+                # press inside the window → True → we break.
+                if ctrl_c_within_window(session, window_sec=2.0):
+                    break
+                console.print(
+                    "[dim]Press Ctrl+C again within 2s, Ctrl+D, or type /quit to exit[/dim]"
+                )
+                continue
 
         text = user_input.strip()
         if not text:

--- a/agent/tests/test_cli_interactive.py
+++ b/agent/tests/test_cli_interactive.py
@@ -224,6 +224,34 @@ class TestMainRouting:
 
         assert cli_main._probe_model_name() == "openai-codex/gpt-5.3-codex"
 
+    def test_resume_prompt_treats_plain_text_as_first_turn(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Typing a chat message at the resume prompt must not discard it."""
+        cli_main = importlib.import_module("cli.main")
+        session = SimpleNamespace(session_id="sess_1", title="hello")
+        store = SimpleNamespace(list_sessions=lambda limit=1: [session])
+
+        monkeypatch.setattr(cli_main, "_session_store", lambda: store)
+        monkeypatch.setattr("builtins.input", lambda _prompt: "hello")
+
+        result = cli_main._maybe_resume_last_session(cli_main.get_console())
+
+        assert result == {"pending_input": "hello"}
+
+    @pytest.mark.parametrize("answer", ["", "n", "new", "no"])
+    def test_resume_prompt_explicit_new_answers_start_new_session(
+        self, monkeypatch: pytest.MonkeyPatch, answer: str
+    ) -> None:
+        cli_main = importlib.import_module("cli.main")
+        session = SimpleNamespace(session_id="sess_1", title="hello")
+        store = SimpleNamespace(list_sessions=lambda limit=1: [session])
+
+        monkeypatch.setattr(cli_main, "_session_store", lambda: store)
+        monkeypatch.setattr("builtins.input", lambda _prompt: answer)
+
+        assert cli_main._maybe_resume_last_session(cli_main.get_console()) is None
+
 
 # ---------------------------------------------------------------------------
 # Main-level dispatch smoke


### PR DESCRIPTION
## Summary

- Preserve non-choice text entered at the interactive resume prompt as the first chat turn.
- Keep explicit resume answers (`r`, `resume`, `y`, `yes`) and explicit new-session answers (`n`, `new`, `no`, blank) behaving as expected.
- Add regression coverage for the swallowed-first-message case.

Fixes #447.

## Verification

- `git diff --check HEAD~2..HEAD`
- `uvx ruff check agent/cli/main.py agent/tests/test_cli_interactive.py`
- `/Users/will/dev/clones/Vibe-Trading/.venv/bin/python -m pytest agent/tests/test_cli_interactive.py -k resume_prompt`
- `/Users/will/dev/clones/Vibe-Trading/.venv/bin/python -m pytest agent/tests/test_cli_interactive.py agent/tests/test_cli_runtime.py`
- `/Users/will/.codex/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests "/Users/will/dev/clones/Vibe-Trading/.venv/bin/python -m pytest agent/tests/test_cli_interactive.py agent/tests/test_cli_runtime.py"`
