### PR TITLE
fix(backtest): make open rebalances causal and order-independent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   @roberttidball).
 - Portfolio optimizers no longer include the decision bar's close-to-close
   return in weights executed at that bar's open (#487, thanks @YZY0108).
+- Open-price rebalances no longer use the decision bar's close for sizing or
+  depend on whether a replacement symbol sorts before the position it closes.
 - Preflight (`vibe-trading run`) no longer resolves provider/model against a
   stale `EnvConfig` snapshot cached before dotenv loads (#479, thanks
   @ananaymital, closes #477).

--- a/agent/backtest/engines/base.py
+++ b/agent/backtest/engines/base.py
@@ -15,6 +15,7 @@ import re as _re
 import sys
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
@@ -39,6 +40,24 @@ from backtest.metrics import (
 from backtest.models import EquitySnapshot, Position, TradeRecord
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _OpenOrder:
+    """A fully priced opening order that can be committed atomically."""
+
+    symbol: str
+    direction: int
+    price: float
+    size: float
+    leverage: float
+    margin: float
+    commission: float
+
+    @property
+    def cost(self) -> float:
+        """Cash consumed by the fill."""
+        return self.margin + self.commission
 
 
 def _run_card_data_sources(config: Dict[str, Any], loader: Any) -> List[str]:
@@ -547,9 +566,13 @@ class BaseEngine(ABC):
                             "Rebalance close failed for %s at %s: %s", c, ts, exc
                         )
 
-            # c. Open target positions only after the close pass.  If a close
-            # was blocked by market rules, do not open the opposite side.
-            for c in codes:
+            # c. Price every opening order before committing any of them.  If
+            # the requested basket does not fit after fees/lot rounding, apply
+            # one common scale factor to all target weights.  This preserves
+            # portfolio proportions and makes fills independent of input code
+            # order; sequential cash clipping would privilege the first name.
+            open_targets: list[tuple[str, float, Optional[pd.DataFrame]]] = []
+            for c in sorted(codes):
                 target_w = target_weights[c]
                 if target_w is None:
                     continue
@@ -559,10 +582,34 @@ class BaseEngine(ABC):
                     target_dir == 0 or target_dir != current_pos.direction
                 ):
                     continue
-                try:
-                    self._rebalance(c, target_w, data_map.get(c), ts, equity)
-                except Exception as exc:
-                    logger.warning("Rebalance open failed for %s at %s: %s", c, ts, exc)
+                if current_pos is None and target_dir != 0:
+                    open_targets.append((c, target_w, data_map.get(c)))
+
+            def _plans(scale: float) -> list[_OpenOrder]:
+                return [
+                    order
+                    for c, target_w, frame in open_targets
+                    if (
+                        order := self._plan_open_order(
+                            c, target_w * scale, frame, ts, equity
+                        )
+                    )
+                    is not None
+                ]
+
+            planned = _plans(1.0)
+            if sum(order.cost for order in planned) > self.capital + 1e-9:
+                low, high = 0.0, 1.0
+                for _ in range(50):
+                    mid = (low + high) / 2.0
+                    candidate = _plans(mid)
+                    if sum(order.cost for order in candidate) <= self.capital + 1e-9:
+                        low, planned = mid, candidate
+                    else:
+                        high = mid
+
+            for order in planned:
+                self._execute_open_order(order, ts)
 
             # d. Apply close/within-bar hooks after open execution.  Hooks use
             # the current bar's close for funding, swaps, and liquidation, so
@@ -706,50 +753,69 @@ class BaseEngine(ABC):
                 else:
                     return  # blocked (e.g. limit-down can't sell)
 
-        # Open new if target non-zero and no remaining position
         if target_dir != 0 and symbol not in self.positions:
-            if not self.can_execute(symbol, target_dir, bar):
-                return  # blocked (e.g. A-share no-short)
+            order = self._plan_open_order(symbol, target_weight, df, ts, equity)
+            if order is not None and order.cost <= self.capital + 1e-9:
+                self._execute_open_order(order, ts)
 
-            open_price = float(bar.get("open", bar.get("close", 0)))
-            if open_price <= 0:
-                return
+    def _plan_open_order(
+        self,
+        symbol: str,
+        target_weight: float,
+        df: Optional[pd.DataFrame],
+        ts: pd.Timestamp,
+        equity: float,
+    ) -> Optional[_OpenOrder]:
+        """Price an opening order without mutating portfolio state."""
+        self._active_symbol = symbol
+        direction = 1 if target_weight > 1e-9 else (-1 if target_weight < -1e-9 else 0)
+        if direction == 0 or symbol in self.positions or df is None or ts not in df.index:
+            return None
+        bar = df.loc[ts]
+        if not self.can_execute(symbol, direction, bar):
+            return None
+        open_price = float(bar.get("open", bar.get("close", 0)))
+        if open_price <= 0:
+            return None
+        price = self.apply_slippage(open_price, direction)
+        leverage = self.default_leverage
+        target_notional = abs(target_weight) * equity * leverage
+        size = self.round_size(
+            self._calc_raw_size(symbol, target_notional, price), price
+        )
+        if size <= 0:
+            return None
+        margin = self._calc_margin(symbol, size, price, leverage)
+        commission = self.calc_commission(
+            size, price, direction, is_open=True
+        )
+        return _OpenOrder(
+            symbol=symbol,
+            direction=direction,
+            price=price,
+            size=size,
+            leverage=leverage,
+            margin=margin,
+            commission=commission,
+        )
 
-            slipped = self.apply_slippage(open_price, target_dir)
-            leverage = self.default_leverage
-            target_notional = abs(target_weight) * equity * leverage
-            raw_size = self._calc_raw_size(symbol, target_notional, slipped)
-            size = self.round_size(raw_size, slipped)
-            if size <= 0:
-                return
-
-            margin = self._calc_margin(symbol, size, slipped, leverage)
-            comm = self.calc_commission(size, slipped, target_dir, is_open=True)
-
-            # Capital check — reduce if insufficient
-            if margin + comm > self.capital:
-                available = self.capital - comm
-                if available <= 0:
-                    return
-                size = self.round_size(
-                    self._calc_raw_size(symbol, available * leverage, slipped), slipped,
-                )
-                if size <= 0:
-                    return
-                margin = self._calc_margin(symbol, size, slipped, leverage)
-                comm = self.calc_commission(size, slipped, target_dir, is_open=True)
-
-            self.capital -= (margin + comm)
-            self.positions[symbol] = Position(
-                symbol=symbol,
-                direction=target_dir,
-                entry_price=slipped,
-                entry_time=ts,
-                size=size,
-                leverage=leverage,
-                entry_bar_idx=self._bar_idx,
-                entry_commission=comm,
+    def _execute_open_order(self, order: _OpenOrder, ts: pd.Timestamp) -> None:
+        """Commit a previously priced opening order."""
+        if order.cost > self.capital + 1e-7:
+            raise RuntimeError(
+                f"planned order for {order.symbol} exceeds available capital"
             )
+        self.capital -= order.cost
+        self.positions[order.symbol] = Position(
+            symbol=order.symbol,
+            direction=order.direction,
+            entry_price=order.price,
+            entry_time=ts,
+            size=order.size,
+            leverage=order.leverage,
+            entry_bar_idx=self._bar_idx,
+            entry_commission=order.commission,
+        )
 
     def _close_position(
         self,

--- a/agent/backtest/engines/base.py
+++ b/agent/backtest/engines/base.py
@@ -516,21 +516,63 @@ class BaseEngine(ABC):
         for i, ts in enumerate(dates):
             self._bar_idx = i
 
-            # a. Per-bar hooks (funding fees, liquidation checks)
+            # a. Value the book at prices observable when orders execute.
+            # Rebalances happen at the bar open, so using close_df[ts] here
+            # would let the yet-unknown decision-bar close affect order size.
+            equity = self._calc_open_equity(data_map, close_df, ts)
+            target_weights: Dict[str, Optional[float]] = {}
+            for c in codes:
+                try:
+                    target_weights[c] = (
+                        float(target_pos.at[ts, c]) if ts in target_pos.index else 0.0
+                    )
+                except Exception as exc:
+                    target_weights[c] = None
+                    logger.warning("Target weight failed for %s at %s: %s", c, ts, exc)
+
+            # b. Release capital before opening replacement positions.  A
+            # single mixed close/open pass makes rotations depend on symbol
+            # iteration order when the new name is visited before the old one.
+            for c in codes:
+                target_w = target_weights[c]
+                current_pos = self.positions.get(c)
+                if target_w is None or current_pos is None:
+                    continue
+                target_dir = 1 if target_w > 1e-9 else (-1 if target_w < -1e-9 else 0)
+                if target_dir == 0 or target_dir != current_pos.direction:
+                    try:
+                        self._rebalance(c, 0.0, data_map.get(c), ts, equity)
+                    except Exception as exc:
+                        logger.warning(
+                            "Rebalance close failed for %s at %s: %s", c, ts, exc
+                        )
+
+            # c. Open target positions only after the close pass.  If a close
+            # was blocked by market rules, do not open the opposite side.
+            for c in codes:
+                target_w = target_weights[c]
+                if target_w is None:
+                    continue
+                target_dir = 1 if target_w > 1e-9 else (-1 if target_w < -1e-9 else 0)
+                current_pos = self.positions.get(c)
+                if current_pos is not None and (
+                    target_dir == 0 or target_dir != current_pos.direction
+                ):
+                    continue
+                try:
+                    self._rebalance(c, target_w, data_map.get(c), ts, equity)
+                except Exception as exc:
+                    logger.warning("Rebalance open failed for %s at %s: %s", c, ts, exc)
+
+            # d. Apply close/within-bar hooks after open execution.  Hooks use
+            # the current bar's close for funding, swaps, and liquidation, so
+            # running them first could liquidate a position that was scheduled
+            # to exit at the open (or charge a position before it was opened).
             for c in codes:
                 if ts in data_map[c].index:
                     self.on_bar(c, data_map[c].loc[ts], ts)
 
-            # b. Rebalance each symbol to target weight
-            equity = self._calc_equity(close_df, ts)
-            for c in codes:
-                try:
-                    target_w = float(target_pos.at[ts, c]) if ts in target_pos.index else 0.0
-                    self._rebalance(c, target_w, data_map.get(c), ts, equity)
-                except Exception as exc:
-                    logger.warning("Rebalance failed for %s at %s: %s", c, ts, exc)
-
-            # c. Record equity snapshot
+            # e. Record equity snapshot
             snap_equity = self._calc_equity(close_df, ts)
             if self.positions and type(self)._calc_pnl is BaseEngine._calc_pnl:
                 _syms = list(self.positions.keys())
@@ -554,12 +596,48 @@ class BaseEngine(ABC):
                 positions=len(self.positions),
             ))
 
-        # d. Force close all remaining positions
+        # f. Force close all remaining positions
         if len(dates) > 0:
             last_ts = dates[-1]
             for c in list(self.positions.keys()):
                 price = self._safe_price(close_df, last_ts, c, self.positions[c].entry_price)
                 self._close_position(c, price, last_ts, "end_of_backtest")
+
+    def _calc_open_equity(
+        self,
+        data_map: Dict[str, pd.DataFrame],
+        close_df: pd.DataFrame,
+        ts: pd.Timestamp,
+    ) -> float:
+        """Value current positions at the execution bar's observable open.
+
+        For a symbol that has a bar at ``ts``, its open is the mark available
+        when next-bar-open orders execute.  Symbols without a bar on the
+        unified calendar retain the aligned close fallback, which is the most
+        recent price carried by ``_align``.
+        """
+        if not self.positions:
+            return self.capital
+
+        equity = self.capital
+        for sym, pos in self.positions.items():
+            current_price = self._safe_price(close_df, ts, sym, pos.entry_price)
+            frame = data_map.get(sym)
+            if frame is not None and ts in frame.index:
+                open_price = frame.loc[ts].get("open")
+                if (
+                    open_price is not None
+                    and pd.notna(open_price)
+                    and float(open_price) > 0
+                ):
+                    current_price = float(open_price)
+
+            margin = self._calc_margin(sym, pos.size, pos.entry_price, pos.leverage)
+            unrealized = self._calc_pnl(
+                sym, pos.direction, pos.size, pos.entry_price, current_price
+            )
+            equity += margin + unrealized
+        return equity
 
     def _calc_equity(self, close_df: pd.DataFrame, ts: pd.Timestamp) -> float:
         """Total equity = free cash + sum(margin + unrealised) per position.

--- a/agent/backtest/engines/base.py
+++ b/agent/backtest/engines/base.py
@@ -586,16 +586,23 @@ class BaseEngine(ABC):
                     open_targets.append((c, target_w, data_map.get(c)))
 
             def _plans(scale: float) -> list[_OpenOrder]:
-                return [
-                    order
-                    for c, target_w, frame in open_targets
-                    if (
-                        order := self._plan_open_order(
+                result: list[_OpenOrder] = []
+                for c, target_w, frame in open_targets:
+                    try:
+                        order = self._plan_open_order(
                             c, target_w * scale, frame, ts, equity
                         )
-                    )
-                    is not None
-                ]
+                    except Exception as exc:
+                        logger.warning(
+                            "Rebalance open plan failed for %s at %s: %s",
+                            c,
+                            ts,
+                            exc,
+                        )
+                        continue
+                    if order is not None:
+                        result.append(order)
+                return result
 
             planned = _plans(1.0)
             if sum(order.cost for order in planned) > self.capital + 1e-9:

--- a/agent/tests/test_engine_robustness.py
+++ b/agent/tests/test_engine_robustness.py
@@ -119,15 +119,15 @@ class TestSymbolIsolation:
 
         engine = ChinaAEngine({"initial_cash": 1_000_000})
 
-        # Patch _rebalance to throw for BAD only
-        original_rebalance = ChinaAEngine._rebalance
+        # Patch the opening-plan boundary to throw for BAD only.
+        original_plan = ChinaAEngine._plan_open_order
 
-        def _exploding_rebalance(self, symbol, target_weight, df, ts, equity):
+        def _exploding_plan(self, symbol, target_weight, df, ts, equity):
             if symbol == "BAD":
                 raise RuntimeError("Simulated failure for BAD")
-            return original_rebalance(self, symbol, target_weight, df, ts, equity)
+            return original_plan(self, symbol, target_weight, df, ts, equity)
 
-        with patch.object(ChinaAEngine, "_rebalance", _exploding_rebalance):
+        with patch.object(ChinaAEngine, "_plan_open_order", _exploding_plan):
             # Should NOT raise — exception is caught internally
             engine._execute_bars(dates, data_map, close_df, target_pos, valid_codes)
 

--- a/agent/tests/test_execution_causality.py
+++ b/agent/tests/test_execution_causality.py
@@ -3,9 +3,17 @@
 from __future__ import annotations
 
 import pandas as pd
+import pytest
 
 from backtest.engines.base import BaseEngine
+from backtest.engines.china_a import ChinaAEngine
+from backtest.engines.china_futures import ChinaFuturesEngine
+from backtest.engines.composite import CompositeEngine
 from backtest.engines.crypto import CryptoEngine
+from backtest.engines.forex import ForexEngine
+from backtest.engines.global_equity import GlobalEquityEngine
+from backtest.engines.global_futures import GlobalFuturesEngine
+from backtest.engines.india_equity import IndiaEquityEngine
 
 
 class _FrictionlessEngine(BaseEngine):
@@ -111,3 +119,107 @@ def test_open_signal_exit_precedes_close_based_liquidation() -> None:
     assert engine.trades[0].exit_reason == "signal"
     assert engine.trades[0].exit_price == 100.0
     assert engine.capital == 1_000.0
+
+
+class _FeeEngine(_FrictionlessEngine):
+    def calc_commission(self, size, price, direction, is_open):
+        return 10.0
+
+
+def test_capital_constrained_open_basket_is_proportional_and_order_independent() -> None:
+    dates = pd.DatetimeIndex(["2026-01-05"])
+    data_map = {
+        code: pd.DataFrame({"open": [100.0], "close": [100.0]}, index=dates)
+        for code in ("A", "B")
+    }
+    close_df = pd.DataFrame({code: frame["close"] for code, frame in data_map.items()})
+    targets = pd.DataFrame({"A": [0.6], "B": [0.6]}, index=dates)
+
+    results = []
+    for codes in (["A", "B"], ["B", "A"]):
+        engine = _FeeEngine({"initial_cash": 1_000.0})
+        engine._execute_bars(dates, data_map, close_df, targets, codes)
+        results.append({trade.symbol: trade.size for trade in engine.trades})
+
+    assert results[0] == results[1]
+    assert results[0]["A"] == pytest.approx(results[0]["B"])
+    assert results[0]["A"] == pytest.approx(4.9)
+
+
+def _engine_case(name: str, codes: list[str], reverse: bool) -> tuple[BaseEngine, list[str]]:
+    ordered = list(reversed(codes)) if reverse else codes
+    config = {
+        "initial_cash": 1_000_000.0,
+        "codes": ordered,
+        "slippage": 0.0,
+        "slippage_us": 0.0,
+        "commission_override": 0.0,
+        "commission_per_contract": 0.0,
+        "maker_rate": 0.0,
+        "taker_rate": 0.0,
+        "funding_rate": 0.0,
+    }
+    factories = {
+        "china_a": lambda: ChinaAEngine(config),
+        "global_equity": lambda: GlobalEquityEngine(config, market="us"),
+        "crypto": lambda: CryptoEngine(config),
+        "china_futures": lambda: ChinaFuturesEngine(config),
+        "global_futures": lambda: GlobalFuturesEngine(config),
+        "forex": lambda: ForexEngine(config),
+        "india_equity": lambda: IndiaEquityEngine(config),
+        "composite": lambda: CompositeEngine(config, ordered),
+    }
+    return factories[name](), ordered
+
+
+@pytest.mark.parametrize(
+    ("name", "codes"),
+    [
+        ("china_a", ["000001.SZ", "000002.SZ"]),
+        ("global_equity", ["AAPL.US", "MSFT.US"]),
+        ("crypto", ["BTC-USDT", "ETH-USDT"]),
+        ("china_futures", ["IF2406.CFFEX", "IF2407.CFFEX"]),
+        ("global_futures", ["ESZ4", "ESH5"]),
+        ("forex", ["EUR/USD", "GBP/USD"]),
+        ("india_equity", ["RELIANCE.NS", "TCS.NS"]),
+        ("composite", ["AAPL.US", "BTC-USDT"]),
+    ],
+)
+def test_engine_family_execution_is_code_order_independent(
+    name: str, codes: list[str]
+) -> None:
+    dates = pd.DatetimeIndex(["2026-01-05"])
+    data_map = {
+        code: pd.DataFrame(
+            {
+                "open": [100.0],
+                "high": [100.0],
+                "low": [100.0],
+                "close": [100.0],
+                "pre_close": [100.0],
+                "volume": [1_000_000.0],
+            },
+            index=dates,
+        )
+        for code in codes
+    }
+    close_df = pd.DataFrame({code: frame["close"] for code, frame in data_map.items()})
+    targets = pd.DataFrame({code: [0.3] for code in codes}, index=dates)
+    signatures = []
+
+    for reverse in (False, True):
+        engine, ordered = _engine_case(name, codes, reverse)
+        engine._execute_bars(dates, data_map, close_df, targets, ordered)
+        signatures.append(
+            sorted(
+                (
+                    trade.symbol,
+                    round(trade.size, 8),
+                    round(trade.entry_price, 8),
+                    round(trade.commission, 8),
+                )
+                for trade in engine.trades
+            )
+        )
+
+    assert signatures[0] == signatures[1]

--- a/agent/tests/test_execution_causality.py
+++ b/agent/tests/test_execution_causality.py
@@ -1,0 +1,113 @@
+"""Causality and ordering regressions for the shared execution loop."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from backtest.engines.base import BaseEngine
+from backtest.engines.crypto import CryptoEngine
+
+
+class _FrictionlessEngine(BaseEngine):
+    def can_execute(self, symbol, direction, bar):
+        return True
+
+    def round_size(self, raw_size, price):
+        return raw_size
+
+    def calc_commission(self, size, price, direction, is_open):
+        return 0.0
+
+    def apply_slippage(self, price, direction):
+        return price
+
+
+def _rotation_run(*, last_close_a: float = 100.0, code_order=None):
+    dates = pd.bdate_range("2026-01-05", periods=2)
+    bars_a = pd.DataFrame(
+        {"open": [100.0, 100.0], "close": [100.0, last_close_a]},
+        index=dates,
+    )
+    bars_b = pd.DataFrame(
+        {"open": [100.0, 100.0], "close": [100.0, 100.0]},
+        index=dates,
+    )
+    data_map = {"A": bars_a, "B": bars_b}
+    close_df = pd.DataFrame(
+        {"A": bars_a["close"], "B": bars_b["close"]},
+        index=dates,
+    )
+    target_pos = pd.DataFrame(
+        {"A": [0.5, 0.0], "B": [0.0, 0.5]},
+        index=dates,
+    )
+    engine = _FrictionlessEngine({"initial_cash": 100_000.0})
+    engine._execute_bars(
+        dates,
+        data_map,
+        close_df,
+        target_pos,
+        code_order or ["A", "B"],
+    )
+    return engine
+
+
+def test_decision_bar_close_cannot_change_open_position_size() -> None:
+    baseline = _rotation_run(last_close_a=100.0)
+    shocked = _rotation_run(last_close_a=200.0)
+
+    baseline_b = next(t for t in baseline.trades if t.symbol == "B")
+    shocked_b = next(t for t in shocked.trades if t.symbol == "B")
+
+    assert baseline_b.size == 500.0
+    assert shocked_b.size == baseline_b.size
+
+
+def test_rotation_is_independent_of_close_open_symbol_order() -> None:
+    a_first = _rotation_run(code_order=["A", "B"])
+    b_first = _rotation_run(code_order=["B", "A"])
+
+    a_first_trades = [(t.symbol, t.size, t.exit_reason) for t in a_first.trades]
+    b_first_trades = [(t.symbol, t.size, t.exit_reason) for t in b_first.trades]
+
+    assert a_first_trades == b_first_trades
+    assert [symbol for symbol, _, _ in a_first_trades] == ["A", "B"]
+
+
+def test_open_signal_exit_precedes_close_based_liquidation() -> None:
+    dates = pd.date_range("2026-01-05", periods=2, freq="D")
+    bars = pd.DataFrame(
+        {
+            "open": [100.0, 100.0],
+            "high": [100.0, 100.0],
+            "low": [100.0, 10.0],
+            "close": [100.0, 10.0],
+        },
+        index=dates,
+    )
+    symbol = "BTC-USDT"
+    close_df = pd.DataFrame({symbol: bars["close"]}, index=dates)
+    target_pos = pd.DataFrame({symbol: [1.0, 0.0]}, index=dates)
+    engine = CryptoEngine(
+        {
+            "initial_cash": 1_000.0,
+            "leverage": 10.0,
+            "maker_rate": 0.0,
+            "taker_rate": 0.0,
+            "slippage": 0.0,
+            "funding_rate": 0.0,
+        }
+    )
+
+    engine._execute_bars(
+        dates,
+        {symbol: bars},
+        close_df,
+        target_pos,
+        [symbol],
+    )
+
+    assert len(engine.trades) == 1
+    assert engine.trades[0].exit_reason == "signal"
+    assert engine.trades[0].exit_price == 100.0
+    assert engine.capital == 1_000.0


### PR DESCRIPTION
## Summary

Make next-bar-open portfolio rebalances causal and independent of symbol iteration order.

## Root cause

The shared execution loop valued the portfolio with the current bar's close before placing orders at that bar's open. A same-day close shock could therefore change open order size. It also mixed closes and opens in one symbol loop, so a replacement position could be visited before the position whose capital it needed.

## Changes

- value existing positions at the execution bar's open before sizing orders
- close exits and direction changes before opening replacement positions
- run close/intrabar hooks after open execution, so an open signal exit cannot be pre-empted by that bar's close-based liquidation logic
- add regressions for close-price leakage, symbol-order dependence, and signal-exit/liquidation ordering

## Validation

- `PYTHONPATH=agent pytest -q agent/tests/test_execution_causality.py agent/tests/test_base_engine.py agent/tests/test_crypto_engine.py agent/tests/test_forex_engine.py agent/tests/test_china_a_engine.py agent/tests/test_china_futures_engine.py agent/tests/test_global_futures_engine.py agent/tests/test_global_equity_engine.py agent/tests/test_india_equity_engine.py agent/tests/test_engine_robustness.py --tb=short`
  - 256 passed, 1 skipped
- `python -m compileall -q agent/backtest/engines/base.py agent/tests/test_execution_causality.py`
- `git diff --check`

The complete `agent/tests` collection is unavailable in this local environment because optional project dependencies such as `fastmcp`, `langchain_core`, `ccxt`, and `python-multipart` are not installed.

## Scope

This PR only changes open-rebalance causality and ordering. Terminal liquidation costs and realized-turnover accounting are intentionally left for separate PRs.
