### PR TITLE
Make daily order limits atomic across SDK and MCP writes

### DIFF
--- a/agent/src/live/daily_count.py
+++ b/agent/src/live/daily_count.py
@@ -9,11 +9,30 @@ read failure reads as ``0`` (fail-open on the count only, never on the order).
 from __future__ import annotations
 
 import json
+import os
+import threading
+from contextlib import contextmanager
 from datetime import datetime, timezone
+from typing import BinaryIO, Iterator
+
+try:  # POSIX advisory lock (Linux/macOS).
+    import fcntl
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None  # type: ignore[assignment]
+
+try:  # Windows advisory byte-range lock.
+    import msvcrt
+except ImportError:  # pragma: no cover - POSIX
+    msvcrt = None  # type: ignore[assignment]
 
 from src.live.paths import broker_dir
 
 _COUNTER_FILENAME = "trade_counter.json"
+_LOCK_FILENAME = ".order_submit.lock"
+
+
+class DailyOrderLockUnavailable(RuntimeError):
+    """Raised when another process holds the broker's order permit lock."""
 
 
 def _counter_path(broker: str):
@@ -23,6 +42,65 @@ def _counter_path(broker: str):
 def _utc_today() -> str:
     """Return today's UTC calendar date as ``YYYY-MM-DD``."""
     return datetime.now(timezone.utc).date().isoformat()
+
+
+def _try_lock(handle: BinaryIO) -> None:
+    """Acquire a non-blocking cross-process advisory lock."""
+    if fcntl is not None:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return
+    if msvcrt is not None:  # pragma: no cover - exercised on Windows CI
+        handle.seek(0, os.SEEK_END)
+        if handle.tell() == 0:
+            handle.write(b"\0")
+            handle.flush()
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+        return
+    raise OSError("no supported advisory lock backend")
+
+
+def _unlock(handle: BinaryIO) -> None:
+    """Release the platform advisory lock."""
+    if fcntl is not None:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    elif msvcrt is not None:  # pragma: no cover - exercised on Windows CI
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+
+
+@contextmanager
+def daily_order_lock(broker: str) -> Iterator[None]:
+    """Hold one non-blocking order-admission lock for ``broker``.
+
+    The caller must keep this lock through the final daily-count check, broker
+    submission, and durable count increment. Lock contention fails closed.
+
+    Raises:
+        DailyOrderLockUnavailable: If the lock cannot be acquired immediately.
+    """
+    path = broker_dir(broker) / _LOCK_FILENAME
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        handle = path.open("a+b")
+    except OSError as exc:
+        raise DailyOrderLockUnavailable(
+            f"the {broker} order-submission lock is unavailable"
+        ) from exc
+    try:
+        _try_lock(handle)
+    except OSError as exc:
+        handle.close()
+        raise DailyOrderLockUnavailable(
+            f"another {broker} order submission is already in progress"
+        ) from exc
+    try:
+        yield
+    finally:
+        try:
+            _unlock(handle)
+        finally:
+            handle.close()
 
 
 def read_daily_count(broker: str) -> int:
@@ -48,7 +126,9 @@ def increment_daily_count(broker: str) -> int:
     count = read_daily_count(broker) + 1
     path = _counter_path(broker)
     path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-    tmp = path.with_name(f".{path.name}.tmp")
+    tmp = path.with_name(
+        f".{path.name}.{os.getpid()}.{threading.get_ident()}.tmp"
+    )
     tmp.write_text(json.dumps({"date": today, "count": count}, ensure_ascii=False), encoding="utf-8")
     tmp.replace(path)
     return count

--- a/agent/src/live/order_guard.py
+++ b/agent/src/live/order_guard.py
@@ -63,7 +63,12 @@ from src.live.extractors import get_extractor
 from src.live.halt import halt_flag_set
 from src.live.mandate.model import MANDATE_SCHEMA_VERSION, Mandate
 from src.live.mandate.store import load_mandate
-from src.live.daily_count import increment_daily_count, read_daily_count
+from src.live.daily_count import (
+    DailyOrderLockUnavailable,
+    daily_order_lock,
+    increment_daily_count,
+    read_daily_count,
+)
 from src.tools.mcp import MCPRemoteTool, MCPRemoteToolSpec, MCPServerAdapter
 
 logger = logging.getLogger(__name__)
@@ -178,22 +183,30 @@ class LiveOrderGuardTool(MCPRemoteTool):
 
         positions = self._read_first(self._read_tools("positions", _POSITIONS_TOOLS))
         balance = self._read_first(self._read_tools("account", _BALANCE_TOOLS))
-        daily_count = self._read_daily_count()
 
-        breach = check_mandate(
-            mandate,
-            intent,
-            positions,
-            balance,
-            broker=self.broker,
-            remote_tool=self.remote_name,
-            daily_count=daily_count,
-        )
+        try:
+            with daily_order_lock(self.broker):
+                daily_count = self._read_daily_count()
+                breach = check_mandate(
+                    mandate,
+                    intent,
+                    positions,
+                    balance,
+                    broker=self.broker,
+                    remote_tool=self.remote_name,
+                    daily_count=daily_count,
+                )
 
-        if breach is None:
-            return self._allow(
-                mandate=mandate, intent=intent, kwargs=kwargs,
-                positions=positions, balance=balance,
+                if breach is None:
+                    return self._allow(
+                        mandate=mandate, intent=intent, kwargs=kwargs,
+                        positions=positions, balance=balance,
+                    )
+        except DailyOrderLockUnavailable as exc:
+            return self._deny(
+                reason=str(exc),
+                checked=["mandate", "expiry", "halt_flag", "daily_order_lock"],
+                mandate=mandate,
             )
 
         if breach.kind in (BREACH_KIND_UNIVERSE, BREACH_KIND_INSTRUMENT):

--- a/agent/src/live/sdk_order_gate.py
+++ b/agent/src/live/sdk_order_gate.py
@@ -28,7 +28,12 @@ from datetime import datetime, timezone
 from typing import Any
 
 from src.live.audit import LiveActionEvent, write_live_action
-from src.live.daily_count import increment_daily_count, read_daily_count
+from src.live.daily_count import (
+    DailyOrderLockUnavailable,
+    daily_order_lock,
+    increment_daily_count,
+    read_daily_count,
+)
 from src.live.enforcement import (
     BREACH_KIND_INSTRUMENT,
     BREACH_KIND_UNIVERSE,
@@ -100,15 +105,29 @@ def execute_live_order(
 
     positions = _safe_read(connector_module, "get_positions", config)
     balance = _safe_read(connector_module, "get_account_snapshot", config)
-    daily_count = read_daily_count(broker)
 
-    breach = check_mandate(
-        mandate, intent, positions, balance,
-        broker=broker, remote_tool=_REMOTE_TOOL, daily_count=daily_count,
-    )
+    try:
+        with daily_order_lock(broker):
+            daily_count = read_daily_count(broker)
+            breach = check_mandate(
+                mandate, intent, positions, balance,
+                broker=broker, remote_tool=_REMOTE_TOOL, daily_count=daily_count,
+            )
 
-    if breach is None:
-        return _allow(broker, session_id, connector_module, config, intent, place_kwargs, mandate)
+            if breach is None:
+                return _allow(
+                    broker, session_id, connector_module, config,
+                    intent, place_kwargs, mandate,
+                )
+    except DailyOrderLockUnavailable as exc:
+        return _deny(
+            broker,
+            session_id,
+            str(exc),
+            ["mandate", "expiry", "halt_flag", "daily_order_lock"],
+            mandate,
+            intent=intent,
+        )
 
     reauth = breach.kind not in (BREACH_KIND_UNIVERSE, BREACH_KIND_INSTRUMENT)
     return _deny_breach(broker, session_id, breach, mandate, intent, reauth)

--- a/agent/tests/test_daily_count.py
+++ b/agent/tests/test_daily_count.py
@@ -1,0 +1,55 @@
+"""Daily order-counter serialization tests with no broker transport."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import src.live.paths as live_paths
+from src.live.daily_count import daily_order_lock
+
+pytestmark = pytest.mark.unit
+
+
+def _child_lock_attempt(repo_root: Path, home: Path) -> subprocess.CompletedProcess[str]:
+    script = """
+from src.live.daily_count import DailyOrderLockUnavailable, daily_order_lock
+try:
+    with daily_order_lock("alpaca"):
+        print("acquired")
+except DailyOrderLockUnavailable:
+    print("blocked")
+"""
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["PYTHONPATH"] = str(repo_root / "agent")
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=10,
+    )
+
+
+def test_daily_order_lock_is_cross_process(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A lock held here denies another process, then becomes available."""
+    runtime_root = tmp_path / ".vibe-trading"
+    monkeypatch.setattr(live_paths, "get_runtime_root", lambda: runtime_root)
+    repo_root = Path(__file__).resolve().parents[2]
+
+    with daily_order_lock("alpaca"):
+        blocked = _child_lock_attempt(repo_root, tmp_path)
+    acquired = _child_lock_attempt(repo_root, tmp_path)
+
+    assert blocked.stdout.strip() == "blocked"
+    assert acquired.stdout.strip() == "acquired"

--- a/agent/tests/test_mandate_enforcement.py
+++ b/agent/tests/test_mandate_enforcement.py
@@ -9,6 +9,7 @@ floors are exercised by monkeypatching the loader-backed helpers (no network).
 from __future__ import annotations
 
 import json
+import threading
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -280,6 +281,51 @@ def test_guard_forwards_in_mandate_order(live_runtime: Path) -> None:
     # Daily counter incremented exactly once on confirmed forward.
     counter = json.loads((live_runtime / "live" / "robinhood" / "trade_counter.json").read_text())
     assert counter["count"] == 1
+
+
+def test_mcp_guard_serializes_the_daily_cap_with_submission(live_runtime: Path) -> None:
+    """MCP placements share the same one-permit transaction as SDK orders."""
+    _write_mandate(live_runtime, _mandate(max_trades_per_day=1))
+    entered = threading.Event()
+    release = threading.Event()
+
+    class _BlockingAdapter(_MockAdapter):
+        def call_tool(self, remote_name, arguments, *, local_name=None):
+            if remote_name in {"get_equity_positions", "get_portfolio"}:
+                return super().call_tool(remote_name, arguments, local_name=local_name)
+            self.order_calls.append({"remote": remote_name, "arguments": arguments})
+            entered.set()
+            assert release.wait(timeout=5)
+            return {"status": "ok", "order_id": "rh_test_1", "state": "accepted"}
+
+    adapter = _BlockingAdapter(positions=[], balance=5000.0)
+    guard = _guard(adapter)
+    outputs: list[dict[str, Any]] = []
+
+    def place() -> None:
+        outputs.append(
+            json.loads(
+                guard.execute(
+                    symbol="AAPL",
+                    side="buy",
+                    instrument_type="equity",
+                    notional_usd=100.0,
+                )
+            )
+        )
+
+    first = threading.Thread(target=place)
+    second = threading.Thread(target=place)
+    first.start()
+    assert entered.wait(timeout=2)
+    second.start()
+    second.join(timeout=1)
+    release.set()
+    first.join(timeout=5)
+    second.join(timeout=5)
+
+    assert len(adapter.order_calls) == 1
+    assert sorted(output["status"] for output in outputs) == ["blocked", "ok"]
 
 
 def test_guard_blocks_over_notional_with_breach(live_runtime: Path) -> None:

--- a/agent/tests/test_sdk_order_gate.py
+++ b/agent/tests/test_sdk_order_gate.py
@@ -7,9 +7,14 @@ connector module + a stubbed mandate/halt so they need no broker SDK.
 
 from __future__ import annotations
 
+import threading
+from contextlib import nullcontext
+
 import pytest
 
+import src.live.paths as live_paths
 from src.live import sdk_order_gate as gate
+from src.live.daily_count import read_daily_count
 from src.live.enforcement import OrderIntent
 from src.live.mandate.model import (
     AssetClass,
@@ -47,7 +52,13 @@ class _FakeConnector:
         return {"status": "ok", "symbol": symbol, "quote": {"last": self._quote_last}}
 
 
-def _mandate(*, max_order=1_000_000.0, assets=(AssetClass.US_EQUITY,), instruments=(InstrumentType.EQUITY,)):
+def _mandate(
+    *,
+    max_order=1_000_000.0,
+    max_trades=100,
+    assets=(AssetClass.US_EQUITY,),
+    instruments=(InstrumentType.EQUITY,),
+):
     return Mandate(
         schema_version=1,
         hard_caps=HardCaps(
@@ -56,7 +67,7 @@ def _mandate(*, max_order=1_000_000.0, assets=(AssetClass.US_EQUITY,), instrumen
             max_total_exposure_usd=1_000_000.0,
             max_leverage=2.0,
             allowed_instruments=tuple(instruments),
-            max_trades_per_day=100,
+            max_trades_per_day=max_trades,
         ),
         universe=UniverseConstraint(
             asset_classes=tuple(assets),
@@ -80,6 +91,7 @@ def _patch_gate(monkeypatch, *, mandate, halted=False):
     monkeypatch.setattr(gate, "write_live_action", lambda *a, **k: {"audited": True})
     monkeypatch.setattr(gate, "read_daily_count", lambda broker: 0)
     monkeypatch.setattr(gate, "increment_daily_count", lambda broker: 1)
+    monkeypatch.setattr(gate, "daily_order_lock", lambda broker: nullcontext())
 
 
 def _intent(notional=500.0, qty=None, asset=AssetClass.US_EQUITY):
@@ -251,6 +263,7 @@ def test_gate_count_consumed_only_on_success(monkeypatch) -> None:
     monkeypatch.setattr(gate, "write_live_action", lambda *a, **k: {"audited": True})
     monkeypatch.setattr(gate, "read_daily_count", lambda b: 0)
     monkeypatch.setattr(gate, "increment_daily_count", lambda b: increments.append(b))
+    monkeypatch.setattr(gate, "daily_order_lock", lambda broker: nullcontext())
 
     # Connector returns an error envelope → no count consumed.
     class _ErrConn(_FakeConnector):
@@ -263,6 +276,61 @@ def test_gate_count_consumed_only_on_success(monkeypatch) -> None:
     )
     assert out["status"] == "error"
     assert increments == []  # failed placement must not consume a daily count
+
+
+def test_concurrent_orders_share_one_daily_cap_permit(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """Two callers racing a cap of one must make only one broker call."""
+    runtime_root = tmp_path / ".vibe-trading"
+    monkeypatch.setattr(live_paths, "get_runtime_root", lambda: runtime_root)
+    monkeypatch.setattr(gate, "load_mandate", lambda broker: _mandate(max_trades=1))
+    monkeypatch.setattr(gate, "halt_flag_set", lambda broker: False)
+    monkeypatch.setattr(gate, "write_live_action", lambda *a, **k: {"audited": True})
+
+    entered = threading.Event()
+    release = threading.Event()
+
+    class _BlockingConnector(_FakeConnector):
+        def place_order(self, config, **kwargs):
+            self.placed.append(kwargs)
+            entered.set()
+            assert release.wait(timeout=5)
+            return {"status": "ok", "order_id": f"OID-{len(self.placed)}", **kwargs}
+
+    connector = _BlockingConnector()
+    outputs: list[dict] = []
+    errors: list[BaseException] = []
+
+    def place() -> None:
+        try:
+            outputs.append(
+                gate.execute_live_order(
+                    broker="alpaca",
+                    connector_module=connector,
+                    config=object(),
+                    intent=_intent(),
+                    place_kwargs={"symbol": "AAPL", "side": "buy", "notional": 500.0},
+                )
+            )
+        except BaseException as exc:  # test captures thread failures explicitly
+            errors.append(exc)
+
+    first = threading.Thread(target=place)
+    second = threading.Thread(target=place)
+    first.start()
+    assert entered.wait(timeout=2)
+    second.start()
+    second.join(timeout=1)
+    release.set()
+    first.join(timeout=5)
+    second.join(timeout=5)
+
+    assert errors == []
+    assert len(connector.placed) == 1
+    assert read_daily_count("alpaca") == 1
+    assert sorted(output["status"] for output in outputs) == ["blocked", "ok"]
 
 
 def test_gate_connector_raise_is_caught(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- Serialize daily-cap admission, broker submission, and count persistence per broker.
- Share the lock across SDK and MCP placement paths.
- Add thread and child-process regressions.

## Why

Closes #665.

Concurrent callers can both pass the same daily count and submit more orders than the mandate allows.

## Changes

- Add a non-blocking cross-process advisory lock.
- Hold it through the final count check, submission, and increment.
- Fail closed on contention or lock failure.
- Use unique counter temporary files.

## Test Plan

- [x] New tests added
- [x] 353 adjacent live-safety tests passed before the final MCP regression
- [x] The final 65-test focused suite passed
- [x] Cross-process acquisition and release passed
- [x] Compile, CI safety gates, diff, DCO, and secret checks passed
- [x] All broker transports were mocked

## Risk

A concurrent placement now fails closed instead of waiting. A crash after broker acceptance but before count persistence remains an ambiguous-submit recovery case. No real broker, account, credential, or order was used.

## Out of scope

Cancellation and broker-side idempotency are unchanged.

## Rollback

Revert this one commit to restore the unlocked placement flow.

## Checklist

- [x] The live safety area is covered by issue #665 and focused tests
- [x] No hardcoded secrets or paths
- [x] Code follows `CONTRIBUTING.md`
- [x] No user-facing documentation change is needed