### PR TITLE
fix(config): refresh cached EnvConfig after dotenv load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   of silently returning daily bars (#467, thanks @Shizoqua).
 
 ### Fixed
+- Loading `.env` now invalidates an `EnvConfig` singleton cached during early
+  CLI imports, so the welcome panel, `/settings`, and dotenv diagnostic report
+  the configured provider and model consistently (#541).
 - FastMCP transport imports work across both module layouts (#469, thanks
   @roberttidball).
 - Portfolio optimizers no longer include the decision bar's close-to-close

--- a/agent/src/providers/llm.py
+++ b/agent/src/providers/llm.py
@@ -441,6 +441,8 @@ def _ensure_dotenv() -> None:
             _load_env_file(candidate)
             loaded = candidate
             break
+    if loaded is not None:
+        reset_env_config()
     _dotenv_loaded = True
     # P08 R1: one-time, behavior-preserving diagnostic so a stale or
     # shadowed .env is observable instead of costing hours. The path is

--- a/agent/tests/test_dotenv_observability.py
+++ b/agent/tests/test_dotenv_observability.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import pytest
 
 import src.providers.llm as llm
+from src.config.accessor import get_env_config, reset_env_config
 
 LOGGER = "src.providers.llm"
 
@@ -69,6 +70,31 @@ def test_logs_none_when_no_env_found(tmp_path, fresh, monkeypatch, caplog):
         llm._ensure_dotenv()
     msg = "\n".join(r.getMessage() for r in caplog.records)
     assert "none (no .env file found)" in msg
+
+
+def test_loaded_dotenv_refreshes_cached_env_config(tmp_path, fresh, monkeypatch):
+    """A config cached before dotenv loading must be refreshed afterwards."""
+    env = tmp_path / ".env"
+    env.write_text(
+        "LANGCHAIN_PROVIDER=deepseek\n"
+        "LANGCHAIN_MODEL_NAME=deepseek-chat\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(llm, "_ENV_CANDIDATES", [env])
+    monkeypatch.setattr(llm, "_ENV_LABELS", ("<TEST_SLOT>",))
+    monkeypatch.delenv("LANGCHAIN_PROVIDER", raising=False)
+    monkeypatch.delenv("LANGCHAIN_MODEL_NAME", raising=False)
+
+    reset_env_config()
+    cached_before_load = get_env_config()
+    assert cached_before_load.llm.langchain_provider == "openai"
+
+    llm._ensure_dotenv()
+
+    refreshed = get_env_config()
+    assert refreshed is not cached_before_load
+    assert refreshed.llm.langchain_provider == "deepseek"
+    assert refreshed.llm.langchain_model_name == "deepseek-chat"
 
 
 def test_logs_redacted_base_url_without_credentials(tmp_path, fresh, monkeypatch, caplog):


### PR DESCRIPTION
## Summary

- Invalidate the cached `EnvConfig` after `_ensure_dotenv()` loads a real `.env` file.
- Ensure the CLI welcome panel, `/settings`, and dotenv diagnostic use the configured provider and model.
- Add a regression reproducing configuration cached before dotenv loading.

## Root cause

Early CLI imports could initialize the `EnvConfig` singleton before `.env` was loaded. `_ensure_dotenv()` populated `os.environ` but did not invalidate that stale singleton.

## Validation

- 6 dotenv tests passed
- 131 focused config/provider/preflight/LLM tests passed
- 5,384 broader tests passed, with 6 evidence-backed baseline/environment exclusions
- Compile, Ruff, env-var gate, and diff checks passed

Closes #541