### PR TITLE
Use one prefetched dataset for every backtest source

### DIFF
--- a/agent/backtest/runner.py
+++ b/agent/backtest/runner.py
@@ -919,9 +919,10 @@ def main(run_dir: Path) -> None:
     else:
         bars_per_year = calc_bars_per_year(interval, effective_source)
 
-    # Auto mode: wrap preloaded data in a dummy loader
-    if source == "auto":
-        loader = _AutoLoader(data_map)
+    # Every source has already been fetched, sanitized, and enriched above.
+    # Reuse that exact snapshot so provider costs and run-card provenance stay
+    # aligned with the data consumed by the engine.
+    loader = _AutoLoader(data_map)
 
     if engine_type == "options":
         from backtest.engines.options_portfolio import run_options_backtest
@@ -1159,7 +1160,7 @@ def _sanitize_data_map(data_map: dict) -> dict:
 
 
 class _AutoLoader:
-    """Dummy loader for auto mode: returns pre-fetched data maps."""
+    """Loader adapter that returns a pre-fetched data map."""
 
     def __init__(self, data_map: dict):
         self._data = data_map

--- a/agent/tests/test_ui_services.py
+++ b/agent/tests/test_ui_services.py
@@ -174,3 +174,68 @@ def test_fetch_data_map_delegates_auto_routing(
     assert calls == [(["AAPL.US"], config, "1D")]
     assert result.source == "auto"
     assert result.effective_sources == ["yfinance"]
+
+
+def test_main_reuses_explicit_source_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_dir = tmp_path / "run"
+    (run_dir / "code").mkdir(parents=True)
+    (run_dir / "code" / "signal_engine.py").write_text(
+        "class SignalEngine:\n    pass\n", encoding="utf-8"
+    )
+    (run_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "codes": ["AAPL.US"],
+                "start_date": "2026-01-01",
+                "end_date": "2026-01-02",
+                "source": "yahoo",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("VIBE_TRADING_ALLOWED_RUN_ROOTS", str(tmp_path))
+
+    first = pd.DataFrame(
+        {"open": [10.0], "high": [10.0], "low": [10.0], "close": [10.0]},
+        index=pd.DatetimeIndex([pd.Timestamp("2026-01-01")]),
+    )
+    second = first.assign(open=20.0, high=20.0, low=20.0, close=20.0)
+
+    class CountingLoader:
+        name = "yahoo"
+        calls = 0
+
+        def fetch(self, codes, start_date, end_date, **kwargs):
+            del start_date, end_date, kwargs
+            type(self).calls += 1
+            frame = first if type(self).calls == 1 else second
+            return {codes[0]: frame}
+
+    observed: dict[str, float] = {}
+
+    class CapturingEngine:
+        def run_backtest(self, config, loader, signal_engine, path, **kwargs):
+            del signal_engine, path, kwargs
+            data = loader.fetch(
+                config["codes"], config["start_date"], config["end_date"]
+            )
+            observed["close"] = float(data["AAPL.US"]["close"].iloc[0])
+
+    monkeypatch.setattr(runner, "_get_loader", lambda source: CountingLoader)
+    monkeypatch.setattr(
+        runner,
+        "_load_module_from_file",
+        lambda path, name: SimpleNamespace(SignalEngine=type("SignalEngine", (), {})),
+    )
+    monkeypatch.setattr(runner, "_validate_signal_engine_class", lambda cls: None)
+    monkeypatch.setattr(
+        runner, "_create_market_engine", lambda source, config, codes: CapturingEngine()
+    )
+
+    runner.main(run_dir)
+
+    assert CountingLoader.calls == 1
+    assert observed["close"] == 10.0


### PR DESCRIPTION
## Summary

- Reuse the dataset already fetched and validated for explicit sources.
- Keep run-card provenance aligned with the data used by the engine.
- Add a regression proving the provider is called once.

## Why

Closes #646.

Explicit-source backtests currently fetch twice. The second call can change the data and repeat provider cost.

## Changes

- Use the existing prefetched loader adapter for every source.
- Keep the auto-source path unchanged.
- Verify the engine receives the first validated snapshot.

## Test Plan

- [ ] Full backend suite run on this branch
- [x] New tests added
- [x] 12 relevant runner and service tests passed
- [x] Diff and DCO checks passed

## Risk

The engine API is unchanged. The input now comes from the validated snapshot already used for provenance. No provider credential or paid endpoint was used.

## Out of scope

This does not change source selection or fallback order.

## Rollback

Revert this one commit to restore the second loader call.

## Checklist

- [x] No protected agent/session/provider area is changed
- [x] No hardcoded secrets or paths
- [x] Code follows `CONTRIBUTING.md`
- [x] No user-facing documentation change is needed