### PR TITLE
feat(mcp): add Streamable HTTP transport for modern clients (fixes 405 from QwenPaw etc.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -967,9 +967,17 @@ profile. `run_swarm` requires an LLM key.
 <summary><b>Cursor / Windsurf / other MCP clients</b></summary>
 
 ```bash
-vibe-trading-mcp                  # stdio (default)
-vibe-trading-mcp --transport sse  # SSE for web clients
+vibe-trading-mcp                   # stdio (default)
+vibe-trading-mcp --transport http  # Streamable HTTP (current MCP spec default) at http://127.0.0.1:8900/mcp
+vibe-trading-mcp --transport sse   # legacy SSE (deprecated) for older clients
 ```
+
+For HTTP clients (QwenPaw, and any client that negotiates by POSTing an
+`InitializeRequest`), use `--transport http` and point the client at the single
+`/mcp` endpoint — e.g. `http://127.0.0.1:8900/mcp`. Do **not** point an HTTP
+client at `/sse`; that path belongs to the deprecated two-endpoint SSE transport
+and will return `405 Method Not Allowed` on `POST`. Override the bind address
+with `--host` / `--port`.
 
 </details>
 

--- a/README_ar.md
+++ b/README_ar.md
@@ -934,8 +934,9 @@ skills:
 <summary><b>Cursor / Windsurf / عملاء MCP آخرون</b></summary>
 
 ```bash
-vibe-trading-mcp                  # stdio (default)
-vibe-trading-mcp --transport sse  # SSE for web clients
+vibe-trading-mcp                   # stdio (default)
+vibe-trading-mcp --transport http  # Streamable HTTP (spec default) at /mcp
+vibe-trading-mcp --transport sse   # legacy SSE (deprecated)
 ```
 
 </details>

--- a/README_ja.md
+++ b/README_ja.md
@@ -931,8 +931,9 @@ skills:
 <summary><b>Cursor / Windsurf / other MCP clients</b></summary>
 
 ```bash
-vibe-trading-mcp                  # stdio (default)
-vibe-trading-mcp --transport sse  # SSE for web clients
+vibe-trading-mcp                   # stdio (default)
+vibe-trading-mcp --transport http  # Streamable HTTP (spec default) at /mcp
+vibe-trading-mcp --transport sse   # legacy SSE (deprecated)
 ```
 
 </details>

--- a/README_ko.md
+++ b/README_ko.md
@@ -934,8 +934,9 @@ skills:
 <summary><b>Cursor / Windsurf / 기타 MCP clients</b></summary>
 
 ```bash
-vibe-trading-mcp                  # stdio (default)
-vibe-trading-mcp --transport sse  # SSE for web clients
+vibe-trading-mcp                   # stdio (default)
+vibe-trading-mcp --transport http  # Streamable HTTP (spec default) at /mcp
+vibe-trading-mcp --transport sse   # legacy SSE (deprecated)
 ```
 
 </details>

--- a/README_zh.md
+++ b/README_zh.md
@@ -928,8 +928,9 @@ skills:
 <summary><b>Cursor / Windsurf / other MCP clients</b></summary>
 
 ```bash
-vibe-trading-mcp                  # stdio (default)
-vibe-trading-mcp --transport sse  # SSE for web clients
+vibe-trading-mcp                   # stdio (default)
+vibe-trading-mcp --transport http  # Streamable HTTP (spec default) at /mcp
+vibe-trading-mcp --transport sse   # legacy SSE (deprecated)
 ```
 
 </details>

--- a/agent/mcp_server.py
+++ b/agent/mcp_server.py
@@ -19,7 +19,14 @@ order-cancelling tool is ever surfaced via MCP.
 
 Usage:
     python mcp_server.py                    # stdio transport (default)
-    python mcp_server.py --transport sse    # SSE transport for web clients
+    python mcp_server.py --transport sse    # legacy SSE transport (GET /sse + POST /messages/)
+    python mcp_server.py --transport http   # Streamable HTTP transport (single POST/GET /mcp endpoint)
+
+The ``http`` (Streamable HTTP) transport is the current MCP spec default
+(2025-03-26+). Modern clients (e.g. QwenPaw, and clients that negotiate by
+POSTing an InitializeRequest) require it; the legacy ``sse`` transport is
+deprecated. The single endpoint is served at ``/mcp``, so point HTTP clients
+at ``http://<host>:<port>/mcp`` (NOT ``/sse``, which is a legacy-SSE artifact).
 
 OpenClaw config (~/.openclaw/config.yaml):
     skills:
@@ -1895,8 +1902,21 @@ def main():
     import argparse
 
     parser = argparse.ArgumentParser(description="Vibe-Trading MCP Server")
-    parser.add_argument("--transport", choices=["stdio", "sse"], default="stdio", help="MCP transport (default: stdio)")
-    parser.add_argument("--port", type=int, default=8900, help="SSE port (only used with --transport sse)")
+    parser.add_argument(
+        "--transport",
+        choices=["stdio", "sse", "http"],
+        default="stdio",
+        help="MCP transport (default: stdio). 'http' = Streamable HTTP (current spec default), "
+        "served at POST/GET /mcp. 'sse' = legacy deprecated SSE (GET /sse + POST /messages/).",
+    )
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Streamable HTTP bind host, --transport http only (default: 127.0.0.1)",
+    )
+    parser.add_argument(
+        "--port", type=int, default=8900, help="SSE/HTTP port (default: 8900)"
+    )
     args = parser.parse_args()
     _include_shell_tools = True if args.transport == "stdio" else _env_shell_tools_enabled()
     _registry = None
@@ -1904,6 +1924,11 @@ def main():
 
     if args.transport == "sse":
         mcp.run(transport="sse", port=args.port)
+    elif args.transport == "http":
+        # Streamable HTTP (MCP spec 2025-03-26+): single endpoint at /mcp that
+        # accepts POST (requests) and GET (notification stream). Replaces the
+        # deprecated two-endpoint SSE transport for modern clients.
+        mcp.run(transport="streamable-http", host=args.host, port=args.port)
     else:
         mcp.run()
 

--- a/agent/tests/test_mcp_server_http_transport.py
+++ b/agent/tests/test_mcp_server_http_transport.py
@@ -1,0 +1,137 @@
+"""Integration test for the Vibe-Trading MCP server's Streamable HTTP transport.
+
+Spawns the real ``mcp_server.py --transport http`` and verifies the single
+``/mcp`` endpoint behaves per the MCP Streamable HTTP transport:
+
+1. POST ``initialize`` returns a valid JSON-RPC InitializeResult with an
+   ``MCP-Session-Id`` header.
+2. The legacy ``/sse`` path is not mounted by this transport (it is only
+   exposed by the separate ``--transport sse`` legacy mode).
+
+This is intentionally scoped to the server-side transport; the client-side
+adapter path is already covered by ``test_mcp_streamable_http_integration.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+import requests
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AGENT_DIR = REPO_ROOT / "agent"
+
+INIT_TIMEOUT = 60.0
+
+
+def _wait_port(host: str, port: int, timeout: float) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        s = socket.socket()
+        s.settimeout(0.5)
+        try:
+            if s.connect_ex((host, port)) == 0:
+                s.close()
+                return True
+        finally:
+            s.close()
+        time.sleep(0.5)
+    return False
+
+
+@pytest.mark.integration
+def test_mcp_server_http_transport() -> None:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(AGENT_DIR) + os.pathsep + env.get("PYTHONPATH", "")
+    env["PYTHONUNBUFFERED"] = "1"
+
+    # Reserve an ephemeral loopback port for the server.
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = int(sock.getsockname()[1])
+
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            str(AGENT_DIR / "mcp_server.py"),
+            "--transport",
+            "http",
+            "--port",
+            str(port),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        env=env,
+        cwd=str(AGENT_DIR),
+    )
+    try:
+        assert _wait_port(
+            "127.0.0.1", port, INIT_TIMEOUT
+        ), f"HTTP MCP server did not bind 127.0.0.1:{port} within {INIT_TIMEOUT}s"
+
+        ep = f"http://127.0.0.1:{port}/mcp"
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+        }
+        r = requests.post(
+            ep,
+            headers=headers,
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test-mcp-server-http", "version": "1"},
+                },
+            },
+            timeout=15.0,
+        )
+        assert (
+            r.status_code == 200
+        ), f"POST /mcp initialize returned {r.status_code}: {r.text[:300]}"
+        assert (
+            "mcp-session-id" in r.headers
+        ), "server did not return an MCP-Session-Id header"
+        assert r.headers.get("content-type", "") in (
+            "application/json",
+            "text/event-stream",
+        ), f"unexpected content-type: {r.headers.get('content-type')}"
+        body = r.text
+        if "text/event-stream" in r.headers.get("content-type", ""):
+            for line in body.splitlines():
+                if line.startswith("data:"):
+                    body = line[5:].strip()
+                    break
+        data = json.loads(body)
+        assert "result" in data, f"initialize response missing result: {data}"
+        server_info = data["result"].get("serverInfo", {})
+        assert server_info.get("name") == "Vibe-Trading", server_info
+
+        # The legacy SSE path is not mounted by the streamable-http transport.
+        legacy = requests.post(
+            f"http://127.0.0.1:{port}/sse",
+            headers=headers,
+            json={"jsonrpc": "2.0", "id": 9, "method": "initialize", "params": {}},
+            timeout=5.0,
+        )
+        assert (
+            legacy.status_code == 404
+        ), f"legacy /sse path should not be mounted by streamable-http, got {legacy.status_code}"
+    finally:
+        try:
+            proc.terminate()
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)


### PR DESCRIPTION
## Goal

Add a `--transport http` option to `vibe-trading-mcp` that exposes the MCP **Streamable HTTP** transport (spec 2025-03-26+) as a single `POST`/`GET` `/mcp` endpoint, alongside the existing `stdio` and legacy `sse` transports.

Modern MCP clients (e.g. [QwenPaw](https://github.com/agentscope-ai/QwenPaw)) negotiate the transport by `POST`ing an `InitializeRequest` to the server URL (per the spec's recommended client flow). The currently-shipped **legacy SSE** transport uses two endpoints — `GET /sse` for the stream and `POST /messages/` for requests — so a client that `POST`s to `/sse` gets **`405 Method Not Allowed`**. Streamable HTTP accepts `POST` on its single endpoint, resolving this.

> The spec is explicit that the legacy HTTP+SSE transport is **deprecated**, and that clients should POST an `InitializeRequest` first to detect the transport.

## Affected areas

- `agent/mcp_server.py` — `main()`: added `"http"` to `--transport` choices and a new `elif args.transport == "http"` branch calling `mcp.run(transport="streamable-http", host=args.host, port=args.port)`. Added a `--host` option scoped to the `http` transport (default `127.0.0.1`). **The legacy `sse` branch is byte-for-byte unchanged** (`mcp.run(transport="sse", port=args.port)`).
- `agent/tests/test_mcp_server_http_transport.py` — new integration test: spawns the real server with `--transport http` and asserts `POST /mcp initialize` → `200` + `MCP-Session-Id` + `serverInfo`, and that the legacy `POST /sse` path returns `404` (not mounted by this transport).
- `README.md` + 4 translations (`README_zh/ja/ko/ar.md`) — document the three transport options and warn not to point HTTP clients at `/sse`.

## Out of scope

- No change to the legacy `sse` transport behavior, the `stdio` transport, any tool, the registry, broker/order/mandate surfaces, or credentials.
- No change to FastMCP version (`fastmcp>=2.14.0` already in `pyproject.toml`; resolves to `3.4.4`).
- No new dependencies.

## Test plan

Run with the project venv (`pip install -e ".[dev]"`):

```bash
python -m py_compile agent/mcp_server.py
pytest agent/tests/test_mcp_server_http_transport.py \
       agent/tests/test_mcp_server_smoke.py \
       agent/tests/test_mcp_sse_integration.py \
       agent/tests/test_mcp_streamable_http_integration.py -q
```

Results (Python 3.12, fastmcp 3.4.4):
- `test_mcp_server_http_transport.py` (new) — **PASS** (POST `/mcp` initialize → 200 + session + `Vibe-Trading` serverInfo; `POST /sse` → 404)
- `test_mcp_server_smoke.py` (stdio regression) — **PASS**
- `test_mcp_sse_integration.py` (legacy SSE, 3 tests) — **PASS**
- `test_mcp_streamable_http_integration.py` (client adapter, 4 tests) — **PASS**
- `git diff --check` — clean

**Not run:** the full suite (`pytest --ignore=agent/tests/e2e_backtest …`) and the frontend build, since this change is backend-MCP-only; the narrowest matching suite (all MCP tests) is green.

I also ran a Streamable HTTP conformance probe against the running endpoint: `POST initialize` → 200 + `MCP-Session-Id`; `notifications/initialized` → 202; `tools/list` → 200 (54 tools); wrong `Accept` → 406; wrong `Content-Type` → 400; missing session id on a post-init request → 400; `DELETE /mcp` with session id → 200 (session termination).

## Risk

- **MCP / network:** additive only — a new optional transport. Default transport remains `stdio`; the new `http` transport binds `127.0.0.1` by default (loopback only), so it does not start an externally reachable server unless the operator explicitly passes `--host 0.0.0.0`. Per the Agent Contributor Guide, starting an externally reachable MCP server requires operator approval; this change does **not** do that by default.
- **Security note (FastMCP default):** FastMCP 3.4.4 ships with Host/Origin (DNS-rebinding) validation **disabled by default**. For loopback use this is low-risk. Operators deploying `--transport http` beyond loopback should enable host-origin protection and front it with an authenticated proxy; this is worth a follow-up CLI flag but is out of scope here.
- **Spec nuance (inherited from FastMCP, not introduced here):** a sessionless `GET /mcp` returns `400 "Missing session ID"` rather than the strict `405`/SSE. A `GET` with a valid session id correctly returns `200 text/event-stream`. Real clients `POST initialize` first, so this does not affect the normal flow. This is FastMCP library behavior; our wrapper adds no protocol logic.
- **No broker, order, mandate, credential, or live-trading surfaces are touched.**

## Rollback / close path

Fully reversible with `git revert <sha>` (or close the PR without merge). The change is additive — reverting removes the `http` branch and `--host` option and restores the prior two-transport CLI, leaving `stdio` and legacy `sse` exactly as they were. No data migrations, no persistent state.

---

DCO: signed off on the commit (`Signed-off-by:` trailer present). Per `CONTRIBUTING.md`, no AI-assistant attribution trailers were added.
