### PR TITLE
Do not invent alpha returns when a price is missing

### DIFF
--- a/agent/src/tools/alpha_bench_tool.py
+++ b/agent/src/tools/alpha_bench_tool.py
@@ -529,7 +529,7 @@ def _compute_forward_returns(panel: dict[str, pd.DataFrame]) -> pd.DataFrame:
     if close is None:
         raise ValueError("panel missing 'close' — cannot derive forward returns")
     # Next-period return aligned to current row (use t+1 close, shift back).
-    fwd = close.pct_change().shift(-1)
+    fwd = close.pct_change(fill_method=None).shift(-1)
     return fwd
 
 

--- a/agent/tests/test_alpha_bench_forward_returns.py
+++ b/agent/tests/test_alpha_bench_forward_returns.py
@@ -1,0 +1,18 @@
+"""Regression tests for alpha-bench forward-return missing-data handling."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from src.tools.alpha_bench_tool import _compute_forward_returns
+
+
+def test_forward_returns_preserve_missing_close_boundaries() -> None:
+    close = pd.DataFrame(
+        {"AAA": [100.0, None, 121.0]},
+        index=pd.date_range("2026-01-01", periods=3, freq="D"),
+    )
+
+    forward = _compute_forward_returns({"close": close})
+
+    assert forward["AAA"].isna().all()


### PR DESCRIPTION
## Summary

- Disable automatic price filling when alpha forward returns are calculated so missing inputs remain missing.

## Why

Closes #581.

## Changes

- Implements only finding A15.
- Adds focused regression coverage for this behavior.

## Test Plan

- [x] Focused regression check passed: cd agent && pytest tests/test_alpha_bench_forward_returns.py -q
- [x] New regression tests added where applicable.
- [x] The combined audit stack passed 5,462 Python tests and 253 frontend tests.

## Risk and scope

This pull request contains one finding and one signed commit. Reverting this commit restores the previous behavior.

## Checklist

- [x] No protected area was changed without prior discussion.
- [x] No API keys, secrets, or machine-specific paths were added.
- [x] The change follows CONTRIBUTING.md.
- [x] Documentation was updated where needed, or no documentation change was required.