### PR TITLE
fix(preflight): reset EnvConfig after dotenv load to pick up .env values

### DIFF
--- a/agent/src/preflight.py
+++ b/agent/src/preflight.py
@@ -15,7 +15,7 @@ from typing import List, Optional
 from rich.console import Console
 from rich.table import Table
 
-from src.config.accessor import get_env_config
+from src.config.accessor import get_env_config, reset_env_config
 
 
 @dataclass(frozen=True)
@@ -34,6 +34,11 @@ def _check_llm_provider() -> CheckResult:
     from src.providers.llm import _ensure_dotenv, _sync_provider_env, provider_diagnostics
 
     _ensure_dotenv()
+    # The EnvConfig singleton may have been cached before _ensure_dotenv()
+    # loaded the .env file (e.g. by theme.py's import-time _is_dark_terminal
+    # call). Reset it so get_env_config() rebuilds from the now-populated
+    # os.environ.
+    reset_env_config()
     _cfg = get_env_config()
     provider = _cfg.llm.langchain_provider.strip()
     model = _cfg.llm.langchain_model_name.strip()


### PR DESCRIPTION
Fixes https://github.com/HKUDS/Vibe-Trading/issues/477

## Problem

Preflight always reports `LLM (openai)` with `LANGCHAIN_MODEL_NAME not set`, even when `agent/.env` correctly configures a different provider (e.g. `openai-codex`).

## Root Cause

`cli/theme.py:187` calls `_is_dark_terminal()` at **module import time**, which calls `get_env_config()` and caches the `EnvConfig` singleton **before** any `.env` file is loaded. When `_check_llm_provider()` later calls `_ensure_dotenv()`, the values are written to `os.environ`, but the subsequent `get_env_config()` returns the stale cached snapshot with defaults (`provider="openai"`, `model=""`).

## Fix

Call `reset_env_config()` after `_ensure_dotenv()` in `_check_llm_provider()` so the singleton is rebuilt from the now-populated `os.environ`.

## Verification

Before fix: `LLM (openai) — LANGCHAIN_MODEL_NAME not set in .env (agent cannot function)`
After fix: `LLM (openai-codex) — openai-codex/gpt-5.4 via ChatGPT OAuth (...)`