### PR TITLE
fix: support Web UI settings persistence on Windows

### DIFF
--- a/agent/src/api/helpers.py
+++ b/agent/src/api/helpers.py
@@ -97,9 +97,19 @@ def _atomic_write_secret(path: Path, content: str) -> None:
         return
     try:
         os.write(fd, data)
-        os.fchmod(fd, 0o600)
+        # ``os.fchmod`` is unavailable on Windows.  Keep descriptor-level
+        # permission hardening on platforms that support it, then use the
+        # portable path-based best effort after the descriptor is closed.
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, 0o600)
     finally:
         os.close(fd)
+    try:
+        os.chmod(tmp, 0o600)
+    except OSError:
+        # Windows ACLs govern effective access and chmod may be unsupported
+        # or map only to the read-only flag.
+        pass
     try:
         os.replace(tmp, path)
     except BaseException:

--- a/agent/tests/test_api_infrastructure.py
+++ b/agent/tests/test_api_infrastructure.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import pytest
 
 import api_server
@@ -241,8 +242,9 @@ def test_write_env_values_creates_private_parent_directory(tmp_path) -> None:
     helpers._write_env_values(target, {"KEY": "value"})
 
     assert helpers._read_env_values(target) == {"KEY": "value"}
-    assert (target.parent.stat().st_mode & 0o777) == 0o700
-    assert (target.stat().st_mode & 0o777) == 0o600
+    if os.name != "nt":
+        assert (target.parent.stat().st_mode & 0o777) == 0o700
+        assert (target.stat().st_mode & 0o777) == 0o600
 
 
 def test_strip_env_value_quotes():

--- a/agent/tests/test_settings_api.py
+++ b/agent/tests/test_settings_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -376,7 +377,8 @@ def test_update_settings_writes_env_file_with_0600_mode(
 
     assert response.status_code == 200
     mode = (tmp_path / ".env").stat().st_mode & 0o777
-    assert mode == 0o600
+    if os.name != "nt":
+        assert mode == 0o600
 
 
 def test_atomic_write_secret_is_crash_safe(
@@ -411,4 +413,19 @@ def test_atomic_write_secret_creates_0600_file(tmp_path: Path) -> None:
     helpers._atomic_write_secret(target, "KEY=value\n")
 
     assert target.read_text(encoding="utf-8") == "KEY=value\n"
-    assert (target.stat().st_mode & 0o777) == 0o600
+    if os.name != "nt":
+        assert (target.stat().st_mode & 0o777) == 0o600
+
+
+def test_atomic_write_secret_supports_platforms_without_fchmod(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Windows must be able to persist Web UI settings without ``os.fchmod``."""
+    from src.api import helpers
+
+    monkeypatch.delattr(helpers.os, "fchmod", raising=False)
+    target = tmp_path / ".env"
+
+    helpers._atomic_write_secret(target, "KEY=value\n")
+
+    assert target.read_text(encoding="utf-8") == "KEY=value\n"


### PR DESCRIPTION
## Summary

- Guard the POSIX-only `os.fchmod` call used while atomically persisting Web UI settings.
- Preserve POSIX permission hardening and atomic replacement.
- Make POSIX mode-bit assertions conditional on non-Windows platforms.
- Add a regression test for platforms without `os.fchmod`.

## Root cause

Saving Agent LLM settings on Windows raised `AttributeError: module 'os' has no attribute 'fchmod'`, causing `PUT /settings/llm` to return HTTP 500.

## Validation

- `python -m pytest agent/tests/test_settings_api.py agent/tests/test_api_infrastructure.py -q`
- Local `PUT /settings/llm` smoke test returns HTTP 200 on Windows.