### PR TITLE
fix(api): tolerate path-less routes when probing for a root mount

### DIFF
--- a/agent/api_server.py
+++ b/agent/api_server.py
@@ -346,7 +346,7 @@ def serve_main(argv: list[str] | None = None) -> int:
         print("[dev] Frontend: http://localhost:5173")
         print(f"[dev] API: http://localhost:{args.port}")
     elif frontend_dist.exists():
-        if not any(route.path == "/" for route in app.routes):
+        if not any(getattr(route, "path", None) == "/" for route in app.routes):
             app.mount("/", SPAStaticFiles(directory=str(frontend_dist), html=True), name="frontend")
         print(f"[prod] Frontend served from {frontend_dist}")
     else:

--- a/agent/tests/test_serve_bind.py
+++ b/agent/tests/test_serve_bind.py
@@ -13,6 +13,7 @@ build in CI) cannot satisfy or break them.
 
 from __future__ import annotations
 
+import types
 from unittest import mock
 
 import pytest
@@ -109,3 +110,32 @@ def test_non_loopback_with_key_does_not_warn(
 
     out = capsys.readouterr().out
     assert _BIND_WARN not in out
+
+
+@pytest.mark.unit
+def test_root_route_probe_tolerates_pathless_routes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """serve_main must not crash when app.routes holds a path-less entry.
+
+    Newer FastAPI records ``app.include_router(...)`` as an ``_IncludedRouter``
+    marker in ``app.routes`` that has no ``path`` attribute (unlike the flattened
+    ``APIRoute`` objects older versions produced). The frontend-mount probe scans
+    every route, so it must read ``path`` defensively or the server aborts at
+    startup with ``AttributeError: '_IncludedRouter' object has no attribute
+    'path'`` (issue #450).
+
+    The path-less route is placed before a real ``/`` route so the probe is
+    forced to inspect it; the ``/`` route then short-circuits the check, so the
+    static-file mount is skipped and the test stays independent of whether a
+    frontend build exists.
+    """
+    pathless_route = types.SimpleNamespace(name="included-router")
+    assert not hasattr(pathless_route, "path")
+    root_route = types.SimpleNamespace(name="root", path="/")
+    monkeypatch.setattr(
+        api_server.app.router, "routes", [pathless_route, root_route]
+    )
+    monkeypatch.setattr(api_server.Path, "exists", lambda self: True, raising=False)
+
+    assert _run_serve([]) == "127.0.0.1"


### PR DESCRIPTION
## Summary

`serve_main` crashes on startup with `AttributeError: '_IncludedRouter' object has no attribute 'path'` on newer FastAPI, so the server (notably the Docker image) never comes up.

## Why

Before mounting the SPA static files, `serve_main` checks whether a `/` route already exists:

```python
if not any(route.path == "/" for route in app.routes):
```

Older FastAPI flattened `app.include_router(...)` into individual `APIRoute` objects, each with a `.path`. Newer FastAPI instead appends an `_IncludedRouter` marker to `app.routes` that has **no** `.path` attribute. This project calls `app.include_router(qveris_router)`, so on a newer FastAPI the probe hits that marker and raises `AttributeError`, aborting startup.

The dependency floor is unpinned (`fastapi>=0.104.0`), so the Docker build pulls a newer FastAPI than local dev — which is why it reproduces there and not locally.

## Changes

- `agent/api_server.py`: read the route path defensively with `getattr(route, "path", None)` so marker routes without a path are skipped instead of crashing.
- `agent/tests/test_serve_bind.py`: add a regression test that injects a path-less route ahead of a real `/` route and asserts `serve_main` starts.

## Test Plan

- [x] ruff check — clean
- [x] pytest (相关测试) — `tests/test_serve_bind.py` 15 passed (new test fails on the pre-fix code with the exact `AttributeError`, passes after)
- [x] pytest (全量 excl e2e) — 4871 passed, 9 skipped (2 unrelated failures preexist on main: a fundamental-factor projection test and a `bottleneck` backend test)

## Checklist

- [x] No changes to protected areas without prior discussion
- [x] No hardcoded values
- [x] Code follows CONTRIBUTING.md guidelines
- [x] Documentation updated (if user-facing change)

Closes #450