### PR TITLE
Include the complete final month in journal filters

### DIFF
--- a/agent/src/tools/trade_journal_tool.py
+++ b/agent/src/tools/trade_journal_tool.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from collections import defaultdict, deque
 from typing import Any
 
@@ -376,8 +377,17 @@ def _apply_filter(df: pd.DataFrame, expr: str) -> pd.DataFrame:
     if " to " in expr:
         try:
             lo_raw, hi_raw = (p.strip() for p in expr.split(" to ", 1))
-            lo = pd.to_datetime(lo_raw)
-            hi = pd.to_datetime(hi_raw) + pd.Timedelta(days=1)
+            lo_month = re.fullmatch(r"\d{4}-\d{2}", lo_raw) is not None
+            hi_month = re.fullmatch(r"\d{4}-\d{2}", hi_raw) is not None
+            lo_format = "%Y-%m" if lo_month else "%Y-%m-%d"
+            hi_format = "%Y-%m" if hi_month else "%Y-%m-%d"
+            lo = pd.to_datetime(lo_raw, format=lo_format, errors="raise")
+            hi_base = pd.to_datetime(hi_raw, format=hi_format, errors="raise")
+            hi = (
+                hi_base + pd.offsets.MonthBegin(1)
+                if hi_month
+                else hi_base + pd.Timedelta(days=1)
+            )
             return df[(df["datetime"] >= lo) & (df["datetime"] < hi)]
         except Exception as exc:
             logger.warning("filter date parse failed: %s", exc)

--- a/agent/tests/test_trade_journal.py
+++ b/agent/tests/test_trade_journal.py
@@ -332,6 +332,39 @@ def test_apply_filter_date_range() -> None:
     assert out.iloc[0]["symbol"] == "AAPL"
 
 
+def test_apply_filter_month_range_includes_entire_leap_month() -> None:
+    df = _df(
+        [
+            _rec("2024-01-31 10:00:00", "JAN", "buy", 1, 10),
+            _rec("2024-02-01 10:00:00", "FEB1", "buy", 1, 10),
+            _rec("2024-02-29 10:00:00", "FEB29", "buy", 1, 10),
+            _rec("2024-03-01 10:00:00", "MAR", "buy", 1, 10),
+        ]
+    )
+
+    out = _apply_filter(df, "2024-01 to 2024-02")
+
+    assert list(out["symbol"]) == ["JAN", "FEB1", "FEB29"]
+
+
+def test_apply_filter_preserves_full_date_and_mixed_precision() -> None:
+    df = _df(
+        [
+            _rec("2024-02-01 10:00:00", "START", "buy", 1, 10),
+            _rec("2024-02-15 10:00:00", "MIDDLE", "buy", 1, 10),
+            _rec("2024-02-29 10:00:00", "END", "buy", 1, 10),
+        ]
+    )
+
+    dates = _apply_filter(df, "2024-02-01 to 2024-02-15")
+    mixed = _apply_filter(df, "2024-02-15 to 2024-02")
+    reversed_range = _apply_filter(df, "2024-03 to 2024-02")
+
+    assert list(dates["symbol"]) == ["START", "MIDDLE"]
+    assert list(mixed["symbol"]) == ["MIDDLE", "END"]
+    assert reversed_range.empty
+
+
 def test_apply_filter_symbol_equals() -> None:
     out = _apply_filter(_filter_df(), "symbol=600519.SH")
     assert len(out) == 2


### PR DESCRIPTION
## Summary

- Treat month-only end values as the end of the whole month while preserving full-date behavior.

## Why

Closes #625.

## Changes

- Implements only finding B31.
- Adds focused regression coverage for this behavior.

## Test Plan

- [x] Focused regression check passed: cd agent && pytest tests/test_trade_journal.py -q
- [x] New regression tests added where applicable.
- [x] The combined audit stack passed 5,462 Python tests and 253 frontend tests.

## Risk and scope

This pull request contains one finding and one signed commit. Reverting this commit restores the previous behavior.

## Checklist

- [x] No protected area was changed without prior discussion.
- [x] No API keys, secrets, or machine-specific paths were added.
- [x] The change follows CONTRIBUTING.md.
- [x] Documentation was updated where needed, or no documentation change was required.