### PR TITLE
Match the standard cron rules for days

### DIFF
--- a/agent/src/scheduled_research/executor.py
+++ b/agent/src/scheduled_research/executor.py
@@ -111,12 +111,19 @@ def _parse_cron_field(part: str, low: int, high: int) -> set[int] | None:
 
 
 def _day_matches(dt: datetime, doms: set[int] | None, months: set[int] | None, dows: set[int] | None) -> bool:
+    if months is not None and dt.month not in months:
+        return False
+
     cron_day_of_week = (dt.weekday() + 1) % 7  # cron convention: Sunday == 0
-    return (
-        (doms is None or dt.day in doms)
-        and (months is None or dt.month in months)
-        and (dows is None or cron_day_of_week in dows)
-    )
+    day_of_month_matches = doms is None or dt.day in doms
+    day_of_week_matches = dows is None or cron_day_of_week in dows
+
+    # Standard five-field cron treats day-of-month and day-of-week as an OR
+    # when both fields are restricted. A wildcard in either field keeps the
+    # other field authoritative.
+    if doms is not None and dows is not None:
+        return day_of_month_matches or day_of_week_matches
+    return day_of_month_matches and day_of_week_matches
 
 
 class ScheduledResearchExecutor:

--- a/agent/tests/test_scheduled_research_executor.py
+++ b/agent/tests/test_scheduled_research_executor.py
@@ -94,6 +94,26 @@ def test_cron_job_next_due_and_not_before_due_time(tmp_path: Path) -> None:
     assert saved.next_run_at == following_due
 
 
+def test_cron_uses_standard_or_semantics_for_restricted_day_fields() -> None:
+    thursday = _ms(2026, 6, 11, 0, 1)
+
+    # The 12th is a Friday, so it matches day-of-week even though it is not
+    # the 13th day of the month.
+    assert next_due("0 0 13 * 5", thursday) == _ms(2026, 6, 12, 0, 0)
+
+    friday = _ms(2026, 6, 12, 0, 1)
+    # The 13th is a Saturday, so the following run matches day-of-month even
+    # though it is not Friday.
+    assert next_due("0 0 13 * 5", friday) == _ms(2026, 6, 13, 0, 0)
+
+
+def test_cron_wildcard_day_field_leaves_other_day_field_authoritative() -> None:
+    thursday = _ms(2026, 6, 11, 0, 1)
+
+    assert next_due("0 0 13 * *", thursday) == _ms(2026, 6, 13, 0, 0)
+    assert next_due("0 0 * * 5", thursday) == _ms(2026, 6, 12, 0, 0)
+
+
 def test_dispatch_failure_marks_failed_and_tick_continues(tmp_path: Path) -> None:
     store = _store(tmp_path)
     store.upsert(_job("bad", next_run_at=10))


### PR DESCRIPTION
## Summary

- Use the standard either-or rule when both day fields are restricted and preserve wildcard behavior.

## Why

Closes #595.

## Changes

- Implements only finding A26.
- Adds focused regression coverage for this behavior.

## Test Plan

- [x] Focused regression check passed: cd agent && pytest tests/test_scheduled_research_executor.py -q
- [x] New regression tests added where applicable.
- [x] The combined audit stack passed 5,462 Python tests and 253 frontend tests.

## Risk and scope

This pull request contains one finding and one signed commit. Reverting this commit restores the previous behavior.

## Checklist

- [x] No protected area was changed without prior discussion.
- [x] No API keys, secrets, or machine-specific paths were added.
- [x] The change follows CONTRIBUTING.md.
- [x] Documentation was updated where needed, or no documentation change was required.