### PR TITLE
Clean up development server processes reliably

### DIFF
--- a/agent/cli/_legacy.py
+++ b/agent/cli/_legacy.py
@@ -5316,9 +5316,8 @@ def cmd_dev(
     )
     console.print("[dim]Press Ctrl+C to stop both servers.[/dim]\n")
 
-    backend = subprocess.Popen(backend_cmd, cwd=str(AGENT_DIR))
-    frontend = subprocess.Popen(frontend_cmd, cwd=str(frontend_dir))
-    children = [backend, frontend]
+    children: List[subprocess.Popen] = []
+    exit_code = EXIT_SUCCESS
 
     def _terminate_all() -> None:
         for child in children:
@@ -5328,28 +5327,41 @@ def cmd_dev(
                 except OSError:
                     pass
 
-    # Wire signal handlers. On Windows, SIGTERM does not exist and signal
-    # handlers must be installed from the main thread; KeyboardInterrupt is
-    # the cross-platform path for Ctrl+C.
-    if threading.current_thread() is threading.main_thread():
-        try:
-            signal.signal(signal.SIGINT, lambda *_: _terminate_all())
-        except (ValueError, OSError):
-            pass
-        try:
-            signal.signal(signal.SIGTERM, lambda *_: _terminate_all())
-        except (AttributeError, ValueError, OSError):
-            pass
-
     try:
+        backend = subprocess.Popen(backend_cmd, cwd=str(AGENT_DIR))
+        children.append(backend)
+        frontend = subprocess.Popen(frontend_cmd, cwd=str(frontend_dir))
+        children.append(frontend)
+
+        # Wire signal handlers only after both children are tracked. On
+        # Windows, SIGTERM may not exist and handlers must be installed from
+        # the main thread; KeyboardInterrupt remains the portable Ctrl+C path.
+        if threading.current_thread() is threading.main_thread():
+            try:
+                signal.signal(signal.SIGINT, lambda *_: _terminate_all())
+            except (ValueError, OSError):
+                pass
+            try:
+                signal.signal(signal.SIGTERM, lambda *_: _terminate_all())
+            except (AttributeError, ValueError, OSError):
+                pass
+
         # Wait for whichever process exits first; if it's the backend we
         # bring the frontend down too, and vice versa.
         while True:
             time.sleep(0.5)
-            if backend.poll() is not None or frontend.poll() is not None:
+            return_codes = [backend.poll(), frontend.poll()]
+            if any(code is not None for code in return_codes):
+                exit_code = next(
+                    (code for code in return_codes if code not in (None, EXIT_SUCCESS)),
+                    EXIT_SUCCESS,
+                )
                 break
     except KeyboardInterrupt:
         pass
+    except OSError as exc:
+        console.print(f"[red]Failed to start development server:[/red] {exc}")
+        exit_code = EXIT_RUN_FAILED
     finally:
         _terminate_all()
         # Give the children a brief grace period, then force-kill.
@@ -5363,8 +5375,12 @@ def cmd_dev(
                     child.kill()
                 except OSError:
                     pass
+                try:
+                    child.wait(timeout=1.0)
+                except (OSError, subprocess.TimeoutExpired):
+                    pass
 
-    return EXIT_SUCCESS
+    return exit_code
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/agent/tests/test_cli_setup_dev.py
+++ b/agent/tests/test_cli_setup_dev.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import cli
+import pytest
 
 
 class TestIsWindows:
@@ -193,6 +194,77 @@ class TestCmdDev:
         frontend_cmd = frontend_call.args[0]
         port_idx = frontend_cmd.index("--port") + 1
         assert frontend_cmd[port_idx] == "6000"
+
+    @pytest.mark.parametrize(
+        ("backend_code", "frontend_code", "expected"),
+        [(7, None, 7), (None, 9, 9)],
+    )
+    def test_returns_first_child_failure_and_stops_sibling(
+        self,
+        tmp_path: Path,
+        backend_code: int | None,
+        frontend_code: int | None,
+        expected: int,
+    ) -> None:
+        frontend_dir = _make_frontend_with_vite(tmp_path)
+        backend = MagicMock()
+        backend.poll.return_value = backend_code
+        frontend = MagicMock()
+        frontend.poll.return_value = frontend_code
+
+        with patch(
+            "cli._legacy._resolve_node_and_npm",
+            return_value=("/usr/bin/node", "/usr/bin/npm"),
+        ):
+            with patch("cli._legacy.subprocess.Popen", side_effect=[backend, frontend]):
+                with patch.object(cli._legacy.time, "sleep", return_value=None):
+                    rc = cli._legacy.cmd_dev(frontend_dir=frontend_dir)
+
+        assert rc == expected
+        running_sibling = frontend if backend_code is not None else backend
+        running_sibling.terminate.assert_called_once()
+
+    def test_second_spawn_failure_cleans_up_backend(self, tmp_path: Path) -> None:
+        frontend_dir = _make_frontend_with_vite(tmp_path)
+        backend = MagicMock()
+        backend.poll.return_value = None
+
+        with patch(
+            "cli._legacy._resolve_node_and_npm",
+            return_value=("/usr/bin/node", "/usr/bin/npm"),
+        ):
+            with patch(
+                "cli._legacy.subprocess.Popen",
+                side_effect=[backend, OSError("frontend failed to start")],
+            ):
+                rc = cli._legacy.cmd_dev(frontend_dir=frontend_dir)
+
+        assert rc == cli._legacy.EXIT_RUN_FAILED
+        backend.terminate.assert_called_once()
+        backend.wait.assert_called_once()
+
+    def test_interrupt_cleans_up_both_children(self, tmp_path: Path) -> None:
+        frontend_dir = _make_frontend_with_vite(tmp_path)
+        backend = MagicMock()
+        backend.poll.return_value = None
+        frontend = MagicMock()
+        frontend.poll.return_value = None
+
+        with patch(
+            "cli._legacy._resolve_node_and_npm",
+            return_value=("/usr/bin/node", "/usr/bin/npm"),
+        ):
+            with patch("cli._legacy.subprocess.Popen", side_effect=[backend, frontend]):
+                with patch.object(
+                    cli._legacy.time, "sleep", side_effect=KeyboardInterrupt
+                ):
+                    rc = cli._legacy.cmd_dev(frontend_dir=frontend_dir)
+
+        assert rc == cli._legacy.EXIT_SUCCESS
+        backend.terminate.assert_called_once()
+        frontend.terminate.assert_called_once()
+        backend.wait.assert_called_once()
+        frontend.wait.assert_called_once()
 
 
 def _make_frontend_with_vite(tmp_path: Path) -> Path:


### PR DESCRIPTION
## Summary

- Track each child immediately, stop and wait for every started process, and return the first nonzero child code.

## Why

Closes #613.

## Changes

- Implements only finding B21.
- Adds focused regression coverage for this behavior.

## Test Plan

- [x] Focused regression check passed: cd agent && pytest tests/test_cli_setup_dev.py -q
- [x] New regression tests added where applicable.
- [x] The combined audit stack passed 5,462 Python tests and 253 frontend tests.

## Risk and scope

This pull request contains one finding and one signed commit. Reverting this commit restores the previous behavior.

## Checklist

- [x] No protected area was changed without prior discussion.
- [x] No API keys, secrets, or machine-specific paths were added.
- [x] The change follows CONTRIBUTING.md.
- [x] Documentation was updated where needed, or no documentation change was required.