### PR TITLE
Add API authentication to CLI live controls

### DIFF
--- a/agent/cli/_legacy.py
+++ b/agent/cli/_legacy.py
@@ -2839,7 +2839,9 @@ def _api_auth_headers() -> Dict[str, str]:
     return {"Authorization": f"Bearer {key}"} if key else {}
 
 
-def _live_api_call(method: str, path: str, *, body: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+def _live_api_call(
+    method: str, path: str, *, body: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
     """Call an R6 live-runner endpoint and decode the JSON response.
 
     Args:
@@ -2856,11 +2858,12 @@ def _live_api_call(method: str, path: str, *, body: Optional[Dict[str, Any]] = N
     import httpx
 
     url = f"{_live_api_base()}{path}"
+    headers = _api_auth_headers()
     try:
         if method.upper() == "GET":
-            response = httpx.get(url, timeout=30.0)
+            response = httpx.get(url, headers=headers, timeout=30.0)
         else:
-            response = httpx.post(url, json=body or {}, timeout=30.0)
+            response = httpx.post(url, json=body or {}, headers=headers, timeout=30.0)
         response.raise_for_status()
         return response.json()
     except Exception as exc:  # noqa: BLE001 — surface a clean error to the user

--- a/agent/cli/main.py
+++ b/agent/cli/main.py
@@ -1043,9 +1043,13 @@ def _commit_mandate(proposal: Dict[str, Any], selected_ordinal: int) -> Dict[str
     """
     import httpx
 
-    from src.config.accessor import get_env_config
+    from src.config.accessor import get_env_config, reset_env_config
 
-    base = get_env_config().api.vibe_trading_api_url.rstrip("/")
+    reset_env_config()
+    api_config = get_env_config().api
+    base = api_config.vibe_trading_api_url.rstrip("/")
+    key = api_config.api_auth_key.strip()
+    headers = {"Authorization": f"Bearer {key}"} if key else {}
     body = {
         "proposal_id": proposal.get("proposal_id"),
         "selected_ordinal": selected_ordinal,
@@ -1054,7 +1058,12 @@ def _commit_mandate(proposal: Dict[str, Any], selected_ordinal: int) -> Dict[str
         "consent_ack": True,
     }
     try:
-        response = httpx.post(f"{base}/mandate/commit", json=body, timeout=30.0)
+        response = httpx.post(
+            f"{base}/mandate/commit",
+            json=body,
+            headers=headers,
+            timeout=30.0,
+        )
         response.raise_for_status()
         return response.json()
     except Exception as exc:  # noqa: BLE001 — surface a clean error to the user

--- a/agent/tests/test_cli_live.py
+++ b/agent/tests/test_cli_live.py
@@ -531,7 +531,9 @@ class TestProposalPickIntercept:
         assert handled is True
         assert ctx.pending_proposal is not None
 
-    def test_commit_posts_to_endpoint_with_consent_ack(self) -> None:
+    def test_commit_posts_to_endpoint_with_consent_ack(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """_commit_mandate POSTs to /mandate/commit — the surface, not the model."""
         captured: Dict[str, Any] = {}
 
@@ -542,11 +544,18 @@ class TestProposalPickIntercept:
             def json(self) -> Dict[str, Any]:
                 return {"status": "ok", "mandate_id": "m1"}
 
-        def _fake_post(url: str, json: Dict[str, Any], timeout: float) -> _Resp:  # noqa: A002
+        def _fake_post(
+            url: str,
+            json: Dict[str, Any],  # noqa: A002
+            headers: Dict[str, str],
+            timeout: float,
+        ) -> _Resp:
             captured["url"] = url
             captured["body"] = json
+            captured["headers"] = headers
             return _Resp()
 
+        monkeypatch.setenv("API_AUTH_KEY", "cli-secret")
         with patch("httpx.post", _fake_post):
             result = _commit_mandate(_proposal(), 2)
 
@@ -555,6 +564,7 @@ class TestProposalPickIntercept:
         assert captured["body"]["selected_ordinal"] == 2
         assert captured["body"]["proposal_id"] == "mp_" + "3" * 32
         assert captured["body"]["consent_ack"] is True
+        assert captured["headers"] == {"Authorization": "Bearer cli-secret"}
 
 
 # ---------------------------------------------------------------------------

--- a/agent/tests/test_cli_runtime.py
+++ b/agent/tests/test_cli_runtime.py
@@ -146,12 +146,36 @@ class TestRunnerDispatch:
 
 
 class TestRunnerControlEndpoints:
+    def test_live_status_request_sends_configured_bearer_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from cli._legacy import _live_api_call
+
+        captured: Dict[str, Any] = {}
+
+        def _get(url: str, headers: Dict[str, str], timeout: float) -> _FakeResp:
+            captured["url"] = url
+            captured["headers"] = headers
+            return _FakeResp({"status": "ok"})
+
+        monkeypatch.setenv("API_AUTH_KEY", "live-secret")
+        with patch("httpx.get", _get):
+            assert _live_api_call("GET", "/live/status") == {"status": "ok"}
+
+        assert captured["url"].endswith("/live/status")
+        assert captured["headers"] == {"Authorization": "Bearer live-secret"}
+
     def test_start_posts_to_runner_start(self) -> None:
         from cli._legacy import EXIT_SUCCESS, cmd_live_start
 
         captured: Dict[str, Any] = {}
 
-        def _post(url: str, json: Dict[str, Any], timeout: float) -> _FakeResp:  # noqa: A002
+        def _post(
+            url: str,
+            json: Dict[str, Any],  # noqa: A002
+            headers: Dict[str, str],
+            timeout: float,
+        ) -> _FakeResp:
             captured["url"] = url
             captured["body"] = json
             return _FakeResp({"runner_id": "live-robinhood", "status": "started"})
@@ -167,7 +191,12 @@ class TestRunnerControlEndpoints:
     ) -> None:
         from cli._legacy import EXIT_SUCCESS, cmd_connector_start
 
-        def _post(url: str, json: Dict[str, Any], timeout: float) -> _FakeResp:  # noqa: A002
+        def _post(
+            url: str,
+            json: Dict[str, Any],  # noqa: A002
+            headers: Dict[str, str],
+            timeout: float,
+        ) -> _FakeResp:
             return _FakeResp({"runner_id": "live-robinhood", "status": "started"})
 
         with patch("httpx.post", _post):
@@ -192,7 +221,12 @@ class TestRunnerControlEndpoints:
 
         captured: Dict[str, Any] = {}
 
-        def _post(url: str, json: Dict[str, Any], timeout: float) -> _FakeResp:  # noqa: A002
+        def _post(
+            url: str,
+            json: Dict[str, Any],  # noqa: A002
+            headers: Dict[str, str],
+            timeout: float,
+        ) -> _FakeResp:
             captured["url"] = url
             captured["body"] = json
             return _FakeResp({"status": "stopped"})
@@ -205,7 +239,12 @@ class TestRunnerControlEndpoints:
     def test_start_server_unreachable_is_run_failed(self) -> None:
         from cli._legacy import EXIT_RUN_FAILED, cmd_live_start
 
-        def _boom(url: str, json: Dict[str, Any], timeout: float) -> _FakeResp:  # noqa: A002
+        def _boom(
+            url: str,
+            json: Dict[str, Any],  # noqa: A002
+            headers: Dict[str, str],
+            timeout: float,
+        ) -> _FakeResp:
             raise OSError("connection refused")
 
         with patch("httpx.post", _boom):
@@ -217,7 +256,12 @@ class TestRunnerControlEndpoints:
 
         calls: List[str] = []
 
-        def _post(url: str, json: Dict[str, Any], timeout: float) -> _FakeResp:  # noqa: A002
+        def _post(
+            url: str,
+            json: Dict[str, Any],  # noqa: A002
+            headers: Dict[str, str],
+            timeout: float,
+        ) -> _FakeResp:
             calls.append(url)
             if url.endswith("/live/runner/start"):
                 assert json["foreground"] is True


### PR DESCRIPTION
## Summary

- Send the configured bearer token on live read, write, and mandate approval requests without logging the secret.

## Why

Closes #615.

## Changes

- Implements only finding B23.
- Adds focused regression coverage for this behavior.

## Test Plan

- [x] Focused regression check passed: cd agent && pytest tests/test_cli_runtime.py tests/test_cli_live.py -q
- [x] New regression tests added where applicable.
- [x] The combined audit stack passed 5,462 Python tests and 253 frontend tests.

## Risk and scope

This pull request contains one finding and one signed commit. Reverting this commit restores the previous behavior.

## Checklist

- [x] No protected area was changed without prior discussion.
- [x] No API keys, secrets, or machine-specific paths were added.
- [x] The change follows CONTRIBUTING.md.
- [x] Documentation was updated where needed, or no documentation change was required.