### PR TITLE
Enforce exposure limits on signed post-trade positions

### DIFF
--- a/agent/src/live/enforcement.py
+++ b/agent/src/live/enforcement.py
@@ -306,6 +306,34 @@ def _positions_market_value(positions: object) -> float | None:
     return total
 
 
+def _post_trade_gross_exposure(
+    positions: object,
+    *,
+    symbol: str,
+    signed_order_notional: float,
+) -> float | None:
+    """Return gross exposure after applying one signed order to its symbol.
+
+    Gross exposure is computed from signed, symbol-level positions. This lets a
+    sell reduce an existing long only until it reaches zero; any excess becomes
+    short exposure instead of subtracting from the whole portfolio.
+    """
+    rows = _coerce_position_rows(positions)
+    if rows is None:
+        return None
+
+    by_symbol: dict[str, float] = {}
+    for row in rows:
+        row_symbol = _position_symbol(row)
+        signed_value = _position_signed_market_value(row)
+        if row_symbol is None or signed_value is None:
+            return None
+        by_symbol[row_symbol] = by_symbol.get(row_symbol, 0.0) + signed_value
+
+    by_symbol[symbol] = by_symbol.get(symbol, 0.0) + signed_order_notional
+    return sum(abs(value) for value in by_symbol.values())
+
+
 def _coerce_position_rows(positions: object) -> list[dict] | None:
     """Normalize a positions payload to a list of position dicts."""
     if isinstance(positions, list):
@@ -353,6 +381,43 @@ def _position_market_value(row: dict) -> float | None:
     if qty is None or price is None:
         return None
     return abs(qty) * price
+
+
+def _position_symbol(row: dict) -> str | None:
+    """Extract one normalized position symbol, or ``None`` if unavailable."""
+    for key in ("symbol", "ticker", "code", "instrument"):
+        value = row.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip().upper()
+    return None
+
+
+def _position_signed_market_value(row: dict) -> float | None:
+    """Extract signed USD value, using quantity or explicit side for direction."""
+    value = _position_market_value(row)
+    if value is None:
+        return None
+
+    quantity = None
+    for key in ("quantity", "qty", "shares"):
+        if key in row:
+            quantity = _as_float(row[key])
+            if quantity is None:
+                return None
+            break
+    if quantity is not None:
+        if quantity == 0:
+            return 0.0 if value == 0 else None
+        return abs(value) if quantity > 0 else -abs(value)
+
+    side = str(row.get("side", "")).strip().lower()
+    if side in {"long", "buy"}:
+        return abs(value)
+    if side in {"short", "sell"}:
+        return -abs(value)
+    if value < 0:
+        return value
+    return value
 
 
 def _account_balance_market_value(balance: object) -> float | None:
@@ -474,18 +539,21 @@ def check_mandate(
             limit_value=caps.max_order_notional_usd, attempted_value=notional,
         )
 
-    # 5–6. Exposure + leverage need observable positions; fail-closed on any
-    #      unparseable position. A sell reduces gross exposure (signed by side).
-    current_exposure = _positions_market_value(positions)
-    if current_exposure is None:
+    # 5–6. Exposure + leverage need symbol-level signed positions so a sell
+    #      reduces only an existing long; fail-closed on ambiguous rows.
+    signed_order = notional if intent.side == "buy" else -notional
+    post_exposure = _post_trade_gross_exposure(
+        positions,
+        symbol=symbol,
+        signed_order_notional=signed_order,
+    )
+    if post_exposure is None:
         return _breach(
             broker=broker, remote_tool=remote_tool, intent=intent,
             kind=BREACH_KIND_QUANTITATIVE, limit="max_total_exposure_usd",
             limit_value=caps.max_total_exposure_usd, attempted_value=0.0,
             detail="current positions could not be read (fail-closed)",
         )
-    signed = notional if intent.side == "buy" else -notional
-    post_exposure = current_exposure + signed
     if post_exposure > caps.max_total_exposure_usd:
         return _breach(
             broker=broker, remote_tool=remote_tool, intent=intent,

--- a/agent/tests/test_mandate_enforcement.py
+++ b/agent/tests/test_mandate_enforcement.py
@@ -294,6 +294,77 @@ def test_guard_blocks_over_notional_with_breach(live_runtime: Path) -> None:
     assert adapter.order_calls == []  # never forwarded
 
 
+def test_guard_blocks_opening_short_above_gross_exposure_cap(live_runtime: Path) -> None:
+    """A sell from zero opens short exposure; it does not reduce risk."""
+    _write_mandate(
+        live_runtime,
+        _mandate(
+            account_funding_usd=1000.0,
+            max_order_notional_usd=1000.0,
+            max_total_exposure_usd=500.0,
+            max_leverage=10.0,
+        ),
+    )
+    adapter = _MockAdapter(positions=[], balance=1000.0)
+    guard = _guard(adapter)
+
+    out = json.loads(
+        guard.execute(
+            symbol="AAPL",
+            side="sell",
+            instrument_type="equity",
+            notional_usd=600.0,
+        )
+    )
+
+    assert out["status"] == "blocked"
+    assert out["breach"]["limit"] == "max_total_exposure_usd"
+    assert out["breach"]["attempted_value"] == 600.0
+    assert adapter.order_calls == []
+
+
+def test_mixed_book_uses_gross_not_net_exposure() -> None:
+    mandate = _mandate(
+        account_funding_usd=1000.0,
+        max_order_notional_usd=1000.0,
+        max_total_exposure_usd=1000.0,
+        max_leverage=10.0,
+    )
+    positions = [
+        {"symbol": "MSFT", "quantity": 10.0, "price": 60.0},
+        {"symbol": "TSLA", "quantity": -10.0, "price": 50.0},
+    ]
+
+    breach = _check(
+        _intent(symbol="AAPL", side="buy", notional_usd=100.0),
+        mandate,
+        positions=positions,
+    )
+
+    assert breach is not None
+    assert breach.limit == "max_total_exposure_usd"
+    assert breach.attempted_value == 1200.0
+
+
+def test_sell_that_only_reduces_long_exposure_stays_allowed() -> None:
+    mandate = _mandate(
+        account_funding_usd=1000.0,
+        max_order_notional_usd=1000.0,
+        max_total_exposure_usd=500.0,
+        max_leverage=10.0,
+    )
+    positions = [{"symbol": "AAPL", "quantity": 10.0, "price": 60.0}]
+
+    assert (
+        _check(
+            _intent(symbol="AAPL", side="sell", notional_usd=200.0),
+            mandate,
+            positions=positions,
+        )
+        is None
+    )
+
+
 def test_guard_structural_breach_denies_no_reauth(live_runtime: Path) -> None:
     _write_mandate(live_runtime, _mandate())
     adapter = _MockAdapter(positions=[], balance=5000.0)


### PR DESCRIPTION
## Summary

- Calculate gross exposure from symbol-level signed positions.
- Count opening and oversized sells as short exposure.
- Add opening-short, mixed-book, and reducing-sell regressions.

## Why

Closes #664.

The current unsigned total lets a sell reduce exposure below zero and bypass a mandate cap.

## Changes

- Resolve each current position's symbol and direction.
- Apply the proposed order to that symbol.
- Sum absolute post-trade values and fail closed on ambiguous rows.

## Test Plan

- [x] New tests added
- [x] 354 adjacent live-safety tests passed
- [x] Ruff, compile, CI safety gates, diff, DCO, and secret checks passed
- [x] All broker transports were mocked

## Risk

This changes the live mandate and leverage calculation. It can block sells that would open or enlarge a short, while still allowing risk-reducing sells. No real broker, account, credential, or order was used.

## Out of scope

This does not change broker sizing or short availability.

## Rollback

Revert this one commit to restore the previous exposure formula.

## Checklist

- [x] The live safety area is covered by issue #664 and focused tests
- [x] No hardcoded secrets or paths
- [x] Code follows `CONTRIBUTING.md`
- [x] No user-facing documentation change is needed