### PR TITLE
Require enough observations in every strict OOS split

### DIFF
--- a/agent/src/factors/bench_runner_strict.py
+++ b/agent/src/factors/bench_runner_strict.py
@@ -250,6 +250,8 @@ def categorise_strict(
         - ``alpha_t_train`` (Optional[float])  — None when no OOS split was run
         - ``alpha_t_test`` (Optional[float])   — None when no OOS split was run
         - ``ic_count`` (int)
+        - ``ic_count_train`` / ``ic_count_test`` (Optional[int]) — split
+          sample counts when OOS was run
 
     Rules:
         - ``alpha_t_full <= -thr``                          → ``reversed_strict``
@@ -273,6 +275,17 @@ def categorise_strict(
     t_full = row["alpha_t_full"]
     t_test = row.get("alpha_t_test")
     thr = thresholds.alpha_t_threshold
+
+    if t_test is not None:
+        train_count = row.get("ic_count_train")
+        test_count = row.get("ic_count_test")
+        if (
+            train_count is None
+            or test_count is None
+            or train_count < thresholds.min_ic_count
+            or test_count < thresholds.min_ic_count
+        ):
+            return "noise"
 
     # Strict reversed: full sample alpha is significantly negative.
     if t_full <= -thr:

--- a/agent/tests/factors/test_bench_strict.py
+++ b/agent/tests/factors/test_bench_strict.py
@@ -126,6 +126,8 @@ def _row(**overrides: Any) -> dict[str, Any]:
         "alpha_t_train": None,
         "alpha_t_test": None,
         "ic_count": 60,
+        "ic_count_train": 60,
+        "ic_count_test": 60,
     }
     base.update(overrides)
     return base
@@ -154,6 +156,17 @@ def test_categorise_train_only_when_oos_fails() -> None:
 def test_categorise_confirmed_alive_when_oos_also_passes() -> None:
     row = _row(alpha_t_full=2.5, alpha_t_train=3.0, alpha_t_test=2.4)
     assert categorise_strict(row) == "confirmed_alive"
+
+
+def test_categorise_rejects_underpowered_oos_split() -> None:
+    row = _row(
+        alpha_t_full=3.0,
+        alpha_t_train=3.0,
+        alpha_t_test=3.0,
+        ic_count_train=58,
+        ic_count_test=2,
+    )
+    assert categorise_strict(row) == "noise"
 
 
 def test_categorise_short_ic_count_is_noise() -> None:


### PR DESCRIPTION
## Summary

- Apply the existing observation floor to both OOS splits.
- Reject missing or undersized split counts.
- Add an underpowered-test-period regression.

## Why

Closes #650.

A large combined sample can currently hide a training or test period with too few observations for strict confirmation.

## Changes

- Read the existing train and test counts during classification.
- Require each count to meet `min_ic_count`.
- Preserve no-split behavior.

## Test Plan

- [ ] Full backend suite run on this branch
- [x] New tests added
- [x] Strict benchmark tests passed
- [x] Factor safety gates passed
- [x] Diff and DCO checks passed

## Risk

Some categories will become noise when either split is underpowered. The configured floor itself is unchanged.

## Out of scope

This does not change split dates or t-statistic calculation.

## Rollback

Revert this one commit to restore the aggregate-only count check.

## Checklist

- [x] No protected agent/session/provider area is changed
- [x] No hardcoded secrets or paths
- [x] Code follows `CONTRIBUTING.md`
- [x] No user-facing documentation change is needed