### PR TITLE
Count each entry fee once across partial exits

### DIFF
--- a/agent/src/tools/trade_journal_tool.py
+++ b/agent/src/tools/trade_journal_tool.py
@@ -78,6 +78,7 @@ def pair_trades_fifo(df: pd.DataFrame) -> list[dict[str, Any]]:
                 "pnl": round(pnl, 2),
                 "pnl_pct": round(pnl_pct, 4),
             })
+            lot["fee"] -= buy_fee
             lot["qty"] -= take
             remaining -= take
             if lot["qty"] <= 1e-9:

--- a/agent/tests/test_trade_journal.py
+++ b/agent/tests/test_trade_journal.py
@@ -245,6 +245,38 @@ def test_fifo_partial_fill_splits_into_two_roundtrips() -> None:
     assert rts[1]["pnl"] == 500.0  # (30-20)*50
 
 
+@pytest.mark.parametrize("exit_quantities", [[5, 5], [4, 4, 4]])
+def test_fifo_partial_exits_conserve_entry_fee(exit_quantities: list[int]) -> None:
+    entry_qty = sum(exit_quantities)
+    records = [
+        _rec(
+            "2026-01-01 10:00:00",
+            "X.SH",
+            "buy",
+            entry_qty,
+            10,
+            fee=entry_qty,
+        )
+    ]
+    records.extend(
+        _rec(
+            f"2026-01-0{day} 10:00:00",
+            "X.SH",
+            "sell",
+            qty,
+            11,
+        )
+        for day, qty in enumerate(exit_quantities, start=2)
+    )
+
+    rts = pair_trades_fifo(_df(records))
+    gross_pnl = sum((trip["sell_price"] - trip["buy_price"]) * trip["qty"] for trip in rts)
+    allocated_entry_fee = gross_pnl - sum(trip["pnl"] for trip in rts)
+
+    assert allocated_entry_fee == pytest.approx(entry_qty)
+    assert sum(trip["pnl"] for trip in rts) == pytest.approx(0.0)
+
+
 def test_fifo_unmatched_sell_ignored() -> None:
     rts = pair_trades_fifo(
         _df([_rec("2026-01-01 10:00:00", "X.SH", "sell", 100, 12)])


### PR DESCRIPTION
## Summary

- Reduce the fee remaining on the open lot after every partial match so all exits add up to the original fee.

## Why

Closes #623.

## Changes

- Implements only finding B28.
- Adds focused regression coverage for this behavior.

## Test Plan

- [x] Focused regression check passed: cd agent && pytest tests/test_trade_journal.py -q
- [x] New regression tests added where applicable.
- [x] The combined audit stack passed 5,462 Python tests and 253 frontend tests.

## Risk and scope

This pull request contains one finding and one signed commit. Reverting this commit restores the previous behavior.

## Checklist

- [x] No protected area was changed without prior discussion.
- [x] No API keys, secrets, or machine-specific paths were added.
- [x] The change follows CONTRIBUTING.md.
- [x] Documentation was updated where needed, or no documentation change was required.