### PR TITLE
Normalize mixed-offset local data timestamps

### DIFF
--- a/agent/backtest/loaders/local_loader.py
+++ b/agent/backtest/loaders/local_loader.py
@@ -152,14 +152,14 @@ def _normalize_columns(
         return None
 
     if date_fmt:
-        df["trade_date"] = pd.to_datetime(df[date_col], format=date_fmt, errors="coerce")
+        parsed_dates = pd.to_datetime(
+            df[date_col], format=date_fmt, errors="coerce", utc=True
+        )
     else:
-        df["trade_date"] = pd.to_datetime(df[date_col], errors="coerce")
-    # Drop any timezone so the tz-naive date-range filter in ``_fetch_one`` never
-    # raises "Invalid comparison between tz-aware and tz-naive" (which was caught
-    # and swallowed into a silently empty result for tz-aware parquet/CSV inputs).
-    if getattr(df["trade_date"].dt, "tz", None) is not None:
-        df["trade_date"] = df["trade_date"].dt.tz_localize(None)
+        parsed_dates = pd.to_datetime(df[date_col], errors="coerce", utc=True)
+    # Normalize every input to the loader's UTC-naive index contract. Parsing
+    # as UTC first also handles files that span daylight-saving offset changes.
+    df["trade_date"] = parsed_dates.dt.tz_convert(None)
     df = df.dropna(subset=["trade_date"])
     df = df.set_index("trade_date").sort_index()
 

--- a/agent/tests/test_local_loader.py
+++ b/agent/tests/test_local_loader.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
+import pandas as pd
 import pytest
 import yaml
 
@@ -249,3 +250,48 @@ def test_local_loader_handles_timezone_aware_timestamps(
 
     assert set(frames) == {"AAPL.US"}
     assert list(frames["AAPL.US"]["close"]) == [10.5, 12.5]
+
+
+def test_local_loader_normalizes_dst_offsets_to_naive_utc(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    csv_path = tmp_path / "dst.csv"
+    csv_path.write_text(
+        "\n".join(
+            [
+                "Date,Open,High,Low,Close,Volume",
+                "2026-01-15T09:30:00-05:00,10,11,9,10.5,1000",
+                "2026-07-15T09:30:00-04:00,12,13,11,12.5,1500",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    _configure(
+        monkeypatch,
+        tmp_path,
+        [
+            {
+                "symbol": "DST.US",
+                "type": "csv",
+                "path": str(csv_path),
+                "columns": {
+                    "date": "Date",
+                    "open": "Open",
+                    "high": "High",
+                    "low": "Low",
+                    "close": "Close",
+                    "volume": "Volume",
+                },
+            }
+        ],
+    )
+
+    frame = local_loader.DataLoader().fetch(
+        ["local:DST.US"], "2026-01-01", "2026-07-31"
+    )["DST.US"]
+
+    assert frame.index.tz is None
+    assert list(frame.index) == [
+        pd.Timestamp("2026-01-15 14:30:00"),
+        pd.Timestamp("2026-07-15 13:30:00"),
+    ]


### PR DESCRIPTION
## Summary

- Parse timestamps as UTC and remove the timezone label to match the timezone-free UTC index used by the loader.

## Why

Closes #619.

## Changes

- Implements only finding B26.
- Adds focused regression coverage for this behavior.

## Test Plan

- [x] Focused regression check passed: cd agent && pytest tests/test_local_loader.py -q
- [x] New regression tests added where applicable.
- [x] The combined audit stack passed 5,462 Python tests and 253 frontend tests.

## Risk and scope

This pull request contains one finding and one signed commit. Reverting this commit restores the previous behavior.

## Checklist

- [x] No protected area was changed without prior discussion.
- [x] No API keys, secrets, or machine-specific paths were added.
- [x] The change follows CONTRIBUTING.md.
- [x] Documentation was updated where needed, or no documentation change was required.