### PR TITLE
fix: support legacy FastMCP transport imports

### DIFF
--- a/agent/src/tools/mcp.py
+++ b/agent/src/tools/mcp.py
@@ -16,9 +16,16 @@ from typing import Any, Awaitable, Callable, Coroutine, Iterable, Protocol, Type
 from fastmcp.client import Client
 from fastmcp.client.auth import OAuth
 from fastmcp.client.client import CallToolResult
-from fastmcp.client.transports.http import StreamableHttpTransport
-from fastmcp.client.transports.sse import SSETransport
-from fastmcp.client.transports.stdio import StdioTransport
+try:
+    from fastmcp.client.transports.http import StreamableHttpTransport
+    from fastmcp.client.transports.sse import SSETransport
+    from fastmcp.client.transports.stdio import StdioTransport
+except ModuleNotFoundError:
+    from fastmcp.client.transports import (
+        SSETransport,
+        StdioTransport,
+        StreamableHttpTransport,
+    )
 from fastmcp.exceptions import McpError, ToolError
 from key_value.aio.stores.filetree import FileTreeStore, FileTreeV1KeySanitizationStrategy
 from mcp import types as mcp_types


### PR DESCRIPTION
## Summary
- keep MCP transport imports compatible with both FastMCP module layouts
- preserves support for environments where fastmcp.client.transports is a module rather than a package

## Context
This was split out from #418 after review feedback to keep the FXMacroData integration scoped. The scheduled-routes 204 fix mentioned there is already present on current main; this PR only carries the remaining FastMCP compatibility fix.

## Validation
- python -m pytest agent/tests/test_market_data_tool.py agent/tests/test_mcp_server_smoke.py -q (5 passed)
- git diff --check