### PR TITLE
Keep comparison results tied to the selected runs

### DIFF
--- a/frontend/src/pages/Compare.tsx
+++ b/frontend/src/pages/Compare.tsx
@@ -208,6 +208,8 @@ export function Compare() {
   const [rightCurve, setRightCurve] = useState<EquityPoint[]>([]);
   const [leftLoading, setLeftLoading] = useState(false);
   const [rightLoading, setRightLoading] = useState(false);
+  const leftRequestGeneration = useRef(0);
+  const rightRequestGeneration = useRef(0);
 
   useEffect(() => {
     api.listRuns().then((items) => {
@@ -220,39 +222,65 @@ export function Compare() {
   }, []);
 
   useEffect(() => {
-    if (leftId) {
-      setLeftLoading(true);
-      api.getRun(leftId).then((d: RunData) => {
+    const generation = ++leftRequestGeneration.current;
+    setLeftData(null);
+    setLeftCurve([]);
+
+    if (!leftId) {
+      setLeftLoading(false);
+      return;
+    }
+
+    setLeftLoading(true);
+    api.getRun(leftId).then((d: RunData) => {
+      if (leftRequestGeneration.current === generation) {
         setLeftData(d.metrics || null);
         setLeftCurve(d.equity_curve || []);
-      }).catch((error) => {
+      }
+    }).catch((error) => {
+      if (leftRequestGeneration.current === generation) {
         setLeftData(null);
         setLeftCurve([]);
         toast.error(error instanceof Error ? error.message : i18n.t("compare.loadError"));
-      })
-        .finally(() => setLeftLoading(false));
-    } else {
-      setLeftData(null);
-      setLeftCurve([]);
-    }
+      }
+    }).finally(() => {
+      if (leftRequestGeneration.current === generation) setLeftLoading(false);
+    });
+
+    return () => {
+      if (leftRequestGeneration.current === generation) leftRequestGeneration.current += 1;
+    };
   }, [leftId]);
 
   useEffect(() => {
-    if (rightId) {
-      setRightLoading(true);
-      api.getRun(rightId).then((d: RunData) => {
+    const generation = ++rightRequestGeneration.current;
+    setRightData(null);
+    setRightCurve([]);
+
+    if (!rightId) {
+      setRightLoading(false);
+      return;
+    }
+
+    setRightLoading(true);
+    api.getRun(rightId).then((d: RunData) => {
+      if (rightRequestGeneration.current === generation) {
         setRightData(d.metrics || null);
         setRightCurve(d.equity_curve || []);
-      }).catch((error) => {
+      }
+    }).catch((error) => {
+      if (rightRequestGeneration.current === generation) {
         setRightData(null);
         setRightCurve([]);
         toast.error(error instanceof Error ? error.message : i18n.t("compare.loadError"));
-      })
-        .finally(() => setRightLoading(false));
-    } else {
-      setRightData(null);
-      setRightCurve([]);
-    }
+      }
+    }).finally(() => {
+      if (rightRequestGeneration.current === generation) setRightLoading(false);
+    });
+
+    return () => {
+      if (rightRequestGeneration.current === generation) rightRequestGeneration.current += 1;
+    };
   }, [rightId]);
 
   const leftRun = runs.find((r) => r.run_id === leftId);

--- a/frontend/src/pages/__tests__/Compare.test.tsx
+++ b/frontend/src/pages/__tests__/Compare.test.tsx
@@ -1,0 +1,96 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { Compare } from "../Compare";
+import type { RunData } from "@/lib/api";
+
+const apiMock = vi.hoisted(() => ({
+  listRuns: vi.fn(),
+  getRun: vi.fn(),
+}));
+const toastMock = vi.hoisted(() => ({ error: vi.fn() }));
+
+vi.mock("@/lib/api", () => ({ api: apiMock }));
+vi.mock("sonner", () => ({ toast: toastMock }));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const runs = [
+  { run_id: "right", prompt: "Right", status: "success" },
+  { run_id: "old", prompt: "Old", status: "success" },
+  { run_id: "new", prompt: "New", status: "success" },
+];
+
+describe("Compare page", () => {
+  beforeEach(() => {
+    apiMock.listRuns.mockReset();
+    apiMock.getRun.mockReset();
+    toastMock.error.mockReset();
+    apiMock.listRuns.mockResolvedValue(runs);
+  });
+
+  it("keeps the newest result when an older request resolves later", async () => {
+    const oldRequest = deferred<RunData>();
+    const newRequest = deferred<RunData>();
+    apiMock.getRun.mockImplementation((runId: string) => {
+      if (runId === "old") return oldRequest.promise;
+      if (runId === "new") return newRequest.promise;
+      return Promise.resolve({ status: "success", run_id: runId });
+    });
+
+    render(<Compare />);
+    const selectors = await screen.findAllByRole("combobox");
+    await waitFor(() => expect(selectors[0]).toHaveValue("old"));
+    fireEvent.change(selectors[0], { target: { value: "new" } });
+
+    await act(async () => {
+      newRequest.resolve({ status: "success", run_id: "new", metrics: { total_return: 0.3 } });
+      await newRequest.promise;
+    });
+    expect(await screen.findByText("30.00%")).toBeInTheDocument();
+
+    await act(async () => {
+      oldRequest.resolve({ status: "success", run_id: "old", metrics: { total_return: 0.1 } });
+      await oldRequest.promise;
+    });
+
+    expect(screen.getByText("30.00%")).toBeInTheDocument();
+    expect(screen.queryByText("10.00%")).not.toBeInTheDocument();
+  });
+
+  it("ignores an older error and keeps loading the current selection", async () => {
+    const oldRequest = deferred<RunData>();
+    const newRequest = deferred<RunData>();
+    apiMock.getRun.mockImplementation((runId: string) => {
+      if (runId === "old") return oldRequest.promise;
+      if (runId === "new") return newRequest.promise;
+      return Promise.resolve({ status: "success", run_id: runId });
+    });
+
+    const { container } = render(<Compare />);
+    const selectors = await screen.findAllByRole("combobox");
+    await waitFor(() => expect(selectors[0]).toHaveValue("old"));
+    fireEvent.change(selectors[0], { target: { value: "new" } });
+
+    await act(async () => {
+      oldRequest.reject(new Error("old request failed"));
+      await oldRequest.promise.catch(() => undefined);
+    });
+
+    expect(toastMock.error).not.toHaveBeenCalled();
+    expect(container.querySelector(".animate-pulse")).toBeInTheDocument();
+    expect(screen.queryByText("Select two runs to compare their metrics.")).not.toBeInTheDocument();
+
+    await act(async () => {
+      newRequest.resolve({ status: "success", run_id: "new", metrics: { total_return: 0.2 } });
+      await newRequest.promise;
+    });
+    expect(await screen.findByText("20.00%")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Track each side's newest request and ignore results, errors, and loading updates from older requests.

## Why

Closes #587.

## Changes

- Implements only finding A19.
- Adds focused regression coverage for this behavior.

## Test Plan

- [x] Focused regression check passed: cd frontend && vitest run src/pages/__tests__/Compare.test.tsx
- [x] New regression tests added where applicable.
- [x] The combined audit stack passed 5,462 Python tests and 253 frontend tests.

## Risk and scope

This pull request contains one finding and one signed commit. Reverting this commit restores the previous behavior.

## Checklist

- [x] No protected area was changed without prior discussion.
- [x] No API keys, secrets, or machine-specific paths were added.
- [x] The change follows CONTRIBUTING.md.
- [x] Documentation was updated where needed, or no documentation change was required.