### PR TITLE
fix(frontend): authenticate correlation requests

### DIFF
--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -39,4 +39,32 @@ describe("api request helper", () => {
       message: expect.stringContaining("Expected JSON from /channels/status, got text/html"),
     } satisfies Partial<ApiError>);
   });
+
+  it("sends the stored API key when fetching a correlation matrix", async () => {
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn(() => "remote-test-key"),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    });
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ labels: ["A", "B"], matrix: [[1, 0], [0, 1]] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { api } = await loadApiModule();
+
+    await expect(api.getCorrelation("A,B", 90, "pearson")).resolves.toEqual({
+      labels: ["A", "B"],
+      matrix: [[1, 0], [0, 1]],
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/correlation?codes=A%2CB&days=90&method=pearson",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer remote-test-key" }),
+      }),
+    );
+  });
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -19,6 +19,11 @@ export function isAuthRequiredError(error: unknown): boolean {
   return error instanceof ApiError && (error.status === 401 || error.status === 403);
 }
 
+export interface CorrelationResponse {
+  labels: string[];
+  matrix: number[][];
+}
+
 async function errorFromResponse(res: Response): Promise<ApiError> {
   let detail = `HTTP ${res.status}`;
   try {
@@ -84,6 +89,10 @@ function appendQueryParam(url: string, key: string, value: string): string {
 
 export const api = {
   uploadFile,
+  getCorrelation: (codes: string, days: number, method: "pearson" | "spearman") =>
+    request<CorrelationResponse>(
+      `/correlation?codes=${encodeURIComponent(codes)}&days=${encodeURIComponent(String(days))}&method=${encodeURIComponent(method)}`,
+    ),
   listRuns: (limit?: number) => request<RunListItem[]>(`/runs${limit ? `?limit=${encodeURIComponent(String(limit))}` : ""}`),
   getRun: (id: string, params: RunDetailParams = {}) => {
     const q = new URLSearchParams();

--- a/frontend/src/pages/Correlation.tsx
+++ b/frontend/src/pages/Correlation.tsx
@@ -2,6 +2,7 @@ import i18n from '@/i18n';
 import { useState } from "react";
 import { BarChart3 } from "lucide-react";
 import { CorrelationMatrix } from "@/components/charts/CorrelationMatrix";
+import { api } from "@/lib/api";
 
 const WINDOWS = [30, 60, 90, 180, 365] as const;
 
@@ -19,9 +20,7 @@ export function Correlation() {
     setError(null);
     setLoading(true);
     try {
-      const result = await request<{ labels: string[]; matrix: number[][] }>(
-        `/correlation?codes=${encodeURIComponent(codes)}&days=${days}&method=${method}`
-      );
+      const result = await api.getCorrelation(codes, days, method);
       setLabels(result.labels);
       setMatrix(result.matrix);
     } catch (e) {
@@ -115,23 +114,4 @@ export function Correlation() {
       {labels.length > 0 && <CorrelationMatrix labels={labels} matrix={matrix} height={520} />}
     </div>
   );
-}
-
-// Minimal request helper (avoids importing the full api client which may have path issues)
-async function request<T>(path: string, options?: RequestInit): Promise<T> {
-  const BASE = "";
-  const res = await fetch(`${BASE}${path}`, {
-    headers: { "Content-Type": "application/json", ...options?.headers },
-    ...options,
-  });
-  if (!res.ok) {
-    let detail = `HTTP ${res.status}`;
-    try {
-      const body = await res.json();
-      detail = body.detail || body.message || detail;
-    } catch { /* ignore */ }
-    throw new Error(detail);
-  }
-  const text = await res.text();
-  return text ? JSON.parse(text) : ({} as T);
 }


### PR DESCRIPTION
## Summary

- Route Correlation requests through the shared authenticated API client.
- Preserve the page's existing query parameters and error handling.
- Add regression coverage for the stored API-key header.

## Root cause

The Correlation page used a local fetch helper, which omitted the stored Authorization header. Remote backends correctly rejected the request.

## Scope

- No changes to broker, live-runner, backtest, or server-side authorization behavior.

## Checks

- `npm run test:run` — 247 passed.
- `npm run build`.
