### PR TITLE
Save nested swarm output files safely

### DIFF
--- a/agent/src/swarm/worker.py
+++ b/agent/src/swarm/worker.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -950,14 +949,34 @@ def _write_summary(artifact_dir: Path, summary: str) -> None:
 
 
 def _collect_artifacts(artifact_dir: Path) -> list[str]:
-    """Collect all artifact file paths from agent's artifact directory.
+    """Collect regular artifacts as deterministic run-relative paths.
 
     Args:
         artifact_dir: Path to artifacts/{agent_id}/ directory.
 
     Returns:
-        List of artifact file path strings.
+        Sorted POSIX-style paths relative to the swarm run directory. Symlinks
+        and files that resolve outside the agent artifact directory are omitted.
     """
     if not artifact_dir.exists():
         return []
-    return [str(p) for p in artifact_dir.iterdir() if p.is_file()]
+
+    run_dir = artifact_dir.parent.parent.resolve()
+    artifact_root = artifact_dir.resolve()
+    if not artifact_root.is_relative_to(run_dir):
+        return []
+
+    artifacts: list[str] = []
+    for path in artifact_dir.rglob("*"):
+        try:
+            if path.is_symlink():
+                continue
+            resolved = path.resolve(strict=True)
+            if not resolved.is_relative_to(artifact_root) or not resolved.is_file():
+                continue
+            artifacts.append(resolved.relative_to(run_dir).as_posix())
+        except (OSError, RuntimeError, ValueError):
+            # A concurrently removed file, symlink loop, or containment
+            # failure is not a durable artifact and must not escape the run.
+            continue
+    return sorted(artifacts)

--- a/agent/tests/test_swarm_output_contract.py
+++ b/agent/tests/test_swarm_output_contract.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import threading
 from pathlib import Path
 
+import pytest
+
 from src.swarm.models import (
     RunStatus,
     SwarmAgentSpec,
@@ -29,6 +31,7 @@ from src.swarm.models import (
 from src.swarm.store import SwarmStore
 from src.swarm.worker import (
     _classify_deliverable,
+    _collect_artifacts,
     _is_data_agent,
     _is_error_result,
     _report_written,
@@ -206,3 +209,34 @@ def test_is_error_result_other_status_values():
     not error envelopes (the worker still credits them as a tool call)."""
     assert _is_error_result('{"status": "degenerate", "warning": "T=0"}') is False
     assert _is_error_result('{"status": "warning"}') is False
+
+
+def test_collect_artifacts_recurses_and_returns_sorted_run_relative_paths(
+    tmp_path: Path,
+) -> None:
+    artifact_dir = tmp_path / "run" / "artifacts" / "analyst"
+    (artifact_dir / "nested").mkdir(parents=True)
+    (artifact_dir / "other").mkdir()
+    (artifact_dir / "summary.md").write_text("summary", encoding="utf-8")
+    (artifact_dir / "nested" / "report.json").write_text("{}", encoding="utf-8")
+    (artifact_dir / "other" / "report.json").write_text("{}", encoding="utf-8")
+
+    assert _collect_artifacts(artifact_dir) == [
+        "artifacts/analyst/nested/report.json",
+        "artifacts/analyst/other/report.json",
+        "artifacts/analyst/summary.md",
+    ]
+
+
+def test_collect_artifacts_rejects_symlink_escape(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "run" / "artifacts" / "analyst"
+    artifact_dir.mkdir(parents=True)
+    outside = tmp_path / "outside.txt"
+    outside.write_text("private", encoding="utf-8")
+    escape = artifact_dir / "escape.txt"
+    try:
+        escape.symlink_to(outside)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are not available on this platform")
+
+    assert _collect_artifacts(artifact_dir) == []


### PR DESCRIPTION
## Summary

- Collect normal files recursively, save sorted run-relative paths, and reject links that leave the artifact folder.

## Why

Closes #603.

## Changes

- Implements only finding B13.
- Adds focused regression coverage for this behavior.

## Test Plan

- [x] Focused regression check passed: cd agent && pytest tests/test_swarm_output_contract.py -q
- [x] New regression tests added where applicable.
- [x] The combined audit stack passed 5,462 Python tests and 253 frontend tests.

## Risk and scope

This pull request contains one finding and one signed commit. Reverting this commit restores the previous behavior.

## Checklist

- [x] No protected area was changed without prior discussion.
- [x] No API keys, secrets, or machine-specific paths were added.
- [x] The change follows CONTRIBUTING.md.
- [x] Documentation was updated where needed, or no documentation change was required.