### PR TITLE
Keep repeated CLI continuations in one history

### DIFF
--- a/agent/cli/_legacy.py
+++ b/agent/cli/_legacy.py
@@ -1444,12 +1444,11 @@ def cmd_run(prompt: str, max_iter: int, *, json_mode: bool = False, no_rich: boo
     return _result_exit_code(result)
 
 
-def _build_history_from_trace(run_dir: Path) -> List[Dict[str, str]]:
+def _build_history_from_trace(trace_dir: Path) -> List[Dict[str, str]]:
     """Build conversation history from trace.jsonl."""
     from src.agent.trace import TraceWriter
 
-    trace_dir = TraceWriter.find_trace_dir(run_dir.name, runs_dir=RUNS_DIR, sessions_dir=SESSIONS_DIR)
-    if trace_dir is None:
+    if not (trace_dir / "trace.jsonl").exists():
         return []
     entries = TraceWriter.read(
         trace_dir,
@@ -1474,6 +1473,8 @@ def cmd_continue(
     no_rich: bool = False,
 ) -> int:
     """Continue an existing run."""
+    from src.agent.trace import TraceWriter
+
     run_dir = RUNS_DIR / run_id
     session_trace_dir = SESSIONS_DIR / run_id
     if not run_dir.exists() and not session_trace_dir.exists():
@@ -1482,10 +1483,17 @@ def cmd_continue(
             return EXIT_USAGE_ERROR
         console.print(f"[red]Run {run_id} not found[/red]")
         return EXIT_USAGE_ERROR
-    if not run_dir.exists():
-        run_dir.mkdir(parents=True, exist_ok=True)
+    trace_dir = TraceWriter.find_trace_dir(
+        run_id, runs_dir=RUNS_DIR, sessions_dir=SESSIONS_DIR
+    )
+    if trace_dir is None:
+        # Preserve support for an existing, empty run/session directory. Once a
+        # trace exists, ``find_trace_dir`` is authoritative so every later
+        # continuation reads and appends to the same conversation.
+        trace_dir = session_trace_dir if session_trace_dir.exists() else run_dir
+    trace_dir.mkdir(parents=True, exist_ok=True)
 
-    history = _build_history_from_trace(run_dir)
+    history = _build_history_from_trace(trace_dir)
     if not json_mode and no_rich:
         print(f"Continue {run_id}: {prompt[:120]}\n")
     if json_mode or no_rich:
@@ -1494,7 +1502,7 @@ def cmd_continue(
             result = _run_agent(
                 prompt,
                 history=history,
-                run_dir_override=str(run_dir),
+                run_dir_override=str(trace_dir),
                 max_iter=max_iter,
                 no_rich=no_rich,
                 stream_output=not json_mode,
@@ -1502,7 +1510,12 @@ def cmd_continue(
         except KeyboardInterrupt:
             if json_mode:
                 _print_json_result(
-                    {"status": "cancelled", "run_id": run_id, "run_dir": str(run_dir), "reason": "Interrupted"}
+                    {
+                        "status": "cancelled",
+                        "run_id": run_id,
+                        "run_dir": str(trace_dir),
+                        "reason": "Interrupted",
+                    }
                 )
             else:
                 print("\nInterrupted")
@@ -1522,7 +1535,7 @@ def cmd_continue(
             result = _run_agent(
                 prompt,
                 history=history,
-                run_dir_override=str(run_dir),
+                run_dir_override=str(trace_dir),
                 max_iter=max_iter,
                 dashboard=dashboard,
             )

--- a/agent/tests/test_cli_continue.py
+++ b/agent/tests/test_cli_continue.py
@@ -1,0 +1,57 @@
+"""Regression tests for continuing a persisted CLI conversation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from cli import _legacy
+from src.agent.trace import TraceWriter
+
+
+def test_repeated_continue_reads_and_appends_one_canonical_trace(
+    tmp_path, monkeypatch
+) -> None:
+    """A session continuation must remain visible to the next continuation."""
+    runs_dir = tmp_path / "runs"
+    sessions_dir = tmp_path / "sessions"
+    trace_dir = sessions_dir / "session-1"
+
+    writer = TraceWriter(trace_dir)
+    writer.write({"type": "start", "prompt": "initial question"})
+    writer.write({"type": "answer", "content": "initial answer"})
+    writer.close()
+
+    histories = []
+
+    def fake_run_agent(prompt, history, run_dir_override, **kwargs):
+        histories.append(list(history))
+        continuation = TraceWriter(Path(run_dir_override))
+        continuation.write({"type": "start", "prompt": prompt})
+        continuation.write({"type": "answer", "content": f"answer to {prompt}"})
+        continuation.close()
+        return {"status": "success", "run_id": "session-1", "run_dir": run_dir_override}
+
+    monkeypatch.setattr(_legacy, "RUNS_DIR", runs_dir)
+    monkeypatch.setattr(_legacy, "SESSIONS_DIR", sessions_dir)
+    monkeypatch.setattr(_legacy, "_run_agent", fake_run_agent)
+    monkeypatch.setattr(_legacy, "_print_json_result", lambda result: None)
+
+    assert (
+        _legacy.cmd_continue("session-1", "first follow-up", 5, json_mode=True)
+        == _legacy.EXIT_SUCCESS
+    )
+    assert (
+        _legacy.cmd_continue("session-1", "second follow-up", 5, json_mode=True)
+        == _legacy.EXIT_SUCCESS
+    )
+
+    assert histories[0] == [
+        {"role": "user", "content": "initial question"},
+        {"role": "assistant", "content": "initial answer"},
+    ]
+    assert histories[1] == [
+        *histories[0],
+        {"role": "user", "content": "first follow-up"},
+        {"role": "assistant", "content": "answer to first follow-up"},
+    ]
+    assert not (runs_dir / "session-1").exists()


### PR DESCRIPTION
## Summary

- Choose one canonical trace folder and read and append every continuation in that same folder.

## Why

Closes #611.

## Changes

- Implements only finding B20.
- Adds focused regression coverage for this behavior.

## Test Plan

- [x] Focused regression check passed: cd agent && pytest tests/test_cli_continue.py -q
- [x] New regression tests added where applicable.
- [x] The combined audit stack passed 5,462 Python tests and 253 frontend tests.

## Risk and scope

This pull request contains one finding and one signed commit. Reverting this commit restores the previous behavior.

## Checklist

- [x] No protected area was changed without prior discussion.
- [x] No API keys, secrets, or machine-specific paths were added.
- [x] The change follows CONTRIBUTING.md.
- [x] Documentation was updated where needed, or no documentation change was required.