### PR TITLE
fix: preserve run data source during chart reconstruction

### DIFF
--- a/agent/backtest/runner.py
+++ b/agent/backtest/runner.py
@@ -13,6 +13,7 @@ import inspect
 import json
 import logging
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
@@ -50,6 +51,17 @@ _VALID_INTERVALS = {"1m", "5m", "15m", "30m", "1H", "4H", "1D"}
 _VALID_ENGINES = {"daily", "options"}
 _PRICE_PANEL_COLUMNS = ("open", "high", "low", "close", "volume", "vwap", "amount")
 _FUND_PREFIX = "fund:"
+
+
+@dataclass(frozen=True)
+class DataFetchResult:
+    """Market data plus the routing metadata selected by the central registry."""
+
+    data_map: Dict[str, pd.DataFrame]
+    codes: List[str]
+    source: str
+    loader: Any
+    effective_sources: List[str]
 
 
 class BacktestConfigSchema(BaseModel):
@@ -875,61 +887,18 @@ def main(run_dir: Path) -> None:
         print(json.dumps({"error": f"SignalEngine interface error: {exc}"}))
         sys.exit(1)
 
-    # Data: auto split vs single loader
+    fetch_result = fetch_data_map(config)
+    data_map = fetch_result.data_map
+    codes = fetch_result.codes
+    source = fetch_result.source
+    loader = fetch_result.loader
+    config["codes"] = codes
+    config["_run_card_effective_sources"] = fetch_result.effective_sources
     interval = config.get("interval", "1D")
-
-    if source == "auto":
-        data_map = _fetch_auto(codes, config, interval)
-    else:
-        codes = _normalize_codes(codes, source)
-        config["codes"] = codes
-        LoaderCls = _get_loader(source)
-        loader = LoaderCls()
-        data_map = loader.fetch(
-            codes,
-            config.get("start_date", ""),
-            config.get("end_date", ""),
-            fields=config.get("extra_fields") or None,
-            interval=interval,
-        )
-        if data_map and len(data_map) < len(codes):
-            missing = set(codes) - set(data_map.keys())
-            logger.warning(
-                "source=%s returned data for %d/%d symbols; missing: %s",
-                source, len(data_map), len(codes), missing,
-            )
-        # Runtime fallback: try next sources in chain when primary returns empty
-        if not data_map and codes:
-            market = _detect_market(codes[0])
-            for fb_name in FALLBACK_CHAINS.get(market, []):
-                if fb_name == source or fb_name not in LOADER_REGISTRY:
-                    continue
-                fb_loader = LOADER_REGISTRY[fb_name]()
-                if not fb_loader.is_available():
-                    continue
-                fb_codes = _normalize_codes(codes, fb_name)
-                data_map = fb_loader.fetch(
-                    fb_codes, config.get("start_date", ""),
-                    config.get("end_date", ""), interval=interval,
-                )
-                if data_map:
-                    logger.info("Runtime fallback: %s -> %s", source, fb_name)
-                    source = fb_name
-                    loader = fb_loader
-                    break
-
-    # Loader-boundary OHLC sanity for every source, centralized at the one
-    # point all fetch paths converge (auto / single / runtime fallback).
-    data_map = _sanitize_data_map(data_map)
     if not data_map:
         print(json.dumps({"error": "No data fetched"}))
         sys.exit(1)
     data_map = _maybe_inject_fundamentals_for_factor_panel(data_map, config)
-
-    if source == "auto":
-        config["_run_card_effective_sources"] = sorted(_group_codes_by_source(codes))
-    else:
-        config["_run_card_effective_sources"] = [source]
 
     # Engine
     engine_type = config.get("engine", "daily")
@@ -1088,6 +1057,79 @@ def _fetch_auto(codes: List[str], config: dict, interval: str = "1D") -> dict:
         merged.update(result)
 
     return merged
+
+
+def fetch_data_map(config: dict) -> DataFetchResult:
+    """Fetch and sanitize bars through the canonical loader registry.
+
+    This is the shared entry point for backtest execution and reconstruction
+    consumers. It preserves auto routing and the runtime fallback chain.
+
+    Args:
+        config: Backtest configuration containing codes, dates, source, and interval.
+
+    Returns:
+        Data and effective routing metadata. The input config is not mutated.
+    """
+    source = str(config.get("source") or "tushare")
+    codes = list(config.get("codes") or [])
+    interval = str(config.get("interval") or "1D")
+
+    if source == "auto":
+        data_map = _fetch_auto(codes, config, interval)
+        loader: Any = _AutoLoader(data_map)
+    else:
+        codes = _normalize_codes(codes, source)
+        loader = _get_loader(source)()
+        data_map = loader.fetch(
+            codes,
+            config.get("start_date", ""),
+            config.get("end_date", ""),
+            fields=config.get("extra_fields") or None,
+            interval=interval,
+        )
+        if data_map and len(data_map) < len(codes):
+            missing = set(codes) - set(data_map)
+            logger.warning(
+                "source=%s returned data for %d/%d symbols; missing: %s",
+                source,
+                len(data_map),
+                len(codes),
+                missing,
+            )
+        if not data_map and codes:
+            market = _detect_market(codes[0])
+            for fallback_source in FALLBACK_CHAINS.get(market, []):
+                if fallback_source == source or fallback_source not in LOADER_REGISTRY:
+                    continue
+                fallback_loader = LOADER_REGISTRY[fallback_source]()
+                if not fallback_loader.is_available():
+                    continue
+                fallback_codes = _normalize_codes(codes, fallback_source)
+                data_map = fallback_loader.fetch(
+                    fallback_codes,
+                    config.get("start_date", ""),
+                    config.get("end_date", ""),
+                    interval=interval,
+                )
+                if data_map:
+                    logger.info("Runtime fallback: %s -> %s", source, fallback_source)
+                    source = fallback_source
+                    codes = fallback_codes
+                    loader = fallback_loader
+                    break
+
+    data_map = _sanitize_data_map(data_map)
+    effective_sources = (
+        sorted(_group_codes_by_source(codes)) if source == "auto" else [source]
+    )
+    return DataFetchResult(
+        data_map=data_map,
+        codes=codes,
+        source=source,
+        loader=loader,
+        effective_sources=effective_sources,
+    )
 
 
 def _sanitize_data_map(data_map: dict) -> dict:

--- a/agent/backtest/runner.py
+++ b/agent/backtest/runner.py
@@ -8,6 +8,7 @@ Usage: ``python -m backtest.runner <run_dir>``
 """
 
 import ast
+import copy
 import importlib.util
 import inspect
 import json
@@ -1071,6 +1072,7 @@ def fetch_data_map(config: dict) -> DataFetchResult:
     Returns:
         Data and effective routing metadata. The input config is not mutated.
     """
+    config = copy.deepcopy(config)
     source = str(config.get("source") or "tushare")
     codes = list(config.get("codes") or [])
     interval = str(config.get("interval") or "1D")

--- a/agent/src/ui_services.py
+++ b/agent/src/ui_services.py
@@ -460,7 +460,8 @@ def reconstruct_price_series(run_dir: Path) -> List[Dict[str, Any]]:
     fetch_start_date = _compute_fetch_start_date(run_dir, start_date)
 
     try:
-        source = context.get("source", "tushare")
+        config_data = load_json_file(run_dir / "config.json") or {}
+        source = str(config_data.get("source") or "tushare")
         if source == "okx":
             from backtest.loaders.okx import DataLoader
         elif source == "yfinance":

--- a/agent/src/ui_services.py
+++ b/agent/src/ui_services.py
@@ -450,7 +450,6 @@ def reconstruct_price_series(run_dir: Path) -> List[Dict[str, Any]]:
     if not signal_path.exists():
         return []
 
-    agent_root = Path(__file__).resolve().parents[1]
     try:
         from src.providers.llm import _ensure_dotenv
 
@@ -461,21 +460,21 @@ def reconstruct_price_series(run_dir: Path) -> List[Dict[str, Any]]:
 
     try:
         config_data = load_json_file(run_dir / "config.json") or {}
-        source = str(config_data.get("source") or "tushare")
-        if source == "okx":
-            from backtest.loaders.okx import DataLoader
-        elif source == "yfinance":
-            from backtest.loaders.yfinance_loader import DataLoader
-        else:
-            from backtest.loaders.tushare import DataLoader
-        loader = DataLoader()
-        data_map = loader.fetch(codes, fetch_start_date, end_date)
+        from backtest.runner import fetch_data_map
+
+        fetch_config = dict(config_data)
+        fetch_config.update(
+            codes=codes,
+            start_date=fetch_start_date,
+            end_date=end_date,
+        )
+        data_map = fetch_data_map(fetch_config).data_map
     except Exception as exc:
         print(f"[WARN] reconstruct_price_series: DataLoader failed ({exc})")
         return []
 
     if not data_map:
-        print(f"[WARN] reconstruct_price_series: DataLoader returned empty")
+        print("[WARN] reconstruct_price_series: DataLoader returned empty")
         return []
 
     return _flatten_data_map(data_map, start_date=start_date)

--- a/agent/tests/test_ui_services.py
+++ b/agent/tests/test_ui_services.py
@@ -1,0 +1,84 @@
+"""Tests for UI-oriented run reconstruction services."""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from src.ui_services import reconstruct_price_series
+
+
+def test_reconstruct_price_series_preserves_configured_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_dir = tmp_path / "completed-run"
+    (run_dir / "code").mkdir(parents=True)
+    (run_dir / "code" / "signal_engine.py").write_text(
+        "class SignalEngine:\n    pass\n", encoding="utf-8"
+    )
+    (run_dir / "req.json").write_text(
+        json.dumps(
+            {
+                "prompt": "test",
+                "context": {
+                    "codes": ["BTC-USDT"],
+                    "start_date": "2026-01-01",
+                    "end_date": "2026-01-02",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "codes": ["BTC-USDT"],
+                "start_date": "2026-01-01",
+                "end_date": "2026-01-02",
+                "source": "okx",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    selected_sources: list[str] = []
+
+    def install_loader(source: str) -> None:
+        module = types.ModuleType(f"backtest.loaders.{source}")
+
+        class StubLoader:
+            def fetch(self, codes, start_date, end_date):
+                selected_sources.append(source)
+                index = pd.DatetimeIndex([pd.Timestamp("2026-01-01")])
+                return {
+                    codes[0]: pd.DataFrame(
+                        {
+                            "open": [1.0],
+                            "high": [1.0],
+                            "low": [1.0],
+                            "close": [1.0],
+                            "volume": [1.0],
+                        },
+                        index=index,
+                    )
+                }
+
+        module.DataLoader = StubLoader
+        monkeypatch.setitem(sys.modules, module.__name__, module)
+
+    install_loader("okx")
+    install_loader("tushare")
+    llm_module = types.ModuleType("src.providers.llm")
+    llm_module._ensure_dotenv = lambda: None
+    monkeypatch.setitem(sys.modules, llm_module.__name__, llm_module)
+
+    rows = reconstruct_price_series(run_dir)
+
+    assert selected_sources == ["okx"]
+    assert rows[0]["code"] == "BTC-USDT"

--- a/agent/tests/test_ui_services.py
+++ b/agent/tests/test_ui_services.py
@@ -118,6 +118,35 @@ def test_fetch_data_map_uses_registry_for_nonlegacy_source(
     assert list(result.data_map) == ["AAPL.US"]
 
 
+def test_fetch_data_map_does_not_expose_config_mutables_to_loader(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    frame = pd.DataFrame(
+        {"open": [1.0], "high": [1.0], "low": [1.0], "close": [1.0]},
+        index=pd.DatetimeIndex([pd.Timestamp("2026-01-01")]),
+    )
+
+    class MutatingLoader:
+        name = "tushare"
+
+        def fetch(self, codes, start_date, end_date, **kwargs):
+            kwargs["fields"].append("injected")
+            return {codes[0]: frame}
+
+    monkeypatch.setattr(runner, "_get_loader", lambda source: MutatingLoader)
+    config = {
+        "codes": ["000001.SZ"],
+        "start_date": "2026-01-01",
+        "end_date": "2026-01-02",
+        "source": "tushare",
+        "extra_fields": ["amount"],
+    }
+
+    runner.fetch_data_map(config)
+
+    assert config["extra_fields"] == ["amount"]
+
+
 def test_fetch_data_map_delegates_auto_routing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/agent/tests/test_ui_services.py
+++ b/agent/tests/test_ui_services.py
@@ -3,19 +3,21 @@
 from __future__ import annotations
 
 import json
-import sys
-import types
 from pathlib import Path
+from types import SimpleNamespace
 
 import pandas as pd
 import pytest
 
+import backtest.runner as runner
 from src.ui_services import reconstruct_price_series
 
 
-def test_reconstruct_price_series_preserves_configured_source(
+@pytest.mark.parametrize("source", ["yahoo", "auto"])
+def test_reconstruct_price_series_uses_central_fetch_router(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    source: str,
 ) -> None:
     run_dir = tmp_path / "completed-run"
     (run_dir / "code").mkdir(parents=True)
@@ -41,44 +43,105 @@ def test_reconstruct_price_series_preserves_configured_source(
                 "codes": ["BTC-USDT"],
                 "start_date": "2026-01-01",
                 "end_date": "2026-01-02",
-                "source": "okx",
+                "source": source,
+                "interval": "1H",
             }
         ),
         encoding="utf-8",
     )
 
-    selected_sources: list[str] = []
+    routed_configs: list[dict] = []
+    frame = pd.DataFrame(
+        {
+            "open": [1.0],
+            "high": [1.0],
+            "low": [1.0],
+            "close": [1.0],
+            "volume": [1.0],
+        },
+        index=pd.DatetimeIndex([pd.Timestamp("2026-01-01")]),
+    )
 
-    def install_loader(source: str) -> None:
-        module = types.ModuleType(f"backtest.loaders.{source}")
+    def fake_fetch_data_map(config: dict) -> SimpleNamespace:
+        routed_configs.append(config)
+        return SimpleNamespace(data_map={"BTC-USDT": frame})
 
-        class StubLoader:
-            def fetch(self, codes, start_date, end_date):
-                selected_sources.append(source)
-                index = pd.DatetimeIndex([pd.Timestamp("2026-01-01")])
-                return {
-                    codes[0]: pd.DataFrame(
-                        {
-                            "open": [1.0],
-                            "high": [1.0],
-                            "low": [1.0],
-                            "close": [1.0],
-                            "volume": [1.0],
-                        },
-                        index=index,
-                    )
-                }
-
-        module.DataLoader = StubLoader
-        monkeypatch.setitem(sys.modules, module.__name__, module)
-
-    install_loader("okx")
-    install_loader("tushare")
-    llm_module = types.ModuleType("src.providers.llm")
-    llm_module._ensure_dotenv = lambda: None
-    monkeypatch.setitem(sys.modules, llm_module.__name__, llm_module)
+    monkeypatch.setattr(runner, "fetch_data_map", fake_fetch_data_map)
 
     rows = reconstruct_price_series(run_dir)
 
-    assert selected_sources == ["okx"]
+    assert routed_configs[0]["source"] == source
+    assert routed_configs[0]["interval"] == "1H"
+    assert routed_configs[0]["codes"] == ["BTC-USDT"]
     assert rows[0]["code"] == "BTC-USDT"
+
+
+def test_fetch_data_map_uses_registry_for_nonlegacy_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple] = []
+    frame = pd.DataFrame(
+        {"open": [1.0], "high": [1.0], "low": [1.0], "close": [1.0]},
+        index=pd.DatetimeIndex([pd.Timestamp("2026-01-01")]),
+    )
+
+    class StubLoader:
+        name = "yahoo"
+
+        def fetch(self, codes, start_date, end_date, **kwargs):
+            calls.append((codes, start_date, end_date, kwargs))
+            return {codes[0]: frame}
+
+    monkeypatch.setattr(runner, "_get_loader", lambda source: StubLoader)
+    config = {
+        "codes": ["AAPL.US"],
+        "start_date": "2026-01-01",
+        "end_date": "2026-01-02",
+        "source": "yahoo",
+        "interval": "1H",
+    }
+    original = dict(config)
+
+    result = runner.fetch_data_map(config)
+
+    assert config == original
+    assert calls == [
+        (
+            ["AAPL.US"],
+            "2026-01-01",
+            "2026-01-02",
+            {"fields": None, "interval": "1H"},
+        )
+    ]
+    assert result.source == "yahoo"
+    assert result.effective_sources == ["yahoo"]
+    assert list(result.data_map) == ["AAPL.US"]
+
+
+def test_fetch_data_map_delegates_auto_routing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    frame = pd.DataFrame(
+        {"open": [1.0], "high": [1.0], "low": [1.0], "close": [1.0]},
+        index=pd.DatetimeIndex([pd.Timestamp("2026-01-01")]),
+    )
+    calls: list[tuple[list[str], dict, str]] = []
+
+    def fake_fetch_auto(codes: list[str], config: dict, interval: str) -> dict:
+        calls.append((codes, config, interval))
+        return {"AAPL.US": frame}
+
+    monkeypatch.setattr(runner, "_fetch_auto", fake_fetch_auto)
+    config = {
+        "codes": ["AAPL.US"],
+        "start_date": "2026-01-01",
+        "end_date": "2026-01-02",
+        "source": "auto",
+        "interval": "1D",
+    }
+
+    result = runner.fetch_data_map(config)
+
+    assert calls == [(["AAPL.US"], config, "1D")]
+    assert result.source == "auto"
+    assert result.effective_sources == ["yfinance"]


### PR DESCRIPTION
## Summary

- Preserve the executed market-data source when reconstructing historical chart prices.
- Add a network-free regression covering an OKX-configured completed run.

## Why

`reconstruct_price_series()` looked for `source` in the run context, but that context does not contain the field. It therefore silently defaulted to `tushare`, even when the canonical `config.json` recorded `okx`.

This can make historical analysis query the wrong loader and return empty or mismatched chart data.

## Changes

- Read `source` from the existing run `config.json` inside reconstruction.
- Preserve the current `tushare` fallback for missing or legacy configuration.
- Test actual loader selection with isolated OKX and Tushare stubs.

## Test Plan

- [ ] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [x] New tests added
- [x] Tested manually

Targeted validation:

- `test_ui_services.py`, `test_api_infrastructure.py`, and `test_run_card.py`: **45 passed**
- New test Ruff and Black checks: **passed**
- Direct offline reproduction selected Tushare before the fix and only OKX afterward
- `git diff --check`: **passed**

The full suite, live market data, LLM, browser, and E2E paths were not run.

## Risk and scope

No request schema, HTTP response, dependency, credential, network, broker, or configuration format changes. Missing or malformed legacy configuration retains the previous Tushare fallback. Rollback is a single commit revert.

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Documentation update is not applicable to this internal reconstruction correction