### PR TITLE
fix(backtest): keep backtest outputs finite and validation.json strict

### DIFF
--- a/agent/backtest/engines/base.py
+++ b/agent/backtest/engines/base.py
@@ -469,17 +469,17 @@ class BaseEngine(ABC):
 
         # 7. Validation (optional — triggered by config["validation"])
         if config.get("validation"):
-            from backtest.validation import run_validation
+            from backtest.validation import run_validation, write_validation_json
             v_results = run_validation(
                 config, equity_series, self.trades, self.initial_capital, bars_per_year,
             )
             m["validation"] = v_results
-            # Write validation.json artifact. The artifacts dir is normally
-            # created by _write_artifacts() below (step 8), so ensure it exists
-            # here to avoid a FileNotFoundError when run_dir/artifacts is absent.
-            v_path = run_dir / "artifacts" / "validation.json"
-            v_path.parent.mkdir(parents=True, exist_ok=True)
-            v_path.write_text(json.dumps(v_results, indent=2, ensure_ascii=False), encoding="utf-8")
+            # Write validation.json through the shared strict writer so a
+            # non-finite validation metric is serialized as null rather than an
+            # invalid bare NaN/Infinity token (matching the standalone
+            # `python -m backtest.validation` path and run_card). The writer
+            # also creates the artifacts dir, which step 8 otherwise creates.
+            write_validation_json(run_dir / "artifacts" / "validation.json", v_results)
 
         # 8. Artifacts
         self._write_artifacts(

--- a/agent/backtest/runner.py
+++ b/agent/backtest/runner.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
 import pandas as pd
-from pydantic import BaseModel, ConfigDict, model_validator, field_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator, field_validator
 
 try:
     from dotenv import load_dotenv
@@ -63,6 +63,10 @@ class BacktestConfigSchema(BaseModel):
     source: str = "tushare"
     interval: str = "1D"
     engine: str = "daily"
+    # Returns divide by initial_cash, so a non-positive value yields inf/NaN
+    # metrics (total_return, annual_return, ...). Reject it at the config
+    # boundary instead of letting the run produce non-finite results.
+    initial_cash: float = Field(default=1_000_000, gt=0)
     fundamental_fields: Optional[Dict[str, List[str]]] = None
     event_feeds: Optional[List[Dict[str, Any]]] = None
 

--- a/agent/backtest/runner.py
+++ b/agent/backtest/runner.py
@@ -66,7 +66,7 @@ class BacktestConfigSchema(BaseModel):
     # Returns divide by initial_cash, so a non-positive value yields inf/NaN
     # metrics (total_return, annual_return, ...). Reject it at the config
     # boundary instead of letting the run produce non-finite results.
-    initial_cash: float = Field(default=1_000_000, gt=0)
+    initial_cash: float = Field(default=1_000_000, gt=0, allow_inf_nan=False)
     fundamental_fields: Optional[Dict[str, List[str]]] = None
     event_feeds: Optional[List[Dict[str, Any]]] = None
 

--- a/agent/backtest/validation.py
+++ b/agent/backtest/validation.py
@@ -372,6 +372,26 @@ def _json_safe(value: Any) -> Any:
     return value
 
 
+def write_validation_json(path: Path, results: Dict[str, Any]) -> Dict[str, Any]:
+    """Write validation results to ``path`` as strict, RFC-8259 JSON.
+
+    A validation metric can be non-finite (e.g. a Sharpe computed from a path
+    whose equity touches zero), and ``json.dumps`` emits bare ``NaN`` /
+    ``Infinity`` tokens for those by default (``allow_nan=True``) — tokens that
+    strict parsers reject. Sanitize with :func:`_json_safe` (non-finite → null)
+    and serialize with ``allow_nan=False`` so every writer of
+    ``artifacts/validation.json`` produces the same valid JSON. Returns the
+    sanitized payload that was written.
+    """
+    safe_results = _json_safe(results)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(safe_results, indent=2, ensure_ascii=False, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    return safe_results
+
+
 def main(run_dir: Path) -> Dict[str, Any]:
     """Run all three validations on existing backtest artifacts.
 
@@ -399,14 +419,9 @@ def main(run_dir: Path) -> Dict[str, Any]:
         "bootstrap": bootstrap_sharpe_ci(equity),
         "walk_forward": walk_forward_analysis(equity, trades),
     }
-    safe_results = _json_safe(results)
 
-    # Write results
     out = run_dir / "artifacts" / "validation.json"
-    out.write_text(
-        json.dumps(safe_results, indent=2, ensure_ascii=False, allow_nan=False) + "\n",
-        encoding="utf-8",
-    )
+    safe_results = write_validation_json(out, results)
 
     print(json.dumps(safe_results, indent=2, allow_nan=False))
     return safe_results

--- a/agent/backtest/validation.py
+++ b/agent/backtest/validation.py
@@ -360,11 +360,12 @@ def _parse_run_dir(argv: List[str]) -> Path:
 
 def _json_safe(value: Any) -> Any:
     """Return a JSON-strict copy of validation results."""
+    if isinstance(value, np.ndarray):
+        return [_json_safe(item) for item in value.tolist()]
+    if isinstance(value, np.generic):
+        return _json_safe(value.item())
     if isinstance(value, float):
         return value if math.isfinite(value) else None
-    if isinstance(value, np.floating):
-        as_float = float(value)
-        return as_float if math.isfinite(as_float) else None
     if isinstance(value, dict):
         return {str(key): _json_safe(item) for key, item in value.items()}
     if isinstance(value, (list, tuple)):

--- a/agent/tests/test_engine_robustness.py
+++ b/agent/tests/test_engine_robustness.py
@@ -355,6 +355,31 @@ class TestBacktestConfigSchema:
                 source="bloomberg",
             )
 
+    @pytest.mark.parametrize("initial_cash", [0, -1, -1_000_000])
+    def test_non_positive_initial_cash_rejected(self, initial_cash: float) -> None:
+        """A non-positive initial_cash makes returns divide by <= 0 and yields
+        inf/NaN metrics; reject it at the config boundary."""
+        with pytest.raises(Exception, match="initial_cash"):
+            BacktestConfigSchema(
+                codes=["AAPL.US"],
+                start_date="2025-01-01",
+                end_date="2025-06-01",
+                initial_cash=initial_cash,
+            )
+
+    def test_initial_cash_defaults_and_accepts_positive(self) -> None:
+        default = BacktestConfigSchema(
+            codes=["AAPL.US"], start_date="2025-01-01", end_date="2025-06-01"
+        )
+        assert default.initial_cash == 1_000_000
+        explicit = BacktestConfigSchema(
+            codes=["AAPL.US"],
+            start_date="2025-01-01",
+            end_date="2025-06-01",
+            initial_cash=50_000,
+        )
+        assert explicit.initial_cash == 50_000
+
     def test_mootdx_and_futu_sources_accepted(self) -> None:
         """mootdx and futu are registered loaders, so config validation must
         accept them. Regression: ``_VALID_SOURCES`` drifted and rejected both

--- a/agent/tests/test_engine_robustness.py
+++ b/agent/tests/test_engine_robustness.py
@@ -355,8 +355,12 @@ class TestBacktestConfigSchema:
                 source="bloomberg",
             )
 
-    @pytest.mark.parametrize("initial_cash", [0, -1, -1_000_000])
-    def test_non_positive_initial_cash_rejected(self, initial_cash: float) -> None:
+    @pytest.mark.parametrize(
+        "initial_cash", [0, -1, -1_000_000, float("inf"), float("-inf"), float("nan"), "Infinity"]
+    )
+    def test_non_finite_or_non_positive_initial_cash_rejected(
+        self, initial_cash: object
+    ) -> None:
         """A non-positive initial_cash makes returns divide by <= 0 and yields
         inf/NaN metrics; reject it at the config boundary."""
         with pytest.raises(Exception, match="initial_cash"):
@@ -585,19 +589,35 @@ class TestValidationArtifactDir:
         assert not (run_dir / "artifacts").exists()
 
         engine = ChinaAEngine({"initial_cash": 1_000_000})
-        metrics = engine.run_backtest(
-            {
-                "codes": ["000001.SZ"],
-                "start_date": "2024-04-01",
-                "end_date": "2024-04-30",
-                "source": "tushare",
-                "initial_cash": 1_000_000,
-                "validation": {"bootstrap": {"n_bootstrap": 20, "seed": 1}},
-            },
-            FakeLoader(),
-            SignalEngine(),
-            run_dir,
-        )
+        non_finite = {
+            "bootstrap": {
+                "observed_sharpe": float("inf"),
+                "median_sharpe": float("nan"),
+            }
+        }
+        with patch("backtest.validation.run_validation", return_value=non_finite):
+            metrics = engine.run_backtest(
+                {
+                    "codes": ["000001.SZ"],
+                    "start_date": "2024-04-01",
+                    "end_date": "2024-04-30",
+                    "source": "tushare",
+                    "initial_cash": 1_000_000,
+                    "validation": {"bootstrap": {"n_bootstrap": 20, "seed": 1}},
+                },
+                FakeLoader(),
+                SignalEngine(),
+                run_dir,
+            )
 
         assert "validation" in metrics
-        assert (run_dir / "artifacts" / "validation.json").exists()
+        validation_path = run_dir / "artifacts" / "validation.json"
+        parsed = json.loads(
+            validation_path.read_text(encoding="utf-8"),
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                ValueError(f"non-strict JSON constant: {value}")
+            ),
+        )
+        assert parsed == {
+            "bootstrap": {"observed_sharpe": None, "median_sharpe": None}
+        }

--- a/agent/tests/test_validation.py
+++ b/agent/tests/test_validation.py
@@ -9,6 +9,9 @@ Validates:
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -19,6 +22,7 @@ from backtest.validation import (
     monte_carlo_test,
     run_validation,
     walk_forward_analysis,
+    write_validation_json,
 )
 
 
@@ -238,3 +242,47 @@ class TestRunValidation:
         result = run_validation(config, eq, trades, 1_000_000)
         assert "bootstrap" in result
         assert "monte_carlo" not in result
+
+
+# ---------------------------------------------------------------------------
+# Strict validation.json writer
+# ---------------------------------------------------------------------------
+
+
+def _strict_json_load(text: str):
+    """Parse ``text`` rejecting non-RFC-8259 NaN/Infinity tokens."""
+
+    def _reject(value: str):
+        raise ValueError(f"non-strict JSON constant: {value}")
+
+    return json.loads(text, parse_constant=_reject)
+
+
+class TestWriteValidationJson:
+    def test_non_finite_metric_written_as_null(self, tmp_path: Path) -> None:
+        """A non-finite metric must be serialized as null, not a bare
+        NaN/Infinity token that strict JSON parsers reject."""
+        out = tmp_path / "artifacts" / "validation.json"
+        results = {
+            "monte_carlo": {
+                "actual_sharpe": float("inf"),
+                "p_value_sharpe": float("nan"),
+                "n_trades": 3,
+            }
+        }
+        written = write_validation_json(out, results)
+
+        text = out.read_text(encoding="utf-8")
+        assert "NaN" not in text
+        assert "Infinity" not in text
+        parsed = _strict_json_load(text)  # must not raise
+        assert parsed["monte_carlo"]["actual_sharpe"] is None
+        assert parsed["monte_carlo"]["p_value_sharpe"] is None
+        assert parsed["monte_carlo"]["n_trades"] == 3
+        assert written["monte_carlo"]["actual_sharpe"] is None
+
+    def test_creates_parent_dir(self, tmp_path: Path) -> None:
+        out = tmp_path / "does" / "not" / "exist" / "validation.json"
+        write_validation_json(out, {"ok": 1.0})
+        assert out.is_file()
+        assert _strict_json_load(out.read_text(encoding="utf-8")) == {"ok": 1.0}

--- a/agent/tests/test_validation.py
+++ b/agent/tests/test_validation.py
@@ -14,7 +14,6 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
-import pytest
 
 from backtest.models import TradeRecord
 from backtest.validation import (
@@ -286,3 +285,36 @@ class TestWriteValidationJson:
         write_validation_json(out, {"ok": 1.0})
         assert out.is_file()
         assert _strict_json_load(out.read_text(encoding="utf-8")) == {"ok": 1.0}
+
+    def test_numpy_scalars_from_public_validators_are_strict_json(
+        self, tmp_path: Path
+    ) -> None:
+        results = {
+            "monte_carlo": monte_carlo_test(
+                _make_trades([100, -50, 200]),
+                1_000_000,
+                n_simulations=np.int64(2),
+                seed=np.int64(1),
+            ),
+            "bootstrap": bootstrap_sharpe_ci(
+                _make_equity(20),
+                n_bootstrap=np.int64(2),
+                seed=np.int64(1),
+            ),
+            "walk_forward": walk_forward_analysis(
+                _make_equity(20),
+                [],
+                n_windows=np.int64(2),
+            ),
+            "array": np.array([1, np.nan]),
+        }
+        out = tmp_path / "validation.json"
+
+        written = write_validation_json(out, results)
+
+        parsed = _strict_json_load(out.read_text(encoding="utf-8"))
+        assert parsed["monte_carlo"]["n_simulations"] == 2
+        assert parsed["bootstrap"]["n_bootstrap"] == 2
+        assert parsed["walk_forward"]["n_windows"] == 2
+        assert parsed["array"] == [1.0, None]
+        assert written == parsed


### PR DESCRIPTION
Two related robustness gaps that let non-finite values into backtest outputs.

## 1. `initial_cash` is not validated → `inf` metrics

`BacktestConfigSchema` uses `extra="allow"` and never declares `initial_cash`, so a config with `initial_cash: 0` (or negative) passes validation untouched and reaches `calc_metrics`, where `equity[-1] / initial_cash - 1` produces `inf` `total_return` / `annual_return`:

```python
BacktestConfigSchema(codes=["AAPL.US"], start_date="2024-01-01",
                     end_date="2024-12-31", initial_cash=0)   # accepted today
```

Both production entry points (the CLI `python -m backtest.runner` and the MCP `backtest` tool, which runs the runner as a subprocess) go through this schema, so it is the right boundary to reject the value.

**Fix:** declare `initial_cash: float = Field(default=1_000_000, gt=0)` — non-positive values are now rejected at config validation with a clear error instead of running to produce non-finite metrics.

## 2. In-engine `validation.json` write bypassed strict JSON

`run_card` and the standalone `python -m backtest.validation` both sanitize validation results with `_json_safe` + `allow_nan=False`, but `BaseEngine.run_backtest` wrote the same artifact with `json.dumps(v_results, indent=2, ensure_ascii=False)` — default `allow_nan=True`. So when a validation metric is non-finite (e.g. a Sharpe from a path whose equity touches zero), the automatic in-engine `validation.json` contains bare `NaN` / `Infinity` tokens, which are invalid RFC-8259 JSON and rejected by strict parsers — while the standalone CLI writes `null` for the same run.

**Fix:** extract the strict write into a shared `write_validation_json` helper (sanitize + `allow_nan=False` + create the artifacts dir) and call it from both the engine and the standalone `main`, so every writer of `validation.json` emits the same valid JSON.

## Tests

- `initial_cash` of `0` / negative is rejected; default (`1_000_000`) and positive values accepted.
- `write_validation_json` serializes `inf` / `NaN` as `null` and its output parses under a strict `parse_constant` loader; it also creates a missing parent directory.

Relevant validation, metrics, and config-schema suites pass; `ruff` clean on the changed code.

Independent of #538 (branched off `main`); they touch different parts of `validation.py` and merge cleanly.