### PR TITLE
docs: fix `pyhton` -> `python` code fence typo in tushare references

### DIFF
--- a/agent/src/skills/tushare/references/ETF专题/ETF复权因子.md
+++ b/agent/src/skills/tushare/references/ETF专题/ETF复权因子.md
@@ -42,7 +42,7 @@ adj_factor | float | Y | 复权因子
 
 **接口使用**
 
-```pyhton
+```python
 
 pro = ts.pro_api()
 

--- a/agent/src/skills/tushare/references/指数专题/国际主要指数.md
+++ b/agent/src/skills/tushare/references/指数专题/国际主要指数.md
@@ -72,7 +72,7 @@ amount | float | N | 成交额 （大部分无此项数据）
 
 **接口使用**
 
-```pyhton
+```python
 
 pro = ts.pro_api()
 

--- a/agent/src/skills/tushare/references/股票数据/参考数据/大宗交易.md
+++ b/agent/src/skills/tushare/references/股票数据/参考数据/大宗交易.md
@@ -38,7 +38,7 @@ seller | str | Y | 卖方营业部
 
 **接口使用**
 
-```pyhton
+```python
 
 pro = ts.pro_api()
 

--- a/agent/src/skills/tushare/references/股票数据/参考数据/股东人数.md
+++ b/agent/src/skills/tushare/references/股票数据/参考数据/股东人数.md
@@ -38,7 +38,7 @@ holder_num | int | Y | 股东户数
 
 **接口使用**
 
-```pyhton
+```python
 
 pro = ts.pro_api()
 

--- a/agent/src/skills/tushare/references/股票数据/参考数据/股权质押明细数据.md
+++ b/agent/src/skills/tushare/references/股票数据/参考数据/股权质押明细数据.md
@@ -34,7 +34,7 @@ is_buyback | str | Y | 是否回购（0否 1是）
 
 
 **接口使用**
-```pyhton
+```python
 pro = ts.pro_api()
 #或者
 #pro = ts.pro_api('your token')

--- a/agent/src/skills/tushare/references/股票数据/参考数据/股权质押统计数据.md
+++ b/agent/src/skills/tushare/references/股票数据/参考数据/股权质押统计数据.md
@@ -28,7 +28,7 @@ pledge_ratio | float | Y | 质押比例
 
 
 **接口使用**
-```pyhton
+```python
 pro = ts.pro_api()
 #或者
 #pro = ts.pro_api('your token')

--- a/agent/src/skills/tushare/references/股票数据/参考数据/股票开户数据(停).md
+++ b/agent/src/skills/tushare/references/股票数据/参考数据/股票开户数据(停).md
@@ -37,7 +37,7 @@ weekly_trade | float | Y | 本周参与交易账户数（万）
 
 **接口使用**
 
-```pyhton
+```python
 
 pro = ts.pro_api()
 

--- a/agent/src/skills/tushare/references/股票数据/参考数据/股票开户数据(旧).md
+++ b/agent/src/skills/tushare/references/股票数据/参考数据/股票开户数据(旧).md
@@ -40,7 +40,7 @@ trade_sz | float | Y | 参与交易账户数（深圳，万户）
 
 **接口使用**
 
-```pyhton
+```python
 
 pro = ts.pro_api()
 

--- a/agent/src/skills/tushare/references/股票数据/参考数据/限售股解禁.md
+++ b/agent/src/skills/tushare/references/股票数据/参考数据/限售股解禁.md
@@ -39,7 +39,7 @@ share_type | str | Y | 股份类型
 
 **接口使用**
 
-```pyhton
+```python
 
 pro = ts.pro_api()
 


### PR DESCRIPTION
Nine markdown files under `agent/src/skills/tushare/references/` tag their code blocks as ````pyhton````, so GitHub renders them as plain text without Python syntax highlighting. This PR fixes the language tag to ````python```` in all nine files — no content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)