### PR TITLE
fix(docs): sync packaged skill capability counts

### DIFF
--- a/agent/SKILL.md
+++ b/agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vibe-trading
 version: 0.1.10
-description: Professional finance research toolkit — backtesting (7 engines + benchmark comparison panel), factor analysis, Alpha Zoo (452 pre-built alphas across qlib158/alpha101/gtja191/academic), options pricing, 79 finance skills, 29 multi-agent swarm teams, Trade Journal analyzer, and Shadow Account (extract → backtest → render) across 18 market-data sources (tushare, yfinance, okx, akshare, baostock, tencent, mootdx, ccxt, futu, local, eastmoney, sina, stooq, yahoo, plus optional-key finnhub/alphavantage/tiingo/fmp).
+description: Professional finance research toolkit — backtesting (8 engines + benchmark comparison panel), factor analysis, Alpha Zoo (460 pre-built alphas across qlib158/alpha101/gtja191/academic/fundamental), options pricing, 86 finance skills, 30 multi-agent swarm teams, Trade Journal analyzer, and Shadow Account (extract → backtest → render) across 20 market-data sources (tushare, yfinance, okx, akshare, baostock, tencent, mootdx, ccxt, futu, local, eastmoney, sina, stooq, yahoo, india_broker, qveris, plus optional-key finnhub/alphavantage/tiingo/fmp).
 dependencies:
   python: ">=3.11"
   pip:
@@ -23,7 +23,7 @@ mcp:
 
 # Vibe-Trading
 
-Professional finance research toolkit with AI-powered backtesting (7 engines), multi-agent teams, 79 specialized skills, the **Alpha Zoo** (452 pre-built quantitative alphas across qlib158 / alpha101 / gtja191 / academic with one-line CLI benchmarking), and the Shadow Account loop — extract your implicit trading rules from a journal, backtest them across A股/港股/美股/crypto, then see where they would have served you better.
+Professional finance research toolkit with AI-powered backtesting (8 engines), multi-agent teams, 86 specialized skills, the **Alpha Zoo** (460 pre-built quantitative alphas across qlib158 / alpha101 / gtja191 / academic / fundamental with one-line CLI benchmarking), and the Shadow Account loop — extract your implicit trading rules from a journal, backtest them across A股/港股/美股/crypto, then see where they would have served you better.
 
 ## Setup
 
@@ -53,7 +53,7 @@ Add to your agent's MCP config:
 
 ### API Key Requirements
 
-Core research MCP tools work with zero API keys for HK/US/crypto. After `pip install`, backtesting, market data, factor analysis, options pricing, chart patterns, web search, document reading, trade journal analysis, shadow-account extraction/backtest/report, the Alpha Zoo (452 pre-built alphas), and all 79 skills are ready to use. IBKR tools require a local TWS / IB Gateway session; `run_swarm` requires an LLM key.
+Core research MCP tools work with zero API keys for HK/US/crypto. After `pip install`, backtesting, market data, factor analysis, options pricing, chart patterns, web search, document reading, trade journal analysis, shadow-account extraction/backtest/report, the Alpha Zoo (460 pre-built alphas), and all 86 skills are ready to use. IBKR tools require a local TWS / IB Gateway session; `run_swarm` requires an LLM key.
 
 | Feature | Key needed | When |
 |---------|-----------|------|
@@ -74,7 +74,7 @@ Feed a CSV broker export (同花顺 / 东财 / 富途 / generic), and the agent 
 5. `scan_shadow_signals` — list today's symbols that match your shadow's entry cadence (research only).
 
 ### Backtesting
-Create and run quantitative strategies across 8 engines (ChinaA, GlobalEquity, IndiaEquity, Crypto, ChinaFutures, GlobalFutures, Forex + options) with 19 market-data sources (auto-detect + ordered fallback):
+Create and run quantitative strategies across 8 engines (ChinaA, GlobalEquity, IndiaEquity, Crypto, ChinaFutures, GlobalFutures, Forex + options) with 20 market-data sources (auto-detect + ordered fallback):
 - **HK/US equities** via yfinance / stooq / yahoo (free, no API key)
 - **India equities (NSE/BSE)** via yahoo / yfinance using `<SYMBOL>.NS` (NSE, e.g. `RELIANCE.NS`) or `<SCRIP>.BO` (BSE, e.g. `500325.BO`) — free, no API key. The `IndiaEquityEngine` models T+1 delivery, no overnight shorts (set `allow_short` for intraday), configurable circuit bands, 1-share lots, and the STT/stamp-duty/exchange/GST cost stack. Optionally back-fill from your live broker via the `india_broker` source (Shoonya/Dhan; requires broker login).
 - **Cryptocurrency** via OKX or CCXT/100+ exchanges (free, no API key)
@@ -82,6 +82,7 @@ Create and run quantitative strategies across 8 engines (ChinaA, GlobalEquity, I
 - **Futures, forex, macro** via AKShare (free, no API key)
 - **HK & A-share equities** via Futu (broker login required, optional)
 - **Local CSV/parquet bars** via the `local` loader (offline, no network)
+- **Premium cross-market data** via QVeris (optional API key)
 - **Premium US data** via optional-key finnhub / alphavantage / tiingo / fmp (graceful fallback to free sources)
 
 Factors: the Alpha101 and QLib158 zoos are tagged for the `equity_in` universe, so they compute on NSE/BSE bars (the GTJA191 zoo stays China-only). Live/paper India trading uses the Shoonya / Dhan connectors (paper + read-only live; live order placement is structurally disabled because those brokers expose no paper/live switch).
@@ -93,7 +94,7 @@ Example workflow:
 4. Use `backtest()` to run and get metrics (Sharpe, return, drawdown, etc.)
 
 ### Multi-Agent Swarm Teams
-29 pre-built agent teams for complex research:
+30 pre-built agent teams for complex research:
 - **Investment Committee**: bull/bear debate → risk review → PM decision
 - **Global Equities Desk**: A-share + HK/US + crypto → global strategist
 - **Crypto Trading Desk**: funding/basis + liquidation + flow → risk manager
@@ -101,20 +102,21 @@ Example workflow:
 - **Macro/Rates/FX Desk**: rates + FX + commodities → macro PM
 - **Quant Strategy Desk**: screening → factor research → backtest → risk audit
 - **Risk Committee**: drawdown, tail risk, regime analysis
-- And 22 more specialized teams
+- And 23 more specialized teams
 
 Use `list_swarm_presets()` to see all teams, then `run_swarm()` to execute.
 
-### Alpha Zoo (452 pre-built alphas)
-One-line cross-sectional IC / IR / alive-reversed-dead categorisation across four bundled zoos:
+### Alpha Zoo (460 pre-built alphas)
+One-line cross-sectional IC / IR / alive-reversed-dead categorisation across five bundled zoos:
 - **qlib158** (154 alphas) — Microsoft Qlib's `Alpha158` feature handler, Apache-2.0 with pinned commit SHA.
 - **alpha101** (101 alphas) — Kakushadze (2015) "101 Formulaic Alphas" (arXiv:1601.00991), written from the paper appendix.
 - **gtja191** (191 alphas) — Guotai Junan 2014 "191 Short-period Trading Alpha Factors" research report.
-- **academic** (6 factors) — Fama-French 5 + Carhart momentum (honest price-based proxies).
+- **academic** (10 factors) — Fama-French 5 + Carhart momentum + Jegadeesh reversal + George-Hwang 52-week-high + Amihud illiquidity + Harvey-Siddique skew (price-based proxies).
+- **fundamental** (4 factors) — PIT-safe earnings yield, ROE, gross profitability, and asset growth from daily fundamental panels.
 
 Each alpha ships with `__alpha_meta__` (formula LaTeX + theme + universe + warmup + columns required), guarded by an AST purity gate + 300-row lookahead sentinel test. Use the `vibe-trading alpha {list,show,bench,compare,export-manifest}` CLI, the `/alpha/*` REST routes (browser at `/alpha-zoo`), or compose multi-factor signals via `ZooSignalEngine.from_zoo(...)`.
 
-### Finance Skills (79)
+### Finance Skills (86)
 Comprehensive knowledge base covering:
 - Technical analysis (candlestick, Elliott wave, Ichimoku, SMC, harmonic, chanlun)
 - Quantitative methods (factor research, ML strategy, pair trading, multi-factor)
@@ -131,7 +133,7 @@ Use `load_skill(name)` to access full methodology docs with code templates.
 
 | Tool | Description | API Key |
 |------|-------------|---------|
-| `list_skills` | List all 79 finance skills | None |
+| `list_skills` | List all 86 finance skills | None |
 | `load_skill` | Load full skill documentation | None |
 | `start_research_goal` | Create an auditable research goal | None |
 | `get_research_goal` | Read the current research goal | None |
@@ -141,7 +143,7 @@ Use `load_skill(name)` to access full methodology docs with code templates.
 | `factor_analysis` | IC/IR analysis + layered backtest | None* |
 | `analyze_options` | Black-Scholes price + Greeks | None |
 | `pattern_recognition` | Detect chart patterns (H&S, double top, etc.) | None |
-| `get_market_data` | Fetch OHLCV data (auto-detect + ordered fallback across 18 sources) | None* |
+| `get_market_data` | Fetch OHLCV data (auto-detect + ordered fallback across 20 sources) | None* |
 | `get_fund_flow` | Capital fund-flow (main/retail net inflow) | None* |
 | `get_dragon_tiger` | Dragon-tiger list (龙虎榜) top buyer/seller seats | None* |
 | `get_northbound_flow` | Northbound (Stock Connect) net flow | None* |
@@ -194,7 +196,7 @@ Use `load_skill(name)` to access full methodology docs with code templates.
 pip install vibe-trading-ai
 ```
 
-That's it — no API keys needed for HK/US/crypto markets. Start using `backtest`, `get_market_data`, `analyze_options`, `analyze_trade_journal`, `extract_shadow_strategy`, `web_search`, the **Alpha Zoo** (`vibe-trading alpha bench --zoo gtja191 --universe csi300 --period 2018-2025`), and all 79 skills immediately.
+That's it — no API keys needed for HK/US/crypto markets. Start using `backtest`, `get_market_data`, `analyze_options`, `analyze_trade_journal`, `extract_shadow_strategy`, `web_search`, the **Alpha Zoo** (`vibe-trading alpha bench --zoo gtja191 --universe csi300 --period 2018-2025`), and all 86 skills immediately.
 
 ## Loading Tools from External MCP Servers
 

--- a/agent/tests/test_distribution_skill_manifest.py
+++ b/agent/tests/test_distribution_skill_manifest.py
@@ -1,0 +1,102 @@
+"""Keep the packaged agent skill's capability counts in sync with source."""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+
+AGENT_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = AGENT_ROOT / "SKILL.md"
+SKILLS_DIR = AGENT_ROOT / "src" / "skills"
+ZOOS_DIR = AGENT_ROOT / "src" / "factors" / "zoo"
+PRESETS_DIR = AGENT_ROOT / "src" / "swarm" / "presets"
+LOADER_REGISTRY_PATH = AGENT_ROOT / "backtest" / "loaders" / "registry.py"
+MCP_SERVER_PATH = AGENT_ROOT / "mcp_server.py"
+
+
+def _manifest_text() -> str:
+    return MANIFEST_PATH.read_text(encoding="utf-8")
+
+
+def _literal_assignment(path: Path, name: str) -> object:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in tree.body:
+        if (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == name
+        ):
+            return ast.literal_eval(node.value)
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == name for target in node.targets
+        ):
+            return ast.literal_eval(node.value)
+    raise AssertionError(f"{name} not found in {path}")
+
+
+def _assert_all_counts(pattern: str, expected: int) -> None:
+    counts = [
+        int(value)
+        for value in re.findall(pattern, _manifest_text(), flags=re.IGNORECASE)
+    ]
+    assert counts, f"No manifest count matched {pattern!r}"
+    assert set(counts) == {expected}, f"Manifest counts {counts} do not match source count {expected}"
+
+
+def test_finance_skill_count_matches_bundled_skill_directories() -> None:
+    expected = sum(
+        1
+        for path in SKILLS_DIR.iterdir()
+        if path.is_dir() and (path / "SKILL.md").is_file()
+    )
+    _assert_all_counts(r"\b(\d+)\s+(?:finance\s+|specialized\s+)?skills\b", expected)
+
+
+def test_engine_counts_are_internally_consistent() -> None:
+    canonical = re.search(
+        r"across\s+(\d+)\s+engines\s*\(",
+        _manifest_text(),
+        flags=re.IGNORECASE,
+    )
+    assert canonical, "Manifest is missing the canonical backtest engine count"
+    _assert_all_counts(r"\b(\d+)\s+engines\b", int(canonical.group(1)))
+
+
+def test_alpha_zoo_counts_match_factor_modules() -> None:
+    zoo_counts = {
+        path.name: sum(1 for module in path.glob("*.py") if module.name != "__init__.py")
+        for path in ZOOS_DIR.iterdir()
+        if path.is_dir()
+    }
+    _assert_all_counts(r"Alpha Zoo\D{0,4}(\d+)\s+pre-built", sum(zoo_counts.values()))
+
+    text = _manifest_text()
+    for zoo, expected in zoo_counts.items():
+        match = re.search(rf"\*\*{re.escape(zoo)}\*\*\s*\((\d+)\s+(?:alphas|factors)\)", text)
+        assert match, f"Manifest is missing the {zoo} factor count"
+        assert int(match.group(1)) == expected
+
+
+def test_swarm_preset_count_matches_bundled_yaml_files() -> None:
+    expected = sum(1 for path in PRESETS_DIR.glob("*.yaml") if path.is_file())
+    _assert_all_counts(r"\b(\d+)\s+(?:multi-agent swarm|pre-built agent) teams\b", expected)
+
+
+def test_market_data_source_count_matches_loader_registry() -> None:
+    sources = _literal_assignment(LOADER_REGISTRY_PATH, "VALID_SOURCES")
+    assert isinstance(sources, set)
+    expected = len(sources - {"auto"})
+    _assert_all_counts(r"\b(\d+)\s+market-data sources\b", expected)
+    _assert_all_counts(r"across\s+(\d+)\s+sources\b", expected)
+
+
+def test_mcp_tool_heading_matches_registered_tools() -> None:
+    registered = len(
+        re.findall(
+            r"(?m)^@mcp\.tool(?:\(\))?\s*$",
+            MCP_SERVER_PATH.read_text(encoding="utf-8"),
+        )
+    )
+    _assert_all_counts(r"Available MCP Tools\s*\((\d+)\)", registered)


### PR DESCRIPTION
## Goal

Synchronize the packaged `agent/SKILL.md` capability counts with the current source tree and prevent the published manifest from drifting again.

## Changes

- Update the manifest to 8 backtest engines, 86 finance skills, 460 alphas across 5 zoos, 30 swarm teams, and 20 registered market-data sources.
- Document the fundamental alpha zoo and QVeris data source in the packaged skill.
- Add a standard-library-only regression test that derives counts from bundled skill directories, factor modules, swarm preset YAML files, the loader registry, and MCP tool decorators.
- Check that repeated engine counts remain internally consistent.

## Scope

Only packaged skill metadata/documentation and its regression test are changed. Runtime behavior, trading logic, broker integrations, network access, credentials, and deployment configuration are out of scope.

## Test plan

- `python -m pytest agent/tests/test_distribution_skill_manifest.py -q` — 6 passed
- `python -m ruff check agent/tests/test_distribution_skill_manifest.py` — passed
- `git diff --check` — passed

## Risk and rollback

Low risk: documentation plus a read-only test. Revert this commit to roll back.