### PR TITLE
Load every page of Futu price history

### DIFF
--- a/agent/backtest/loaders/futu.py
+++ b/agent/backtest/loaders/futu.py
@@ -77,7 +77,8 @@ def _normalize_frame(df: pd.DataFrame) -> pd.DataFrame:
     result = result.apply(pd.to_numeric, errors="coerce")
     result["volume"] = result["volume"].fillna(0.0)
     result = result.dropna(subset=["open", "high", "low", "close"])
-    return result.sort_index()
+    result = result.sort_index()
+    return result[~result.index.duplicated(keep="last")]
 
 
 @register
@@ -158,7 +159,7 @@ class FutuLoader:
                 end_date=end_date,
                 fields=None,
             )
-            if cached is not None:
+            if cached is not None and not cached.empty:
                 results[code] = cached.copy()
             else:
                 pending.append(code)
@@ -178,17 +179,35 @@ class FutuLoader:
         try:
             for code in pending:
                 futu_code = _to_futu_symbol(code)
-                ret, data = ctx.request_history_kline(
-                    futu_code,
-                    start=start_date,
-                    end=end_date,
-                    ktype=ktype,
-                    max_count=10_000,
-                )
-                if ret != futu.RET_OK:
-                    logger.warning("Futu returned error for %s: %s", futu_code, data)
+                page_key = None
+                pages: List[pd.DataFrame] = []
+                failed = False
+                while True:
+                    ret, data, next_page_key = ctx.request_history_kline(
+                        futu_code,
+                        start=start_date,
+                        end=end_date,
+                        ktype=ktype,
+                        max_count=10_000,
+                        page_req_key=page_key,
+                    )
+                    if ret != futu.RET_OK:
+                        logger.warning(
+                            "Futu returned error for %s: %s", futu_code, data
+                        )
+                        failed = True
+                        break
+                    if isinstance(data, pd.DataFrame) and not data.empty:
+                        pages.append(data)
+                    if not next_page_key:
+                        break
+                    page_key = next_page_key
+
+                if failed or not pages:
                     continue
-                normalized = _normalize_frame(data)
+                normalized = _normalize_frame(pd.concat(pages, ignore_index=True))
+                if normalized.empty:
+                    continue
                 loader_cache_put(
                     source=self.name,
                     symbol=code,

--- a/agent/tests/test_futu_loader.py
+++ b/agent/tests/test_futu_loader.py
@@ -206,7 +206,7 @@ class TestFetch:
         assert loader.fetch([], "2024-01-01", "2024-01-31") == {}
 
     def test_returns_normalized_dataframe(self, loader, mock_ctx):
-        mock_ctx.request_history_kline.return_value = (0, _make_kline_df())
+        mock_ctx.request_history_kline.return_value = (0, _make_kline_df(), None)
         result = loader.fetch(["700.HK"], "2024-01-01", "2024-01-31")
         assert "700.HK" in result
         df = result["700.HK"]
@@ -214,7 +214,7 @@ class TestFetch:
         assert df.index.name == "trade_date"
 
     def test_futu_symbol_converted_correctly(self, loader, mock_ctx):
-        mock_ctx.request_history_kline.return_value = (0, _make_kline_df())
+        mock_ctx.request_history_kline.return_value = (0, _make_kline_df(), None)
         loader.fetch(["700.HK"], "2024-01-01", "2024-01-31")
         args, _ = mock_ctx.request_history_kline.call_args
         assert args[0] == "HK.00700"
@@ -225,11 +225,82 @@ class TestFetch:
             loader.fetch(["700.HK"], "2024-01-01", "2024-01-31")
 
     def test_skips_symbol_on_non_ret_ok(self, loader, mock_ctx):
-        mock_ctx.request_history_kline.return_value = (1, "error message")
+        mock_ctx.request_history_kline.return_value = (1, "error message", None)
         result = loader.fetch(["700.HK"], "2024-01-01", "2024-01-31")
         assert "700.HK" not in result
 
     def test_context_always_closed(self, loader, mock_ctx):
-        mock_ctx.request_history_kline.return_value = (0, _make_kline_df())
+        mock_ctx.request_history_kline.return_value = (0, _make_kline_df(), None)
         loader.fetch(["700.HK"], "2024-01-01", "2024-01-31")
         mock_ctx.close.assert_called_once()
+
+    def test_forwards_page_key_and_normalizes_all_pages_once(
+        self, loader, mock_ctx, monkeypatch
+    ):
+        import backtest.loaders.futu as futu_loader
+
+        first = _make_kline_df(["2024-01-02 00:00:00"])
+        second = _make_kline_df(["2024-01-03 00:00:00"])
+        mock_ctx.request_history_kline.side_effect = [
+            (0, first, b"next-page"),
+            (0, second, None),
+        ]
+        normalize = MagicMock(side_effect=_normalize_frame)
+        monkeypatch.setattr(futu_loader, "_normalize_frame", normalize)
+
+        result = loader.fetch(["700.HK"], "2024-01-01", "2024-01-31")
+
+        assert len(result["700.HK"]) == 2
+        assert normalize.call_count == 1
+        assert len(normalize.call_args.args[0]) == 2
+        assert (
+            mock_ctx.request_history_kline.call_args_list[0].kwargs["page_req_key"]
+            is None
+        )
+        assert (
+            mock_ctx.request_history_kline.call_args_list[1].kwargs["page_req_key"]
+            == b"next-page"
+        )
+
+    def test_later_page_failure_discards_symbol(self, loader, mock_ctx, monkeypatch):
+        import backtest.loaders.futu as futu_loader
+
+        mock_ctx.request_history_kline.side_effect = [
+            (0, _make_kline_df(["2024-01-02 00:00:00"]), b"next-page"),
+            (1, "page failed", None),
+        ]
+        cache_put = MagicMock()
+        monkeypatch.setattr(futu_loader, "loader_cache_put", cache_put)
+
+        result = loader.fetch(["700.HK"], "2024-01-01", "2024-01-31")
+
+        assert "700.HK" not in result
+        cache_put.assert_not_called()
+
+    def test_empty_success_is_not_returned_or_cached(
+        self, loader, mock_ctx, monkeypatch
+    ):
+        import backtest.loaders.futu as futu_loader
+
+        mock_ctx.request_history_kline.return_value = (0, pd.DataFrame(), None)
+        cache_put = MagicMock()
+        monkeypatch.setattr(futu_loader, "loader_cache_put", cache_put)
+
+        result = loader.fetch(["700.HK"], "2024-01-01", "2024-01-31")
+
+        assert "700.HK" not in result
+        cache_put.assert_not_called()
+
+    def test_duplicate_timestamps_keep_last_page_value(self, loader, mock_ctx):
+        first = _make_kline_df(["2024-01-02 00:00:00"])
+        second = _make_kline_df(["2024-01-02 00:00:00"])
+        second.loc[0, "close"] = 360.0
+        mock_ctx.request_history_kline.side_effect = [
+            (0, first, b"next-page"),
+            (0, second, None),
+        ]
+
+        result = loader.fetch(["700.HK"], "2024-01-01", "2024-01-31")
+
+        assert len(result["700.HK"]) == 1
+        assert result["700.HK"].iloc[0]["close"] == 360.0


### PR DESCRIPTION
## Summary

- Read Futu's complete response and keep requesting pages until no page key remains. Do not save a partial symbol when a later page fails.

## Why

Closes #575.

## Changes

- Implements only finding A12.
- Adds focused regression coverage for this behavior.

## Test Plan

- [x] Focused regression check passed: cd agent && pytest tests/test_futu_loader.py -q
- [x] New regression tests added where applicable.
- [x] The combined audit stack passed 5,462 Python tests and 253 frontend tests.

## Risk and scope

This pull request contains one finding and one signed commit. Reverting this commit restores the previous behavior.

## Checklist

- [x] No protected area was changed without prior discussion.
- [x] No API keys, secrets, or machine-specific paths were added.
- [x] The change follows CONTRIBUTING.md.
- [x] Documentation was updated where needed, or no documentation change was required.