### PR TITLE
refactor: centralize duplicated credential resolution in llm.py

### DIFF
--- a/agent/src/api/system_routes.py
+++ b/agent/src/api/system_routes.py
@@ -121,7 +121,7 @@ def _provider_readiness() -> Tuple[bool, str]:
     """
     try:
         from src.config.accessor import get_env_config
-        from src.providers.capabilities import provider_env_names
+        from src.providers.capabilities import get_llm_credentials
         from src.providers.llm import _sync_provider_env
     except Exception as exc:  # noqa: BLE001 — degrade to not-ready, never crash the probe
         logger.warning("readiness: provider config import failed: %r", exc)
@@ -148,12 +148,9 @@ def _provider_readiness() -> Tuple[bool, str]:
         return True, "ready"
 
     _sync_provider_env()
-    key_env, _base_env = provider_env_names(provider, model)
-    # key_env is None for keyless local providers (e.g. Ollama).
-    if key_env is not None:
-        has_key = bool(os.getenv(key_env, "") or os.getenv("OPENAI_API_KEY", ""))  # noqa: env-gate — readiness credential probe
-        if not has_key:
-            return False, "LLM provider credential not configured"
+    creds = get_llm_credentials(provider, model)
+    if not creds["api_key"]:
+        return False, "LLM provider credential not configured"
     return True, "ready"
 
 

--- a/agent/src/providers/capabilities.py
+++ b/agent/src/providers/capabilities.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from importlib.metadata import PackageNotFoundError, version
 from typing import Mapping, Optional
@@ -202,3 +203,26 @@ def provider_env_names(provider: str | None, model: str | None = None) -> tuple[
     """Return the API-key and base-URL env names for a provider/model pair."""
     caps = get_provider_capabilities(provider, model)
     return caps.api_key_env, caps.base_url_env
+
+
+def get_llm_credentials(
+    provider: str | None,
+    model: str | None = None,
+) -> dict[str, str]:
+    """Resolve API key and base URL for a provider/model pair.
+
+    Returns a dict with ``api_key`` and ``base_url`` resolved from
+    provider-specific environment variables, falling back to
+    ``OPENAI_API_KEY`` / ``OPENAI_BASE_URL`` / ``OPENAI_API_BASE``.
+    Keyless local providers (e.g. Ollama) get a placeholder key.
+    """
+    key_env, base_env = provider_env_names(provider, model)
+
+    if key_env is not None:
+        api_key = os.getenv(key_env, "") or os.getenv("OPENAI_API_KEY", "")  # noqa: env-gate — dynamic provider key resolution
+    else:
+        api_key = os.getenv("OPENAI_API_KEY", "") or "ollama"  # noqa: env-gate — keyless local provider fallback
+
+    base_url = os.getenv(base_env, "") or os.getenv("OPENAI_BASE_URL", "") or os.getenv("OPENAI_API_BASE", "")  # noqa: env-gate — dynamic provider URL resolution
+
+    return {"api_key": api_key, "base_url": base_url}

--- a/agent/src/providers/llm.py
+++ b/agent/src/providers/llm.py
@@ -14,7 +14,7 @@ from urllib.parse import urlsplit
 from pydantic import PrivateAttr
 
 from src.config.accessor import get_env_config, reset_env_config
-from src.providers.capabilities import get_provider_capabilities, provider_env_names
+from src.providers.capabilities import get_llm_credentials, get_provider_capabilities, provider_env_names
 
 try:
     from dotenv import load_dotenv
@@ -401,17 +401,15 @@ def _build_native_deepseek(
         logger.info("DeepSeek native adapter unavailable; using OpenAI-compatible path: %s", exc)
         return None
 
-    key_env, base_env = provider_env_names("deepseek", model)
-    api_key = os.getenv(key_env or "", "") or os.getenv("OPENAI_API_KEY", "")  # noqa: env-gate — dynamic provider key resolution
-    base_url = os.getenv(base_env, "") or os.getenv("OPENAI_BASE_URL", "") or os.getenv("OPENAI_API_BASE", "")  # noqa: env-gate — dynamic provider URL resolution
+    creds = get_llm_credentials("deepseek", model)
     return chat_deepseek(
         model=model,
         temperature=temperature,
         timeout=get_env_config().llm.timeout_seconds,
         max_retries=get_env_config().llm.max_retries,
         callbacks=callbacks,
-        api_key=api_key or None,
-        base_url=base_url or None,
+        api_key=creds["api_key"] or None,
+        base_url=creds["base_url"] or None,
     )
 
 
@@ -485,16 +483,10 @@ def _sync_provider_env() -> None:
         os.environ.pop("OPENAI_API_KEY", None)
         return
 
-    key_env, base_env = provider_env_names(provider, get_env_config().llm.langchain_model_name)
+    creds = get_llm_credentials(provider, get_env_config().llm.langchain_model_name)
+    api_key = creds["api_key"]
+    base_url = creds["base_url"]
 
-    # Resolve API key: provider-specific env → OPENAI_API_KEY fallback
-    if key_env is not None:
-        api_key = os.getenv(key_env, "") or os.getenv("OPENAI_API_KEY", "")  # noqa: env-gate — dynamic provider key fallback
-    else:
-        api_key = os.getenv("OPENAI_API_KEY", "") or "ollama"  # noqa: env-gate — ollama default key
-
-    # Resolve base URL: provider-specific env → OPENAI_BASE_URL fallback
-    base_url = os.getenv(base_env, "") or os.getenv("OPENAI_BASE_URL", "") or os.getenv("OPENAI_API_BASE", "")  # noqa: env-gate — dynamic provider URL chain
     if provider == "ollama" and base_url:
         base_url = _normalize_ollama_base_url(base_url)
 
@@ -516,8 +508,9 @@ def provider_diagnostics() -> dict[str, Any]:
     provider = get_env_config().llm.langchain_provider.strip().lower()
     model = get_env_config().llm.langchain_model_name.strip()
     caps = get_provider_capabilities(provider, model)
-    key_env, base_env = provider_env_names(provider, model)
-    base_url = os.getenv(base_env, "") or os.getenv("OPENAI_BASE_URL", "") or os.getenv("OPENAI_API_BASE", "")  # noqa: env-gate — dynamic provider URL resolution
+    key_env, _base_env = provider_env_names(provider, model)
+    creds = get_llm_credentials(provider, model)
+    base_url = creds["base_url"]
     proxy_names = ["HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "all_proxy", "no_proxy"]
     package_names = ["langchain-openai", "langchain-core", "langchain", "openai", "langchain-deepseek"]
     native_package_version = (


### PR DESCRIPTION
Closes #553

Extracts the duplicated credential resolution pattern into a single get_llm_credentials() function in capabilities.py.

Changes:
1. capabilities.py added get_llm_credentials(provider, model) returning dict with api_key and base_url
2. llm.py refactored _sync_provider_env(), provider_diagnostics(), _build_native_deepseek() to use it
3. system_routes.py readiness check uses it instead of independent resolution

The function respects the same fallback chain every call site used:
- api_key: provider-specific env var -> OPENAI_API_KEY -> ollama for keyless providers
- base_url: provider-specific env var -> OPENAI_BASE_URL -> OPENAI_API_BASE

Tests: all credential-related tests pass (26/33; 7 pre-existing failures from missing langchain-openai).
CI env var gate: 0 violations.