### PR TITLE
Apply alpha_t_train during strict OOS confirmation

### DIFF
--- a/agent/src/factors/bench_runner_strict.py
+++ b/agent/src/factors/bench_runner_strict.py
@@ -253,7 +253,7 @@ def categorise_strict(
 
     Rules:
         - ``alpha_t_full <= -thr``                          → ``reversed_strict``
-        - ``alpha_t_full >=  thr`` and (no OOS or ``alpha_t_test >= thr``)
+        - ``alpha_t_full >=  thr`` and (no OOS or both split t-stats pass)
                                                             → ``confirmed_alive``
         - ``alpha_t_full >=  thr`` and ``alpha_t_test <= -thr`` (OOS sign-flip)
                                                             → ``reversed_strict``
@@ -271,6 +271,7 @@ def categorise_strict(
         return "noise"
 
     t_full = row["alpha_t_full"]
+    t_train = row.get("alpha_t_train")
     t_test = row.get("alpha_t_test")
     thr = thresholds.alpha_t_threshold
 
@@ -279,14 +280,18 @@ def categorise_strict(
         return "reversed_strict"
 
     # Confirmed alive requires full-sample alpha_t > thr AND, when OOS was
-    # run, the test-period alpha must also clear thr (same sign as train).
+    # run, both train and test periods must independently clear the threshold.
     if t_full >= thr:
-        if t_test is None or t_test >= thr:
+        if t_test is None:
             return "confirmed_alive"
         # OOS sign-flip is the most diagnostic failure — treat as
         # reversed_strict, not train_only.
         if t_test <= -thr:
             return "reversed_strict"
+        if t_train is None or t_train < thr:
+            return "noise"
+        if t_test >= thr:
+            return "confirmed_alive"
         # Full sample passes but OOS sits in the noise band → train-only.
         return "train_only"
 

--- a/agent/tests/factors/test_bench_strict.py
+++ b/agent/tests/factors/test_bench_strict.py
@@ -156,6 +156,11 @@ def test_categorise_confirmed_alive_when_oos_also_passes() -> None:
     assert categorise_strict(row) == "confirmed_alive"
 
 
+def test_categorise_rejects_oos_confirmation_when_training_fails() -> None:
+    row = _row(alpha_t_full=2.5, alpha_t_train=-1.0, alpha_t_test=4.0)
+    assert categorise_strict(row) == "noise"
+
+
 def test_categorise_short_ic_count_is_noise() -> None:
     # Below min_ic_count even strong t-stats are downgraded.
     row = _row(alpha_t_full=10.0, ic_count=10)


### PR DESCRIPTION
## Summary

- Require the training statistic during strict out-of-sample confirmation.
- Preserve behavior when no split is requested.
- Add a regression for a failing train period and passing test period.

## Why

Closes #649.

Strict Alpha Bench currently reads the full and test statistics but can ignore a failed training statistic.

## Changes

- Gate `confirmed_alive` on both split statistics.
- Return noise when training does not meet the configured threshold.
- Keep the existing test-period sign-flip rule.

## Test Plan

- [ ] Full backend suite run on this branch
- [x] New tests added
- [x] Strict benchmark tests passed
- [x] Factor safety gates passed
- [x] Diff and DCO checks passed

## Risk

Some previously confirmed factors will be downgraded when their training evidence is weak. No factor formula or market data is changed.

## Out of scope

This does not change thresholds or no-split mode.

## Rollback

Revert this one commit to restore the previous classifier.

## Checklist

- [x] No protected agent/session/provider area is changed
- [x] No hardcoded secrets or paths
- [x] Code follows `CONTRIBUTING.md`
- [x] No user-facing documentation change is needed