### PR TITLE
Make mandate activation fail closed across both files

### DIFF
--- a/agent/src/live/mandate/commit.py
+++ b/agent/src/live/mandate/commit.py
@@ -413,8 +413,6 @@ def commit_mandate(
             "expires_at": expires_iso,
         },
     }
-    _atomic_write_json(broker_dir(broker) / _MANDATE_FILENAME, mandate_doc)
-
     consent_record = {
         "consent_record_id": consent_record_id,
         "mandate_id": mandate_id,
@@ -431,7 +429,11 @@ def commit_mandate(
         "created_at": created_iso,
         "expires_at": expires_iso,
     }
+    # Persist evidence before authority. If the consent write fails, no mandate
+    # becomes usable. If mandate publication fails afterward, the orphaned
+    # consent record is harmless and useful for audit/retry diagnosis.
     _atomic_write_json(_consent_dir(broker) / f"{consent_record_id}.json", consent_record)
+    _atomic_write_json(broker_dir(broker) / _MANDATE_FILENAME, mandate_doc)
 
     # One-shot: the proposal can never be committed again.
     _invalidate_proposal(broker, proposal_id)

--- a/agent/tests/test_consent_commit.py
+++ b/agent/tests/test_consent_commit.py
@@ -19,6 +19,7 @@ from pathlib import Path
 import pytest
 
 import src.live.paths as paths
+import src.live.mandate.commit as mandate_commit
 from src.live.mandate.commit import (
     CommitError,
     DEFAULT_MANDATE_LIFETIME_DAYS,
@@ -156,6 +157,62 @@ def test_commit_consumes_proposal_no_replay(live_runtime: Path) -> None:
             consent_ack=True,
             broker="robinhood",
         )
+
+
+def test_failed_consent_write_does_not_publish_mandate(
+    live_runtime: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed approval record must not leave usable live authority."""
+    proposal = _propose()
+    real_write = mandate_commit._atomic_write_json
+
+    def fail_consent(path: Path, payload: dict) -> None:
+        if path.parent.name == "consent":
+            raise OSError("synthetic consent write failure")
+        real_write(path, payload)
+
+    monkeypatch.setattr(mandate_commit, "_atomic_write_json", fail_consent)
+
+    with pytest.raises(OSError, match="synthetic consent write failure"):
+        commit_mandate(
+            proposal_id=proposal["proposal_id"],
+            ordinal=1,
+            adjustments=None,
+            consent_ack=True,
+            broker="robinhood",
+        )
+
+    assert load_mandate("robinhood") is None
+    assert not (paths.broker_dir("robinhood") / "mandate.json").exists()
+
+
+def test_failed_mandate_write_leaves_only_harmless_consent(
+    live_runtime: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Publishing authority last makes its failure fail closed."""
+    proposal = _propose()
+    real_write = mandate_commit._atomic_write_json
+
+    def fail_mandate(path: Path, payload: dict) -> None:
+        if path.name == "mandate.json":
+            raise OSError("synthetic mandate write failure")
+        real_write(path, payload)
+
+    monkeypatch.setattr(mandate_commit, "_atomic_write_json", fail_mandate)
+
+    with pytest.raises(OSError, match="synthetic mandate write failure"):
+        commit_mandate(
+            proposal_id=proposal["proposal_id"],
+            ordinal=1,
+            adjustments=None,
+            consent_ack=True,
+            broker="robinhood",
+        )
+
+    assert load_mandate("robinhood") is None
+    assert len(list((paths.broker_dir("robinhood") / "consent").glob("*.json"))) == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Write immutable consent evidence before live mandate authority.
- Publish `mandate.json` only after consent succeeds.
- Test failures in both write directions.

## Why

Closes #666.

A failed consent write can currently leave a loadable mandate even though the commit returned an error.

## Changes

- Reverse the two existing atomic writes.
- Keep proposal invalidation after both writes.
- Leave a harmless audit record if mandate publication fails.

## Test Plan

- [x] New tests added
- [x] 353 adjacent live-safety tests passed
- [x] Ruff, compile, CI safety gates, diff, DCO, and secret checks passed
- [x] All paths and identities were temporary

## Risk

A failed mandate write can leave an orphan consent record, but that record grants no authority. No live account, credential, or broker was used.

## Out of scope

This does not redesign storage transactions or proposal retry behavior.

## Rollback

Revert this one commit to restore the previous write order.

## Checklist

- [x] The live safety area is covered by issue #666 and focused tests
- [x] No hardcoded secrets or paths
- [x] Code follows `CONTRIBUTING.md`
- [x] No user-facing documentation change is needed