### PR TITLE
fix(security): harden shutdown authorization

### DIFF
--- a/agent/src/api/security.py
+++ b/agent/src/api/security.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hmac
 import ipaddress
 import logging
+import os
 import re
 import secrets
 import threading
@@ -353,19 +354,40 @@ def _require_shutdown_authorization(
     request: Request,
     cred: Optional[HTTPAuthorizationCredentials],
 ) -> None:
-    """Authorize the local shutdown control-plane action."""
+    """Authorize the local shutdown control-plane action.
+
+    Require an explicit confirmation and either a valid API key or a local-only
+    lab opt-in, so a bare loopback POST cannot stop the process.
+    """
     _reject_cross_site_browser_request(request)
+
+    confirm_q = (request.query_params.get("confirm") or "").strip().lower()
+    confirm_h = (request.headers.get("x-confirm-shutdown") or "").strip().lower()
+    if confirm_q not in {"1", "true", "yes"} and confirm_h not in {"1", "true", "yes"}:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Shutdown requires confirm=true (query) or X-Confirm-Shutdown: true",
+        )
+
     api_key = _configured_api_key()
     if api_key:
         token = _auth_credential_from_header_or_query(cred, None, allow_query=False)
         if not token or not hmac.compare_digest(token, api_key):
             raise HTTPException(status_code=401, detail="Invalid or missing API key")
         return
-    if not _is_local_client(request):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="API_AUTH_KEY is required for non-local API access",
-        )
+
+    allow_local = os.environ.get("VIBE_TRADING_ALLOW_LOCAL_SHUTDOWN", "").strip().lower()
+    if allow_local in {"1", "true", "yes", "on"} and _is_local_client(request):
+        return
+
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail=(
+            "Shutdown disabled without API_AUTH_KEY. "
+            "Set API_AUTH_KEY and send Authorization, or set "
+            "VIBE_TRADING_ALLOW_LOCAL_SHUTDOWN=1 for lab use only."
+        ),
+    )
 
 
 def _validate_api_auth(

--- a/agent/tests/test_security_auth_api.py
+++ b/agent/tests/test_security_auth_api.py
@@ -501,7 +501,7 @@ def test_loopback_shutdown_requires_bearer_when_api_key_configured(
     monkeypatch.setattr(api_server, "_API_KEY", "secret")
     monkeypatch.setattr(api_server, "_terminate_current_process", lambda: called.append(True))
 
-    response = _local_client().post("/system/shutdown")
+    response = _local_client().post("/system/shutdown?confirm=true")
 
     assert response.status_code == 401
     assert called == []
@@ -517,7 +517,7 @@ def test_loopback_shutdown_rejects_cross_site_browser_request(
     monkeypatch.setattr(api_server, "_terminate_current_process", lambda: called.append(True))
 
     response = _local_client().post(
-        "/system/shutdown",
+        "/system/shutdown?confirm=true",
         headers={"Origin": "https://attacker.example"},
     )
 
@@ -534,7 +534,7 @@ def test_loopback_shutdown_accepts_valid_bearer(
     monkeypatch.setattr(api_server, "_terminate_current_process", lambda: called.append(True))
 
     response = _local_client().post(
-        "/system/shutdown",
+        "/system/shutdown?confirm=true",
         headers={"Authorization": "Bearer secret", "Origin": "http://127.0.0.1:8899"},
     )
 


### PR DESCRIPTION
Split from #543 for independent review.\n\nRequires explicit shutdown confirmation plus either a valid `API_AUTH_KEY` or local-only `VIBE_TRADING_ALLOW_LOCAL_SHUTDOWN=1` opt-in.\n\nVerification: `PYTHONPATH=agent ~/.venvs/vibe-trading/bin/python -m pytest agent/tests/test_security_auth_api.py -q` (53 passed).