### PR TITLE
Do not mark successful local data as missing

### DIFF
--- a/agent/src/market_data.py
+++ b/agent/src/market_data.py
@@ -89,6 +89,12 @@ def fetch_market_data(
 ) -> dict[str, Any]:
     """Fetch normalized OHLCV data through the repository loader layer."""
     results: dict[str, Any] = {}
+    result_aliases = {
+        code: code.split(":", 1)[1]
+        if code.lower().startswith("local:")
+        else code
+        for code in codes
+    }
 
     if source == "auto":
         groups: dict[str, list[str]] = {}
@@ -117,7 +123,11 @@ def fetch_market_data(
                     row[key] = _json_safe(value)
             results[symbol] = cap_rows(records, max_rows)
 
-    unresolved = [code for code in codes if code not in results]
+    unresolved = [
+        code
+        for code in codes
+        if code not in results and result_aliases[code] not in results
+    ]
     if unresolved:
         results["_unresolved"] = unresolved
 

--- a/agent/tests/test_market_data.py
+++ b/agent/tests/test_market_data.py
@@ -155,6 +155,16 @@ class _PartialLoader:
         return {codes[0]: pd.DataFrame({"close": [1.0]}, index=idx)}
 
 
+class _LocalAliasLoader:
+    """Mirrors the local loader, which returns keys without ``local:``."""
+
+    def fetch(self, codes, start_date, end_date, interval="1D"):
+        idx = pd.to_datetime(["2026-01-01"])
+        idx.name = "trade_date"
+        clean = codes[0].split(":", 1)[-1]
+        return {clean: pd.DataFrame({"close": [1.0]}, index=idx)}
+
+
 def test_fetch_explicit_source_normalizes_rows() -> None:
     out = fetch_market_data(
         codes=["AAPL.US"],
@@ -209,6 +219,19 @@ def test_fetch_missing_symbol_listed_as_unresolved() -> None:
     )
     assert "A.US" in out
     assert out["_unresolved"] == ["B.US"]
+
+
+def test_fetch_local_result_alias_is_not_unresolved() -> None:
+    out = fetch_market_data(
+        codes=["local:AAPL.US"],
+        start_date="2026-01-01",
+        end_date="2026-01-02",
+        source="auto",
+        loader_resolver=lambda src: _LocalAliasLoader,
+    )
+
+    assert "AAPL.US" in out
+    assert "_unresolved" not in out
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Match both the requested local-prefixed symbol and the shorter result name when checking for missing data.

## Why

Closes #621.

## Changes

- Implements only finding B27.
- Adds focused regression coverage for this behavior.

## Test Plan

- [x] Focused regression check passed: cd agent && pytest tests/test_market_data.py -q
- [x] New regression tests added where applicable.
- [x] The combined audit stack passed 5,462 Python tests and 253 frontend tests.

## Risk and scope

This pull request contains one finding and one signed commit. Reverting this commit restores the previous behavior.

## Checklist

- [x] No protected area was changed without prior discussion.
- [x] No API keys, secrets, or machine-specific paths were added.
- [x] The change follows CONTRIBUTING.md.
- [x] Documentation was updated where needed, or no documentation change was required.