### PR TITLE
Fix crash in backtest metrics on negative final equity

### DIFF
--- a/agent/backtest/metrics.py
+++ b/agent/backtest/metrics.py
@@ -213,7 +213,15 @@ def calc_metrics(
     port_ret = equity_curve.pct_change().fillna(0.0)
 
     total_ret = float(equity_curve.iloc[-1] / initial_cash - 1)
-    ann_ret = float((1 + total_ret) ** (bpy / max(n, 1)) - 1)
+    # A leveraged/short book can end at or below zero equity (``total_ret <= -1``).
+    # ``(1 + total_ret) ** fractional`` would then raise a negative base to a
+    # fractional power, which Python evaluates to a ``complex`` and crashes the
+    # subsequent ``float(...)``. A total wipeout annualises to -100%.
+    growth = 1 + total_ret
+    if growth <= 0:
+        ann_ret = -1.0
+    else:
+        ann_ret = float(growth ** (bpy / max(n, 1)) - 1)
     vol = float(port_ret.std())
     sharpe = float(port_ret.mean() / (vol + 1e-10) * np.sqrt(bpy))
 

--- a/agent/tests/test_metrics.py
+++ b/agent/tests/test_metrics.py
@@ -289,6 +289,28 @@ class TestCalcMetrics:
         if m["annual_return"] > 0:
             assert m["calmar"] > 0
 
+    def test_zero_final_equity(self) -> None:
+        """A full wipeout (equity reaches 0) annualises to -100%, not a crash."""
+        dates = pd.bdate_range("2025-01-01", periods=252)
+        eq = pd.Series(np.linspace(1_000_000, 0.0, 252), index=dates)
+        m = calc_metrics(eq, [], 1_000_000, 252)
+        assert m["total_return"] == pytest.approx(-1.0)
+        assert m["annual_return"] == pytest.approx(-1.0)
+
+    def test_negative_final_equity_does_not_crash(self) -> None:
+        """A leveraged/short book can end below zero equity (total_return < -1).
+
+        ``(1 + total_return) ** fractional`` would raise a negative base to a
+        fractional power (a ``complex``) and crash ``float(...)``; the metric
+        must instead report a -100% annualised return.
+        """
+        dates = pd.bdate_range("2025-01-01", periods=252)
+        eq = pd.Series(np.linspace(1_000_000, -500_000, 252), index=dates)
+        m = calc_metrics(eq, [], 1_000_000, 252)
+        assert m["total_return"] == pytest.approx(-1.5)
+        assert m["annual_return"] == pytest.approx(-1.0)
+        assert m["final_value"] == pytest.approx(-500_000)
+
 
 # ---------------------------------------------------------------------------
 # turnover


### PR DESCRIPTION
## Summary

- `calc_metrics` raised `TypeError: ... not 'complex'` and crashed whenever a backtest ended with negative equity.
- The annualised-return step raised a non-positive base to a fractional power, producing a Python `complex` that the wrapping `float(...)` rejected.
- Guarded so a total wipeout reports a -100% annualised return; normal runs are unchanged.

## Why

Closes #524

`calc_metrics` annualised the return as `(1 + total_return) ** (bpy / n)`. A leveraged or short book can finish at or below zero equity (`total_return <= -1`), making the base non-positive. `_calc_equity` in `backtest/engines/base.py` returns `capital + sum(margin + pnl)` with no floor at zero, so a leveraged position gapping past its maintenance margin (crypto-perp / futures engines) yields a negative final equity that flows into `calc_metrics` and crashes the run's metrics.

## Changes

- `backtest/metrics.py`: compute `growth = 1 + total_return`; when `growth <= 0`, report `annual_return = -1.0` (a total wipeout) instead of evaluating a complex power. The positive path is unchanged.
- `agent/tests/test_metrics.py`: regression tests for a zero-equity wipeout and a negative-final-equity book (the latter reproduces the pre-fix `TypeError`).

## Test Plan

- [x] Existing tests pass (`pytest agent/tests/test_metrics.py -q` → 46 passed, 44 existing + 2 new)
- [x] New tests added (zero-equity wipeout, negative final equity)
- [x] `ruff check` clean, `py_compile` clean; confirmed the pre-fix code raises `TypeError` on the negative-equity series

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`)
- [x] No hardcoded values
- [x] Code follows CONTRIBUTING.md guidelines (DCO signed off)