### PR TITLE
Report nonzero background exits as errors

### DIFF
--- a/agent/src/tools/background_tools.py
+++ b/agent/src/tools/background_tools.py
@@ -32,27 +32,36 @@ class BackgroundManager:
             JSON string containing status and task_id.
         """
         task_id = uuid.uuid4().hex[:8]
-        self.tasks[task_id] = {"status": "running", "result": None, "command": command}
+        self.tasks[task_id] = {
+            "status": "running",
+            "result": None,
+            "command": command,
+            "exit_code": None,
+        }
         threading.Thread(target=self._execute, args=(task_id, command), daemon=True).start()
         return json.dumps({"status": "ok", "task_id": task_id, "message": f"Started: {command[:80]}"})
 
     def _execute(self, task_id: str, command: str) -> None:
+        exit_code: int | None = None
         try:
             r = subprocess.run(command, shell=True, cwd=WORKDIR,
                                capture_output=True, text=True, timeout=300,
                                encoding="utf-8", errors="replace")
             output = (r.stdout + r.stderr).strip()[:50000]
-            status = "completed"
+            exit_code = r.returncode
+            status = "completed" if exit_code == 0 else "error"
         except subprocess.TimeoutExpired:
             output, status = "Timeout (300s)", "timeout"
         except Exception as e:
             output, status = str(e), "error"
         self.tasks[task_id]["status"] = status
         self.tasks[task_id]["result"] = output or "(no output)"
+        self.tasks[task_id]["exit_code"] = exit_code
         with self._lock:
             self._notifications.append({
                 "task_id": task_id, "status": status,
                 "command": command[:80], "result": (output or "")[:500],
+                "exit_code": exit_code,
             })
 
     def check(self, task_id: Optional[str] = None) -> str:
@@ -61,7 +70,8 @@ class BackgroundManager:
             if not t:
                 return json.dumps({"status": "error", "error": f"Unknown task {task_id}"})
             return json.dumps({"status": t["status"], "command": t["command"][:60],
-                                "result": t.get("result") or "(running)"}, ensure_ascii=False)
+                                "result": t.get("result") or "(running)",
+                                "exit_code": t.get("exit_code")}, ensure_ascii=False)
         lines = [f"{tid}: [{t['status']}] {t['command'][:60]}" for tid, t in self.tasks.items()]
         return "\n".join(lines) if lines else "No background tasks."
 

--- a/agent/tests/test_background_tools.py
+++ b/agent/tests/test_background_tools.py
@@ -1,0 +1,42 @@
+"""Regression tests for background command lifecycle reporting."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from src.tools.background_tools import BackgroundManager
+
+
+def _execute(manager: BackgroundManager, task_id: str, command: str) -> dict:
+    manager.tasks[task_id] = {
+        "status": "running",
+        "result": None,
+        "command": command,
+        "exit_code": None,
+    }
+    manager._execute(task_id, command)
+    return manager.tasks[task_id]
+
+
+def test_nonzero_exit_is_reported_as_error() -> None:
+    manager = BackgroundManager()
+    command = f'"{sys.executable}" -c "import sys; print(\'failed output\'); sys.exit(7)"'
+
+    task = _execute(manager, "failed", command)
+
+    assert task["status"] == "error"
+    assert task["exit_code"] == 7
+    assert "failed output" in task["result"]
+    checked = json.loads(manager.check("failed"))
+    assert checked["status"] == "error"
+    assert checked["exit_code"] == 7
+    assert manager.drain_notifications() == [
+        {
+            "task_id": "failed",
+            "status": "error",
+            "command": command[:80],
+            "result": "failed output",
+            "exit_code": 7,
+        }
+    ]


### PR DESCRIPTION
## Summary

- Save the exit code and mark a background command complete only when that code is zero.

## Why

Closes #597.

## Changes

- Implements only finding A27.
- Adds focused regression coverage for this behavior.

## Test Plan

- [x] Focused regression check passed: cd agent && pytest tests/test_background_tools.py -q
- [x] New regression tests added where applicable.
- [x] The combined audit stack passed 5,462 Python tests and 253 frontend tests.

## Risk and scope

This pull request contains one finding and one signed commit. Reverting this commit restores the previous behavior.

## Checklist

- [x] No protected area was changed without prior discussion.
- [x] No API keys, secrets, or machine-specific paths were added.
- [x] The change follows CONTRIBUTING.md.
- [x] Documentation was updated where needed, or no documentation change was required.