### PR TITLE
fix(preflight): refresh config after loading dotenv

### DIFF
--- a/agent/src/preflight.py
+++ b/agent/src/preflight.py
@@ -15,7 +15,7 @@ from typing import List, Optional
 from rich.console import Console
 from rich.table import Table
 
-from src.config.accessor import get_env_config
+from src.config.accessor import get_env_config, reset_env_config
 
 
 @dataclass(frozen=True)
@@ -34,6 +34,7 @@ def _check_llm_provider() -> CheckResult:
     from src.providers.llm import _ensure_dotenv, _sync_provider_env, provider_diagnostics
 
     _ensure_dotenv()
+    reset_env_config()
     _cfg = get_env_config()
     provider = _cfg.llm.langchain_provider.strip()
     model = _cfg.llm.langchain_model_name.strip()

--- a/agent/tests/test_preflight.py
+++ b/agent/tests/test_preflight.py
@@ -75,6 +75,40 @@ def test_llm_preflight_probe_reports_request_errors(monkeypatch) -> None:
     assert "Timeout: timed out" in result.message
 
 
+def test_llm_preflight_refreshes_config_after_loading_dotenv(monkeypatch) -> None:
+    """Preflight must not reuse a config snapshot created before dotenv loading."""
+    import src.providers.llm as llm
+    from src.config.accessor import get_env_config
+
+    for name in ("LANGCHAIN_PROVIDER", "LANGCHAIN_MODEL_NAME", "OPENAI_BASE_URL"):
+        monkeypatch.delenv(name, raising=False)
+    get_env_config()
+
+    def load_dotenv() -> None:
+        monkeypatch.setenv("LANGCHAIN_PROVIDER", "openai")
+        monkeypatch.setenv("LANGCHAIN_MODEL_NAME", "gpt-test")
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://example.test/v1")
+
+    monkeypatch.setattr(llm, "_ensure_dotenv", load_dotenv)
+    monkeypatch.setattr(llm, "_sync_provider_env", lambda: None)
+    monkeypatch.setattr(
+        llm,
+        "provider_diagnostics",
+        lambda: {
+            "base_url": "https://example.test/v1",
+            "timeout_seconds": 120,
+            "max_retries": 2,
+            "proxy": {},
+        },
+    )
+    monkeypatch.setattr(requests, "get", lambda *args, **kwargs: requests.Response())
+
+    result = preflight._check_llm_provider()
+
+    assert result.name == "LLM (openai)"
+    assert result.status == "ready"
+
+
 def test_akshare_check_uses_spec_without_import(monkeypatch) -> None:
     """AKShare's package import is heavy; preflight should only check discovery."""
     monkeypatch.delitem(sys.modules, "akshare", raising=False)


### PR DESCRIPTION
## Summary

- refresh the cached environment schema immediately after preflight loads dotenv
- add a regression test for a config snapshot created before dotenv loading

## Why

Closes #477.

`run` preflight could cache `EnvConfig` before `_ensure_dotenv()` populated `os.environ`. It then continued using that stale snapshot and reported the model as missing even though `~/.vibe-trading/.env` contained it. Provider setup already resets this cache on its own path; preflight now does the same before reading provider and model values.

## Changes

- call `reset_env_config()` between `_ensure_dotenv()` and `get_env_config()`
- reproduce the stale-cache ordering and assert the loaded provider/model are used

## Test Plan

- [x] New regression test added
- [x] `python -m pytest agent/tests/test_preflight.py agent/tests/test_dotenv_observability.py -q --basetemp .pytest-tmp` (12 passed)
- [x] `python -m ruff check agent/src/preflight.py agent/tests/test_preflight.py`
- [x] `python -m compileall -q agent/src/preflight.py`

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`)
- [x] No hardcoded credentials or local application paths
- [x] Code follows `CONTRIBUTING.md`, including DCO sign-off
- [x] Documentation is unchanged because this restores the documented `.env` behavior

## Risk and rollback

No broker, order, MCP, credential-write, network-listener, or deployment behavior changes. The reset only discards an in-memory config snapshot immediately after dotenv loading. Rollback is a direct revert of this commit.
