### PR TITLE
fix(napcat): send pairing codes for private messages

### DIFF
--- a/agent/src/channels/napcat.py
+++ b/agent/src/channels/napcat.py
@@ -291,6 +291,7 @@ class NapcatChannel(BaseChannel):
                 "nickname": nickname,
                 "reply_to": reply_to_id,
             },
+            is_dm=message_type == "private",
         )
 
     @staticmethod


### PR DESCRIPTION
## Problem

When an unapproved sender DMs the bot through the Napcat (QQ/OneBot v11) channel, they get **no response at all**. The server log shows:

```
Access denied for sender <qq>. Add them to allow_from list in config to grant access.
```

`NapcatChannel._on_event` forwards private messages to `BaseChannel._handle_message` without `is_dm`, which defaults to `False`. The base class only issues pairing codes when `is_dm=True`, so private senders fall into the silent group-deny branch and the owner never learns a pairing request happened.

Other DM-capable adapters (e.g. `weixin`) pass `is_dm=True` and correctly reply with a pairing code.

## Fix

Pass `is_dm=message_type == "private"` in the `_handle_message` call. Group behaviour is unchanged (`is_dm=False` as before).

## Repro / verification

1. Configure napcat channel, connect a QQ account, leave `allow_from` empty.
2. DM the bot from another QQ account.
3. Before: silence + "Access denied" warning in logs. After: the sender receives the standard pairing-code reply, and `vibe-trading channels pairing --channel napcat list` shows the pending request. Verified end-to-end against a live NapCat (OneBot v11 WS, array message format).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YEshFSpjkW7EFuPCMGE64A