### PR TITLE
fix(tools): make write_file robust to aliased/missing path arg

### DIFF
--- a/agent/src/tools/write_file_tool.py
+++ b/agent/src/tools/write_file_tool.py
@@ -36,8 +36,28 @@ class WriteFileTool(BaseTool):
         Returns:
             JSON string with bytes_written or an error.
         """
-        file_path = kwargs["path"]
-        content = kwargs["content"]
+        # DeepSeek-v4-pro (and some other models) sometimes emit write_file
+        # with the path under an aliased key, or omit it entirely. Accept the
+        # common aliases and return a correctable error instead of raising a
+        # hard KeyError the model can't recover from.
+        file_path = (
+            kwargs.get("path")
+            or kwargs.get("file_path")
+            or kwargs.get("filepath")
+            or kwargs.get("filename")
+            or kwargs.get("file")
+        )
+        if not file_path:
+            return json.dumps(
+                {
+                    "status": "error",
+                    "error": "missing required argument 'path' (string): the file path relative to run_dir",
+                },
+                ensure_ascii=False,
+            )
+        content = kwargs.get("content")
+        if content is None:
+            content = kwargs.get("text", kwargs.get("data", ""))
         run_dir = kwargs.get("run_dir")
 
         try:


### PR DESCRIPTION
## Problem

`WriteFileTool.execute` does `kwargs["path"]` / `kwargs["content"]` directly. When a model emits a `write_file` call with the path under an aliased key (e.g. `file_path`, `filename`) or omits it, this raises an **uncaught `KeyError`**.

In swarm runs this is fatal: the worker crash-loops on the same malformed call with no error message the model can read and self-correct from, so the DAG never advances past the layer that writes handoff files.

### Reproduction

- Provider: `deepseek` / model `deepseek-v4-pro`
- `vibe-trading --swarm-run commodity_research_team '{"commodity":"iron ore","horizon":"12 months"}'`
- `supply_analyst` / `demand_analyst` repeatedly hit:
  ```
  Tool write_file failed
  KeyError: 'path'
    File ".../src/tools/write_file_tool.py", line 39, in execute
      file_path = kwargs["path"]
  ```
  The run never completes.

## Fix

- Resolve `path` from common aliases (`file_path`, `filepath`, `filename`, `file`) and `content` from (`text`, `data`).
- If no path can be resolved, return a structured `{"status":"error", ...}` the model can recover from, instead of raising.

No schema change — `path`/`content` remain the declared/required params; this only hardens execution against real-world model tool-call variance.

## Verification

After the change, the same `commodity_research_team` run completes end-to-end (3-agent DAG + backtest) with `write_file ✓` on all agents.