### PR TITLE
fix(backtest): keep Sharpe and information ratio finite for single-bar runs

### DIFF
--- a/agent/backtest/metrics.py
+++ b/agent/backtest/metrics.py
@@ -222,7 +222,10 @@ def calc_metrics(
         ann_ret = -1.0
     else:
         ann_ret = float(growth ** (bpy / max(n, 1)) - 1)
-    vol = float(port_ret.std())
+    # ``Series.std()`` uses ddof=1, so a single-observation return series
+    # (e.g. a one-bar backtest) yields NaN and poisons the Sharpe ratio.
+    # Guard the small sample the same way ``downside_std`` is guarded below.
+    vol = float(port_ret.std()) if len(port_ret) > 1 else 0.0
     sharpe = float(port_ret.mean() / (vol + 1e-10) * np.sqrt(bpy))
 
     # Drawdown
@@ -252,7 +255,9 @@ def calc_metrics(
         bench_return = float((1 + bench_ret).prod() - 1)
         excess = total_ret - bench_return
         active_ret = port_ret - bench_ret.reindex(port_ret.index).fillna(0.0)
-        active_std = float(active_ret.std())
+        # Same ddof=1 small-sample guard as ``vol`` / ``downside_std`` so the
+        # information ratio stays finite for a single-observation series.
+        active_std = float(active_ret.std()) if len(active_ret) > 1 else 0.0
         ir = float(active_ret.mean() / (active_std + 1e-10) * np.sqrt(bpy))
 
     return {

--- a/agent/tests/test_metrics.py
+++ b/agent/tests/test_metrics.py
@@ -9,6 +9,8 @@ Validates:
 
 from __future__ import annotations
 
+import math
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -264,6 +266,20 @@ class TestCalcMetrics:
         m = calc_metrics(pd.Series(dtype=float), [], 1_000_000, 252)
         assert m["final_value"] == 1_000_000
         assert m["total_return"] == 0
+
+    def test_single_bar_equity_metrics_finite(self) -> None:
+        # A one-bar backtest yields a single-observation return series.
+        # ``Series.std()`` (ddof=1) is NaN for a single element, which used
+        # to poison Sharpe and the information ratio (Sortino was already
+        # guarded). Every risk metric must stay finite.
+        eq = pd.Series([1_000_000.0], index=pd.bdate_range("2025-01-01", periods=1))
+        bench_ret = pd.Series([0.0], index=eq.index)
+        m = calc_metrics(eq, [], 1_000_000, 252, bench_ret=bench_ret)
+        for key in ("sharpe", "sortino", "information_ratio",
+                    "annual_return", "max_drawdown", "calmar"):
+            assert math.isfinite(m[key]), f"{key} is not finite: {m[key]!r}"
+        assert m["sharpe"] == 0.0
+        assert m["information_ratio"] == 0.0
 
     def test_final_value(self) -> None:
         eq = self._growing_equity()


### PR DESCRIPTION
### Problem

`calc_metrics` (`agent/backtest/metrics.py`) computes the Sortino denominator with a small-sample guard:

```python
downside_std = float(downside.std()) if len(downside) > 1 else 1e-10
```

but the **Sharpe** and **information-ratio** denominators use `Series.std()` unguarded:

```python
vol = float(port_ret.std())                 # Sharpe
active_std = float(active_ret.std())         # information ratio
```

`Series.std()` defaults to `ddof=1`, so a **single-observation** return series returns `NaN`. A one-bar backtest (`start_date == end_date`, or a data window with a single bar) produces a length-1 `equity_series` in `engines/base.py`, which flows straight into `calc_metrics` — only `len == 0` is guarded (the empty-equity early return), so `n == 1` falls through. The result is `sharpe = NaN` and `information_ratio = NaN`, while `sortino` is correctly `0.0`. The asymmetry is the giveaway: the small-sample pitfall was already handled for Sortino but missed for the other two.

The run-card writer sanitizes non-finite metrics to `null`, so today a legitimate one-bar run silently reports `sharpe: null` instead of `0.0`.

### Reproduction (against current `main`, pandas 3.0.3 / numpy 2.5.1)

```python
import pandas as pd, numpy as np, math
eq = pd.Series([1_000_000.0], index=pd.bdate_range("2025-01-01", periods=1))
port_ret = eq.pct_change().fillna(0.0)
vol = float(port_ret.std())                                   # -> nan  (ddof=1, single element)
sharpe = float(port_ret.mean() / (vol + 1e-10) * np.sqrt(252))
assert not math.isfinite(sharpe)   # NaN
```

### Fix

Apply the same `len > 1` guard `downside_std` already uses to `vol` and `active_std`, so all three risk metrics stay finite. A one-bar run now reports `0.0` instead of `NaN`.

### Tests

Added `TestCalcMetrics::test_single_bar_equity_metrics_finite` (a one-bar equity curve; asserts `sharpe`, `sortino`, `information_ratio`, `annual_return`, `max_drawdown`, `calmar` are all finite and Sharpe/IR are `0.0`). It fails on `main` (`isfinite(nan) → False`) and passes with this change.

`agent/tests/test_metrics.py`: **47 passed**. `ruff check` clean.
