### PR TITLE
fix(config): let project dotenv override stale shell values

### DIFF
--- a/agent/api_server.py
+++ b/agent/api_server.py
@@ -156,6 +156,18 @@ from src.api.scheduled_routes import (  # noqa: E402
 @app.on_event("startup")
 async def _run_startup_preflight() -> None:
     """Run preflight checks on server startup."""
+    # Load shared configuration before any cached EnvConfig is consumed.
+    try:
+        from src.config.accessor import reset_env_config
+        from src.providers.llm import _ensure_dotenv
+        import src.providers.llm as _llm_mod
+
+        _llm_mod._dotenv_loaded = False
+        _ensure_dotenv()
+        reset_env_config()
+    except Exception:
+        logger.exception("Failed to load shared ~/.vibe-trading/.env on startup")
+
     from src.preflight import run_preflight
 
     run_preflight(console)

--- a/agent/src/config/env_schema.py
+++ b/agent/src/config/env_schema.py
@@ -136,6 +136,10 @@ class LLMConfig(_EnvBase):
         default="https://chatgpt.com/backend-api/codex/responses",
     )
     openai_model: str = Field(alias="OPENAI_MODEL", default="")
+    vibe_trading_dotenv_override: EnvBool = Field(
+        alias="VIBE_TRADING_DOTENV_OVERRIDE",
+        default=True,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/agent/src/providers/llm.py
+++ b/agent/src/providers/llm.py
@@ -416,9 +416,14 @@ def _build_native_deepseek(
 
 
 def _load_env_file(path: Path) -> None:
-    """Load a single .env file into os.environ (setdefault, no override)."""
+    """Load a single .env file into os.environ.
+
+    The project .env is canonical by default; set
+    ``VIBE_TRADING_DOTENV_OVERRIDE=0`` to preserve existing shell values.
+    """
+    override = bool(get_env_config().llm.vibe_trading_dotenv_override)
     if load_dotenv is not None:
-        load_dotenv(dotenv_path=path, override=False)
+        load_dotenv(dotenv_path=path, override=override)
     else:
         for raw in path.read_text(encoding="utf-8").splitlines():
             line = raw.strip()
@@ -426,8 +431,10 @@ def _load_env_file(path: Path) -> None:
                 continue
             key, value = line.split("=", 1)
             key = key.strip()
-            if key:
-                os.environ.setdefault(key, value.strip().strip('"').strip("'"))
+            if not key:
+                continue
+            if override or key not in os.environ:
+                os.environ[key] = value.strip().strip('"').strip("'")
 
 
 def _ensure_dotenv() -> None:

--- a/agent/tests/test_dotenv_override.py
+++ b/agent/tests/test_dotenv_override.py
@@ -1,0 +1,59 @@
+"""Regression coverage for project dotenv precedence."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+import src.providers.llm as llm
+from src.config.accessor import reset_env_config
+from src.config.env_schema import EnvConfig
+
+
+@pytest.fixture
+def fresh_dotenv(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(llm, "_dotenv_loaded", False)
+
+
+def test_dotenv_override_defaults_to_project_env() -> None:
+    assert EnvConfig().llm.vibe_trading_dotenv_override is True
+
+
+def test_dotenv_override_can_preserve_shell_value(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fresh_dotenv: None,
+) -> None:
+    env = tmp_path / ".env"
+    env.write_text("VT_TEST_TOKEN=from_dotenv\n", encoding="utf-8")
+    monkeypatch.setattr(llm, "_ENV_CANDIDATES", [env])
+    monkeypatch.setattr(llm, "_ENV_LABELS", ("<TEST_SLOT>",))
+    monkeypatch.setenv("VT_TEST_TOKEN", "from_shell")
+    monkeypatch.setenv("VIBE_TRADING_DOTENV_OVERRIDE", "0")
+    reset_env_config()
+    try:
+        llm._ensure_dotenv()
+        assert os.environ["VT_TEST_TOKEN"] == "from_shell"
+    finally:
+        reset_env_config()
+
+
+def test_dotenv_override_replaces_stale_shell_value_by_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fresh_dotenv: None,
+) -> None:
+    env = tmp_path / ".env"
+    env.write_text("VT_TEST_TOKEN=from_dotenv\n", encoding="utf-8")
+    monkeypatch.setattr(llm, "_ENV_CANDIDATES", [env])
+    monkeypatch.setattr(llm, "_ENV_LABELS", ("<TEST_SLOT>",))
+    monkeypatch.setenv("VT_TEST_TOKEN", "from_shell")
+    monkeypatch.delenv("VIBE_TRADING_DOTENV_OVERRIDE", raising=False)
+    reset_env_config()
+    try:
+        llm._ensure_dotenv()
+        assert os.environ["VT_TEST_TOKEN"] == "from_dotenv"
+    finally:
+        reset_env_config()


### PR DESCRIPTION
Split from #543 for independent discussion.\n\nThe default makes the project `.env` canonical, with `VIBE_TRADING_DOTENV_OVERRIDE=0` preserving existing shell values.\n\nCoordination: this touches `agent/src/providers/llm.py`, whose pre-change blob is also the base for #563. A current three-way merge is text-clean, but the configuration behavior needs independent review before this draft is marked ready.\n\nVerification: `PYTHONPATH=agent ~/.venvs/vibe-trading/bin/python -m pytest agent/tests/test_dotenv_override.py -q` (3 passed).