### PR TITLE
Send the required details when approving a mandate

### DIFF
--- a/agent/cli/main.py
+++ b/agent/cli/main.py
@@ -1043,18 +1043,29 @@ def _commit_mandate(proposal: Dict[str, Any], selected_ordinal: int) -> Dict[str
     """
     import httpx
 
+    from src.api.live_routes import CommitMandateRequest
     from src.config.accessor import get_env_config
 
-    base = get_env_config().api.vibe_trading_api_url.rstrip("/")
-    body = {
-        "proposal_id": proposal.get("proposal_id"),
-        "selected_ordinal": selected_ordinal,
-        "adjustments": None,
-        "session_id": proposal.get("session_id"),
-        "consent_ack": True,
-    }
     try:
-        response = httpx.post(f"{base}/mandate/commit", json=body, timeout=30.0)
+        account = proposal.get("account") or {}
+        body = CommitMandateRequest.model_validate(
+            {
+                "broker": account.get("broker"),
+                "proposal_id": proposal.get("proposal_id"),
+                "selected_ordinal": selected_ordinal,
+                "adjustments": None,
+                "session_id": proposal.get("session_id"),
+                "account_ref": account.get("account_ref", ""),
+                "consent_ack": True,
+            }
+        ).model_dump(mode="json")
+
+        base = get_env_config().api.vibe_trading_api_url.rstrip("/")
+        response = httpx.post(
+            f"{base}/mandate/commit",
+            json=body,
+            timeout=30.0,
+        )
         response.raise_for_status()
         return response.json()
     except Exception as exc:  # noqa: BLE001 — surface a clean error to the user

--- a/agent/tests/test_cli_live.py
+++ b/agent/tests/test_cli_live.py
@@ -472,7 +472,7 @@ def _proposal() -> Dict[str, Any]:
         "proposal_id": "mp_" + "3" * 32,
         "session_id": "sess_1",
         "intent_normalized": "aggressive tech, ~$5000",
-        "account": {"broker": "robinhood", "type": "cash"},
+        "account": {"broker": "robinhood", "account_ref": "acct-demo", "type": "cash"},
         "profiles": [
             {"ordinal": 1, "label": "稳健", "max_order_usd": 250, "daily_trade_cap": 2},
             {"ordinal": 2, "label": "均衡", "max_order_usd": 750, "daily_trade_cap": 5},
@@ -542,7 +542,11 @@ class TestProposalPickIntercept:
             def json(self) -> Dict[str, Any]:
                 return {"status": "ok", "mandate_id": "m1"}
 
-        def _fake_post(url: str, json: Dict[str, Any], timeout: float) -> _Resp:  # noqa: A002
+        def _fake_post(
+            url: str,
+            json: Dict[str, Any],  # noqa: A002
+            timeout: float,
+        ) -> _Resp:
             captured["url"] = url
             captured["body"] = json
             return _Resp()
@@ -554,7 +558,21 @@ class TestProposalPickIntercept:
         assert captured["url"].endswith("/mandate/commit")
         assert captured["body"]["selected_ordinal"] == 2
         assert captured["body"]["proposal_id"] == "mp_" + "3" * 32
+        assert captured["body"]["broker"] == "robinhood"
+        assert captured["body"]["account_ref"] == "acct-demo"
         assert captured["body"]["consent_ack"] is True
+
+    def test_commit_rejects_missing_broker_before_network_call(self) -> None:
+        """The CLI validates the exact API request model before sending."""
+        proposal = _proposal()
+        proposal["account"] = {"type": "cash"}
+
+        with patch("httpx.post") as post:
+            result = _commit_mandate(proposal, 1)
+
+        assert result["status"] == "error"
+        assert "broker" in result["error"]
+        post.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Copy broker and account reference from the proposal, validate the complete request, and stop before the network call when required data is missing.

## Why

Closes #609.

## Changes

- Implements only finding B19.
- Adds focused regression coverage for this behavior.

## Test Plan

- [x] Focused regression check passed: cd agent && pytest tests/test_cli_live.py -q
- [x] New regression tests added where applicable.
- [x] The combined audit stack passed 5,462 Python tests and 253 frontend tests.

## Risk and scope

This pull request contains one finding and one signed commit. Reverting this commit restores the previous behavior.

## Checklist

- [x] No protected area was changed without prior discussion.
- [x] No API keys, secrets, or machine-specific paths were added.
- [x] The change follows CONTRIBUTING.md.
- [x] Documentation was updated where needed, or no documentation change was required.