### PR TITLE
Reconcile the union of recorded and broker positions

### DIFF
--- a/agent/src/live/runtime/reconcile.py
+++ b/agent/src/live/runtime/reconcile.py
@@ -463,10 +463,12 @@ def _diff_positions(
     }
 
     deltas: list[ReconcileDelta] = []
+    broker_symbols: set[str] = set()
     for position in broker_positions:
         symbol = _position_symbol(position)
         if symbol is None:
             continue
+        broker_symbols.add(symbol)
         broker_qty = _position_qty(position)
         recorded_qty = recorded_by_symbol.get(symbol)
         if recorded_qty is not None and recorded_qty == broker_qty:
@@ -501,6 +503,25 @@ def _diff_positions(
                     broker=dict(position),
                 )
             )
+
+    for symbol, recorded_qty in recorded_by_symbol.items():
+        if symbol in broker_symbols or recorded_qty == 0:
+            continue
+        deltas.append(
+            ReconcileDelta(
+                kind=DeltaKind.UNKNOWN_FILL,
+                subject="position",
+                identity=symbol,
+                client_order_id=None,
+                detail=(
+                    "recorded nonzero position is absent from broker truth "
+                    f"(recorded={recorded_qty}, broker=absent); real money "
+                    "moved without a matching audit record"
+                ),
+                recorded={"symbol": symbol, "qty": recorded_qty},
+                broker=None,
+            )
+        )
     return deltas
 
 

--- a/agent/tests/test_runtime_reconcile.py
+++ b/agent/tests/test_runtime_reconcile.py
@@ -145,6 +145,27 @@ def test_unknown_fill_on_quantity_drift(live_runtime: Path) -> None:
     assert report.requires_halt is True
 
 
+@pytest.mark.parametrize("quantity", [3, -3])
+def test_recorded_position_missing_at_broker_forces_halt(
+    live_runtime: Path,
+    quantity: int,
+) -> None:
+    """A recorded long or short cannot disappear without a halting delta."""
+    state_path = _seed_state(
+        "robinhood",
+        positions=[{"symbol": "NVDA", "qty": quantity}],
+    )
+    before = state_path.read_text(encoding="utf-8")
+    rp, rb, ro = _readers(positions=[])
+
+    report = reconcile("robinhood", rp, rb, ro)
+
+    assert DeltaKind.UNKNOWN_FILL in _kinds(report)
+    assert report.requires_halt is True
+    assert report.state_persisted is False
+    assert state_path.read_text(encoding="utf-8") == before
+
+
 # ---------------------------------------------------------------------------
 # orphan_order  (we recorded a CONFIRMED order the broker no longer shows)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Detect nonzero recorded positions missing from the broker snapshot.
- Emit a halting unknown-fill delta.
- Preserve prior state for operator review.

## Why

Closes #667.

The current broker-only loop can silently erase a recorded long or short when that symbol is omitted.

## Changes

- Track symbols seen in broker results.
- Compare remaining recorded nonzero positions after the broker loop.
- Add long and short regressions.

## Test Plan

- [x] New tests added
- [x] 353 adjacent live-safety tests passed
- [x] Compile, CI safety gates, diff, DCO, and secret checks passed
- [x] All broker readers were mocks

## Risk

A legitimate manual close can now require operator review, which is the fail-closed behavior for unexplained live-state changes. No real broker, account, credential, or order was used.

## Out of scope

Recorded zero quantities remain ignored.

## Rollback

Revert this one commit to restore one-way position comparison.

## Checklist

- [x] The live safety area is covered by issue #667 and focused tests
- [x] No hardcoded secrets or paths
- [x] Code follows `CONTRIBUTING.md`
- [x] No user-facing documentation change is needed