### PR TITLE
fix(backtest): cap annual return after full loss

### DIFF
--- a/agent/backtest/metrics.py
+++ b/agent/backtest/metrics.py
@@ -213,7 +213,7 @@ def calc_metrics(
     port_ret = equity_curve.pct_change().fillna(0.0)
 
     total_ret = float(equity_curve.iloc[-1] / initial_cash - 1)
-    ann_ret = float((1 + total_ret) ** (bpy / max(n, 1)) - 1)
+    ann_ret = -1.0 if total_ret <= -1 else float((1 + total_ret) ** (bpy / max(n, 1)) - 1)
     vol = float(port_ret.std())
     sharpe = float(port_ret.mean() / (vol + 1e-10) * np.sqrt(bpy))
 

--- a/agent/tests/test_metrics.py
+++ b/agent/tests/test_metrics.py
@@ -229,6 +229,15 @@ class TestCalcMetrics:
         m = calc_metrics(eq, [], 1_000_000, 252)
         assert m["total_return"] < 0
 
+    def test_negative_final_equity_caps_annual_return(self) -> None:
+        dates = pd.bdate_range("2025-01-01", periods=100)
+        eq = pd.Series(np.linspace(1_000_000, -500_000, 100), index=dates)
+
+        m = calc_metrics(eq, [], 1_000_000, 252)
+
+        assert m["total_return"] == pytest.approx(-1.5)
+        assert m["annual_return"] == pytest.approx(-1.0)
+
     def test_max_drawdown_negative(self) -> None:
         eq = self._declining_equity()
         m = calc_metrics(eq, [], 1_000_000, 252)


### PR DESCRIPTION
## Summary

- Prevent `calc_metrics` from raising when final equity is below zero and annualization uses a fractional exponent.
- Cap `annual_return` at `-1.0` once total return reaches or exceeds a full loss.
- Add regression coverage for a negative final-equity curve.

## Why

Closes #524.

A leveraged or short strategy can produce a valid equity curve whose final value is below zero. In that case `1 + total_return` is negative, and fractional annualization can produce a complex number before `float(...)` raises. The metrics path should report a bounded loss metric instead of crashing the backtest report.

## Changes

- Guard annualized return calculation in `agent/backtest/metrics.py` for `total_ret <= -1`.
- Add `test_negative_final_equity_caps_annual_return` in `agent/tests/test_metrics.py`.

## Test Plan

- [x] Existing tests pass (`.venv/bin/python -m pytest agent/tests/test_metrics.py -q`)
- [x] New tests added
- [ ] Tested manually (describe below)

Manual check: reproduced the negative-final-equity case locally and confirmed it now returns `annual_return == -1.0` instead of raising.

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Documentation updated (if user-facing change)

## AI assistance disclosure

This PR was prepared with AI assistance from OpenAI Codex/Catalina for repository inspection, patch drafting, and validation. I reviewed the change and ran the focused tests locally.
