### PR TITLE
fix(providers): replace stale OpenAI base URL

### DIFF
--- a/agent/src/providers/llm.py
+++ b/agent/src/providers/llm.py
@@ -501,7 +501,7 @@ def _sync_provider_env() -> None:
         os.environ["OPENAI_API_KEY"] = api_key
     if base_url:
         os.environ["OPENAI_API_BASE"] = base_url
-        os.environ.setdefault("OPENAI_BASE_URL", base_url)
+        os.environ["OPENAI_BASE_URL"] = base_url
 
 
 def provider_diagnostics() -> dict[str, Any]:

--- a/agent/tests/test_llm.py
+++ b/agent/tests/test_llm.py
@@ -177,6 +177,17 @@ class TestSyncProviderEnv:
         })
         assert result["OPENAI_API_KEY"] == "sk-shared"
 
+    def test_provider_base_url_replaces_stale_openai_url(self) -> None:
+        result = self._run_sync({
+            "LANGCHAIN_PROVIDER": "openrouter",
+            "OPENROUTER_API_KEY": "openrouter-key",
+            "OPENROUTER_BASE_URL": "https://openrouter.ai/api/v1",
+            "OPENAI_BASE_URL": "https://stale-provider.example/v1",
+        })
+
+        assert result["OPENAI_API_BASE"] == "https://openrouter.ai/api/v1"
+        assert result["OPENAI_BASE_URL"] == "https://openrouter.ai/api/v1"
+
     def test_minimax_provider(self) -> None:
         result = self._run_sync({
             "LANGCHAIN_PROVIDER": "minimax",


### PR DESCRIPTION
## Summary

- replace stale `OPENAI_BASE_URL` when synchronizing a provider-specific endpoint
- add a provider-switch regression test using OpenRouter and a stale prior URL

## Why

Closes #482.

`_sync_provider_env()` resolves provider-specific base URLs before generic OpenAI fallbacks, but wrote the resolved URL to `OPENAI_BASE_URL` with `setdefault`. If that variable survived a previous provider configuration, the OpenAI SDK continued sending requests to the stale endpoint even while `OPENAI_API_BASE` showed the new endpoint.

## Changes

- assign the resolved base URL to both OpenAI-compatible SDK variables
- verify an explicit `OPENROUTER_BASE_URL` replaces stale generic state

## Test Plan

- [x] `python -m pytest agent/tests/test_llm.py::TestSyncProviderEnv -q --basetemp .pytest-tmp` (13 passed)
- [x] `python -m ruff check agent/src/providers/llm.py agent/tests/test_llm.py`
- [x] `python -m compileall -q agent/src/providers/llm.py`

The remainder of `test_llm.py` requires the optional `langchain-openai` runtime, which is not installed in this local environment; the provider-sync class covering this change passes completely.

## Checklist

- [x] Provider code change is issue-discussed and covered by a targeted regression
- [x] No credentials, local application paths, or hardcoded production endpoints added
- [x] Code follows `CONTRIBUTING.md`, including DCO sign-off
- [x] Documentation is unchanged because this restores the documented provider-specific URL precedence

## Risk and rollback

No broker, order, MCP, credential-write, listener, or deployment behavior changes. The resolved provider-specific endpoint now consistently replaces stale OpenAI-compatible SDK state. Rollback is a direct revert of this commit.
