### PR TITLE
feat(data): add Binance USD-M symbol routing + execution/mark split

### DIFF
--- a/agent/backtest/loaders/ccxt_loader.py
+++ b/agent/backtest/loaders/ccxt_loader.py
@@ -95,12 +95,18 @@ class DataLoader:
     def __init__(self) -> None:
         pass
 
-    def _get_exchange(self):
-        """Create exchange instance."""
+    def _get_exchange(self, instrument_type: str = "spot"):
+        """Create an exchange instance for spot or Binance USD-M swaps."""
         import ccxt
         from src.config.accessor import get_env_config
 
         exchange_id = get_env_config().data.ccxt_exchange.lower()
+        if instrument_type == "swap":
+            if exchange_id not in {"binance", "binanceusdm"}:
+                raise ValueError(
+                    "BASE-USDT-PERP currently requires CCXT_EXCHANGE=binance"
+                )
+            exchange_id = "binanceusdm"
         exchange_cls = getattr(ccxt, exchange_id, None)
         if exchange_cls is None:
             logger.warning("Unknown CCXT exchange %s, falling back to binance", exchange_id)
@@ -143,15 +149,27 @@ class DataLoader:
         # opens an exchange object.
         exchange_holder: Dict[str, object] = {}
 
-        def get_exchange():
-            if "exchange" not in exchange_holder:
-                exchange_holder["exchange"] = self._get_exchange()
-            return exchange_holder["exchange"]
+        def get_exchange(instrument_type: str):
+            if instrument_type not in exchange_holder:
+                exchange_holder[instrument_type] = self._get_exchange(instrument_type)
+            return exchange_holder[instrument_type]
 
         result: Dict[str, pd.DataFrame] = {}
         for code in codes:
+            instrument_type = "spot"
             try:
-                ccxt_symbol, _instrument_type = _parse_ccxt_symbol(code)
+                ccxt_symbol, instrument_type = _parse_ccxt_symbol(code)
+                exchange = get_exchange(instrument_type)
+
+                def fetch_frame():
+                    if instrument_type == "swap":
+                        return self._fetch_perpetual(
+                            exchange, ccxt_symbol, timeframe, since_ms, end_ms
+                        )
+                    return self._fetch_one(
+                        exchange, ccxt_symbol, timeframe, since_ms, end_ms
+                    )
+
                 df = cached_loader_fetch(
                     source=self.name,
                     symbol=code,
@@ -159,19 +177,48 @@ class DataLoader:
                     start_date=start_date,
                     end_date=end_date,
                     fields=None,
-                    fetch=lambda ccxt_symbol=ccxt_symbol: self._fetch_one(
-                        get_exchange(), ccxt_symbol, timeframe, since_ms, end_ms
-                    ),
+                    fetch=fetch_frame,
                 )
                 if df is not None and not df.empty:
                     result[code] = df
             except Exception as exc:
+                if instrument_type == "swap" or code.strip().upper().endswith("-PERP"):
+                    raise
                 logger.warning("CCXT failed for %s: %s", code, exc)
+        return result
+
+    @classmethod
+    def _fetch_perpetual(
+        cls, exchange, symbol: str, timeframe: str, since_ms: int, end_ms: int,
+    ) -> pd.DataFrame:
+        """Fetch aligned trade-price and mark-price candles for one USD-M swap."""
+        trade = cls._fetch_one(exchange, symbol, timeframe, since_ms, end_ms)
+        mark = cls._fetch_one(
+            exchange,
+            symbol,
+            timeframe,
+            since_ms,
+            end_ms,
+            params={"price": "mark"},
+        )
+        if trade is None or mark is None or not trade.index.equals(mark.index):
+            raise ValueError(f"mark-price timestamps are incomplete or unsynchronized for {symbol}")
+
+        result = trade.copy()
+        result["execution_open"] = trade["open"]
+        for column in ("open", "high", "low", "close"):
+            result[f"mark_{column}"] = mark[column]
         return result
 
     @staticmethod
     def _fetch_one(
-        exchange, symbol: str, timeframe: str, since_ms: int, end_ms: int,
+        exchange,
+        symbol: str,
+        timeframe: str,
+        since_ms: int,
+        end_ms: int,
+        *,
+        params: dict[str, str] | None = None,
     ) -> Optional[pd.DataFrame]:
         """Paginated OHLCV fetch for one symbol."""
         import ccxt
@@ -187,8 +234,14 @@ class DataLoader:
             # ``ccxt.NetworkError`` covers RequestTimeout / DDoSProtection /
             # ExchangeNotAvailable — the transient family. Anything else
             # (e.g. ``ExchangeError`` for a bad symbol) is not retried.
+            def fetch_page():
+                kwargs = {"since": cursor, "limit": limit}
+                if params is not None:
+                    kwargs["params"] = params
+                return exchange.fetch_ohlcv(symbol, timeframe, **kwargs)
+
             ohlcv = retry_with_budget(
-                lambda: exchange.fetch_ohlcv(symbol, timeframe, since=cursor, limit=limit),
+                fetch_page,
                 transient=ccxt.NetworkError,
                 deadline=deadline,
                 label=label,

--- a/agent/backtest/loaders/ccxt_loader.py
+++ b/agent/backtest/loaders/ccxt_loader.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import time
 from typing import Dict, List, Optional
 
@@ -38,6 +39,19 @@ _INTERVAL_MAP = {
 # scheduling is delegated to :mod:`backtest.loaders.base`.
 _CCXT_TIMEOUT_MS = positive_env_int("CCXT_TIMEOUT_MS", 15_000)
 _CCXT_FETCH_BUDGET_S = positive_env_float("CCXT_FETCH_BUDGET_S", 60.0)
+
+
+def _parse_ccxt_symbol(code: str) -> tuple[str, str]:
+    """Return the canonical CCXT symbol and instrument type for ``code``."""
+    normalized = code.strip().upper()
+    if normalized.endswith("-PERP"):
+        match = re.fullmatch(r"([A-Z0-9]+)-USDT-PERP", normalized)
+        if match is None:
+            raise ValueError(
+                "USD-M perpetual symbol must use BASE-USDT-PERP, e.g. BTC-USDT-PERP"
+            )
+        return f"{match.group(1)}/USDT:USDT", "swap"
+    return normalized.replace("-", "/"), "spot"
 
 
 def _first_proxy_env(*names: str) -> str:
@@ -137,7 +151,7 @@ class DataLoader:
         result: Dict[str, pd.DataFrame] = {}
         for code in codes:
             try:
-                ccxt_symbol = code.replace("-", "/").upper()
+                ccxt_symbol, _instrument_type = _parse_ccxt_symbol(code)
                 df = cached_loader_fetch(
                     source=self.name,
                     symbol=code,

--- a/agent/tests/test_ccxt_perpetual_loader.py
+++ b/agent/tests/test_ccxt_perpetual_loader.py
@@ -1,0 +1,35 @@
+"""Historical Binance USD-M data-contract tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from backtest.loaders.base import make_loader_cache_key
+from backtest.loaders.ccxt_loader import _parse_ccxt_symbol
+
+
+def test_spot_symbol_keeps_existing_ccxt_contract() -> None:
+    assert _parse_ccxt_symbol("BTC-USDT") == ("BTC/USDT", "spot")
+
+
+def test_perpetual_symbol_maps_to_binance_usdm_contract() -> None:
+    assert _parse_ccxt_symbol("BTC-USDT-PERP") == ("BTC/USDT:USDT", "swap")
+
+
+@pytest.mark.parametrize("code", ["BTC-PERP", "-USDT-PERP", "BTC--PERP"])
+def test_malformed_perpetual_symbol_is_rejected(code: str) -> None:
+    with pytest.raises(ValueError, match="USD-M perpetual symbol"):
+        _parse_ccxt_symbol(code)
+
+
+def test_spot_and_perpetual_cache_keys_cannot_collide() -> None:
+    common = {
+        "source": "ccxt",
+        "timeframe": "1H",
+        "start_date": "2024-01-01",
+        "end_date": "2024-01-31",
+        "fields": None,
+    }
+    spot = make_loader_cache_key(symbol="BTC-USDT", **common)
+    perpetual = make_loader_cache_key(symbol="BTC-USDT-PERP", **common)
+    assert spot != perpetual

--- a/agent/tests/test_ccxt_perpetual_loader.py
+++ b/agent/tests/test_ccxt_perpetual_loader.py
@@ -3,9 +3,36 @@
 from __future__ import annotations
 
 import pytest
+import pandas as pd
 
 from backtest.loaders.base import make_loader_cache_key
 from backtest.loaders.ccxt_loader import _parse_ccxt_symbol
+
+
+def _hourly_rows(opens: list[float]) -> list[list[float]]:
+    start = int(pd.Timestamp("2024-01-01 00:00:00").timestamp() * 1000)
+    hour = 3_600_000
+    return [
+        [start + i * hour, value, value + 2, value - 2, value + 1, 10 + i]
+        for i, value in enumerate(opens)
+    ]
+
+
+class _PerpetualExchange:
+    def __init__(self, *, mark_rows: list[list[float]] | None = None) -> None:
+        self.trade_rows = _hourly_rows([100.0, 101.0])
+        self.mark_rows = mark_rows if mark_rows is not None else _hourly_rows([99.0, 100.0])
+        self.calls: list[dict[str, object]] = []
+
+    def fetch_ohlcv(self, symbol, timeframe, since=None, limit=None, params=None):
+        self.calls.append({
+            "symbol": symbol,
+            "timeframe": timeframe,
+            "since": since,
+            "limit": limit,
+            "params": params,
+        })
+        return self.mark_rows if params == {"price": "mark"} else self.trade_rows
 
 
 def test_spot_symbol_keeps_existing_ccxt_contract() -> None:
@@ -33,3 +60,43 @@ def test_spot_and_perpetual_cache_keys_cannot_collide() -> None:
     spot = make_loader_cache_key(symbol="BTC-USDT", **common)
     perpetual = make_loader_cache_key(symbol="BTC-USDT-PERP", **common)
     assert spot != perpetual
+
+
+def test_perpetual_fetch_separates_execution_and_mark_prices(monkeypatch) -> None:
+    exchange = _PerpetualExchange()
+    monkeypatch.setattr(
+        "backtest.loaders.ccxt_loader.DataLoader._get_exchange",
+        lambda _self, instrument_type="spot": exchange,
+    )
+
+    from backtest.loaders.ccxt_loader import DataLoader
+
+    frame = DataLoader().fetch(
+        ["BTC-USDT-PERP"], "2024-01-01", "2024-01-01", interval="1H"
+    )["BTC-USDT-PERP"]
+
+    assert frame["execution_open"].tolist() == [100.0, 101.0]
+    assert frame["mark_open"].tolist() == [99.0, 100.0]
+    assert frame["mark_high"].tolist() == [101.0, 102.0]
+    assert frame["mark_low"].tolist() == [97.0, 98.0]
+    assert frame["mark_close"].tolist() == [100.0, 101.0]
+    assert exchange.calls[0]["symbol"] == "BTC/USDT:USDT"
+    assert exchange.calls[0]["params"] is None
+    assert exchange.calls[1]["params"] == {"price": "mark"}
+
+
+def test_perpetual_fetch_rejects_unsynchronized_mark_rows(monkeypatch) -> None:
+    mark_rows = _hourly_rows([99.0, 100.0])
+    mark_rows[1][0] += 60_000
+    exchange = _PerpetualExchange(mark_rows=mark_rows)
+    monkeypatch.setattr(
+        "backtest.loaders.ccxt_loader.DataLoader._get_exchange",
+        lambda _self, instrument_type="spot": exchange,
+    )
+
+    from backtest.loaders.ccxt_loader import DataLoader
+
+    with pytest.raises(ValueError, match="mark-price timestamps"):
+        DataLoader().fetch(
+            ["BTC-USDT-PERP"], "2024-01-01", "2024-01-01", interval="1H"
+        )


### PR DESCRIPTION
## Summary

- Add an explicit `*-USDT-PERP` symbol contract for Binance USD-M history.
- Fetch execution (trade) OHLC and mark-price OHLC separately for perpetual symbols.
- Fail closed when mark-price history is missing or unsynchronized with trade history.

## Why

Part of #462. Maintainer guidance approved the narrower first slice: "explicit
`BTC-USDT-PERP` routing + execution/mark OHLC separation first, with historical
funding + maintenance brackets as a follow-up." Historical funding settlement
alignment is **not** in this PR — it becomes PR 1b. This PR does not change order
execution or add a live connector; existing `CryptoEngine`/spot behavior is
unchanged and remains the default.

## Changes

- Map `BTC-USDT-PERP` to CCXT `BTC/USDT:USDT` on `binanceusdm`.
- Keep `execution_open` separate from `mark_open`/`mark_high`/`mark_low`/`mark_close`.
- Spot symbols and cache identities stay backward-compatible; spot and perpetual
  cache keys cannot collide.
- Perpetual routing only activates on an explicit `-PERP` suffix (opt-in).

## Test Plan

- [x] `pytest agent/tests/test_ccxt_perpetual_loader.py agent/tests/test_ccxt_loader_bounded.py agent/tests/test_ccxt_loader_proxy.py -q` — 19 passed.
- [x] `pytest agent/tests/test_crypto_engine.py agent/tests/test_base_engine.py -q` — 48 passed (default-path regression).
- [x] `ruff check agent/backtest/loaders/ccxt_loader.py agent/tests/test_ccxt_perpetual_loader.py` — clean.
- [x] `bash tools/ci_grep_gates.sh` — all 5 gates pass (zero raw `os.getenv`/`os.environ` in new code).
- [x] `git diff --stat upstream/main` — 2 files, 181(+)/12(-), 193 lines total.
- [x] Full suite (`--continue-on-collection-errors`): 4,842 passed, 19 failed, 11 skipped, 21 errors — all failures/errors independently confirmed to reproduce on a clean, unmodified `upstream/main`; none touch this PR's files.

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`)
- [x] No hardcoded values; no raw env reads (AST-gated)
- [x] Follows CONTRIBUTING.md
- [x] No market data files committed; test fixtures are synthetic/mocked
- [x] No live-endpoint imports reachable from the backtest path
