### PR TITLE
Use separate China and global futures rules in composite backtests

### DIFF
--- a/agent/backtest/engines/composite.py
+++ b/agent/backtest/engines/composite.py
@@ -47,15 +47,13 @@ def _build_rule_engines(config: dict, codes: List[str]) -> Dict[str, BaseEngine]
             from backtest.engines.forex import ForexEngine
             engines["forex"] = ForexEngine(config)
         elif market == "futures":
-            china = any(
-                _is_china_futures(c) for c in codes if _detect_market(c) == "futures"
-            )
-            if china:
+            futures_codes = [c for c in codes if _detect_market(c) == "futures"]
+            if any(_is_china_futures(c) for c in futures_codes):
                 from backtest.engines.china_futures import ChinaFuturesEngine
-                engines["futures"] = ChinaFuturesEngine(config)
-            else:
+                engines["china_futures"] = ChinaFuturesEngine(config)
+            if any(not _is_china_futures(c) for c in futures_codes):
                 from backtest.engines.global_futures import GlobalFuturesEngine
-                engines["futures"] = GlobalFuturesEngine(config)
+                engines["global_futures"] = GlobalFuturesEngine(config)
 
     return engines
 
@@ -90,6 +88,8 @@ class CompositeEngine(BaseEngine):
     def _rule_for(self, symbol: str) -> BaseEngine:
         """Get the sub-engine that provides rules for this symbol."""
         market = self._symbol_market.get(symbol, "a_share")
+        if market == "futures":
+            market = "china_futures" if _is_china_futures(symbol) else "global_futures"
         return self._rule_engines[market]
 
     # ── Stateless method dispatch ──

--- a/agent/tests/test_terminal_close_accounting.py
+++ b/agent/tests/test_terminal_close_accounting.py
@@ -25,6 +25,17 @@ class _TerminalCostEngine(BaseEngine):
         return price + direction if self.positions else price
 
 
+def test_composite_routes_futures_rules_by_submarket() -> None:
+    engine = CompositeEngine(
+        {"initial_cash": 1_000_000, "codes": ["IF2406.CFFEX", "ESZ4"]},
+        ["IF2406.CFFEX", "ESZ4"],
+    )
+
+    assert isinstance(engine._rule_for("IF2406.CFFEX"), ChinaFuturesEngine)
+    assert isinstance(engine._rule_for("ESZ4"), GlobalFuturesEngine)
+    assert engine._calc_raw_size("ESZ4", 500_000.0, 5_000.0) == pytest.approx(2.0)
+
+
 @pytest.mark.parametrize(
     ("target_weight", "expected_exit"),
     [(0.5, 99.0), (-0.5, 101.0)],


### PR DESCRIPTION
## Summary

- Build China and global futures rule engines independently.
- Route each futures symbol by its own submarket.
- Add a mixed-contract sizing regression.

## Why

Closes #648.

One China contract currently causes every futures symbol in a composite backtest to use China rules.

## Changes

- Store separate futures sub-engines.
- Select the sub-engine in per-symbol dispatch.
- Verify `IF2406.CFFEX` and `ESZ4` use different rules.

## Test Plan

- [ ] Full backend suite run on this branch
- [x] New tests added
- [x] 91 relevant engine tests passed
- [x] Diff and DCO checks passed

## Risk

Only mixed futures portfolios change behavior. Single-submarket futures runs keep their existing engine. Tests use synthetic configuration and place no orders.

## Out of scope

This does not change contract metadata or market detection rules.

## Rollback

Revert this one commit to restore one shared futures sub-engine.

## Checklist

- [x] No protected agent/session/provider area is changed
- [x] No hardcoded secrets or paths
- [x] Code follows `CONTRIBUTING.md`
- [x] No user-facing documentation change is needed