### PR TITLE
Hide private fields in swarm task details

### DIFF
--- a/agent/src/api/swarm_routes.py
+++ b/agent/src/api/swarm_routes.py
@@ -141,6 +141,8 @@ def register_swarm_routes(
 
         run = runtime._store.reconcile_run(loaded, write=True)
 
+        from src.swarm.serialization import serialize_task
+
         return {
             "id": run.id,
             "preset_name": run.preset_name,
@@ -148,7 +150,15 @@ def register_swarm_routes(
             "is_stale": runtime._store.is_run_stale(run),
             "user_vars": run.user_vars,
             "agents": [a.model_dump() for a in run.agents],
-            "tasks": [t.model_dump() for t in run.tasks],
+            "tasks": [
+                {
+                    **serialize_task(t),
+                    # Keep the existing REST field while sharing the public
+                    # serializer used by the other swarm read paths.
+                    "worker_iterations": getattr(t, "worker_iterations", 0),
+                }
+                for t in run.tasks
+            ],
             "created_at": run.created_at,
             "completed_at": run.completed_at,
             "final_report": run.final_report,

--- a/agent/tests/test_swarm_route_contracts.py
+++ b/agent/tests/test_swarm_route_contracts.py
@@ -1,0 +1,83 @@
+"""Public swarm REST and SSE contract regressions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+import api_server
+import src.api.swarm_routes as swarm_routes
+from src.swarm.models import RunStatus, SwarmRun, SwarmTask
+from src.swarm.store import SwarmStore
+
+
+@pytest.fixture
+def swarm_store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> SwarmStore:
+    """Route the process-wide swarm endpoint at an isolated on-disk store."""
+    store = SwarmStore(base_dir=tmp_path / "runs")
+    monkeypatch.delenv("API_AUTH_KEY", raising=False)
+    monkeypatch.setattr(api_server, "_API_KEY", "")
+    monkeypatch.setattr(swarm_routes, "_swarm_runtime", SimpleNamespace(_store=store))
+    return store
+
+
+def _client() -> TestClient:
+    return TestClient(api_server.app, client=("127.0.0.1", 50000))
+
+
+def _create_run(
+    store: SwarmStore,
+    *,
+    run_id: str = "run-contract",
+    status: RunStatus = RunStatus.pending,
+    tasks: list[SwarmTask] | None = None,
+) -> SwarmRun:
+    run = SwarmRun(
+        id=run_id,
+        preset_name="contract-test",
+        status=status,
+        created_at="2026-07-16T00:00:00+00:00",
+        completed_at=(
+            "2026-07-16T00:00:01+00:00" if status == RunStatus.completed else None
+        ),
+        tasks=tasks or [],
+    )
+    store.create_run(run)
+    return run
+
+
+def test_swarm_detail_uses_redacted_public_task_projection(
+    swarm_store: SwarmStore,
+) -> None:
+    internal_path = str(
+        Path.cwd() / "agent" / ".swarm" / "runs" / "secret" / "task.log"
+    )
+    _create_run(
+        swarm_store,
+        tasks=[
+            SwarmTask(
+                id="task-1",
+                agent_id="analyst",
+                prompt_template="internal prompt",
+                summary="Public summary",
+                artifacts=[internal_path],
+                error=f"failed while reading {internal_path}",
+                worker_iterations=3,
+            )
+        ],
+    )
+
+    response = _client().get("/swarm/runs/run-contract")
+
+    assert response.status_code == 200
+    task = response.json()["tasks"][0]
+    assert task["summary"] == "Public summary"
+    assert "<redacted>" in task["error"]
+    assert internal_path not in response.text
+    assert "artifacts" not in task
+    assert "prompt_template" not in task
+    assert task["worker_iterations"] == 3
+    assert task["iterations"] == 3


### PR DESCRIPTION
## Summary

- Use the public task projection while preserving the existing worker iteration field expected by the frontend.

## Why

Closes #605.

## Changes

- Implements only finding B14.
- Adds focused regression coverage for this behavior.

## Test Plan

- [x] Focused regression check passed: cd agent && pytest tests/test_swarm_route_contracts.py -q
- [x] New regression tests added where applicable.
- [x] The combined audit stack passed 5,462 Python tests and 253 frontend tests.

## Risk and scope

This pull request contains one finding and one signed commit. Reverting this commit restores the previous behavior.

## Checklist

- [x] No protected area was changed without prior discussion.
- [x] No API keys, secrets, or machine-specific paths were added.
- [x] The change follows CONTRIBUTING.md.
- [x] Documentation was updated where needed, or no documentation change was required.