### PR TITLE
Fix reliability across packaging, web, scheduler, swarm, and CLI

### DIFF
--- a/agent/cli/_legacy.py
+++ b/agent/cli/_legacy.py
@@ -5332,9 +5332,8 @@ def cmd_dev(
     )
     console.print("[dim]Press Ctrl+C to stop both servers.[/dim]\n")
 
-    backend = subprocess.Popen(backend_cmd, cwd=str(AGENT_DIR))
-    frontend = subprocess.Popen(frontend_cmd, cwd=str(frontend_dir))
-    children = [backend, frontend]
+    children: List[subprocess.Popen] = []
+    exit_code = EXIT_SUCCESS
 
     def _terminate_all() -> None:
         for child in children:
@@ -5344,28 +5343,41 @@ def cmd_dev(
                 except OSError:
                     pass
 
-    # Wire signal handlers. On Windows, SIGTERM does not exist and signal
-    # handlers must be installed from the main thread; KeyboardInterrupt is
-    # the cross-platform path for Ctrl+C.
-    if threading.current_thread() is threading.main_thread():
-        try:
-            signal.signal(signal.SIGINT, lambda *_: _terminate_all())
-        except (ValueError, OSError):
-            pass
-        try:
-            signal.signal(signal.SIGTERM, lambda *_: _terminate_all())
-        except (AttributeError, ValueError, OSError):
-            pass
-
     try:
+        backend = subprocess.Popen(backend_cmd, cwd=str(AGENT_DIR))
+        children.append(backend)
+        frontend = subprocess.Popen(frontend_cmd, cwd=str(frontend_dir))
+        children.append(frontend)
+
+        # Wire signal handlers only after both children are tracked. On
+        # Windows, SIGTERM may not exist and handlers must be installed from
+        # the main thread; KeyboardInterrupt remains the portable Ctrl+C path.
+        if threading.current_thread() is threading.main_thread():
+            try:
+                signal.signal(signal.SIGINT, lambda *_: _terminate_all())
+            except (ValueError, OSError):
+                pass
+            try:
+                signal.signal(signal.SIGTERM, lambda *_: _terminate_all())
+            except (AttributeError, ValueError, OSError):
+                pass
+
         # Wait for whichever process exits first; if it's the backend we
         # bring the frontend down too, and vice versa.
         while True:
             time.sleep(0.5)
-            if backend.poll() is not None or frontend.poll() is not None:
+            return_codes = [backend.poll(), frontend.poll()]
+            if any(code is not None for code in return_codes):
+                exit_code = next(
+                    (code for code in return_codes if code not in (None, EXIT_SUCCESS)),
+                    EXIT_SUCCESS,
+                )
                 break
     except KeyboardInterrupt:
         pass
+    except OSError as exc:
+        console.print(f"[red]Failed to start development server:[/red] {exc}")
+        exit_code = EXIT_RUN_FAILED
     finally:
         _terminate_all()
         # Give the children a brief grace period, then force-kill.
@@ -5379,8 +5391,12 @@ def cmd_dev(
                     child.kill()
                 except OSError:
                     pass
+                try:
+                    child.wait(timeout=1.0)
+                except (OSError, subprocess.TimeoutExpired):
+                    pass
 
-    return EXIT_SUCCESS
+    return exit_code
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/agent/cli/_legacy.py
+++ b/agent/cli/_legacy.py
@@ -2963,31 +2963,35 @@ def cmd_channels_status(*, json_mode: bool = False, local: bool = False) -> int:
 def cmd_channels_start(*, json_mode: bool = False) -> int:
     """Start configured IM channels through the API runtime."""
     payload = _channels_api_call("POST", "/channels/start")
+    failed = payload.get("status") == "error"
     if json_mode:
         print(json.dumps(payload, indent=2, ensure_ascii=False))
-    elif payload.get("status") == "error":
+    elif failed:
         console.print(f"[red]Failed to start IM channels:[/red] {payload.get('error')}")
-        console.print("[dim]Run `vibe-trading serve --port 8000` first, or set VIBE_TRADING_API_URL.[/dim]")
-        return EXIT_RUN_FAILED
+        console.print(
+            "[dim]Run `vibe-trading serve --port 8000` first, or set VIBE_TRADING_API_URL.[/dim]"
+        )
     else:
         console.print("[green]IM channels started.[/green]")
         _print_channels_status(payload)
-    return EXIT_SUCCESS
+    return EXIT_RUN_FAILED if failed else EXIT_SUCCESS
 
 
 def cmd_channels_stop(*, json_mode: bool = False) -> int:
     """Stop configured IM channels through the API runtime."""
     payload = _channels_api_call("POST", "/channels/stop")
+    failed = payload.get("status") == "error"
     if json_mode:
         print(json.dumps(payload, indent=2, ensure_ascii=False))
-    elif payload.get("status") == "error":
+    elif failed:
         console.print(f"[red]Failed to stop IM channels:[/red] {payload.get('error')}")
-        console.print("[dim]Run `vibe-trading serve --port 8000` first, or set VIBE_TRADING_API_URL.[/dim]")
-        return EXIT_RUN_FAILED
+        console.print(
+            "[dim]Run `vibe-trading serve --port 8000` first, or set VIBE_TRADING_API_URL.[/dim]"
+        )
     else:
         console.print("[green]IM channels stopped.[/green]")
         _print_channels_status(payload)
-    return EXIT_SUCCESS
+    return EXIT_RUN_FAILED if failed else EXIT_SUCCESS
 
 
 def cmd_channels_pairing(channel: str, command: str) -> int:

--- a/agent/cli/_legacy.py
+++ b/agent/cli/_legacy.py
@@ -1444,12 +1444,11 @@ def cmd_run(prompt: str, max_iter: int, *, json_mode: bool = False, no_rich: boo
     return _result_exit_code(result)
 
 
-def _build_history_from_trace(run_dir: Path) -> List[Dict[str, str]]:
+def _build_history_from_trace(trace_dir: Path) -> List[Dict[str, str]]:
     """Build conversation history from trace.jsonl."""
     from src.agent.trace import TraceWriter
 
-    trace_dir = TraceWriter.find_trace_dir(run_dir.name, runs_dir=RUNS_DIR, sessions_dir=SESSIONS_DIR)
-    if trace_dir is None:
+    if not (trace_dir / "trace.jsonl").exists():
         return []
     entries = TraceWriter.read(
         trace_dir,
@@ -1474,6 +1473,8 @@ def cmd_continue(
     no_rich: bool = False,
 ) -> int:
     """Continue an existing run."""
+    from src.agent.trace import TraceWriter
+
     run_dir = RUNS_DIR / run_id
     session_trace_dir = SESSIONS_DIR / run_id
     if not run_dir.exists() and not session_trace_dir.exists():
@@ -1482,10 +1483,17 @@ def cmd_continue(
             return EXIT_USAGE_ERROR
         console.print(f"[red]Run {run_id} not found[/red]")
         return EXIT_USAGE_ERROR
-    if not run_dir.exists():
-        run_dir.mkdir(parents=True, exist_ok=True)
+    trace_dir = TraceWriter.find_trace_dir(
+        run_id, runs_dir=RUNS_DIR, sessions_dir=SESSIONS_DIR
+    )
+    if trace_dir is None:
+        # Preserve support for an existing, empty run/session directory. Once a
+        # trace exists, ``find_trace_dir`` is authoritative so every later
+        # continuation reads and appends to the same conversation.
+        trace_dir = session_trace_dir if session_trace_dir.exists() else run_dir
+    trace_dir.mkdir(parents=True, exist_ok=True)
 
-    history = _build_history_from_trace(run_dir)
+    history = _build_history_from_trace(trace_dir)
     if not json_mode and no_rich:
         print(f"Continue {run_id}: {prompt[:120]}\n")
     if json_mode or no_rich:
@@ -1494,7 +1502,7 @@ def cmd_continue(
             result = _run_agent(
                 prompt,
                 history=history,
-                run_dir_override=str(run_dir),
+                run_dir_override=str(trace_dir),
                 max_iter=max_iter,
                 no_rich=no_rich,
                 stream_output=not json_mode,
@@ -1502,7 +1510,12 @@ def cmd_continue(
         except KeyboardInterrupt:
             if json_mode:
                 _print_json_result(
-                    {"status": "cancelled", "run_id": run_id, "run_dir": str(run_dir), "reason": "Interrupted"}
+                    {
+                        "status": "cancelled",
+                        "run_id": run_id,
+                        "run_dir": str(trace_dir),
+                        "reason": "Interrupted",
+                    }
                 )
             else:
                 print("\nInterrupted")
@@ -1522,7 +1535,7 @@ def cmd_continue(
             result = _run_agent(
                 prompt,
                 history=history,
-                run_dir_override=str(run_dir),
+                run_dir_override=str(trace_dir),
                 max_iter=max_iter,
                 dashboard=dashboard,
             )

--- a/agent/src/api/swarm_routes.py
+++ b/agent/src/api/swarm_routes.py
@@ -141,6 +141,8 @@ def register_swarm_routes(
 
         run = runtime._store.reconcile_run(loaded, write=True)
 
+        from src.swarm.serialization import serialize_task
+
         return {
             "id": run.id,
             "preset_name": run.preset_name,
@@ -148,7 +150,15 @@ def register_swarm_routes(
             "is_stale": runtime._store.is_run_stale(run),
             "user_vars": run.user_vars,
             "agents": [a.model_dump() for a in run.agents],
-            "tasks": [t.model_dump() for t in run.tasks],
+            "tasks": [
+                {
+                    **serialize_task(t),
+                    # Keep the existing REST field while sharing the public
+                    # serializer used by the other swarm read paths.
+                    "worker_iterations": getattr(t, "worker_iterations", 0),
+                }
+                for t in run.tasks
+            ],
             "created_at": run.created_at,
             "completed_at": run.completed_at,
             "final_report": run.final_report,

--- a/agent/src/scheduled_research/executor.py
+++ b/agent/src/scheduled_research/executor.py
@@ -111,12 +111,19 @@ def _parse_cron_field(part: str, low: int, high: int) -> set[int] | None:
 
 
 def _day_matches(dt: datetime, doms: set[int] | None, months: set[int] | None, dows: set[int] | None) -> bool:
+    if months is not None and dt.month not in months:
+        return False
+
     cron_day_of_week = (dt.weekday() + 1) % 7  # cron convention: Sunday == 0
-    return (
-        (doms is None or dt.day in doms)
-        and (months is None or dt.month in months)
-        and (dows is None or cron_day_of_week in dows)
-    )
+    day_of_month_matches = doms is None or dt.day in doms
+    day_of_week_matches = dows is None or cron_day_of_week in dows
+
+    # Standard five-field cron treats day-of-month and day-of-week as an OR
+    # when both fields are restricted. A wildcard in either field keeps the
+    # other field authoritative.
+    if doms is not None and dows is not None:
+        return day_of_month_matches or day_of_week_matches
+    return day_of_month_matches and day_of_week_matches
 
 
 class ScheduledResearchExecutor:

--- a/agent/src/swarm/worker.py
+++ b/agent/src/swarm/worker.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -958,14 +957,34 @@ def _write_summary(artifact_dir: Path, summary: str) -> None:
 
 
 def _collect_artifacts(artifact_dir: Path) -> list[str]:
-    """Collect all artifact file paths from agent's artifact directory.
+    """Collect regular artifacts as deterministic run-relative paths.
 
     Args:
         artifact_dir: Path to artifacts/{agent_id}/ directory.
 
     Returns:
-        List of artifact file path strings.
+        Sorted POSIX-style paths relative to the swarm run directory. Symlinks
+        and files that resolve outside the agent artifact directory are omitted.
     """
     if not artifact_dir.exists():
         return []
-    return [str(p) for p in artifact_dir.iterdir() if p.is_file()]
+
+    run_dir = artifact_dir.parent.parent.resolve()
+    artifact_root = artifact_dir.resolve()
+    if not artifact_root.is_relative_to(run_dir):
+        return []
+
+    artifacts: list[str] = []
+    for path in artifact_dir.rglob("*"):
+        try:
+            if path.is_symlink():
+                continue
+            resolved = path.resolve(strict=True)
+            if not resolved.is_relative_to(artifact_root) or not resolved.is_file():
+                continue
+            artifacts.append(resolved.relative_to(run_dir).as_posix())
+        except (OSError, RuntimeError, ValueError):
+            # A concurrently removed file, symlink loop, or containment
+            # failure is not a durable artifact and must not escape the run.
+            continue
+    return sorted(artifacts)

--- a/agent/src/tools/background_tools.py
+++ b/agent/src/tools/background_tools.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import os
+import signal
 import subprocess
 import threading
 import uuid
@@ -12,6 +14,77 @@ from typing import Any, Dict, List, Optional
 from src.agent.tools import BaseTool
 
 WORKDIR = Path(__file__).resolve().parents[2]
+_COMMAND_TIMEOUT_SECONDS = 300.0
+_TERMINATION_GRACE_SECONDS = 2.0
+_MAX_OUTPUT_CHARS = 50_000
+
+
+def _start_process(command: str) -> subprocess.Popen[str]:
+    """Start a shell command in a process group that can be stopped as a unit."""
+    kwargs: dict[str, Any] = {
+        "shell": True,
+        "cwd": WORKDIR,
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "text": True,
+        "encoding": "utf-8",
+        "errors": "replace",
+    }
+    if os.name == "nt":
+        kwargs["creationflags"] = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+    else:
+        kwargs["start_new_session"] = True
+    return subprocess.Popen(command, **kwargs)
+
+
+def _signal_posix_process_group(process: subprocess.Popen[str], sig: int) -> None:
+    try:
+        os.killpg(process.pid, sig)
+    except ProcessLookupError:
+        pass
+
+
+def _taskkill_windows_process_tree(process: subprocess.Popen[str]) -> None:
+    """Ask Windows to stop the process and every descendant."""
+    try:
+        subprocess.run(
+            ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+    except OSError:
+        if process.poll() is None:
+            process.kill()
+
+
+def _terminate_process_tree(process: subprocess.Popen[str]) -> tuple[str, str]:
+    """Terminate a timed-out process tree, drain its pipes, and reap its root."""
+    if os.name == "nt":
+        _taskkill_windows_process_tree(process)
+        try:
+            return process.communicate(timeout=_TERMINATION_GRACE_SECONDS)
+        except subprocess.TimeoutExpired:
+            if process.poll() is None:
+                process.kill()
+            return process.communicate()
+
+    _signal_posix_process_group(process, signal.SIGTERM)
+    try:
+        stdout, stderr = process.communicate(timeout=_TERMINATION_GRACE_SECONDS)
+    except subprocess.TimeoutExpired:
+        _signal_posix_process_group(process, signal.SIGKILL)
+        return process.communicate()
+
+    # The shell can exit before a descendant that ignored SIGTERM. The group
+    # retains the shell's process-group id, so this final signal prevents an
+    # orphan even when that descendant closed its inherited output pipes.
+    _signal_posix_process_group(process, signal.SIGKILL)
+    return stdout, stderr
+
+
+def _combined_output(stdout: str | None, stderr: str | None) -> str:
+    return ((stdout or "") + (stderr or "")).strip()[:_MAX_OUTPUT_CHARS]
 
 
 class BackgroundManager:
@@ -43,15 +116,25 @@ class BackgroundManager:
 
     def _execute(self, task_id: str, command: str) -> None:
         exit_code: int | None = None
+        process: subprocess.Popen[str] | None = None
         try:
-            r = subprocess.run(command, shell=True, cwd=WORKDIR,
-                               capture_output=True, text=True, timeout=300,
-                               encoding="utf-8", errors="replace")
-            output = (r.stdout + r.stderr).strip()[:50000]
-            exit_code = r.returncode
-            status = "completed" if exit_code == 0 else "error"
-        except subprocess.TimeoutExpired:
-            output, status = "Timeout (300s)", "timeout"
+            process = _start_process(command)
+            try:
+                stdout, stderr = process.communicate(timeout=_COMMAND_TIMEOUT_SECONDS)
+                output = _combined_output(stdout, stderr)
+                exit_code = process.returncode
+                status = "completed" if exit_code == 0 else "error"
+            except subprocess.TimeoutExpired:
+                stdout, stderr = _terminate_process_tree(process)
+                partial_output = _combined_output(stdout, stderr)
+                timeout_message = f"Timeout ({_COMMAND_TIMEOUT_SECONDS:g}s)"
+                output = (
+                    f"{partial_output}\n{timeout_message}"
+                    if partial_output
+                    else timeout_message
+                )
+                output = output[:_MAX_OUTPUT_CHARS]
+                status = "timeout"
         except Exception as e:
             output, status = str(e), "error"
         self.tasks[task_id]["status"] = status

--- a/agent/tests/test_background_tools.py
+++ b/agent/tests/test_background_tools.py
@@ -3,8 +3,15 @@
 from __future__ import annotations
 
 import json
+import os
+import shlex
 import sys
+import time
+from pathlib import Path
 
+import pytest
+
+from src.tools import background_tools
 from src.tools.background_tools import BackgroundManager
 
 
@@ -40,3 +47,39 @@ def test_nonzero_exit_is_reported_as_error() -> None:
             "exit_code": 7,
         }
     ]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group regression")
+def test_timeout_kills_descendant_and_reaps_shell(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started_marker = tmp_path / "child-started"
+    orphan_marker = tmp_path / "orphan-wrote-after-timeout"
+    child_code = (
+        "import time; from pathlib import Path; "
+        f"Path({str(started_marker)!r}).write_text('started', encoding='utf-8'); "
+        "time.sleep(1.5); "
+        f"Path({str(orphan_marker)!r}).write_text('orphan', encoding='utf-8')"
+    )
+    command = f"{shlex.quote(sys.executable)} -c {shlex.quote(child_code)} & wait"
+    processes: list[background_tools.subprocess.Popen[str]] = []
+    real_popen = background_tools.subprocess.Popen
+
+    def tracked_popen(*args, **kwargs):
+        process = real_popen(*args, **kwargs)
+        processes.append(process)
+        return process
+
+    monkeypatch.setattr(background_tools, "_COMMAND_TIMEOUT_SECONDS", 0.8)
+    monkeypatch.setattr(background_tools, "_TERMINATION_GRACE_SECONDS", 0.2)
+    monkeypatch.setattr(background_tools.subprocess, "Popen", tracked_popen)
+
+    manager = BackgroundManager()
+    task = _execute(manager, "timeout", command)
+
+    assert started_marker.exists()
+    assert task["status"] == "timeout"
+    assert processes[0].poll() is not None
+    time.sleep(1.0)
+    assert not orphan_marker.exists()

--- a/agent/tests/test_cli_channels.py
+++ b/agent/tests/test_cli_channels.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from cli import _legacy
 
 
@@ -77,3 +79,36 @@ def test_channels_api_call_sends_configured_bearer_token(monkeypatch) -> None:
 
     assert _legacy._channels_api_call("GET", "/channels/status") == {"status": "ok"}
     assert captured["headers"] == {"Authorization": "Bearer secret-token"}
+
+
+@pytest.mark.parametrize(
+    "command", [_legacy.cmd_channels_start, _legacy.cmd_channels_stop]
+)
+@pytest.mark.parametrize("json_mode", [False, True])
+def test_channels_start_stop_return_failure_in_every_output_mode(
+    command, json_mode, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        _legacy,
+        "_channels_api_call",
+        lambda *args, **kwargs: {"status": "error", "error": "offline"},
+    )
+
+    assert command(json_mode=json_mode) == _legacy.EXIT_RUN_FAILED
+
+
+@pytest.mark.parametrize(
+    "command", [_legacy.cmd_channels_start, _legacy.cmd_channels_stop]
+)
+@pytest.mark.parametrize("json_mode", [False, True])
+def test_channels_start_stop_return_success_in_every_output_mode(
+    command, json_mode, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        _legacy,
+        "_channels_api_call",
+        lambda *args, **kwargs: {"status": "ok", "channels": {}},
+    )
+    monkeypatch.setattr(_legacy, "_print_channels_status", lambda payload: None)
+
+    assert command(json_mode=json_mode) == _legacy.EXIT_SUCCESS

--- a/agent/tests/test_cli_continue.py
+++ b/agent/tests/test_cli_continue.py
@@ -1,0 +1,57 @@
+"""Regression tests for continuing a persisted CLI conversation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from cli import _legacy
+from src.agent.trace import TraceWriter
+
+
+def test_repeated_continue_reads_and_appends_one_canonical_trace(
+    tmp_path, monkeypatch
+) -> None:
+    """A session continuation must remain visible to the next continuation."""
+    runs_dir = tmp_path / "runs"
+    sessions_dir = tmp_path / "sessions"
+    trace_dir = sessions_dir / "session-1"
+
+    writer = TraceWriter(trace_dir)
+    writer.write({"type": "start", "prompt": "initial question"})
+    writer.write({"type": "answer", "content": "initial answer"})
+    writer.close()
+
+    histories = []
+
+    def fake_run_agent(prompt, history, run_dir_override, **kwargs):
+        histories.append(list(history))
+        continuation = TraceWriter(Path(run_dir_override))
+        continuation.write({"type": "start", "prompt": prompt})
+        continuation.write({"type": "answer", "content": f"answer to {prompt}"})
+        continuation.close()
+        return {"status": "success", "run_id": "session-1", "run_dir": run_dir_override}
+
+    monkeypatch.setattr(_legacy, "RUNS_DIR", runs_dir)
+    monkeypatch.setattr(_legacy, "SESSIONS_DIR", sessions_dir)
+    monkeypatch.setattr(_legacy, "_run_agent", fake_run_agent)
+    monkeypatch.setattr(_legacy, "_print_json_result", lambda result: None)
+
+    assert (
+        _legacy.cmd_continue("session-1", "first follow-up", 5, json_mode=True)
+        == _legacy.EXIT_SUCCESS
+    )
+    assert (
+        _legacy.cmd_continue("session-1", "second follow-up", 5, json_mode=True)
+        == _legacy.EXIT_SUCCESS
+    )
+
+    assert histories[0] == [
+        {"role": "user", "content": "initial question"},
+        {"role": "assistant", "content": "initial answer"},
+    ]
+    assert histories[1] == [
+        *histories[0],
+        {"role": "user", "content": "first follow-up"},
+        {"role": "assistant", "content": "answer to first follow-up"},
+    ]
+    assert not (runs_dir / "session-1").exists()

--- a/agent/tests/test_cli_setup_dev.py
+++ b/agent/tests/test_cli_setup_dev.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import cli
+import pytest
 
 
 class TestIsWindows:
@@ -193,6 +194,77 @@ class TestCmdDev:
         frontend_cmd = frontend_call.args[0]
         port_idx = frontend_cmd.index("--port") + 1
         assert frontend_cmd[port_idx] == "6000"
+
+    @pytest.mark.parametrize(
+        ("backend_code", "frontend_code", "expected"),
+        [(7, None, 7), (None, 9, 9)],
+    )
+    def test_returns_first_child_failure_and_stops_sibling(
+        self,
+        tmp_path: Path,
+        backend_code: int | None,
+        frontend_code: int | None,
+        expected: int,
+    ) -> None:
+        frontend_dir = _make_frontend_with_vite(tmp_path)
+        backend = MagicMock()
+        backend.poll.return_value = backend_code
+        frontend = MagicMock()
+        frontend.poll.return_value = frontend_code
+
+        with patch(
+            "cli._legacy._resolve_node_and_npm",
+            return_value=("/usr/bin/node", "/usr/bin/npm"),
+        ):
+            with patch("cli._legacy.subprocess.Popen", side_effect=[backend, frontend]):
+                with patch.object(cli._legacy.time, "sleep", return_value=None):
+                    rc = cli._legacy.cmd_dev(frontend_dir=frontend_dir)
+
+        assert rc == expected
+        running_sibling = frontend if backend_code is not None else backend
+        running_sibling.terminate.assert_called_once()
+
+    def test_second_spawn_failure_cleans_up_backend(self, tmp_path: Path) -> None:
+        frontend_dir = _make_frontend_with_vite(tmp_path)
+        backend = MagicMock()
+        backend.poll.return_value = None
+
+        with patch(
+            "cli._legacy._resolve_node_and_npm",
+            return_value=("/usr/bin/node", "/usr/bin/npm"),
+        ):
+            with patch(
+                "cli._legacy.subprocess.Popen",
+                side_effect=[backend, OSError("frontend failed to start")],
+            ):
+                rc = cli._legacy.cmd_dev(frontend_dir=frontend_dir)
+
+        assert rc == cli._legacy.EXIT_RUN_FAILED
+        backend.terminate.assert_called_once()
+        backend.wait.assert_called_once()
+
+    def test_interrupt_cleans_up_both_children(self, tmp_path: Path) -> None:
+        frontend_dir = _make_frontend_with_vite(tmp_path)
+        backend = MagicMock()
+        backend.poll.return_value = None
+        frontend = MagicMock()
+        frontend.poll.return_value = None
+
+        with patch(
+            "cli._legacy._resolve_node_and_npm",
+            return_value=("/usr/bin/node", "/usr/bin/npm"),
+        ):
+            with patch("cli._legacy.subprocess.Popen", side_effect=[backend, frontend]):
+                with patch.object(
+                    cli._legacy.time, "sleep", side_effect=KeyboardInterrupt
+                ):
+                    rc = cli._legacy.cmd_dev(frontend_dir=frontend_dir)
+
+        assert rc == cli._legacy.EXIT_SUCCESS
+        backend.terminate.assert_called_once()
+        frontend.terminate.assert_called_once()
+        backend.wait.assert_called_once()
+        frontend.wait.assert_called_once()
 
 
 def _make_frontend_with_vite(tmp_path: Path) -> Path:

--- a/agent/tests/test_packaging_dependencies.py
+++ b/agent/tests/test_packaging_dependencies.py
@@ -136,3 +136,13 @@ def test_channel_optional_extras_cover_all_sdk_backed_adapters() -> None:
         "wecom-aibot-sdk",
     }
     assert expected_packages.issubset(channel_extra)
+
+
+def test_slack_markdown_dependency_uses_a_published_version_range() -> None:
+    """Both Slack extras should use the same resolvable dependency range."""
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text())
+    extras = pyproject["project"]["optional-dependencies"]
+
+    expected = "slackify-markdown>=0.2.4,<1"
+    assert expected in extras["slack"]
+    assert expected in extras["channels"]

--- a/agent/tests/test_scheduled_research_executor.py
+++ b/agent/tests/test_scheduled_research_executor.py
@@ -94,6 +94,26 @@ def test_cron_job_next_due_and_not_before_due_time(tmp_path: Path) -> None:
     assert saved.next_run_at == following_due
 
 
+def test_cron_uses_standard_or_semantics_for_restricted_day_fields() -> None:
+    thursday = _ms(2026, 6, 11, 0, 1)
+
+    # The 12th is a Friday, so it matches day-of-week even though it is not
+    # the 13th day of the month.
+    assert next_due("0 0 13 * 5", thursday) == _ms(2026, 6, 12, 0, 0)
+
+    friday = _ms(2026, 6, 12, 0, 1)
+    # The 13th is a Saturday, so the following run matches day-of-month even
+    # though it is not Friday.
+    assert next_due("0 0 13 * 5", friday) == _ms(2026, 6, 13, 0, 0)
+
+
+def test_cron_wildcard_day_field_leaves_other_day_field_authoritative() -> None:
+    thursday = _ms(2026, 6, 11, 0, 1)
+
+    assert next_due("0 0 13 * *", thursday) == _ms(2026, 6, 13, 0, 0)
+    assert next_due("0 0 * * 5", thursday) == _ms(2026, 6, 12, 0, 0)
+
+
 def test_dispatch_failure_marks_failed_and_tick_continues(tmp_path: Path) -> None:
     store = _store(tmp_path)
     store.upsert(_job("bad", next_run_at=10))

--- a/agent/tests/test_swarm_output_contract.py
+++ b/agent/tests/test_swarm_output_contract.py
@@ -34,6 +34,7 @@ from src.swarm.models import (
 from src.swarm.store import SwarmStore
 from src.swarm.worker import (
     _classify_deliverable,
+    _collect_artifacts,
     _is_data_agent,
     _is_error_result,
     _report_written,
@@ -297,3 +298,34 @@ def test_tool_result_event_status_and_evidence_credit_agree(
     tool_result = next(event for event in events if event.type == "tool_result")
     assert tool_result.data["status"] == expected_event_status
     assert worker_result.status == expected_worker_status
+
+
+def test_collect_artifacts_recurses_and_returns_sorted_run_relative_paths(
+    tmp_path: Path,
+) -> None:
+    artifact_dir = tmp_path / "run" / "artifacts" / "analyst"
+    (artifact_dir / "nested").mkdir(parents=True)
+    (artifact_dir / "other").mkdir()
+    (artifact_dir / "summary.md").write_text("summary", encoding="utf-8")
+    (artifact_dir / "nested" / "report.json").write_text("{}", encoding="utf-8")
+    (artifact_dir / "other" / "report.json").write_text("{}", encoding="utf-8")
+
+    assert _collect_artifacts(artifact_dir) == [
+        "artifacts/analyst/nested/report.json",
+        "artifacts/analyst/other/report.json",
+        "artifacts/analyst/summary.md",
+    ]
+
+
+def test_collect_artifacts_rejects_symlink_escape(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "run" / "artifacts" / "analyst"
+    artifact_dir.mkdir(parents=True)
+    outside = tmp_path / "outside.txt"
+    outside.write_text("private", encoding="utf-8")
+    escape = artifact_dir / "escape.txt"
+    try:
+        escape.symlink_to(outside)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are not available on this platform")
+
+    assert _collect_artifacts(artifact_dir) == []

--- a/agent/tests/test_swarm_route_contracts.py
+++ b/agent/tests/test_swarm_route_contracts.py
@@ -10,7 +10,7 @@ from fastapi.testclient import TestClient
 
 import api_server
 import src.api.swarm_routes as swarm_routes
-from src.swarm.models import RunStatus, SwarmEvent, SwarmRun
+from src.swarm.models import RunStatus, SwarmEvent, SwarmRun, SwarmTask
 from src.swarm.store import SwarmStore
 
 
@@ -33,6 +33,7 @@ def _create_run(
     *,
     run_id: str = "run-contract",
     status: RunStatus = RunStatus.pending,
+    tasks: list[SwarmTask] | None = None,
 ) -> SwarmRun:
     run = SwarmRun(
         id=run_id,
@@ -42,6 +43,7 @@ def _create_run(
         completed_at=(
             "2026-07-16T00:00:01+00:00" if status == RunStatus.completed else None
         ),
+        tasks=tasks or [],
     )
     store.create_run(run)
     return run
@@ -100,3 +102,37 @@ def test_swarm_events_keeps_last_index_query_compatibility(
     assert response.status_code == 200
     assert "event: query_step_1" not in response.text
     assert "id: 2\nevent: query_step_2" in response.text
+
+
+def test_swarm_detail_uses_redacted_public_task_projection(
+    swarm_store: SwarmStore,
+) -> None:
+    internal_path = str(
+        Path.cwd() / "agent" / ".swarm" / "runs" / "secret" / "task.log"
+    )
+    _create_run(
+        swarm_store,
+        tasks=[
+            SwarmTask(
+                id="task-1",
+                agent_id="analyst",
+                prompt_template="internal prompt",
+                summary="Public summary",
+                artifacts=[internal_path],
+                error=f"failed while reading {internal_path}",
+                worker_iterations=3,
+            )
+        ],
+    )
+
+    response = _client().get("/swarm/runs/run-contract")
+
+    assert response.status_code == 200
+    task = response.json()["tasks"][0]
+    assert task["summary"] == "Public summary"
+    assert "<redacted>" in task["error"]
+    assert internal_path not in response.text
+    assert "artifacts" not in task
+    assert "prompt_template" not in task
+    assert task["worker_iterations"] == 3
+    assert task["iterations"] == 3

--- a/frontend/src/__tests__/viteProxy.test.ts
+++ b/frontend/src/__tests__/viteProxy.test.ts
@@ -14,4 +14,8 @@ describe("Vite API proxy config", () => {
     expect(config).toContain('"/settings/llm"');
     expect(config).toContain('"/settings/data-sources"');
   });
+
+  it("proxies authentication endpoints", () => {
+    expect(config).toContain('"/auth"');
+  });
 });

--- a/frontend/src/hooks/__tests__/useSSE.test.ts
+++ b/frontend/src/hooks/__tests__/useSSE.test.ts
@@ -355,4 +355,43 @@ describe("useSSE — SSE ticket auth (VT-003)", () => {
     // The long-lived key must never appear in the stream URL.
     expect(MockEventSource.latest.url).not.toContain("remote-key");
   });
+
+  it("ignores a ticket that resolves after a newer connection", async () => {
+    localStorage.setItem("vibe_trading_api_auth_key", "remote-key");
+    const ticketResolvers: Array<(response: Response) => void> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        () =>
+          new Promise<Response>((resolve) => {
+            ticketResolvers.push(resolve);
+          }),
+      ),
+    );
+
+    const { result } = renderHook(() => useSSE());
+    act(() => {
+      result.current.connect("http://test/session-a/events", {});
+      result.current.connect("http://test/session-b/events", {});
+    });
+
+    await act(async () => {
+      ticketResolvers[1](
+        new Response(JSON.stringify({ ticket: "TICKET-B" }), { status: 200 }),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      ticketResolvers[0](
+        new Response(JSON.stringify({ ticket: "TICKET-A" }), { status: 200 }),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(MockEventSource.latest.url).toContain("session-b/events");
+    expect(MockEventSource.latest.url).toContain("ticket=TICKET-B");
+  });
 });

--- a/frontend/src/hooks/useSSE.ts
+++ b/frontend/src/hooks/useSSE.ts
@@ -35,6 +35,7 @@ export function useSSE(config?: SSEConfig) {
   const lastEventIdRef = useRef<string | null>(null);
   const statusRef = useRef<SSEStatus>("disconnected");
   const onStatusChangeRef = useRef<((s: SSEStatus) => void) | null>(null);
+  const generationRef = useRef(0);
 
   // LRU dedup set
   const seenIdsRef = useRef<Set<string>>(new Set());
@@ -67,13 +68,16 @@ export function useSSE(config?: SSEConfig) {
     return baseUrl;
   }, []);
 
-  const attach = useCallback((url: string) => {
-    if (closedRef.current) return;
+  const attach = useCallback((url: string, generation: number) => {
+    if (closedRef.current || generation !== generationRef.current) return;
 
     const source = new EventSource(url);
     sourceRef.current = source;
 
     source.onopen = () => {
+      if (generation !== generationRef.current || sourceRef.current !== source) {
+        return;
+      }
       retryCountRef.current = 0;
       setStatus("connected");
     };
@@ -91,6 +95,9 @@ export function useSSE(config?: SSEConfig) {
     ];
 
     const handleRaw = (eventType: string, raw: MessageEvent) => {
+      if (generation !== generationRef.current || sourceRef.current !== source) {
+        return;
+      }
       if (raw.lastEventId) {
         lastEventIdRef.current = raw.lastEventId;
       }
@@ -112,15 +119,21 @@ export function useSSE(config?: SSEConfig) {
     }
 
     source.onerror = () => {
-      if (closedRef.current) return;
+      if (
+        closedRef.current ||
+        generation !== generationRef.current ||
+        sourceRef.current !== source
+      ) {
+        return;
+      }
       source.close();
       sourceRef.current = null;
-      scheduleReconnect();
+      scheduleReconnect(generation);
     };
   }, [trackEventId, setStatus]);
 
-  const doConnect = useCallback(() => {
-    if (closedRef.current) return;
+  const doConnect = useCallback((generation: number) => {
+    if (closedRef.current || generation !== generationRef.current) return;
 
     const baseUrl = buildUrl(urlRef.current);
 
@@ -129,18 +142,20 @@ export function useSSE(config?: SSEConfig) {
     // key) the backend bypasses auth, so we connect synchronously and preserve
     // the original zero-round-trip behavior (and the synchronous test path).
     if (!getApiAuthKey()) {
-      attach(baseUrl);
+      attach(baseUrl, generation);
       return;
     }
     withAuthTicket(baseUrl)
-      .then(attach)
+      .then((url) => attach(url, generation))
       .catch(() => {
-        if (!closedRef.current) scheduleReconnect();
+        if (!closedRef.current && generation === generationRef.current) {
+          scheduleReconnect(generation);
+        }
       });
   }, [buildUrl, attach]);
 
-  const scheduleReconnect = useCallback(() => {
-    if (closedRef.current) return;
+  const scheduleReconnect = useCallback((generation: number) => {
+    if (closedRef.current || generation !== generationRef.current) return;
     retryCountRef.current += 1;
     const delay = Math.min(
       opts.initialRetryMs * Math.pow(opts.backoffFactor, retryCountRef.current - 1),
@@ -151,11 +166,14 @@ export function useSSE(config?: SSEConfig) {
 
     retryTimerRef.current = setTimeout(() => {
       retryTimerRef.current = null;
-      doConnect();
+      if (generation === generationRef.current) {
+        doConnect(generation);
+      }
     }, delay);
   }, [opts.initialRetryMs, opts.backoffFactor, opts.maxRetryMs, setStatus, doConnect]);
 
   const connect = useCallback((url: string, handlers: Handlers) => {
+    const generation = ++generationRef.current;
     closedRef.current = true;
     sourceRef.current?.close();
     if (retryTimerRef.current) {
@@ -171,10 +189,11 @@ export function useSSE(config?: SSEConfig) {
     seenIdsRef.current.clear();
     seenOrderRef.current.length = 0;
 
-    doConnect();
+    doConnect(generation);
   }, [doConnect]);
 
   const disconnect = useCallback(() => {
+    generationRef.current += 1;
     closedRef.current = true;
     if (retryTimerRef.current) {
       clearTimeout(retryTimerRef.current);

--- a/frontend/src/pages/Compare.tsx
+++ b/frontend/src/pages/Compare.tsx
@@ -208,6 +208,8 @@ export function Compare() {
   const [rightCurve, setRightCurve] = useState<EquityPoint[]>([]);
   const [leftLoading, setLeftLoading] = useState(false);
   const [rightLoading, setRightLoading] = useState(false);
+  const leftRequestGeneration = useRef(0);
+  const rightRequestGeneration = useRef(0);
 
   useEffect(() => {
     api.listRuns().then((items) => {
@@ -220,39 +222,65 @@ export function Compare() {
   }, []);
 
   useEffect(() => {
-    if (leftId) {
-      setLeftLoading(true);
-      api.getRun(leftId).then((d: RunData) => {
+    const generation = ++leftRequestGeneration.current;
+    setLeftData(null);
+    setLeftCurve([]);
+
+    if (!leftId) {
+      setLeftLoading(false);
+      return;
+    }
+
+    setLeftLoading(true);
+    api.getRun(leftId).then((d: RunData) => {
+      if (leftRequestGeneration.current === generation) {
         setLeftData(d.metrics || null);
         setLeftCurve(d.equity_curve || []);
-      }).catch((error) => {
+      }
+    }).catch((error) => {
+      if (leftRequestGeneration.current === generation) {
         setLeftData(null);
         setLeftCurve([]);
         toast.error(error instanceof Error ? error.message : i18n.t("compare.loadError"));
-      })
-        .finally(() => setLeftLoading(false));
-    } else {
-      setLeftData(null);
-      setLeftCurve([]);
-    }
+      }
+    }).finally(() => {
+      if (leftRequestGeneration.current === generation) setLeftLoading(false);
+    });
+
+    return () => {
+      if (leftRequestGeneration.current === generation) leftRequestGeneration.current += 1;
+    };
   }, [leftId]);
 
   useEffect(() => {
-    if (rightId) {
-      setRightLoading(true);
-      api.getRun(rightId).then((d: RunData) => {
+    const generation = ++rightRequestGeneration.current;
+    setRightData(null);
+    setRightCurve([]);
+
+    if (!rightId) {
+      setRightLoading(false);
+      return;
+    }
+
+    setRightLoading(true);
+    api.getRun(rightId).then((d: RunData) => {
+      if (rightRequestGeneration.current === generation) {
         setRightData(d.metrics || null);
         setRightCurve(d.equity_curve || []);
-      }).catch((error) => {
+      }
+    }).catch((error) => {
+      if (rightRequestGeneration.current === generation) {
         setRightData(null);
         setRightCurve([]);
         toast.error(error instanceof Error ? error.message : i18n.t("compare.loadError"));
-      })
-        .finally(() => setRightLoading(false));
-    } else {
-      setRightData(null);
-      setRightCurve([]);
-    }
+      }
+    }).finally(() => {
+      if (rightRequestGeneration.current === generation) setRightLoading(false);
+    });
+
+    return () => {
+      if (rightRequestGeneration.current === generation) rightRequestGeneration.current += 1;
+    };
   }, [rightId]);
 
   const leftRun = runs.find((r) => r.run_id === leftId);

--- a/frontend/src/pages/Correlation.tsx
+++ b/frontend/src/pages/Correlation.tsx
@@ -1,5 +1,5 @@
 import i18n from '@/i18n';
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { BarChart3 } from "lucide-react";
 import { CorrelationMatrix } from "@/components/charts/CorrelationMatrix";
 import { api } from "@/lib/api";
@@ -15,18 +15,34 @@ export function Correlation() {
 
   const [labels, setLabels] = useState<string[]>([]);
   const [matrix, setMatrix] = useState<number[][]>([]);
+  const requestGeneration = useRef(0);
+
+  const invalidateResult = () => {
+    requestGeneration.current += 1;
+    setLabels([]);
+    setMatrix([]);
+    setError(null);
+    setLoading(false);
+  };
 
   const compute = async () => {
+    const generation = ++requestGeneration.current;
     setError(null);
+    setLabels([]);
+    setMatrix([]);
     setLoading(true);
     try {
       const result = await api.getCorrelation(codes, days, method);
-      setLabels(result.labels);
-      setMatrix(result.matrix);
+      if (requestGeneration.current === generation) {
+        setLabels(result.labels);
+        setMatrix(result.matrix);
+      }
     } catch (e) {
-      setError(e instanceof Error ? e.message : i18n.t("correlation.failedToCompute"));
+      if (requestGeneration.current === generation) {
+        setError(e instanceof Error ? e.message : i18n.t("correlation.failedToCompute"));
+      }
     } finally {
-      setLoading(false);
+      if (requestGeneration.current === generation) setLoading(false);
     }
   };
 
@@ -45,7 +61,10 @@ export function Correlation() {
           <input
             type="text"
             value={codes}
-            onChange={(e) => setCodes(e.target.value)}
+            onChange={(e) => {
+              invalidateResult();
+              setCodes(e.target.value);
+            }}
             placeholder="000001.SZ,600519.SH,000858.SZ"
             className="w-full px-3 py-2 rounded-md border bg-background text-sm"
           />
@@ -61,7 +80,10 @@ export function Correlation() {
               {WINDOWS.map((w) => (
                 <button
                   key={w}
-                  onClick={() => setDays(w)}
+                  onClick={() => {
+                    invalidateResult();
+                    setDays(w);
+                  }}
                   className={`px-3 py-1.5 rounded text-sm border transition-colors ${
                     days === w
                       ? "bg-primary text-primary-foreground"
@@ -80,7 +102,10 @@ export function Correlation() {
               {(["pearson", "spearman"] as const).map((m) => (
                 <button
                   key={m}
-                  onClick={() => setMethod(m)}
+                  onClick={() => {
+                    invalidateResult();
+                    setMethod(m);
+                  }}
                   className={`px-3 py-1.5 rounded text-sm border transition-colors capitalize ${
                     method === m
                       ? "bg-primary text-primary-foreground"

--- a/frontend/src/pages/RunDetail.tsx
+++ b/frontend/src/pages/RunDetail.tsx
@@ -106,6 +106,7 @@ export function RunDetail() {
   const [bulkChartProgress, setBulkChartProgress] = useState<ChartLoadProgress>({ done: 0, total: 0 });
   const chartCacheRef = useRef<ChartCache>({});
   const cancelBulkChartLoadRef = useRef(false);
+  const runGenerationRef = useRef(0);
 
   const hasValidation = !!run?.validation;
   const hasRunCard = !!run?.run_card;
@@ -118,11 +119,32 @@ export function RunDetail() {
   ];
 
   useEffect(() => {
-    if (!runId) return;
+    const generation = ++runGenerationRef.current;
+    cancelBulkChartLoadRef.current = true;
+    setRun(null);
+    setCode({});
+    setTab("chart");
+    setLoading(true);
+    setSelectedSymbol("");
+    setChartPickerSymbol("");
+    setSelectedSymbols([]);
+    chartCacheRef.current = {};
+    setChartCache({});
+    setChartLoadingSymbols({});
+    setBulkChartLoading(false);
+    setBulkChartProgress({ done: 0, total: 0 });
+
+    if (!runId) {
+      setLoading(false);
+      return;
+    }
+
+    const requestedRunId = runId;
     Promise.all([
-      api.getRun(runId, { chart_payload: "summary" }).catch(() => null),
-      api.getRunCode(runId).catch(() => ({})),
+      api.getRun(requestedRunId, { chart_payload: "summary" }).catch(() => null),
+      api.getRunCode(requestedRunId).catch(() => ({})),
     ]).then(([r, c]) => {
+      if (runGenerationRef.current !== generation) return;
       setRun(r);
       setCode(c || {});
       const firstSymbol = r?.chart_symbols?.[0] || Object.keys(r?.price_series || {})[0] || "";
@@ -133,9 +155,16 @@ export function RunDetail() {
       chartCacheRef.current = initialCache;
       setChartCache(initialCache);
       if (firstSymbol && !initialCache[firstSymbol]?.price_series?.[firstSymbol]?.length) {
-        void loadChartSymbol(firstSymbol);
+        void loadChartSymbol(firstSymbol, requestedRunId, generation);
       }
-    }).finally(() => setLoading(false));
+    }).finally(() => {
+      if (runGenerationRef.current === generation) setLoading(false);
+    });
+
+    return () => {
+      cancelBulkChartLoadRef.current = true;
+      if (runGenerationRef.current === generation) runGenerationRef.current += 1;
+    };
   }, [runId]);
 
   if (loading) {
@@ -165,12 +194,17 @@ export function RunDetail() {
 
   const ok = run.status === "success";
 
-  async function loadChartSymbol(symbol: string) {
-    if (!runId || !symbol) return;
+  async function loadChartSymbol(
+    symbol: string,
+    requestedRunId = runId,
+    generation = runGenerationRef.current,
+  ) {
+    if (!requestedRunId || !symbol || runGenerationRef.current !== generation) return;
     if (chartCacheRef.current[symbol]?.price_series?.[symbol]?.length) return;
     setChartLoadingSymbols((prev) => ({ ...prev, [symbol]: true }));
     try {
-      const nextRun = await api.getRun(runId, { chart_symbol: symbol });
+      const nextRun = await api.getRun(requestedRunId, { chart_symbol: symbol });
+      if (runGenerationRef.current !== generation) return;
       const nextCache = cacheFromRun(nextRun, symbol);
       const mergedCache = { ...chartCacheRef.current, ...nextCache };
       chartCacheRef.current = mergedCache;
@@ -182,11 +216,13 @@ export function RunDetail() {
         trade_log: nextRun.trade_log?.length ? nextRun.trade_log : prev.trade_log,
       } : nextRun);
     } finally {
-      setChartLoadingSymbols((prev) => {
-        const next = { ...prev };
-        delete next[symbol];
-        return next;
-      });
+      if (runGenerationRef.current === generation) {
+        setChartLoadingSymbols((prev) => {
+          const next = { ...prev };
+          delete next[symbol];
+          return next;
+        });
+      }
     }
   }
 
@@ -219,22 +255,25 @@ export function RunDetail() {
   async function handleLoadAllChartSymbols() {
     const symbols = run?.chart_symbols || [];
     if (symbols.length === 0 || bulkChartLoading) return;
+    const generation = runGenerationRef.current;
+    const requestedRunId = runId;
     cancelBulkChartLoadRef.current = false;
     setBulkChartLoading(true);
     setBulkChartProgress({ done: 0, total: symbols.length });
     try {
       for (let index = 0; index < symbols.length; index += 1) {
-        if (cancelBulkChartLoadRef.current) break;
+        if (cancelBulkChartLoadRef.current || runGenerationRef.current !== generation) break;
         const symbol = symbols[index];
         setSelectedSymbol(symbol);
         setChartPickerSymbol(symbol);
         setSelectedSymbols((prev) => prev.includes(symbol) ? prev : [...prev, symbol]);
-        await loadChartSymbol(symbol);
+        await loadChartSymbol(symbol, requestedRunId, generation);
+        if (runGenerationRef.current !== generation) break;
         setBulkChartProgress({ done: index + 1, total: symbols.length });
         await yieldToBrowser();
       }
     } finally {
-      setBulkChartLoading(false);
+      if (runGenerationRef.current === generation) setBulkChartLoading(false);
     }
   }
 

--- a/frontend/src/pages/__tests__/Compare.test.tsx
+++ b/frontend/src/pages/__tests__/Compare.test.tsx
@@ -1,0 +1,96 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { Compare } from "../Compare";
+import type { RunData } from "@/lib/api";
+
+const apiMock = vi.hoisted(() => ({
+  listRuns: vi.fn(),
+  getRun: vi.fn(),
+}));
+const toastMock = vi.hoisted(() => ({ error: vi.fn() }));
+
+vi.mock("@/lib/api", () => ({ api: apiMock }));
+vi.mock("sonner", () => ({ toast: toastMock }));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const runs = [
+  { run_id: "right", prompt: "Right", status: "success" },
+  { run_id: "old", prompt: "Old", status: "success" },
+  { run_id: "new", prompt: "New", status: "success" },
+];
+
+describe("Compare page", () => {
+  beforeEach(() => {
+    apiMock.listRuns.mockReset();
+    apiMock.getRun.mockReset();
+    toastMock.error.mockReset();
+    apiMock.listRuns.mockResolvedValue(runs);
+  });
+
+  it("keeps the newest result when an older request resolves later", async () => {
+    const oldRequest = deferred<RunData>();
+    const newRequest = deferred<RunData>();
+    apiMock.getRun.mockImplementation((runId: string) => {
+      if (runId === "old") return oldRequest.promise;
+      if (runId === "new") return newRequest.promise;
+      return Promise.resolve({ status: "success", run_id: runId });
+    });
+
+    render(<Compare />);
+    const selectors = await screen.findAllByRole("combobox");
+    await waitFor(() => expect(selectors[0]).toHaveValue("old"));
+    fireEvent.change(selectors[0], { target: { value: "new" } });
+
+    await act(async () => {
+      newRequest.resolve({ status: "success", run_id: "new", metrics: { total_return: 0.3 } });
+      await newRequest.promise;
+    });
+    expect(await screen.findByText("30.00%")).toBeInTheDocument();
+
+    await act(async () => {
+      oldRequest.resolve({ status: "success", run_id: "old", metrics: { total_return: 0.1 } });
+      await oldRequest.promise;
+    });
+
+    expect(screen.getByText("30.00%")).toBeInTheDocument();
+    expect(screen.queryByText("10.00%")).not.toBeInTheDocument();
+  });
+
+  it("ignores an older error and keeps loading the current selection", async () => {
+    const oldRequest = deferred<RunData>();
+    const newRequest = deferred<RunData>();
+    apiMock.getRun.mockImplementation((runId: string) => {
+      if (runId === "old") return oldRequest.promise;
+      if (runId === "new") return newRequest.promise;
+      return Promise.resolve({ status: "success", run_id: runId });
+    });
+
+    const { container } = render(<Compare />);
+    const selectors = await screen.findAllByRole("combobox");
+    await waitFor(() => expect(selectors[0]).toHaveValue("old"));
+    fireEvent.change(selectors[0], { target: { value: "new" } });
+
+    await act(async () => {
+      oldRequest.reject(new Error("old request failed"));
+      await oldRequest.promise.catch(() => undefined);
+    });
+
+    expect(toastMock.error).not.toHaveBeenCalled();
+    expect(container.querySelector(".animate-pulse")).toBeInTheDocument();
+    expect(screen.queryByText("Select two runs to compare their metrics.")).not.toBeInTheDocument();
+
+    await act(async () => {
+      newRequest.resolve({ status: "success", run_id: "new", metrics: { total_return: 0.2 } });
+      await newRequest.promise;
+    });
+    expect(await screen.findByText("20.00%")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/__tests__/Correlation.test.tsx
+++ b/frontend/src/pages/__tests__/Correlation.test.tsx
@@ -1,0 +1,50 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { Correlation } from "../Correlation";
+import type { CorrelationResponse } from "@/lib/api";
+
+const apiMock = vi.hoisted(() => ({
+  getCorrelation: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({ api: apiMock }));
+vi.mock("@/components/charts/CorrelationMatrix", () => ({
+  CorrelationMatrix: ({ labels }: { labels: string[] }) => (
+    <div data-testid="correlation-result">{labels.join(",")}</div>
+  ),
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe("Correlation page", () => {
+  beforeEach(() => {
+    apiMock.getCorrelation.mockReset();
+  });
+
+  it("clears old output and ignores an in-flight result after the query changes", async () => {
+    apiMock.getCorrelation.mockResolvedValueOnce({ labels: ["OLD"], matrix: [[1]] });
+    const pending = deferred<CorrelationResponse>();
+    apiMock.getCorrelation.mockReturnValueOnce(pending.promise);
+
+    render(<Correlation />);
+    fireEvent.click(screen.getByRole("button", { name: "Compute" }));
+    expect(await screen.findByTestId("correlation-result")).toHaveTextContent("OLD");
+
+    fireEvent.click(screen.getByRole("button", { name: "Compute" }));
+    expect(screen.queryByTestId("correlation-result")).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "AAPL,SPY" } });
+    expect(screen.getByRole("button", { name: "Compute" })).toBeEnabled();
+
+    await act(async () => {
+      pending.resolve({ labels: ["STALE"], matrix: [[1]] });
+      await pending.promise;
+    });
+    expect(screen.queryByTestId("correlation-result")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/__tests__/RunDetail.test.tsx
+++ b/frontend/src/pages/__tests__/RunDetail.test.tsx
@@ -1,0 +1,109 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
+import { RunDetail } from "../RunDetail";
+import type { RunData } from "@/lib/api";
+
+const apiMock = vi.hoisted(() => ({
+  getRun: vi.fn(),
+  getRunCode: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({ api: apiMock }));
+vi.mock("@/components/charts/CandlestickChart", () => ({
+  CandlestickChart: () => <div data-testid="candlestick-chart" />,
+}));
+vi.mock("@/components/charts/EquityChart", () => ({
+  EquityChart: () => <div data-testid="equity-chart" />,
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function renderRunDetail(path = "/runs/old") {
+  const router = createMemoryRouter(
+    [{ path: "/runs/:runId", element: <RunDetail /> }],
+    { initialEntries: [path] },
+  );
+  render(<RouterProvider router={router} />);
+  return router;
+}
+
+describe("RunDetail page", () => {
+  beforeEach(() => {
+    apiMock.getRun.mockReset();
+    apiMock.getRunCode.mockReset();
+  });
+
+  it("does not let an older route load replace the current run or code", async () => {
+    const oldRun = deferred<RunData>();
+    const oldCode = deferred<Record<string, string>>();
+    const newRun = deferred<RunData>();
+    const newCode = deferred<Record<string, string>>();
+
+    apiMock.getRun.mockImplementation((runId: string) => runId === "old" ? oldRun.promise : newRun.promise);
+    apiMock.getRunCode.mockImplementation((runId: string) => runId === "old" ? oldCode.promise : newCode.promise);
+
+    const router = renderRunDetail();
+    await act(async () => { await router.navigate("/runs/new"); });
+
+    await act(async () => {
+      newRun.resolve({ status: "success", run_id: "new", prompt: "New run" });
+      newCode.resolve({ "new.py": "NEW_CODE" });
+      await Promise.all([newRun.promise, newCode.promise]);
+    });
+    expect(await screen.findByText("New run")).toBeInTheDocument();
+
+    await act(async () => {
+      oldRun.resolve({ status: "success", run_id: "old", prompt: "Old run" });
+      oldCode.resolve({ "old.py": "OLD_CODE" });
+      await Promise.all([oldRun.promise, oldCode.promise]);
+    });
+
+    expect(screen.getByText("New run")).toBeInTheDocument();
+    expect(screen.queryByText("Old run")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Code" }));
+    expect(await screen.findByText("NEW_CODE")).toBeInTheDocument();
+    expect(screen.queryByText("OLD_CODE")).not.toBeInTheDocument();
+  });
+
+  it("ignores a chart response that finishes after the route changes", async () => {
+    const oldChart = deferred<RunData>();
+    apiMock.getRun.mockImplementation((runId: string, params: Record<string, string>) => {
+      if (runId === "old" && params.chart_payload === "summary") {
+        return Promise.resolve({ status: "success", run_id: "old", prompt: "Old run", chart_symbols: ["OLD"] });
+      }
+      if (runId === "old" && params.chart_symbol === "OLD") return oldChart.promise;
+      return Promise.resolve({ status: "success", run_id: "new", prompt: "New run" });
+    });
+    apiMock.getRunCode.mockResolvedValue({});
+
+    const router = renderRunDetail();
+    expect(await screen.findByText("Old run")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(apiMock.getRun).toHaveBeenCalledWith("old", { chart_symbol: "OLD" });
+    });
+
+    await act(async () => { await router.navigate("/runs/new"); });
+    expect(await screen.findByText("New run")).toBeInTheDocument();
+
+    await act(async () => {
+      oldChart.resolve({
+        status: "success",
+        run_id: "old",
+        chart_symbols: ["OLD"],
+        trade_log: [{ note: "OLD TRADE" }],
+      });
+      await oldChart.promise;
+    });
+
+    expect(screen.getByText("New run")).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "OLD" })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Trades" }));
+    expect(screen.queryByText("OLD TRADE")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,6 +3,7 @@ import react from "@vitejs/plugin-react";
 import path from "path";
 
 const PROXY_PATHS = [
+  "/auth",
   "/sessions",
   "/swarm/presets",
   "/swarm/runs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,7 +146,7 @@ qq = [
 ]
 slack = [
     "slack-sdk>=3.33.0",
-    "slackify-markdown>=4.4.0",
+    "slackify-markdown>=0.2.4,<1",
 ]
 telegram = [
     "python-telegram-bot>=21.0",
@@ -177,7 +177,7 @@ channels = [
     "qrcode>=7.4.2",
     "qq-botpy>=1.2.0",
     "slack-sdk>=3.33.0",
-    "slackify-markdown>=4.4.0",
+    "slackify-markdown>=0.2.4,<1",
     "websockets>=12.0",
     "wecom-aibot-sdk>=1.0.0",
 ]


### PR DESCRIPTION
## Summary

- Consolidates the thirteen single-purpose fixes into PR #584, as requested
- Keeps every fix as a separate DCO-signed commit and rebases the full batch onto current `main`.
- Fixes confirmed problems in packaging, the web app, scheduled research, background commands, swarm runs, and the CLI.

## Changes

1. PR #584 fixes the Slack optional dependency so the published package can be installed.
2. PR #586 sends frontend `/auth` requests through the Vite development proxy.
3. PR #588 prevents an old comparison request from replacing newer results.
4. PR #590 keeps run-detail data tied to the current route and ignores late responses from the previous run.
5. PR #592 clears correlation output when its inputs change and ignores stale responses.
6. PR #596 applies standard cron rules when both day-of-month and day-of-week are restricted.
7. PR #600 stops the full process tree after a background-command timeout while preserving exit-code reporting.
8. PR #604 finds nested swarm artifacts, returns stable run-relative paths, and excludes symlink escapes.
9. PR #606 removes private task fields and local paths from the public swarm run response.
10. PR #612 reads and writes continued CLI sessions in one trace directory.
11. PR #614 cleans up development-server child processes after startup failures, interrupts, and exits.
12. PR #618 returns a failure status when a channel start or stop command fails, including JSON output mode.
13. PR #642 ignores authenticated SSE connections that become stale while waiting for a ticket or retry.

## Integration notes

- PR #600 keeps the newer `main` behavior that reports background exit codes and treats a nonzero exit as an error.
- PR #604 keeps the newer swarm output contract tests while adding recursive, contained artifact collection.
- PR #606 keeps the newer swarm SSE behavior and the existing `worker_iterations` response field while adding task redaction.

## Scope and risk

- Affected areas: optional dependencies, the Vite development server, frontend request state, scheduled research, background commands, swarm artifacts and API responses, and CLI process handling.
- Deliberately out of scope: broker and order behavior, live trading, MCP providers, database schemas, deployment, and public documentation.
- Network and secret risk: the Vite change only proxies the existing local `/auth` endpoint. No credentials, tokens, local paths, or private run data were added.
- Rollback: each fix is a separate commit, so a maintainer can revert one fix without reverting the full batch.

## Test Plan

- [x] Full Python suite: 5,557 passed and 10 skipped with the CI exclusions and coverage enabled.
- [x] Focused and adjacent Python regressions: 112 passed.
- [x] Full frontend suite under Node 20.20.2: 284 passed.
- [x] TypeScript compilation and the Vite production build passed under Node 20.20.2.
- [x] Repository safety gates, environment gate, and Python compile checks passed.
- [x] New regression tests cover every fix.
- [x] `git diff --check` passed, and all thirteen commits have matching DCO sign-offs.
- [ ] Manual live testing was not run because these paths are covered by automated regressions and do not require a live broker, deployment, or external service.

## Checklist

- [x] No protected `src/agent/`, `src/session/`, or `src/providers/` area was changed.
- [x] No API keys, secrets, local machine paths, or private data were added.
- [x] Code follows `CONTRIBUTING.md` and `AGENT_CONTRIBUTOR_GUIDE.md`.
- [x] Documentation is not needed because these changes restore existing behavior and add regression coverage.
