### PR TITLE
docs: establish HQATL project foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Instructions for AI Coding Agents
+
+These instructions apply throughout this repository.
+
+1. Read `HQATL_MANIFEST.md` and `docs/HQATL_MASTER_REQUIREMENTS.md` before modifying anything.
+2. HQATL is separate from Paperclip AI. Do not mention, integrate, import, modify, or design around Paperclip AI. Do not include DARWIN Zero.
+3. Never commit credentials. Keep secrets out of source, prompts, logs, screenshots, and documentation.
+4. Never enable live execution without a separate, explicit, human-approved task.
+5. Preserve existing Vibe functionality unless an approved requirement explicitly replaces it.
+6. Distinguish executable capabilities from prompt-only descriptions. Never present a prompt description as implemented behavior.
+7. Avoid look-ahead bias in research, signals, tests, labels, and datasets.
+8. Confirmed signals must use completed bars unless explicitly marked provisional.
+9. Do not duplicate backend calculations in the frontend.
+10. Analytical and backtesting calculations must share the same implementation.
+11. All new analytical calculations require tests.
+12. Every confidence result must explain its contributing, opposing, and missing evidence. No black-box scores.
+13. Keep primary and alternate Elliott counts separate.
+14. Keep Fibonacci projections and statistical projections separate.
+15. Keep data-provider-specific logic outside strategy and analytical logic.
+16. Do not claim a capability is implemented without auditing executable code and relevant tests.
+17. Stop after completing the explicitly assigned phase. Do not begin a later phase without approval.

--- a/HQATL_MANIFEST.md
+++ b/HQATL_MANIFEST.md
@@ -1,0 +1,31 @@
+# HQATL Manifest
+
+## Identity
+
+**Project:** Hew's Quant Analytics Trading Lab (HQATL)
+**Business umbrella:** Hew's Trading Edge
+
+HQATL is a personal quantitative research and trade-decision-support workstation. Its mission is to organize, measure, test, and explain market evidence so that research and trading decisions become more disciplined, reproducible, and transparent.
+
+HQATL does not connect to a broker or trading account during the foundation phase.
+
+## Vision
+
+HQATL will become a maintainable research environment in which structural market interpretations, statistical context, and validation results can be examined together without confusing probability with certainty.
+
+> "HQATL is not designed to tell the trader what to think. It is designed to organize, measure, and explain the quality of the evidence so the trader can make better decisions."
+
+## Governing principles
+
+1. **Increase the quality of the evidence.** Evidence quality is the central measure of progress.
+2. **Evidence over indicator quantity.** Add a module only when it contributes independent, measurable evidence; indicator counting and duplicated evidence are not confirmation.
+3. **Elliott Wave is the structural framework.** Other modules may validate, challenge, qualify, or statistically contextualize an Elliott interpretation.
+4. **Research before implementation.** Significant hypotheses require documented sources, specifications, and validation plans before production work begins.
+5. **Test before trust.** Historical tests, out-of-sample checks, and walk-forward analysis must precede reliance on important analytical claims.
+6. **Explainability is mandatory.** Conclusions and confidence results must identify supporting, opposing, and missing evidence. HQATL will not use black-box confidence scores.
+7. **Provider-neutral design.** Analytical and strategy logic must not depend directly on a particular data or execution provider.
+8. **Human decision authority.** HQATL supports decisions; it does not replace the trader's judgment or imply autonomous authority.
+9. **No guaranteed outcomes.** Probabilistic evidence never guarantees a forecast, setup, or result.
+10. **Stand aside with discipline.** The system should explicitly recommend waiting when evidence is missing, contradictory, stale, or unreliable.
+11. **Preserve and refine.** Preserve established analytical methods while identifying weaknesses through evidence rather than assumption.
+12. **Maintain for the long term.** Shared calculations, tests, clear boundaries, durable documentation, and traceable decisions are required for sustainable evolution.

--- a/docs/HQATL_ARCHITECTURE_OVERVIEW.md
+++ b/docs/HQATL_ARCHITECTURE_OVERVIEW.md
@@ -1,0 +1,30 @@
+# HQATL Architecture Overview
+
+## Architectural intent
+
+HQATL will separate data acquisition, analytical calculations, research validation, evidence synthesis, presentation, and any future execution capability. This document is a target architecture, not an implementation claim.
+
+## Logical layers
+
+1. **Provider adapters** implement historical, realtime, depth, execution, and instrument-mapping interfaces.
+2. **Canonical market data** normalizes instruments, timestamps, timeframes, sessions, completeness, provenance, and quality flags.
+3. **Shared analytics** contains a single implementation for calculations used by interactive analysis and backtesting.
+4. **Structural interpretation** maintains Elliott primary and alternate counts, their evidence, and separate invalidation levels.
+5. **Evidence modules** contribute measurable, non-duplicative context such as Fibonacci, EMA deviation, structure, iFVG, volume, CVD, and intermarket evidence.
+6. **Research and validation** evaluates hypotheses with reproducible tests, leakage controls, baselines, and walk-forward analysis.
+7. **Evidence synthesis** exposes supporting, opposing, and missing evidence without black-box certainty.
+8. **Workspaces** present the research/chart view and Trade Decision Workspace without duplicating backend calculations.
+9. **Execution boundary** remains disabled by default and requires a separate human-approved phase.
+
+## Core boundaries
+
+- Strategy and analytical code depend on provider interfaces, never OANDA or Moomoo directly.
+- Frontend components render backend results rather than recalculate them.
+- Confirmed signals use completed bars; provisional results are labeled.
+- Elliott primary and alternate counts never collapse into one result.
+- Fibonacci projections never masquerade as statistical projections.
+- Every result carries provenance, parameters, timeframe, data-quality state, and an explanation.
+
+## Quality attributes
+
+Explainability, reproducibility, testability, provider neutrality, security, observable data quality, and long-term maintainability take precedence over feature count.

--- a/docs/HQATL_DASHBOARD_VISION.md
+++ b/docs/HQATL_DASHBOARD_VISION.md
@@ -1,0 +1,39 @@
+# HQATL Dashboard Vision
+
+This is a future visual specification only. No dashboard code is authorized in Phase 0.
+
+## Side-by-side layout
+
+### Left — Research and chart workspace
+
+The research side will support exploration and validation with:
+
+- Linked 4H and 1H charts
+- Optional 15M futures execution-research chart
+- Elliott Wave labels with separate primary and alternate counts
+- Fibonacci retracements and extensions
+- EMA 9, 21, 89, 200, and 233
+- EMA-89 standard-deviation channel
+- EMA-200 standard-deviation channel
+- KAMA adaptive bands
+- Linear-regression deviation channel
+- iFVG
+- Volume and RVOL
+- CVD
+- Dow/intermarket confirmation
+- Backtest evidence
+- Data-quality status
+
+Layers should be independently toggled, disclose parameters and provenance, and avoid visual confirmation by indicator quantity.
+
+### Right — Trade Decision Workspace
+
+The decision side will summarize Bullish Bias, Bearish Bias, or Neutral Bias; confidence; risk references; Elliott scenarios; supporting, opposing, and missing evidence; data warnings; and stand-aside status. It must remain decision support rather than an autonomous trading command system.
+
+## Interaction principles
+
+- Symbol, timestamp, and timeframe context remain synchronized where meaningful.
+- Confirmed and provisional evidence are visibly distinct.
+- The interface retrieves shared backend calculations; it does not recreate formulas.
+- Confidence expands into contributing evidence rather than hiding behind a score.
+- Missing or unreliable evidence is prominent enough to support waiting.

--- a/docs/HQATL_DATA_PROVIDER_PLAN.md
+++ b/docs/HQATL_DATA_PROVIDER_PLAN.md
@@ -1,0 +1,40 @@
+# HQATL Data Provider Plan
+
+## Goal
+
+HQATL will use provider-neutral contracts so research, analytical, and strategy logic remain portable and testable. This is a future design; no provider connection is authorized in Phase 0.
+
+## Provider contracts
+
+### HistoricalDataProvider
+
+Retrieves normalized completed bars and approved historical datasets with instrument, timeframe, timezone, session, provenance, completeness, and adjustment metadata.
+
+### RealtimeDataProvider
+
+Supplies timestamped realtime quotes/bars, explicitly distinguishes provisional from completed bars, and reports freshness, gaps, and connection quality.
+
+### MarketDepthProvider
+
+Supplies entitlement-aware depth/order-book events with venue, sequence, timestamp, coverage, and known limitations.
+
+### ExecutionProvider
+
+Encapsulates future practice/demo or order operations. It remains disabled by default and unavailable to strategy logic without a separately approved, order-capable development phase.
+
+### InstrumentMapper
+
+Maps canonical HQATL instruments to provider identifiers, contract metadata, price precision, trading calendars, and rollover/expiry rules.
+
+## Providers
+
+- **Initial provider: OANDA.** Future work may implement historical and practice adapters after official API, account, instrument, rate-limit, and licensing review.
+- **Future provider: Moomoo/OpenD.** Work is conditional on account access, API support, data entitlements, licensing, regional availability, Level 2 coverage, and demo-trading verification.
+
+## Boundary rules
+
+- Strategies and analytics depend only on canonical data and provider contracts.
+- Provider adapters perform translation; they do not contain strategy decisions.
+- Recorded fixtures or test doubles support deterministic tests.
+- Data-quality warnings propagate to research and decision workspaces.
+- Provider differences must be disclosed rather than silently normalized away.

--- a/docs/HQATL_IMPLEMENTATION_ROADMAP.md
+++ b/docs/HQATL_IMPLEMENTATION_ROADMAP.md
@@ -1,0 +1,59 @@
+# HQATL Implementation Roadmap
+
+This roadmap describes future gated work. Only Phase 0 documentation is in scope now; no later phase is implemented or authorized.
+
+## Phase 0 — Foundation and governance
+
+Create governing, requirements, architecture, research, security, provider, dashboard, workspace, audit, and roadmap documents. Stop for human review.
+
+## Phase 1 — Complete Vibe repository audit
+
+Inventory executable code, prompts, tests, data flows, current behavior, and preservation constraints. Classify requirements without changing behavior.
+
+## Phase 2 — Elliott Wave executable gap audit
+
+Compare executable Elliott behavior with documented rules; identify prompt-only, partial, missing, and untested capabilities.
+
+## Phase 3 — Approved Elliott source standard
+
+Create a copyright-safe, human-approved rule standard with conflicts, interpretations, examples, and validation criteria.
+
+## Phase 4 — EMA 9/21/89/200/233 and deviation specifications
+
+Specify shared EMA calculations and EMA-89/EMA-200 standard-deviation analytics, parameters, outputs, and tests.
+
+## Phase 5 — Market structure, iFVG, and candle-control interpretation
+
+Define completed-bar semantics, provisional states, invalidation rules, timeframe behavior, and test cases.
+
+## Phase 6 — Adaptive Bollinger, adaptive Supertrend, KAMA, and regression research
+
+Assess independent information value, formulas, parameter stability, overlap, and validation designs before approval.
+
+## Phase 7 — Volume, RVOL, CVD, and order-flow research
+
+Specify data needs, session normalization, limitations, provider differences, and measurable contribution.
+
+## Phase 8 — Dow Theory and intermarket confirmation
+
+Define instruments, timing alignment, confirmation/divergence logic, data quality, and statistical evaluation.
+
+## Phase 9 — Dashboard and Trade Decision Workspace
+
+Implement the approved side-by-side research and decision-support design with explainable evidence and stand-aside states.
+
+## Phase 10 — Backtesting and validation
+
+Use shared analytical implementations for leakage-aware backtests, baselines, costs, robustness, and walk-forward evaluation.
+
+## Phase 11 — OANDA historical and practice integration
+
+Implement provider adapters for approved historical and practice capabilities. Keep live execution disabled unless separately approved.
+
+## Phase 12 — Moomoo Level 2 and demo integration
+
+Proceed only after verifying account access, OpenD/API support, market-data entitlements, licensing, instrument coverage, and demo-trading capability.
+
+## Phase gates
+
+Each phase requires documented entry criteria, deliverables, tests where applicable, updated requirement statuses, and explicit human approval before the next phase begins.

--- a/docs/HQATL_MASTER_REQUIREMENTS.md
+++ b/docs/HQATL_MASTER_REQUIREMENTS.md
@@ -1,0 +1,44 @@
+# HQATL Master Requirements
+
+## Status vocabulary
+
+Use only: `NOT AUDITED`, `EXISTING`, `PROMPT ONLY`, `PARTIAL`, `MISSING`, `PLANNED`, `APPROVED`, `IMPLEMENTED`, `TESTED`, `REJECTED`.
+
+No existing capability has been audited in Phase 0. `PLANNED` means documented future work, not executable functionality.
+
+## Master checklist
+
+| Area | Requirement | Status | Evidence / next gate |
+|---|---|---|---|
+| Vibe framework audit | Inventory executable features, prompt-only claims, architecture, tests, and preservation constraints. | PLANNED | Phase 1 audit required. |
+| Elliott Wave completion | Audit executable rules, labeling, invalidation, alternates, and gaps. | PLANNED | Phases 2-3; do not infer from prompts. |
+| Fibonacci | Specify retracements/extensions while keeping Fib and statistical projections separate. | PLANNED | Source approval and tests required. |
+| EMA stack | Specify EMA 9/21/89/200/233 behavior and timeframe use. | PLANNED | Phase 4 specification. |
+| EMA standard-deviation analytics | Specify EMA-89 and EMA-200 deviation calculations and interpretation. | PLANNED | Phase 4 specification and validation. |
+| KAMA adaptive bands | Research independent contribution, formula, parameters, and tests. | PLANNED | Phase 6 research gate. |
+| Linear-regression deviation channels | Research calculation, anchoring, leakage controls, and value. | PLANNED | Phase 6 research gate. |
+| Modern adaptive Bollinger | Define and validate an adaptive design without duplicating other volatility evidence. | PLANNED | Phase 6 research gate. |
+| Modern adaptive Supertrend | Define and validate an adaptive design without indicator counting. | PLANNED | Phase 6 research gate. |
+| Market structure | Specify swing, trend, break, and invalidation semantics. | PLANNED | Phase 5 specification. |
+| iFVG | Define identification, confirmation, mitigation, timeframe, and invalidation rules. | PLANNED | Phase 5 specification. |
+| Candle-control interpretation | Specify explainable completed-bar interpretations and provisional states. | PLANNED | Phase 5 specification. |
+| Elliott-related harmonics | Research compatibility, conflicts, independence, and validation. | PLANNED | Source and backtest review required. |
+| Volume and RVOL | Specify normalization, session handling, data limits, and independent evidence. | PLANNED | Phase 7 research gate. |
+| CVD and order flow | Define provider/data requirements, approximations, and limitations. | PLANNED | Phase 7 research gate. |
+| Dow Theory and intermarket confirmation | Specify instruments, timing, divergence, and confirmation rules. | PLANNED | Phase 8 research gate. |
+| OANDA | Plan historical and practice adapters behind provider interfaces. | PLANNED | Phase 11; no connection now. |
+| Moomoo Level 2 and demo trading | Verify OpenD/API access, entitlements, licensing, and demo capability. | PLANNED | Phase 12; verification required. |
+| Dashboard | Design linked research/chart workspace beside decision support. | PLANNED | Phase 9; no code now. |
+| Backtesting | Share production calculations, prevent leakage, define costs and baselines. | PLANNED | Phase 10 validation. |
+| Walk-forward testing | Define rolling train/validation/test windows and parameter governance. | PLANNED | Phase 10 validation. |
+| Security | Enforce analysis-only defaults, secret controls, dependency review, and approval gates. | APPROVED | Foundation policy documented; implementation audit pending. |
+| Data quality | Track completeness, freshness, mapping, adjustments, provenance, and warnings. | PLANNED | Provider and dashboard specifications. |
+| Trade Decision Workspace | Present bias, evidence, uncertainty, invalidation, and stand-aside status. | PLANNED | Phase 9; decision support only. |
+| Source review and approval | Register claims, licensing, conflicts, validation, and human approval. | APPROVED | Foundation policy and templates documented. |
+
+## Update rules
+
+- Add evidence links or commit references whenever a status changes.
+- `IMPLEMENTED` requires executable code review; `TESTED` requires relevant tests and results.
+- `APPROVED` records human approval, not implementation.
+- Preserve rejected ideas and rationale for traceability.

--- a/docs/HQATL_PROJECT_CHARTER.md
+++ b/docs/HQATL_PROJECT_CHARTER.md
@@ -1,0 +1,34 @@
+# HQATL Project Charter
+
+## Purpose
+
+Hew's Quant Analytics Trading Lab (HQATL), under Hew's Trading Edge, is a personal quantitative research and trade-decision-support workstation. It will organize, measure, test, and explain market evidence while preserving human decision authority.
+
+## Objectives
+
+- Establish Elliott Wave as the central structural framework.
+- Add only independent, measurable evidence that validates, challenges, qualifies, or contextualizes a structural interpretation.
+- Make conclusions explainable and uncertainty explicit.
+- Turn important hypotheses into documented, testable specifications.
+- Support disciplined stand-aside decisions when evidence is insufficient.
+- Maintain provider-neutral boundaries and shared analytical/backtesting calculations.
+
+## Current phase scope
+
+Phase 0 creates governance, requirements, architecture, research, security, provider, dashboard, and roadmap documentation only.
+
+## Out of scope
+
+- Application behavior or strategy-logic changes
+- Production refactoring or package installation
+- Broker/account connections, credentials, order execution, or live trading
+- Deletion or replacement of existing Vibe functionality
+- Unrelated external systems, copyrighted books, private scripts, or full transcripts
+
+## Success criteria
+
+Phase 0 succeeds when the requested foundation documents are committed on a dedicated branch, no source-code files or behavior are changed, no secrets are introduced, and the work is held for human review without merging or pushing.
+
+## Governance
+
+The manifest governs philosophy; the master requirements track status; the source policy governs research claims; and explicit human approval gates movement between phases. Status labels must reflect verified evidence rather than aspiration.

--- a/docs/HQATL_RESEARCH_BACKLOG.md
+++ b/docs/HQATL_RESEARCH_BACKLOG.md
@@ -1,0 +1,19 @@
+# HQATL Research Backlog
+
+This backlog captures questions, not accepted conclusions. Prioritize work that could improve evidence quality or disprove an assumption.
+
+| Priority | Research question | Independent evidence hypothesis | Required data/source | Validation approach | Status |
+|---|---|---|---|---|---|
+| High | Which Elliott rules are executable, prompt-only, or absent in Vibe? | Establishes a reliable structural baseline. | Repository audit and approved sources | Code/test traceability review | PLANNED |
+| High | How should primary and alternate Elliott counts be compared without merging them? | Preserves uncertainty and falsifiability. | Approved Elliott standard | Scenario-based tests | PLANNED |
+| High | Do EMA-89/EMA-200 deviation measures add information beyond raw trend and volatility? | Quantifies stretch independently. | Multi-regime historical data | Out-of-sample ablation study | PLANNED |
+| High | What data-quality failures should force a stand-aside state? | Prevents weak inputs from appearing conclusive. | Provider data and failure cases | Fault-injection tests | PLANNED |
+| Medium | Which market-structure, iFVG, and candle-control definitions are reproducible? | Reduces subjective interpretation. | Approved sources and labeled examples | Inter-rater and rule tests | PLANNED |
+| Medium | Do adaptive Bollinger, Supertrend, KAMA, or regression channels duplicate volatility/trend evidence? | Avoids indicator counting. | Historical data across regimes | Correlation, ablation, walk-forward tests | PLANNED |
+| Medium | When do RVOL, CVD, and order-flow data materially qualify Elliott evidence? | Adds participation evidence if reliable. | Provider-specific volume/depth data | Data-quality-aware event studies | PLANNED |
+| Medium | Which Dow/intermarket relationships remain stable by regime and timeframe? | Adds cross-market confirmation. | Synchronized instruments | Rolling and walk-forward tests | PLANNED |
+| Later | What OANDA and Moomoo capabilities, entitlements, and licenses are available? | Defines feasible adapters without provider coupling. | Official provider documentation | Capability and legal review | PLANNED |
+
+## Intake rule
+
+Every new item should state the claim, possible contradiction, required evidence, acceptance/rejection criteria, copyright/license status, and human approval gate.

--- a/docs/HQATL_RESEARCH_REGISTRY.md
+++ b/docs/HQATL_RESEARCH_REGISTRY.md
@@ -1,0 +1,23 @@
+# HQATL Research Registry
+
+Copy the template below for each research entry. Link or summarize sources; never insert full copyrighted transcripts or unauthorized material.
+
+## Research entry template
+
+- **Source title:**
+- **Author/creator:**
+- **URL or publication:**
+- **Date accessed:**
+- **Topic:**
+- **Source category:**
+- **Structural rules:**
+- **Fibonacci guidance:**
+- **Time guidance:**
+- **Volume guidance:**
+- **Examples available:**
+- **Contradictions:**
+- **Copyright/license:**
+- **HQATL relevance:**
+- **Validation status:**
+- **User approval:**
+- **Notes:**

--- a/docs/HQATL_SECURITY_POLICY.md
+++ b/docs/HQATL_SECURITY_POLICY.md
@@ -1,0 +1,36 @@
+# HQATL Security Policy
+
+## Defaults
+
+- HQATL is analysis-only by default.
+- Live execution is disabled.
+- Order-capable development requires a separate, explicit human approval before work begins.
+
+## Secrets and credentials
+
+- Never commit credentials, tokens, account identifiers, private keys, or secret configuration to Git.
+- Use `.env` locally and keep it ignored.
+- Provide only placeholder names in `.env.example`; never include real or realistic secret values.
+- Never place secrets in prompts, logs, screenshots, test fixtures, issue text, commit messages, or documentation.
+- Rotate and revoke any secret suspected of exposure; do not merely delete it from the latest commit.
+
+## Public repository warning
+
+Treat the current repository as public. Private proprietary research, account information, licensed datasets, private scripts, and restricted source material must not be committed without explicit legal, security, and human review.
+
+## Dependency and supply-chain controls
+
+- Review package necessity, provenance, license, maintenance, vulnerabilities, checksums/locks, and transitive risk before adoption.
+- Prefer pinned/locked reproducible dependencies and minimal privileges.
+- Do not install packages during documentation or audit-only phases.
+
+## Provider and execution controls
+
+- Separate provider adapters from strategy logic and isolate execution capability.
+- Use least-privilege practice/demo credentials during any later approved integration.
+- Require visible environment and account-mode indicators, audit logging that redacts secrets, and explicit human confirmation before order-capable development or activation.
+- Never infer live-trading authorization from approval of analysis, historical data, practice data, or dashboard work.
+
+## Review
+
+Security review is required before provider integration, dependency changes, handling proprietary data, or any order-capable work.

--- a/docs/HQATL_SOURCE_EVIDENCE_POLICY.md
+++ b/docs/HQATL_SOURCE_EVIDENCE_POLICY.md
@@ -1,0 +1,55 @@
+# HQATL Source and Evidence Policy
+
+## Purpose
+
+Research claims must be traceable, copyright-safe, challengeable, and tested in proportion to their importance. A source category indicates context, not automatic truth.
+
+## Source levels
+
+- **Foundational published authority** — influential primary or canonical published work.
+- **Advanced published reference** — detailed specialist treatment requiring critical comparison.
+- **Academic or official technical source** — peer-reviewed research, standards, or official provider documentation.
+- **Open-source implementation** — inspectable code whose behavior, tests, provenance, and license require review.
+- **Specialized educational source** — focused instruction such as an article, course, or video; claims require corroboration.
+- **External backtest study** — third-party empirical results requiring methodology, data, bias, and reproducibility review.
+- **User observation** — experience-derived claim recorded as a hypothesis until validated.
+- **User backtest** — user-produced evidence reviewed for data, implementation, leakage, costs, and reproducibility.
+- **Unverified hypothesis** — a testable proposition with no accepted support yet.
+
+## Required claim record
+
+Every research claim should record:
+
+- Source
+- Topic
+- Summary
+- Evidence type
+- Copyright/license status
+- Conflicts with other sources
+- Implementation relevance
+- Backtest status
+- User approval status
+
+## Evaluation rules
+
+- Do not accept claims solely because a source is famous, advanced, open source, or statistically presented.
+- Separate structural rules, interpretations, observations, and empirical results.
+- Record contradictions and uncertainty; do not force consensus.
+- Test significant hypotheses before trusting or implementing them.
+- Avoid look-ahead and other research biases, and require reproducible parameters and data provenance.
+- Summarize or link sources within copyright and license limits. Do not store full copyrighted books or transcripts.
+- Expensive purchases are not a prerequisite for development. Use lawful available material and defer unsupported claims.
+
+## Current source foundation
+
+The available starting foundation includes:
+
+- *Elliott Wave Principle* by Frost and Prechter
+- Selected free website resources
+- Selected educational videos
+- Available legal excerpts
+- User experience and backtests
+- The Vibe-Trading implementation
+- Future authoritative sources as resources permit
+
+These sources are inputs for review, not blanket approval of every claim.

--- a/docs/HQATL_TRADE_DECISION_WORKSPACE.md
+++ b/docs/HQATL_TRADE_DECISION_WORKSPACE.md
@@ -1,0 +1,36 @@
+# HQATL Trade Decision Workspace
+
+## Purpose
+
+The future Trade Decision Workspace sits beside the research workspace and converts approved analytical output into explainable decision support. It is not an autonomous trading command system and does not grant order authority.
+
+## Primary conclusion labels
+
+Use only these primary bias labels:
+
+- **Bullish Bias**
+- **Bearish Bias**
+- **Neutral Bias**
+
+Do not use `BUY` or `SELL` as the primary conclusion label.
+
+## Workspace fields
+
+| Section | Required content |
+|---|---|
+| Decision context | Market bias; confidence level with explanation; timeframe alignment; stand-aside status; trader notes |
+| Researched trade references | Suggested researched entry zone; stop-loss reference; primary take-profit reference; secondary take-profit reference; risk-to-reward estimate |
+| Invalidation | Elliott invalidation level; setup invalidation conditions |
+| Evidence ledger | Evidence supporting the bias; evidence opposing the bias; evidence still missing |
+| Structural view | Primary Elliott count; alternate Elliott count; Fib levels |
+| Analytical context | EMA-deviation context; iFVG status; volume/RVOL status; CVD status; Dow/intermarket confirmation |
+| Integrity | Data-quality warnings; timestamps; completed-bar/provisional state; source/provenance |
+
+## Behavioral rules
+
+- Keep primary and alternate Elliott counts distinct, each with its own evidence and invalidation.
+- Explain confidence through evidence; never display a black-box score.
+- Treat entry, stop, and target values as researched references, not commands or guarantees.
+- Show opposing and missing evidence with the same care as supporting evidence.
+- Activate stand-aside when required evidence, data quality, timeframe alignment, or invalidation clarity is insufficient.
+- Preserve human review and decision authority at all times.

--- a/docs/HQATL_VIBE_AUDIT_CHECKLIST.md
+++ b/docs/HQATL_VIBE_AUDIT_CHECKLIST.md
@@ -1,0 +1,46 @@
+# HQATL Vibe Audit Checklist
+
+Use this checklist in Phase 1. Nothing below is audited by this foundation task.
+
+## Repository and runtime
+
+- [ ] Map applications, services, packages, entry points, configuration, and deployment assets.
+- [ ] Record supported runtimes, dependency locks, and development/test commands.
+- [ ] Identify generated, vendored, legacy, and inactive paths.
+
+## Capability verification
+
+- [ ] Inventory user-visible and backend capabilities.
+- [ ] Trace every claimed capability to executable code or classify it `PROMPT ONLY`.
+- [ ] Identify duplicated frontend/backend calculations.
+- [ ] Map current Elliott, indicator, data, chart, backtest, and confidence behavior.
+- [ ] Record primary/alternate count handling and invalidation behavior.
+- [ ] Record completed-bar versus provisional behavior.
+
+## Data and providers
+
+- [ ] Map data sources, schemas, instruments, timestamps, timeframes, sessions, and caching.
+- [ ] Identify provider-specific logic inside analytical or strategy code.
+- [ ] Audit missing, stale, duplicate, adjusted, and out-of-order data handling.
+- [ ] Confirm that no credentials are tracked.
+
+## Validation quality
+
+- [ ] Inventory unit, integration, regression, backtest, and end-to-end tests.
+- [ ] Check for look-ahead, survivorship, selection, and optimization bias.
+- [ ] Verify analytical and backtesting calculations share implementations.
+- [ ] Identify untested analytical calculations and undocumented parameters.
+
+## Safety and preservation
+
+- [ ] Baseline existing Vibe behavior that must be preserved.
+- [ ] Locate order-capable code and confirm defaults and approval boundaries.
+- [ ] Review logs, prompts, screenshots, fixtures, and docs for secrets/private data.
+- [ ] Record dependencies, licenses, vulnerabilities, and supply-chain risks.
+
+## Audit output
+
+- [ ] Update the master requirements with evidence-backed statuses.
+- [ ] Produce an architecture/data-flow map and executable gap list.
+- [ ] Separate findings from recommendations.
+- [ ] Stop for human review without implementing fixes.


### PR DESCRIPTION
## Summary

Establishes the documentation and governance foundation for Hew's Quant Analytics Trading Lab (HQATL).

## Changes

- Added HQATL governing and planning documents
- Added AI-agent instructions
- Added project architecture, roadmap, dashboard, provider, research, and security documentation
- Added the Trade Decision Workspace specification

## Safety

- No application source code changed
- No trading logic changed
- No credentials or private account information added
- No broker connections added
- No packages installed
- Tests were not run because this pull request contains documentation only
- Phase 1 has not started<!-- What does this PR do? 1-3 bullet points. -->

-

## Why

<!-- What problem does it solve? Link related issues with "Closes #123". -->

## Changes

<!-- List key changes. For new skills/presets, describe what they cover. -->

-

## Test Plan

- [ ] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [ ] New tests added (if applicable)
- [ ] Tested manually (describe below)

## Checklist

- [ ] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [ ] No hardcoded values (API keys, file paths, magic numbers)
- [ ] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] Documentation updated (if user-facing change)
