### PR TITLE
Reject blank required hypothesis updates

### DIFF
--- a/agent/src/hypotheses/registry.py
+++ b/agent/src/hypotheses/registry.py
@@ -242,26 +242,39 @@ class HypothesisRegistry:
 
         Raises:
             KeyError: If the hypothesis does not exist.
-            ValueError: If status is unknown.
+            ValueError: If a required field is blank or status is unknown.
         """
+        normalized_title = title.strip() if title is not None else None
+        if title is not None and not normalized_title:
+            raise ValueError("title is required")
+        normalized_thesis = thesis.strip() if thesis is not None else None
+        if thesis is not None and not normalized_thesis:
+            raise ValueError("thesis is required")
+        normalized_status = _validate_status(status) if status is not None else None
+        normalized_universe = universe.strip() if universe is not None else None
+        normalized_signal_definition = signal_definition.strip() if signal_definition is not None else None
+        normalized_data_sources = _coerce_str_list(data_sources) if data_sources is not None else None
+        normalized_skills = _coerce_str_list(skills) if skills is not None else None
+        normalized_invalidation_notes = invalidation_notes.strip() if invalidation_notes is not None else None
+
         records = self.list()
         hyp = self._find_required(records, hypothesis_id)
-        if title is not None:
-            hyp.title = title.strip()
-        if thesis is not None:
-            hyp.thesis = thesis.strip()
-        if status is not None:
-            hyp.status = _validate_status(status)
-        if universe is not None:
-            hyp.universe = universe.strip()
-        if signal_definition is not None:
-            hyp.signal_definition = signal_definition.strip()
-        if data_sources is not None:
-            hyp.data_sources = _coerce_str_list(data_sources)
-        if skills is not None:
-            hyp.skills = _coerce_str_list(skills)
-        if invalidation_notes is not None:
-            hyp.invalidation_notes = invalidation_notes.strip()
+        if normalized_title is not None:
+            hyp.title = normalized_title
+        if normalized_thesis is not None:
+            hyp.thesis = normalized_thesis
+        if normalized_status is not None:
+            hyp.status = normalized_status
+        if normalized_universe is not None:
+            hyp.universe = normalized_universe
+        if normalized_signal_definition is not None:
+            hyp.signal_definition = normalized_signal_definition
+        if normalized_data_sources is not None:
+            hyp.data_sources = normalized_data_sources
+        if normalized_skills is not None:
+            hyp.skills = normalized_skills
+        if normalized_invalidation_notes is not None:
+            hyp.invalidation_notes = normalized_invalidation_notes
         hyp.updated_at = _utc_now()
         self._save(records)
         return hyp

--- a/agent/tests/test_hypothesis_registry.py
+++ b/agent/tests/test_hypothesis_registry.py
@@ -72,6 +72,43 @@ def test_reject_invalid_status(storage_path: Path) -> None:
         registry.update(hyp.hypothesis_id, status="live_trading")
 
 
+@pytest.mark.parametrize(
+    ("updates", "error"),
+    [
+        ({"title": "   "}, "title is required"),
+        ({"title": "Changed title", "thesis": "\t\n"}, "thesis is required"),
+    ],
+)
+def test_update_rejects_blank_required_fields_before_mutation(
+    storage_path: Path,
+    updates: dict[str, str],
+    error: str,
+) -> None:
+    registry = HypothesisRegistry()
+    hyp = registry.create(title="Original title", thesis="Original thesis")
+    before = storage_path.read_text(encoding="utf-8")
+
+    with pytest.raises(ValueError, match=error):
+        registry.update(hyp.hypothesis_id, **updates)
+
+    assert storage_path.read_text(encoding="utf-8") == before
+    persisted = HypothesisRegistry().list()[0]
+    assert persisted.title == "Original title"
+    assert persisted.thesis == "Original thesis"
+
+
+def test_update_tool_reports_blank_required_field_without_persisting_it(storage_path: Path) -> None:
+    registry = HypothesisRegistry()
+    hyp = registry.create(title="Tool title", thesis="Tool thesis")
+
+    result = json.loads(UpdateHypothesisTool().execute(hypothesis_id=hyp.hypothesis_id, title="  "))
+
+    assert result == {"status": "error", "error": "title is required"}
+    persisted = HypothesisRegistry().list()[0]
+    assert persisted.title == "Tool title"
+    assert persisted.thesis == "Tool thesis"
+
+
 def test_link_backtest_run_card(storage_path: Path) -> None:
     registry = HypothesisRegistry()
     hyp = registry.create(title="ETF momentum", thesis="ETF momentum persists monthly.")


### PR DESCRIPTION
## Summary

- Validate and normalize update values before changing memory or disk, using the same required-field rules as creation.

## Why

Closes #593.

## Changes

- Implements only finding A25.
- Adds focused regression coverage for this behavior.

## Test Plan

- [x] Focused regression check passed: cd agent && pytest tests/test_hypothesis_registry.py -q
- [x] New regression tests added where applicable.
- [x] The combined audit stack passed 5,462 Python tests and 253 frontend tests.

## Risk and scope

This pull request contains one finding and one signed commit. Reverting this commit restores the previous behavior.

## Checklist

- [x] No protected area was changed without prior discussion.
- [x] No API keys, secrets, or machine-specific paths were added.
- [x] The change follows CONTRIBUTING.md.
- [x] Documentation was updated where needed, or no documentation change was required.