### PR TITLE
Stop all child processes after a background timeout

### DIFF
--- a/agent/src/tools/background_tools.py
+++ b/agent/src/tools/background_tools.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import os
+import signal
 import subprocess
 import threading
 import uuid
@@ -12,6 +14,77 @@ from typing import Any, Dict, List, Optional
 from src.agent.tools import BaseTool
 
 WORKDIR = Path(__file__).resolve().parents[2]
+_COMMAND_TIMEOUT_SECONDS = 300.0
+_TERMINATION_GRACE_SECONDS = 2.0
+_MAX_OUTPUT_CHARS = 50_000
+
+
+def _start_process(command: str) -> subprocess.Popen[str]:
+    """Start a shell command in a process group that can be stopped as a unit."""
+    kwargs: dict[str, Any] = {
+        "shell": True,
+        "cwd": WORKDIR,
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "text": True,
+        "encoding": "utf-8",
+        "errors": "replace",
+    }
+    if os.name == "nt":
+        kwargs["creationflags"] = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+    else:
+        kwargs["start_new_session"] = True
+    return subprocess.Popen(command, **kwargs)
+
+
+def _signal_posix_process_group(process: subprocess.Popen[str], sig: int) -> None:
+    try:
+        os.killpg(process.pid, sig)
+    except ProcessLookupError:
+        pass
+
+
+def _taskkill_windows_process_tree(process: subprocess.Popen[str]) -> None:
+    """Ask Windows to stop the process and every descendant."""
+    try:
+        subprocess.run(
+            ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+    except OSError:
+        if process.poll() is None:
+            process.kill()
+
+
+def _terminate_process_tree(process: subprocess.Popen[str]) -> tuple[str, str]:
+    """Terminate a timed-out process tree, drain its pipes, and reap its root."""
+    if os.name == "nt":
+        _taskkill_windows_process_tree(process)
+        try:
+            return process.communicate(timeout=_TERMINATION_GRACE_SECONDS)
+        except subprocess.TimeoutExpired:
+            if process.poll() is None:
+                process.kill()
+            return process.communicate()
+
+    _signal_posix_process_group(process, signal.SIGTERM)
+    try:
+        stdout, stderr = process.communicate(timeout=_TERMINATION_GRACE_SECONDS)
+    except subprocess.TimeoutExpired:
+        _signal_posix_process_group(process, signal.SIGKILL)
+        return process.communicate()
+
+    # The shell can exit before a descendant that ignored SIGTERM. The group
+    # retains the shell's process-group id, so this final signal prevents an
+    # orphan even when that descendant closed its inherited output pipes.
+    _signal_posix_process_group(process, signal.SIGKILL)
+    return stdout, stderr
+
+
+def _combined_output(stdout: str | None, stderr: str | None) -> str:
+    return ((stdout or "") + (stderr or "")).strip()[:_MAX_OUTPUT_CHARS]
 
 
 class BackgroundManager:
@@ -37,14 +110,24 @@ class BackgroundManager:
         return json.dumps({"status": "ok", "task_id": task_id, "message": f"Started: {command[:80]}"})
 
     def _execute(self, task_id: str, command: str) -> None:
+        process: subprocess.Popen[str] | None = None
         try:
-            r = subprocess.run(command, shell=True, cwd=WORKDIR,
-                               capture_output=True, text=True, timeout=300,
-                               encoding="utf-8", errors="replace")
-            output = (r.stdout + r.stderr).strip()[:50000]
-            status = "completed"
-        except subprocess.TimeoutExpired:
-            output, status = "Timeout (300s)", "timeout"
+            process = _start_process(command)
+            try:
+                stdout, stderr = process.communicate(timeout=_COMMAND_TIMEOUT_SECONDS)
+                output = _combined_output(stdout, stderr)
+                status = "completed"
+            except subprocess.TimeoutExpired:
+                stdout, stderr = _terminate_process_tree(process)
+                partial_output = _combined_output(stdout, stderr)
+                timeout_message = f"Timeout ({_COMMAND_TIMEOUT_SECONDS:g}s)"
+                output = (
+                    f"{partial_output}\n{timeout_message}"
+                    if partial_output
+                    else timeout_message
+                )
+                output = output[:_MAX_OUTPUT_CHARS]
+                status = "timeout"
         except Exception as e:
             output, status = str(e), "error"
         self.tasks[task_id]["status"] = status

--- a/agent/tests/test_background_tools.py
+++ b/agent/tests/test_background_tools.py
@@ -1,0 +1,60 @@
+"""Regression tests for background command lifecycle reporting."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from src.tools import background_tools
+from src.tools.background_tools import BackgroundManager
+
+
+def _execute(manager: BackgroundManager, task_id: str, command: str) -> dict:
+    manager.tasks[task_id] = {
+        "status": "running",
+        "result": None,
+        "command": command,
+    }
+    manager._execute(task_id, command)
+    return manager.tasks[task_id]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group regression")
+def test_timeout_kills_descendant_and_reaps_shell(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started_marker = tmp_path / "child-started"
+    orphan_marker = tmp_path / "orphan-wrote-after-timeout"
+    child_code = (
+        "import time; from pathlib import Path; "
+        f"Path({str(started_marker)!r}).write_text('started', encoding='utf-8'); "
+        "time.sleep(1.5); "
+        f"Path({str(orphan_marker)!r}).write_text('orphan', encoding='utf-8')"
+    )
+    command = f"{shlex.quote(sys.executable)} -c {shlex.quote(child_code)} & wait"
+    processes: list[background_tools.subprocess.Popen[str]] = []
+    real_popen = background_tools.subprocess.Popen
+
+    def tracked_popen(*args, **kwargs):
+        process = real_popen(*args, **kwargs)
+        processes.append(process)
+        return process
+
+    monkeypatch.setattr(background_tools, "_COMMAND_TIMEOUT_SECONDS", 0.8)
+    monkeypatch.setattr(background_tools, "_TERMINATION_GRACE_SECONDS", 0.2)
+    monkeypatch.setattr(background_tools.subprocess, "Popen", tracked_popen)
+
+    manager = BackgroundManager()
+    task = _execute(manager, "timeout", command)
+
+    assert started_marker.exists()
+    assert task["status"] == "timeout"
+    assert processes[0].poll() is not None
+    time.sleep(1.0)
+    assert not orphan_marker.exists()


### PR DESCRIPTION
## Summary

- Run each command in a process group, stop the whole group on timeout, drain output, and reap the main process.

## Why

Closes #599.

## Changes

- Implements only finding A28.
- Adds focused regression coverage for this behavior.

## Test Plan

- [x] Focused regression check passed: cd agent && pytest tests/test_background_tools.py -q
- [x] New regression tests added where applicable.
- [x] The combined audit stack passed 5,462 Python tests and 253 frontend tests.

## Risk and scope

This pull request contains one finding and one signed commit. Reverting this commit restores the previous behavior.

## Checklist

- [x] No protected area was changed without prior discussion.
- [x] No API keys, secrets, or machine-specific paths were added.
- [x] The change follows CONTRIBUTING.md.
- [x] Documentation was updated where needed, or no documentation change was required.