### PR TITLE
feat(config): add LONGBRIDGE_APP_KEY/APP_SECRET/ACCESS_TOKEN env vars (PR3)

### DIFF
--- a/agent/.env.example
+++ b/agent/.env.example
@@ -126,6 +126,11 @@ TUSHARE_TOKEN=your-tushare-token
 # Download FutuOpenD: https://www.futunn.com/download/openAPI
 # FUTU_HOST=127.0.0.1
 # FUTU_PORT=11111
+# US / HK equities via LongPort OpenAPI (optional, requires LongPort developer account)
+# Sign up: https://open.longbridge.com
+# LONGBRIDGE_APP_KEY=your-app-key
+# LONGBRIDGE_APP_SECRET=your-app-secret
+# LONGBRIDGE_ACCESS_TOKEN=your-access-token
 # Free direct-API sources need NO key and auto-join the fallback chain: Eastmoney / Sina / Stooq / Yahoo.
 
 # Optional API-key data sources (enabled only when the key is set; silently skipped otherwise)

--- a/agent/src/config/env_schema.py
+++ b/agent/src/config/env_schema.py
@@ -170,6 +170,9 @@ class DataConfig(_EnvBase):
     qveris_base_url: str = Field(alias="QVERIS_BASE_URL", default="")
     rsshub_base_url: str = Field(alias="RSSHUB_BASE_URL", default="")
     dashscope_api_key: str = Field(alias="DASHSCOPE_API_KEY", default="")
+    longbridge_app_key: str = Field(alias="LONGBRIDGE_APP_KEY", default="")
+    longbridge_app_secret: str = Field(alias="LONGBRIDGE_APP_SECRET", default="")
+    longbridge_access_token: str = Field(alias="LONGBRIDGE_ACCESS_TOKEN", default="")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Declares `LONGBRIDGE_APP_KEY`, `LONGBRIDGE_APP_SECRET`, `LONGBRIDGE_ACCESS_TOKEN` in `DataConfig`
- Documents the three vars in `agent/.env.example`

## Test plan
- [ ] `get_env_config().data.longbridge_app_key` reads from `LONGBRIDGE_APP_KEY` env var
- [ ] `get_env_config().data.longbridge_app_secret` reads from `LONGBRIDGE_APP_SECRET`
- [ ] `get_env_config().data.longbridge_access_token` reads from `LONGBRIDGE_ACCESS_TOKEN`
- [ ] Missing env vars fall back to `""` (empty string) without validation errors

Relates to: feat/longbridge-support (PR3 of 4)
Co-authored-by: fanfpy <fanfpy@gmail.com>