### PR TITLE
Keep unmatched Shadow Account markets at zero

### DIFF
--- a/agent/src/shadow_account/templates/signal_engine.py.j2
+++ b/agent/src/shadow_account/templates/signal_engine.py.j2
@@ -75,7 +75,7 @@ class SignalEngine:
         for rule in RULES:
             if rule["market"] == market or rule["market"] == "other":
                 return rule
-        return RULES[0] if RULES else None
+        return None
 
     @staticmethod
     def _conditional_entry(

--- a/agent/tests/test_shadow_account.py
+++ b/agent/tests/test_shadow_account.py
@@ -1378,6 +1378,52 @@ def _daily_index(start: str = "2026-01-02", periods: int = 30) -> pd.DatetimeInd
 
 
 @pytest.mark.unit
+def test_generated_engine_keeps_unmatched_markets_flat() -> None:
+    rule = ShadowRule(
+        rule_id="R1",
+        human_text="US time-only rule",
+        entry_condition={
+            "market": "us",
+            "entry_hour": {"min": 0, "max": 23},
+        },
+        exit_condition={"holding_days": {"min": 2, "max": 5}},
+        holding_days_range=(3, 3),
+        support_count=10,
+        coverage_rate=0.5,
+        sample_trades=("AAPL@2026-01-10",),
+    )
+    profile = ShadowProfile(
+        shadow_id="shadow_us_only",
+        created_at="2026-01-01T00:00:00",
+        journal_hash="test",
+        source_market="us",
+        profitable_roundtrips=10,
+        total_roundtrips=20,
+        date_range=("2025-01-01", "2026-01-01"),
+        profile_text="test",
+        rules=(rule,),
+        preferred_markets=("us",),
+        typical_holding_days=(3.0,),
+    )
+    index = _daily_index(periods=20)
+    frame = pd.DataFrame({"close": range(20, 40)}, index=index)
+
+    signals = _generate_signals(
+        profile,
+        {
+            "AAPL": frame,
+            "600519.SH": frame,
+            "0700.HK": frame,
+            "BTC-USDT": frame,
+        },
+    )
+
+    assert signals["AAPL"].ne(0).any()
+    for code in ("600519.SH", "0700.HK", "BTC-USDT"):
+        assert signals[code].eq(0).all(), code
+
+
+@pytest.mark.unit
 def test_conditional_entry_emits_signal_when_rsi_in_range() -> None:
     """RSI in [25, 45] → signal fires."""
     rule = _rule_with_rsi(25.0, 45.0)
@@ -1645,5 +1691,4 @@ def test_conditional_entry_rsi_nan_bars_are_skipped() -> None:
         assert series.iloc[i] == 0.0, f"bar {i} should be zero (RSI warmup)"
     # At least one entry after warmup.
     assert (series.iloc[14:] > 0).any(), "no entry after RSI warmup"
-
 


### PR DESCRIPTION
## Summary

- Remove the implicit first-rule fallback for unmatched markets.
- Preserve matching rules and the explicit `other` wildcard.
- Add generated-engine coverage across four markets.

## Why

Closes #651.

A market with no matching rule currently receives the first unrelated rule and can trade.

## Changes

- Return no rule after an unsuccessful market lookup.
- Verify a US-only profile stays flat in China, Hong Kong, and crypto.

## Test Plan

- [ ] Full backend suite run on this branch
- [x] New tests added
- [x] The complete Shadow Account test suite passed
- [x] Diff and DCO checks passed

## Risk

Unmatched markets will now remain flat. Explicit cross-market `other` rules continue to work. Tests use synthetic prices only.

## Out of scope

This does not change symbol market detection.

## Rollback

Revert this one commit to restore the first-rule fallback.

## Checklist

- [x] No protected agent/session/provider area is changed
- [x] No hardcoded secrets or paths
- [x] Code follows `CONTRIBUTING.md`
- [x] No user-facing documentation change is needed