### PR TITLE
fix: filter unsupported hypothesis update fields

### DIFF
--- a/agent/src/tools/hypothesis_tool.py
+++ b/agent/src/tools/hypothesis_tool.py
@@ -96,13 +96,30 @@ class UpdateHypothesisTool(BaseTool):
             "invalidation_notes": {"type": "string"},
         },
         "required": ["hypothesis_id"],
+        "additionalProperties": False,
     }
 
     def execute(self, **kwargs: Any) -> str:
         """Update a hypothesis and return it as JSON."""
         try:
             hypothesis_id = str(kwargs.pop("hypothesis_id", ""))
-            updates = {key: value for key, value in kwargs.items() if value is not None}
+
+            allowed_fields = {
+                "title",
+                "thesis",
+                "status",
+                "universe",
+                "signal_definition",
+                "data_sources",
+                "skills",
+                "invalidation_notes",
+            }
+            updates = {
+                key: value
+                for key, value in kwargs.items()
+                if key in allowed_fields and value is not None
+            }
+
             hyp = HypothesisRegistry().update(hypothesis_id, **updates)
             return _ok({"hypothesis": hyp.to_dict()})
         except Exception as exc:

--- a/agent/tests/test_hypothesis_registry.py
+++ b/agent/tests/test_hypothesis_registry.py
@@ -142,3 +142,25 @@ def test_tool_wrappers_use_env_isolated_storage(storage_path: Path) -> None:
     assert found["hypotheses"][0]["hypothesis_id"] == hypothesis_id
 
     assert storage_path.exists()
+
+
+def test_update_hypothesis_tool_ignores_unknown_fields(storage_path: Path) -> None:
+    created = json.loads(
+        CreateHypothesisTool().execute(
+            title="Unknown field regression",
+            thesis="Unexpected tool arguments must not reach the registry.",
+        )
+    )
+    hypothesis_id = created["hypothesis"]["hypothesis_id"]
+
+    updated = json.loads(
+        UpdateHypothesisTool().execute(
+            hypothesis_id=hypothesis_id,
+            status="testing",
+            run_dir="runs/should-be-ignored",
+        )
+    )
+
+    assert updated["status"] == "ok"
+    assert updated["hypothesis"]["status"] == "testing"
+    assert "run_dir" not in updated["hypothesis"]


### PR DESCRIPTION
## Summary

- Prevent `UpdateHypothesisTool` from forwarding unsupported arguments to `HypothesisRegistry.update()`
- Reject undeclared properties in the tool schema
- Filter update fields through an explicit allowlist
- Add a regression test for the unexpected `run_dir` argument

## Why

The agent could pass `run_dir` to `update_hypothesis`, causing:

`HypothesisRegistry.update() got an unexpected keyword argument 'run_dir'`

## Test Plan

- [x] Existing hypothesis registry tests pass
- [x] New regression test added
- [x] `python -m pytest agent/tests/test_hypothesis_registry.py -q`
- [x] 8 tests passed