### PR TITLE
Return an error when a channel command fails in JSON mode

### DIFF
--- a/agent/cli/_legacy.py
+++ b/agent/cli/_legacy.py
@@ -2947,31 +2947,35 @@ def cmd_channels_status(*, json_mode: bool = False, local: bool = False) -> int:
 def cmd_channels_start(*, json_mode: bool = False) -> int:
     """Start configured IM channels through the API runtime."""
     payload = _channels_api_call("POST", "/channels/start")
+    failed = payload.get("status") == "error"
     if json_mode:
         print(json.dumps(payload, indent=2, ensure_ascii=False))
-    elif payload.get("status") == "error":
+    elif failed:
         console.print(f"[red]Failed to start IM channels:[/red] {payload.get('error')}")
-        console.print("[dim]Run `vibe-trading serve --port 8000` first, or set VIBE_TRADING_API_URL.[/dim]")
-        return EXIT_RUN_FAILED
+        console.print(
+            "[dim]Run `vibe-trading serve --port 8000` first, or set VIBE_TRADING_API_URL.[/dim]"
+        )
     else:
         console.print("[green]IM channels started.[/green]")
         _print_channels_status(payload)
-    return EXIT_SUCCESS
+    return EXIT_RUN_FAILED if failed else EXIT_SUCCESS
 
 
 def cmd_channels_stop(*, json_mode: bool = False) -> int:
     """Stop configured IM channels through the API runtime."""
     payload = _channels_api_call("POST", "/channels/stop")
+    failed = payload.get("status") == "error"
     if json_mode:
         print(json.dumps(payload, indent=2, ensure_ascii=False))
-    elif payload.get("status") == "error":
+    elif failed:
         console.print(f"[red]Failed to stop IM channels:[/red] {payload.get('error')}")
-        console.print("[dim]Run `vibe-trading serve --port 8000` first, or set VIBE_TRADING_API_URL.[/dim]")
-        return EXIT_RUN_FAILED
+        console.print(
+            "[dim]Run `vibe-trading serve --port 8000` first, or set VIBE_TRADING_API_URL.[/dim]"
+        )
     else:
         console.print("[green]IM channels stopped.[/green]")
         _print_channels_status(payload)
-    return EXIT_SUCCESS
+    return EXIT_RUN_FAILED if failed else EXIT_SUCCESS
 
 
 def cmd_channels_pairing(channel: str, command: str) -> int:

--- a/agent/tests/test_cli_channels.py
+++ b/agent/tests/test_cli_channels.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from cli import _legacy
 
 
@@ -77,3 +79,36 @@ def test_channels_api_call_sends_configured_bearer_token(monkeypatch) -> None:
 
     assert _legacy._channels_api_call("GET", "/channels/status") == {"status": "ok"}
     assert captured["headers"] == {"Authorization": "Bearer secret-token"}
+
+
+@pytest.mark.parametrize(
+    "command", [_legacy.cmd_channels_start, _legacy.cmd_channels_stop]
+)
+@pytest.mark.parametrize("json_mode", [False, True])
+def test_channels_start_stop_return_failure_in_every_output_mode(
+    command, json_mode, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        _legacy,
+        "_channels_api_call",
+        lambda *args, **kwargs: {"status": "error", "error": "offline"},
+    )
+
+    assert command(json_mode=json_mode) == _legacy.EXIT_RUN_FAILED
+
+
+@pytest.mark.parametrize(
+    "command", [_legacy.cmd_channels_start, _legacy.cmd_channels_stop]
+)
+@pytest.mark.parametrize("json_mode", [False, True])
+def test_channels_start_stop_return_success_in_every_output_mode(
+    command, json_mode, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        _legacy,
+        "_channels_api_call",
+        lambda *args, **kwargs: {"status": "ok", "channels": {}},
+    )
+    monkeypatch.setattr(_legacy, "_print_channels_status", lambda payload: None)
+
+    assert command(json_mode=json_mode) == _legacy.EXIT_SUCCESS


### PR DESCRIPTION
## Summary

- Choose the exit code separately from output formatting so normal and JSON modes return the same result.

## Why

Closes #617.

## Changes

- Implements only finding B24.
- Adds focused regression coverage for this behavior.

## Test Plan

- [x] Focused regression check passed: cd agent && pytest tests/test_cli_channels.py -q
- [x] New regression tests added where applicable.
- [x] The combined audit stack passed 5,462 Python tests and 253 frontend tests.

## Risk and scope

This pull request contains one finding and one signed commit. Reverting this commit restores the previous behavior.

## Checklist

- [x] No protected area was changed without prior discussion.
- [x] No API keys, secrets, or machine-specific paths were added.
- [x] The change follows CONTRIBUTING.md.
- [x] Documentation was updated where needed, or no documentation change was required.