### PR TITLE
feat(agent): add stream retry configuration

### DIFF
--- a/agent/src/agent/loop.py
+++ b/agent/src/agent/loop.py
@@ -101,6 +101,15 @@ def _stream_retry_delay_s() -> float:
     return get_env_config().agent_tuning.vt_stream_retry_delay_s
 
 
+def _stream_max_retries() -> int:
+    """Return the configured retry count for transient stream failures."""
+    ov = _override("STREAM_MAX_RETRIES")
+    if ov is not None:
+        return max(0, int(ov))
+    from src.config.accessor import get_env_config
+    return max(0, get_env_config().agent_tuning.vt_stream_max_retries)
+
+
 def _tool_timeout_seconds() -> float:
     ov = _override("TOOL_TIMEOUT_SECONDS")
     if ov is not None:
@@ -1596,6 +1605,7 @@ _LEGACY_LAZY = {
     "HEARTBEAT_INTERVAL_S": _heartbeat_interval_s,
     "REASONING_DELTA_MIN_INTERVAL_S": _reasoning_delta_min_interval_s,
     "STREAM_RETRY_DELAY_S": _stream_retry_delay_s,
+    "STREAM_MAX_RETRIES": _stream_max_retries,
     "TOOL_TIMEOUT_SECONDS": _tool_timeout_seconds,
     "GOAL_MAX_CONTINUATIONS": _goal_max_continuations,
 }

--- a/agent/src/config/env_schema.py
+++ b/agent/src/config/env_schema.py
@@ -269,6 +269,7 @@ class AgentTuningConfig(_EnvBase):
         alias="VT_REASONING_DELTA_MIN_INTERVAL_S", default=1.0,
     )
     vt_stream_retry_delay_s: float = Field(alias="VT_STREAM_RETRY_DELAY_S", default=1.0)
+    vt_stream_max_retries: int = Field(alias="VT_STREAM_MAX_RETRIES", default=3)
     vibe_trading_tool_timeout_seconds: float = Field(
         alias="VIBE_TRADING_TOOL_TIMEOUT_SECONDS", default=1800.0,
     )

--- a/agent/tests/test_stream_retry_config.py
+++ b/agent/tests/test_stream_retry_config.py
@@ -1,0 +1,10 @@
+"""Configuration contract for stream retry limits."""
+
+from __future__ import annotations
+
+import src.agent.loop as loop
+
+
+def test_stream_max_retries_honors_runtime_override(monkeypatch) -> None:
+    monkeypatch.setattr(loop, "STREAM_MAX_RETRIES", 5, raising=False)
+    assert loop._stream_max_retries() == 5


### PR DESCRIPTION
Split from #543 as the parent for stream-retry consumers.\n\nAdds `VT_STREAM_MAX_RETRIES` and its bounded runtime accessor without changing retry-loop behavior. Follow-up PRs can independently review agent and swarm retry behavior.\n\nVerification: `PYTHONPATH=agent ~/.venvs/vibe-trading/bin/python -m pytest agent/tests/test_stream_retry_config.py -q` (1 passed).