### PR TITLE
feat(optimizers): add turnover-aware portfolio optimizer

### DIFF
--- a/agent/backtest/optimizers/__init__.py
+++ b/agent/backtest/optimizers/__init__.py
@@ -1,10 +1,11 @@
 """Portfolio optimizer package.
 
-Provides four weighting schemes:
+Provides five weighting schemes:
 - equal_volatility: inverse-volatility weights
 - risk_parity: equal risk contribution (Spinu-style)
 - mean_variance: max Sharpe via scipy
 - max_diversification: maximize diversification ratio
+- turnover_aware: mean-variance utility with an L1 turnover penalty
 
 Select via ``optimizer`` in ``config.json``; default is off (1/N).
 Add a new optimizer by dropping a module here that exposes ``optimize()``.

--- a/agent/backtest/optimizers/turnover_aware.py
+++ b/agent/backtest/optimizers/turnover_aware.py
@@ -1,0 +1,132 @@
+"""Turnover-aware optimizer: max-Sharpe objective with an L1 turnover penalty.
+
+Solves, per rebalance date::
+
+    min  -w'mu + lambda * w'Sigma w + gamma * ||w - w_prev||_1
+    s.t. w >= 0, sum(w) = 1
+
+where ``w_prev`` is the weight vector applied at the previous rebalance,
+restricted to the current active set (assets absent last time have prior
+weight 0, so entries and exits both count as turnover). With ``gamma == 0``
+the objective reduces to the mean-variance utility baseline.
+
+The penalty ``gamma`` is scale-sensitive: it is measured against the return
+term ``w'mu``, so an appropriate magnitude depends on the return units of the
+input window. For daily returns (~1e-3), even ``gamma`` around 0.5 makes the
+optimizer strongly prefer holding still. Callers should tune ``gamma`` relative
+to their data frequency.
+
+Realized per-rebalance turnover (``0.5 * ||w_t - w_{t-1}||_1``) is accumulated
+on the instance for cost-adjusted analysis.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import numpy as np
+import pandas as pd
+
+from backtest.optimizers.base import BaseOptimizer
+
+
+class TurnoverAwareOptimizer(BaseOptimizer):
+    """Mean-variance weights penalized for turnover against prior weights.
+
+    Attributes:
+        risk_aversion: Weight on the variance term (lambda).
+        turnover_penalty: Weight on the L1 turnover term (gamma). 0 reduces to
+            the mean-variance baseline.
+        risk_free: Risk-free rate subtracted from mean returns.
+        realized_turnover: Per-rebalance realized turnover collected during
+            ``optimize`` (``0.5 * ||w_t - w_{t-1}||_1``).
+    """
+
+    def __init__(
+        self,
+        lookback: int = 60,
+        risk_aversion: float = 1.0,
+        turnover_penalty: float = 0.0,
+        risk_free: float = 0.0,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(lookback=lookback, **kwargs)
+        self.risk_aversion = float(risk_aversion)
+        self.turnover_penalty = float(turnover_penalty)
+        self.risk_free = float(risk_free)
+        self._prev: Dict[str, float] = {}
+        self.realized_turnover: List[float] = []
+
+    def _build_context(
+        self, window: pd.DataFrame, active: List[str]
+    ) -> "Dict[str, Any] | None":
+        """Mean vector, covariance, and active codes for the current window."""
+        mu = window.mean().values
+        cov = window.cov().values
+        if np.isnan(cov).any() or np.isnan(mu).any():
+            return None
+        return {"cov": cov, "mu": mu, "active": list(active)}
+
+    def _calc_weights(self, ctx: Dict[str, Any]) -> np.ndarray:
+        """SLSQP weights for the penalized objective; updates turnover state."""
+        from scipy.optimize import minimize
+
+        mu = np.asarray(ctx["mu"], dtype=float)
+        cov = np.asarray(ctx["cov"], dtype=float)
+        active: List[str] = ctx["active"]
+        n = len(mu)
+        if n == 0:
+            return self._equal_weight(0)
+
+        w_prev = np.array([self._prev.get(code, 0.0) for code in active], dtype=float)
+        rf = self.risk_free
+        lam = self.risk_aversion
+        gamma = self.turnover_penalty
+
+        def objective(w: np.ndarray) -> float:
+            ret = w @ mu - rf
+            var = w @ cov @ w
+            turn = np.abs(w - w_prev).sum()
+            return -ret + lam * var + gamma * turn
+
+        x0 = w_prev if w_prev.sum() > 1e-12 else self._equal_weight(n)
+        result = minimize(
+            objective,
+            x0,
+            method="SLSQP",
+            bounds=[(0.0, 1.0)] * n,
+            constraints={"type": "eq", "fun": lambda w: w.sum() - 1.0},
+            options={"maxiter": 200, "ftol": 1e-10},
+        )
+
+        weights = self._normalize(result.x) if result.success else self._equal_weight(n)
+        self._record_turnover(active, weights)
+        return weights
+
+    def _record_turnover(self, active: List[str], weights: np.ndarray) -> None:
+        """Accumulate realized turnover and roll prior weights forward."""
+        codes = set(active) | set(self._prev)
+        new_map = {code: float(weights[i]) for i, code in enumerate(active)}
+        turnover = 0.5 * sum(
+            abs(new_map.get(code, 0.0) - self._prev.get(code, 0.0)) for code in codes
+        )
+        self.realized_turnover.append(turnover)
+        self._prev = new_map
+
+
+def optimize(
+    ret: pd.DataFrame,
+    pos: pd.DataFrame,
+    dates: pd.DatetimeIndex,
+    lookback: int = 60,
+    risk_aversion: float = 1.0,
+    turnover_penalty: float = 0.0,
+    risk_free: float = 0.0,
+) -> pd.DataFrame:
+    """Module-level entry: turnover-penalized mean-variance positions."""
+    return TurnoverAwareOptimizer(
+        lookback=lookback,
+        risk_aversion=risk_aversion,
+        turnover_penalty=turnover_penalty,
+        risk_free=risk_free,
+    ).optimize(ret, pos, dates)

--- a/agent/tests/test_turnover_aware_optimizer.py
+++ b/agent/tests/test_turnover_aware_optimizer.py
@@ -1,0 +1,143 @@
+"""Tests for the turnover-aware optimizer."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from backtest.optimizers.turnover_aware import TurnoverAwareOptimizer, optimize
+
+
+def _sample_data(n_days: int = 200, n_assets: int = 4, seed: int = 0):
+    """Return (ret, pos, dates) for a small long-only universe."""
+    rng = np.random.default_rng(seed)
+    dates = pd.bdate_range("2025-01-01", periods=n_days)
+    codes = [f"A{i}" for i in range(n_assets)]
+    ret = pd.DataFrame(
+        rng.normal(0.001, 0.02, (n_days, n_assets)), index=dates, columns=codes
+    )
+    pos = pd.DataFrame(1.0, index=dates, columns=codes)
+    return ret, pos, dates
+
+
+class TestTurnoverAwareCalcWeights:
+    """Unit tests for the core weight calculation."""
+
+    def test_weights_sum_to_one(self) -> None:
+        rng = np.random.default_rng(42)
+        n = 5
+        A = rng.standard_normal((120, n))
+        ctx = {"cov": np.cov(A.T), "mu": A.mean(axis=0), "active": [f"A{i}" for i in range(n)]}
+        opt = TurnoverAwareOptimizer(turnover_penalty=0.5)
+        w = opt._calc_weights(ctx)
+        assert abs(w.sum() - 1.0) < 1e-8
+
+    def test_weights_nonnegative(self) -> None:
+        rng = np.random.default_rng(7)
+        n = 4
+        A = rng.standard_normal((120, n))
+        ctx = {"cov": np.cov(A.T), "mu": A.mean(axis=0), "active": [f"A{i}" for i in range(n)]}
+        opt = TurnoverAwareOptimizer(turnover_penalty=0.5)
+        w = opt._calc_weights(ctx)
+        assert np.all(w >= -1e-9)
+
+    def test_zero_penalty_is_path_independent(self) -> None:
+        """With gamma=0 the prior weights must not affect the solution."""
+        rng = np.random.default_rng(3)
+        n = 4
+        A = rng.standard_normal((120, n))
+        codes = [f"A{i}" for i in range(n)]
+        ctx = {"cov": np.cov(A.T), "mu": A.mean(axis=0), "active": codes}
+
+        fresh = TurnoverAwareOptimizer(turnover_penalty=0.0)
+        w_fresh = fresh._calc_weights(dict(ctx))
+
+        seeded = TurnoverAwareOptimizer(turnover_penalty=0.0)
+        seeded._prev = {codes[0]: 1.0}  # arbitrary prior concentration
+        w_seeded = seeded._calc_weights(dict(ctx))
+
+        np.testing.assert_allclose(w_fresh, w_seeded, atol=1e-4)
+
+    def test_empty_active_set(self) -> None:
+        opt = TurnoverAwareOptimizer()
+        w = opt._calc_weights({"cov": np.empty((0, 0)), "mu": np.array([]), "active": []})
+        assert len(w) == 0
+
+
+class TestTurnoverAwareOptimize:
+    """Integration tests through the module-level optimize()."""
+
+    def test_higher_penalty_lowers_turnover(self) -> None:
+        ret, pos, dates = _sample_data()
+
+        low = TurnoverAwareOptimizer(lookback=60, risk_aversion=5.0, turnover_penalty=0.0)
+        low.optimize(ret, pos, dates)
+
+        high = TurnoverAwareOptimizer(lookback=60, risk_aversion=5.0, turnover_penalty=2.0)
+        high.optimize(ret, pos, dates)
+
+        assert sum(high.realized_turnover) <= sum(low.realized_turnover) + 1e-9
+
+    def test_turnover_monotone_non_increasing_in_penalty(self) -> None:
+        """Realized turnover must not rise as the penalty grows."""
+        ret, pos, dates = _sample_data()
+        totals = []
+        for gamma in (0.0, 0.5, 1.0, 2.0, 5.0):
+            opt = TurnoverAwareOptimizer(
+                lookback=60, risk_aversion=5.0, turnover_penalty=gamma
+            )
+            opt.optimize(ret, pos, dates)
+            totals.append(sum(opt.realized_turnover))
+        assert all(totals[i] >= totals[i + 1] - 1e-9 for i in range(len(totals) - 1))
+
+    def test_all_nan_column_does_not_raise(self) -> None:
+        """A fully NaN asset column must not crash the optimizer."""
+        ret, pos, dates = _sample_data()
+        ret["A0"] = np.nan
+        opt = TurnoverAwareOptimizer(lookback=60, turnover_penalty=0.5)
+        result = opt.optimize(ret, pos, dates)
+        assert result.shape == pos.shape
+
+    def test_result_weights_on_simplex(self) -> None:
+        ret, pos, dates = _sample_data()
+        opt = TurnoverAwareOptimizer(lookback=60, risk_aversion=5.0, turnover_penalty=0.5)
+        result = opt.optimize(ret, pos, dates)
+        last = result.iloc[-1].values
+        assert abs(last.sum() - 1.0) < 1e-6
+        assert (last >= -1e-9).all()
+
+    def test_preserves_sign(self) -> None:
+        dates = pd.bdate_range("2025-01-01", periods=120)
+        codes = ["A", "B"]
+        rng = np.random.default_rng(11)
+        ret = pd.DataFrame(rng.normal(0, 0.02, (120, 2)), index=dates, columns=codes)
+        pos = pd.DataFrame(0.0, index=dates, columns=codes)
+        pos.iloc[60:, 0] = 1.0
+        pos.iloc[60:, 1] = -1.0
+
+        result = optimize(ret, pos, dates, lookback=60, turnover_penalty=0.5)
+        assert (result.iloc[61:, 0] >= 0).all()
+        assert (result.iloc[61:, 1] <= 0).all()
+
+    def test_short_window_and_nan_do_not_raise(self) -> None:
+        ret, pos, dates = _sample_data(n_days=80)
+        ret.iloc[10:20, 0] = np.nan
+        opt = TurnoverAwareOptimizer(lookback=60, turnover_penalty=0.5)
+        result = opt.optimize(ret, pos, dates)
+        assert result.shape == pos.shape
+
+    def test_turnover_recorded(self) -> None:
+        ret, pos, dates = _sample_data()
+        opt = TurnoverAwareOptimizer(lookback=60, turnover_penalty=0.5)
+        opt.optimize(ret, pos, dates)
+        assert len(opt.realized_turnover) > 0
+        assert all(t >= 0.0 for t in opt.realized_turnover)
+
+    def test_single_asset_unchanged(self) -> None:
+        dates = pd.bdate_range("2025-01-01", periods=100)
+        ret = pd.DataFrame(
+            np.random.default_rng(1).normal(0, 0.02, (100, 1)), index=dates, columns=["A"]
+        )
+        pos = pd.DataFrame(1.0, index=dates, columns=["A"])
+        result = optimize(ret, pos, dates, lookback=60)
+        pd.testing.assert_frame_equal(result, pos)


### PR DESCRIPTION
## Summary

Adds a new opt-in `turnover_aware` portfolio optimizer under `backtest/optimizers/`. It maximizes a mean-variance utility minus an L1 penalty on the change in weights relative to the previously held weights, solved with SLSQP on the long-only simplex.

This is the first step of Portfolio Studio (#456), scoped per the maintainer guidance there: turnover-aware optimization first, existing four schemes untouched, config-driven parameters, changes confined to `backtest/`.

## Why

The engine already loads optimizers dynamically via `config.optimizer` → `backtest.optimizers.<name>.optimize(ret, pos, dates, **optimizer_params)` (`backtest/engines/base.py`), with four schemes today (mean-variance, risk parity, equal-volatility, max-diversification). None of them account for **turnover cost**: because weights are recomputed on a rolling window each rebalance, an optimizer can churn positions every bar, so an optimized backtest can overstate net returns once real transaction costs apply. This optimizer lets the objective trade off expected risk-adjusted return against turnover, and reports realized turnover so cost-adjusted performance is visible.

## Changes

- `backtest/optimizers/turnover_aware.py`: new `TurnoverAwareOptimizer(BaseOptimizer)` + module-level `optimize()`. Objective `min −wᵀμ + λ·wᵀΣw + γ·‖w − w_prev‖₁`, long-only simplex via SLSQP, warm-started from prior weights, falling back to equal weight on non-convergence / NaN covariance. Prior weights are tracked over the full universe (entries and exits both count as turnover). Realized per-rebalance turnover is accumulated on the instance.
- `backtest/optimizers/__init__.py`: document the new scheme.
- `tests/test_turnover_aware_optimizer.py`: 12 tests.

Notes:
- Opt-in only; default backtest behavior is unchanged (optimizer off → 1/N).
- With `turnover_penalty=0` the objective is path-independent and equals the un-penalized mean-variance-utility solution (verified against a brute-force simplex search).
- The penalty is scale-sensitive relative to the return term; this is documented in the module docstring so callers can tune it to their data frequency.
- No new dependencies (reuses `numpy` / `scipy.optimize`, already used by `mean_variance.py`).

## Test Plan

- [x] ruff check — clean
- [x] pytest tests/test_turnover_aware_optimizer.py — 12 passed
- [x] pytest full suite (excl e2e) — 4895 passed, 9 skipped (2 pre-existing env failures unrelated to this change: `test_factor_gate_fund_prefix`, `test_factor_operators::test_bottleneck_available`, both reproduce on clean main)

Test coverage: zero-penalty path-independence, higher penalty lowers realized turnover, turnover monotone non-increasing across penalty levels, long-only simplex feasibility, input sign preservation, short-window / NaN / all-NaN-column graceful handling, single-asset passthrough, realized-turnover reporting.

## Checklist

- [x] No changes to protected areas without prior discussion (direction approved in #456)
- [x] No hardcoded values (all parameters config-driven with defaults)
- [x] Code follows CONTRIBUTING.md guidelines (type hints, Google-style docstrings, DCO sign-off)
- [x] Documentation updated (package docstring lists the new scheme)

Refs #456
