### PR TITLE
Keep Shadow entry features point-in-time safe

### DIFF
--- a/agent/src/shadow_account/extractor.py
+++ b/agent/src/shadow_account/extractor.py
@@ -190,8 +190,9 @@ def _fetch_price_history(
             normalization in v1).
         market: Journal market label (e.g. ``"china_a"``).
         start: Inclusive fetch start (already buffered for indicator warmup).
-        end: Inclusive fetch end — never later than the roundtrip's buy_dt, so
-            look-ahead is structurally impossible.
+        end: Inclusive fetch end. Entry features still exclude the buy date
+            because this loader returns completed daily bars, not intraday
+            availability timestamps.
 
     Returns:
         A ``trade_date``-indexed OHLCV frame, or ``None`` when unavailable.
@@ -224,17 +225,18 @@ def _fetch_price_history(
 
 
 def _as_of_index(frame: pd.DataFrame, buy_dt: pd.Timestamp) -> pd.DataFrame:
-    """Slice a price frame to bars dated on or before *buy_dt*.
+    """Slice a daily price frame to bars completed before *buy_dt*.
 
     The loader frame is indexed by a tz-naive ``DatetimeIndex`` at day
     granularity; ``buy_dt`` carries a time-of-day and may be tz-aware. Normalize
-    to a tz-naive date before slicing, otherwise the ``.loc`` comparison raises.
+    to a tz-naive date before filtering. A bar labelled with the buy date is
+    excluded because its daily close was not available at an intraday entry.
     """
     as_of = pd.Timestamp(buy_dt)
     if as_of.tzinfo is not None:
         as_of = as_of.tz_localize(None)
     as_of = as_of.normalize()
-    return frame.loc[:as_of]
+    return frame.loc[frame.index < as_of]
 
 
 def _price_features_as_of(
@@ -243,9 +245,9 @@ def _price_features_as_of(
 ) -> dict[str, float]:
     """Compute price-context features as-of *buy_dt* from a price frame.
 
-    Every value is read from bars dated ``<= buy_dt`` only; bars in the
-    ``(buy_dt, sell_dt]`` exit window are never consulted. Insufficient history
-    leaves the affected feature as ``NaN``.
+    Every value is read from completed daily bars strictly before the buy date;
+    buy-day and later bars are never consulted. Insufficient history leaves the
+    affected feature as ``NaN``.
     """
     out: dict[str, float] = {name: float("nan") for name in _PRICE_FEATURES}
     if frame is None:

--- a/agent/tests/test_shadow_account.py
+++ b/agent/tests/test_shadow_account.py
@@ -693,8 +693,25 @@ def test_price_features_as_of_reads_only_past_bars() -> None:
 
     feats = _price_features_as_of(frame, buy_dt)
     assert not pd.isna(feats["entry_rsi14"])
-    # prior_5d_return over a +0.1/step ramp ending at 11.9 vs 5 steps back (11.4)
-    assert feats["prior_5d_return"] == pytest.approx((11.9 - 11.4) / 11.4, rel=1e-6)
+    # Buy-day close is unavailable. The last completed close is 11.8, with
+    # 11.3 five sessions earlier.
+    assert feats["prior_5d_return"] == pytest.approx((11.8 - 11.3) / 11.3, rel=1e-6)
+
+
+@pytest.mark.unit
+def test_price_features_ignore_incomplete_buy_day_close() -> None:
+    dates = [f"2026-02-{d:02d}" for d in range(1, 21)]
+    completed_closes = [10.0 + 0.1 * i for i in range(19)]
+    buy_dt = pd.Timestamp("2026-02-20 10:30:00")
+
+    ordinary = _price_frame(dates, completed_closes + [11.9])
+    unavailable_spike = _price_frame(dates, completed_closes + [1000.0])
+
+    expected = _price_features_as_of(ordinary, buy_dt)
+    actual = _price_features_as_of(unavailable_spike, buy_dt)
+
+    assert actual["entry_rsi14"] == pytest.approx(expected["entry_rsi14"])
+    assert actual["prior_5d_return"] == pytest.approx(expected["prior_5d_return"])
 
 
 @pytest.mark.unit
@@ -1645,5 +1662,3 @@ def test_conditional_entry_rsi_nan_bars_are_skipped() -> None:
         assert series.iloc[i] == 0.0, f"bar {i} should be zero (RSI warmup)"
     # At least one entry after warmup.
     assert (series.iloc[14:] > 0).any(), "no entry after RSI warmup"
-
-


### PR DESCRIPTION
## Summary

- Exclude the incomplete buy-date daily bar from entry features.
- Use only completed prior sessions for RSI and prior return.
- Add an extreme-close invariance regression.

## Why

Closes #652.

The buy-day close is not available at an intraday entry, but it currently changes the learned Shadow features.

## Changes

- Slice daily history strictly before the normalized buy date.
- Update the availability comments.
- Prove an extreme buy-day close cannot change the features.

## Test Plan

- [ ] Full backend suite run on this branch
- [x] New tests added
- [x] The complete Shadow Account test suite passed
- [x] Diff and DCO checks passed

## Risk

Entries recorded after market close also use the prior day because the journal does not provide a reliable per-market availability calendar. This is the conservative point-in-time rule. Tests use synthetic prices only.

## Out of scope

This does not add exchange calendars or intraday bars.

## Rollback

Revert this one commit to restore the inclusive daily slice.

## Checklist

- [x] No protected agent/session/provider area is changed
- [x] No hardcoded secrets or paths
- [x] Code follows `CONTRIBUTING.md`
- [x] No user-facing documentation change is needed