### PR TITLE
Honor cancellation before the first AgentLoop iteration

### DIFF
--- a/agent/src/agent/loop.py
+++ b/agent/src/agent/loop.py
@@ -550,6 +550,7 @@ class AgentLoop:
         self._previous_summary: str = ""
         self._persistent_memory = persistent_memory
         self._run_iteration: int = 0
+        self._has_run = False
 
     def cancel(self) -> None:
         """Cancel the current loop.
@@ -571,8 +572,13 @@ class AgentLoop:
         Returns:
             Execution result dict.
         """
-        # Reset per-run state (safe for reuse across multiple run() calls)
-        self._cancel_event.clear()
+        # Preserve cancellation accepted while the first run is queued.  A
+        # completed loop may still be reused deliberately, so clear terminal
+        # state only after the first run has begun.
+        if self._has_run:
+            self._cancel_event.clear()
+        else:
+            self._has_run = True
         self._called_ok = set()
         self._previous_summary = ""
 

--- a/agent/tests/test_agent_loop_terminal_state.py
+++ b/agent/tests/test_agent_loop_terminal_state.py
@@ -73,6 +73,29 @@ class _StubLLMWithUsage:
         return _StubLLMResponse()
 
 
+class _StubLLMSuccess:
+    """LLM stub that records calls and returns a final answer."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def stream_chat(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[Any] | None = None,
+        on_text_chunk: Callable[[str], None] | None = None,
+        on_reasoning_chunk: Callable[[str], None] | None = None,
+        should_cancel: Callable[[], bool] | None = None,
+    ) -> _StubLLMResponse:
+        self.calls += 1
+        response = _StubLLMResponse()
+        response.content = "done"
+        return response
+
+    def chat(self, messages: list[dict[str, Any]], **_: Any) -> _StubLLMResponse:
+        return _StubLLMResponse()
+
+
 class _StubLLMCancelMidStream:
     """LLM stub that cancels the loop from inside the LLM call.
 
@@ -150,6 +173,24 @@ def test_cancelled_terminal_returns_reason(tmp_path: Path) -> None:
     assert result["status"] == "cancelled"
     assert result["reason"] == "cancelled by user"
     assert result["max_iterations"] == 3
+
+
+def test_cancel_before_first_run_is_not_cleared(tmp_path: Path) -> None:
+    """A cancellation accepted while queued must stop before the LLM call."""
+    llm = _StubLLMSuccess()
+    agent = _build_agent(llm, max_iter=1, tmp_run_dir=tmp_path / "run")
+
+    agent.cancel()
+    cancelled = agent.run(user_message="stale request")
+
+    assert cancelled["status"] == "cancelled"
+    assert cancelled["reason"] == "cancelled by user"
+    assert llm.calls == 0
+
+    reused = agent.run(user_message="new request")
+
+    assert reused["status"] == "success"
+    assert llm.calls == 1
 
 
 class _StubLLMCancelWithToolCalls:


### PR DESCRIPTION
## Summary

- Preserve cancellation accepted while an AgentLoop is waiting to start.
- Reset cancellation only when a completed loop is deliberately reused.
- Add a regression proving the cancelled run makes zero model calls.

## Why

Closes #638.

A queued cancellation is currently cleared at the start of `run()`, so work that the user cancelled can still call the model.

## Changes

- Track whether the loop has run before.
- Keep the initial cancellation event intact.
- Preserve the existing reuse behavior after a completed run.

## Test Plan

- [ ] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [x] New tests added
- [ ] Tested manually
- [x] 9 AgentLoop terminal-state tests passed
- [x] 12 adjacent stream, content-filter, and session tests passed
- [x] Ruff and diff checks passed

## Risk

This changes AgentLoop lifecycle state. Existing mid-stream cancellation behavior is unchanged. No real provider, broker, network server, or credential was used.

## Out of scope

This does not change cancellation after model or tool execution has started.

## Rollback

Revert this one commit to restore the previous cancellation reset behavior.

## Checklist

- [x] The protected agent area is covered by issue #638 and focused tests
- [x] No hardcoded API keys, file paths, or magic values
- [x] Code follows `CONTRIBUTING.md`
- [x] No user-facing documentation change is needed