### PR TITLE
fix(tools): mark core query tools as repeatable to prevent silent dedup

### DIFF
--- a/agent/src/tools/get_fundamentals_tool.py
+++ b/agent/src/tools/get_fundamentals_tool.py
@@ -114,6 +114,7 @@ class GetFundamentalsTool(BaseTool):
         },
         "required": ["symbols", "fields", "start", "end"],
     }
+    repeatable = True
 
     def execute(self, **kwargs: Any) -> str:
         """Validate inputs, call the loader, and return a JSON envelope.

--- a/agent/src/tools/market_data_tool.py
+++ b/agent/src/tools/market_data_tool.py
@@ -76,6 +76,7 @@ class MarketDataTool(BaseTool):
         },
         "required": ["codes", "start_date", "end_date"],
     }
+    repeatable = True
 
     def execute(self, **kwargs: Any) -> str:
         return fetch_market_data_json(

--- a/agent/src/tools/market_screener_tool.py
+++ b/agent/src/tools/market_screener_tool.py
@@ -208,6 +208,7 @@ class MarketScreenerTool(BaseTool):
         },
         "required": ["market"],
     }
+    repeatable = True
 
     def execute(self, **kwargs: Any) -> str:
         """Validate inputs, screen the market, and return a JSON envelope.

--- a/agent/src/tools/symbol_search_tool.py
+++ b/agent/src/tools/symbol_search_tool.py
@@ -101,6 +101,7 @@ class SymbolSearchTool(BaseTool):
         },
         "required": ["query"],
     }
+    repeatable = True
 
     def execute(self, **kwargs: Any) -> str:
         """Fan out across providers and return a merged candidate envelope.

--- a/agent/tests/test_agent_loop_repeatable_tools.py
+++ b/agent/tests/test_agent_loop_repeatable_tools.py
@@ -6,23 +6,75 @@ import json
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from src.agent.context import ContextBuilder
 from src.agent.loop import AgentLoop
 from src.agent.tools import ToolRegistry
 from src.agent.trace import TraceWriter
+from src.tools.get_fundamentals_tool import GetFundamentalsTool
 from src.tools.market_data_tool import MarketDataTool
+from src.tools.market_screener_tool import MarketScreenerTool
+from src.tools.symbol_search_tool import SymbolSearchTool
 
 
-def test_market_data_executes_again_with_different_arguments(
-    monkeypatch, tmp_path: Path
+@pytest.mark.parametrize(
+    ("tool_cls", "first_args", "second_args"),
+    [
+        (
+            MarketDataTool,
+            {
+                "codes": ["AAPL.US"],
+                "start_date": "2025-01-01",
+                "end_date": "2025-01-31",
+            },
+            {
+                "codes": ["MSFT.US"],
+                "start_date": "2025-01-01",
+                "end_date": "2025-01-31",
+            },
+        ),
+        (
+            GetFundamentalsTool,
+            {
+                "symbols": ["AAPL.US"],
+                "fields": ["roe"],
+                "start": "2025-01-01",
+                "end": "2025-01-31",
+            },
+            {
+                "symbols": ["MSFT.US"],
+                "fields": ["roe"],
+                "start": "2025-01-01",
+                "end": "2025-01-31",
+            },
+        ),
+        (
+            MarketScreenerTool,
+            {"market": "us", "sort_by": "volume", "top_n": 5},
+            {"market": "hk", "sort_by": "amount", "top_n": 10},
+        ),
+        (
+            SymbolSearchTool,
+            {"query": "Apple", "limit": 5},
+            {"query": "Microsoft", "limit": 5},
+        ),
+    ],
+)
+def test_repeatable_query_executes_again_with_different_arguments(
+    monkeypatch,
+    tmp_path: Path,
+    tool_cls: type,
+    first_args: dict[str, object],
+    second_args: dict[str, object],
 ) -> None:
     """A successful query must not suppress the next iteration's symbol."""
-    calls: list[list[str]] = []
-    tool = MarketDataTool()
+    calls: list[dict[str, object]] = []
+    tool = tool_cls()
 
     def _execute(**kwargs: object) -> str:
-        calls.append(list(kwargs["codes"]))  # type: ignore[arg-type]
-        return json.dumps({"status": "ok", "codes": kwargs["codes"]})
+        calls.append(kwargs)
+        return json.dumps({"status": "ok"})
 
     monkeypatch.setattr(tool, "execute", _execute)
     registry = ToolRegistry()
@@ -36,19 +88,15 @@ def test_market_data_executes_again_with_different_arguments(
     messages: list[dict[str, object]] = []
     react_trace: list[dict[str, object]] = []
 
-    for iteration, (call_id, code) in enumerate(
-        (("call_aapl", "AAPL.US"), ("call_msft", "MSFT.US")), start=1
+    for iteration, (call_id, arguments) in enumerate(
+        (("call_first", first_args), ("call_second", second_args)), start=1
     ):
         agent._process_tool_calls(
             [
                 SimpleNamespace(
                     id=call_id,
-                    name="get_market_data",
-                    arguments={
-                        "codes": [code],
-                        "start_date": "2025-01-01",
-                        "end_date": "2025-01-31",
-                    },
+                    name=tool.name,
+                    arguments=arguments,
                 )
             ],
             ContextBuilder,
@@ -59,7 +107,10 @@ def test_market_data_executes_again_with_different_arguments(
         )
     trace.close()
 
-    assert calls == [["AAPL.US"], ["MSFT.US"]]
+    assert [
+        {key: value for key, value in call.items() if key != "run_dir"}
+        for call in calls
+    ] == [first_args, second_args]
     assert len(messages) == 2
     assert not any(
         event["type"] == "tool_skipped" for event in TraceWriter.read(run_dir)

--- a/agent/tests/test_agent_loop_repeatable_tools.py
+++ b/agent/tests/test_agent_loop_repeatable_tools.py
@@ -1,0 +1,66 @@
+"""Regression tests for parameter-dependent query tools in the agent loop."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from src.agent.context import ContextBuilder
+from src.agent.loop import AgentLoop
+from src.agent.tools import ToolRegistry
+from src.agent.trace import TraceWriter
+from src.tools.market_data_tool import MarketDataTool
+
+
+def test_market_data_executes_again_with_different_arguments(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """A successful query must not suppress the next iteration's symbol."""
+    calls: list[list[str]] = []
+    tool = MarketDataTool()
+
+    def _execute(**kwargs: object) -> str:
+        calls.append(list(kwargs["codes"]))  # type: ignore[arg-type]
+        return json.dumps({"status": "ok", "codes": kwargs["codes"]})
+
+    monkeypatch.setattr(tool, "execute", _execute)
+    registry = ToolRegistry()
+    registry.register(tool)
+    agent = AgentLoop(registry=registry, llm=SimpleNamespace(), max_iterations=2)
+
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    agent.memory.run_dir = str(run_dir)
+    trace = TraceWriter(run_dir)
+    messages: list[dict[str, object]] = []
+    react_trace: list[dict[str, object]] = []
+
+    for iteration, (call_id, code) in enumerate(
+        (("call_aapl", "AAPL.US"), ("call_msft", "MSFT.US")), start=1
+    ):
+        agent._process_tool_calls(
+            [
+                SimpleNamespace(
+                    id=call_id,
+                    name="get_market_data",
+                    arguments={
+                        "codes": [code],
+                        "start_date": "2025-01-01",
+                        "end_date": "2025-01-31",
+                    },
+                )
+            ],
+            ContextBuilder,
+            messages,
+            trace,
+            react_trace,
+            iteration,
+        )
+    trace.close()
+
+    assert calls == [["AAPL.US"], ["MSFT.US"]]
+    assert len(messages) == 2
+    assert not any(
+        event["type"] == "tool_skipped" for event in TraceWriter.read(run_dir)
+    )


### PR DESCRIPTION
## Summary

- Mark 4 core query tools (`get_market_data`, `search_symbol`, `screen_market`, `get_fundamentals`) as `repeatable = True`
- Fixes silent dedup that drops second tool call when user queries multiple symbols

## Why

`loop.py` deduplicates tool calls by name: once a non-repeatable tool succeeds, subsequent calls with different arguments are silently skipped with `{"skipped": true}`. `BaseTool.repeatable` defaults to `False`, but four core query tools were missing the override.

This causes the most common multi-symbol workflow ("compare AAPL and MSFT") to silently drop the second call, returning stale or missing data with no error.

**Reproduction:**
1. Start a session and ask: "Compare AAPL and MSFT recent prices"
2. Agent calls `get_market_data(codes=["AAPL.US"])` → succeeds
3. Agent calls `get_market_data(codes=["MSFT.US"])` → silently skipped
4. User sees only AAPL data, MSFT data is missing

**Affected tools:**
| Tool | File | Issue |
|------|------|-------|
| `get_market_data` | `market_data_tool.py` | Missing `repeatable = True` |
| `search_symbol` | `symbol_search_tool.py` | Missing `repeatable = True` |
| `screen_market` | `market_screener_tool.py` | Missing `repeatable = True` |
| `get_fundamentals` | `get_fundamentals_tool.py` | Missing `repeatable = True` |

## Changes

Added `repeatable = True` to 4 tool classes:
- `agent/src/tools/market_data_tool.py`
- `agent/src/tools/symbol_search_tool.py`
- `agent/src/tools/market_screener_tool.py`
- `agent/src/tools/get_fundamentals_tool.py`

All 4 tools are idempotent read-only queries that users naturally call multiple times per session.

## Test Plan

- [x] Verified all 4 tools now have `repeatable = True` via Python import test
- [x] No existing tests broken (ran `test_agent_config.py`)
- [ ] Manual test: ask agent to compare two stocks and verify both return data

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Documentation not needed (behavioral fix, no API change)
