### PR TITLE
Apply the QVeris budget to backtest data calls

### DIFF
--- a/agent/backtest/loaders/qveris_loader.py
+++ b/agent/backtest/loaders/qveris_loader.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import time
 from dataclasses import dataclass
@@ -67,6 +68,7 @@ class QVerisConfig:
     base_url: str
     api_key: str
     mode: str
+    budget_credits_per_session: float
 
 
 def _load_config() -> QVerisConfig:
@@ -82,6 +84,7 @@ def _load_config() -> QVerisConfig:
         "base_url": _DEFAULT_BASE_URL,
         "api_key": "",
         "mode": "free",
+        "budget_credits_per_session": 50.0,
     }
     try:
         if _CONFIG_PATH.is_file():
@@ -95,11 +98,18 @@ def _load_config() -> QVerisConfig:
 
     api_key = (get_env_config().data.qveris_api_key or str(raw.get("api_key") or "")).strip()
     base_url = (get_env_config().data.qveris_base_url or str(raw.get("base_url") or _DEFAULT_BASE_URL)).strip()
+    try:
+        budget = float(raw.get("budget_credits_per_session", 50.0))
+    except (TypeError, ValueError):
+        budget = 50.0
+    if not math.isfinite(budget):
+        budget = 50.0
     return QVerisConfig(
         enabled=bool(raw.get("enabled")),
         base_url=(base_url or _DEFAULT_BASE_URL).rstrip("/"),
         api_key=api_key,
         mode=_normalize_mode(str(raw.get("mode") or "free")),
+        budget_credits_per_session=max(budget, 0.0),
     )
 
 
@@ -296,6 +306,7 @@ class DataLoader:
             return {}
 
         client = QVerisClient(self._config)
+        budget_state = {"spent": 0.0}
         result: Dict[str, pd.DataFrame] = {}
         for code in codes:
             try:
@@ -307,7 +318,12 @@ class DataLoader:
                     end_date=end_date,
                     fields=None,
                     fetch=lambda code=code: self._fetch_one(
-                        client, code, start_date, end_date, interval
+                        client,
+                        code,
+                        start_date,
+                        end_date,
+                        interval,
+                        budget_state,
                     ),
                 )
                 if df is not None and not df.empty:
@@ -323,6 +339,7 @@ class DataLoader:
         start_date: str,
         end_date: str,
         interval: str,
+        budget_state: dict[str, float],
     ) -> Optional[pd.DataFrame]:
         search_payload = client.search(_search_query(code, interval))
         candidates = _select_capabilities(search_payload.get("results"), interval)
@@ -331,8 +348,29 @@ class DataLoader:
             tool_id = str(capability.get("tool_id") or "").strip()
             if not tool_id:
                 continue
+            quoted_cost = _expected_cost(capability.get("expected_cost"))
+            if (
+                not math.isfinite(quoted_cost)
+                or quoted_cost < 0.0
+                or budget_state["spent"] + quoted_cost
+                > self._config.budget_credits_per_session
+            ):
+                logger.warning(
+                    "QVeris paid capability skipped for %s: credit budget exceeded",
+                    code,
+                )
+                continue
             parameters = _build_parameters(capability, code, start_date, end_date, interval)
+            # Reserve the quoted cost before the request. If transport fails
+            # after the provider accepted it, later symbols still fail closed.
+            budget_state["spent"] += quoted_cost
             execute_payload = client.execute(tool_id, parameters, search_id=search_id)
+            try:
+                actual_cost = float(execute_payload.get("cost"))
+            except (TypeError, ValueError):
+                actual_cost = quoted_cost
+            if math.isfinite(actual_cost) and actual_cost > quoted_cost:
+                budget_state["spent"] += actual_cost - quoted_cost
             if execute_payload.get("success") is False:
                 logger.warning("QVeris execute failed for %s via %s", code, tool_id)
                 continue

--- a/agent/tests/test_qveris_loader.py
+++ b/agent/tests/test_qveris_loader.py
@@ -74,6 +74,7 @@ def _write_config(
     enabled: bool = True,
     api_key: str = "sk_test",
     mode: str = "paid",
+    budget: float = 50.0,
 ) -> None:
     path.write_text(
         json.dumps(
@@ -82,7 +83,7 @@ def _write_config(
                 "base_url": "https://qveris.test/api/v1",
                 "api_key": api_key,
                 "mode": mode,
-                "budget_credits_per_session": 50.0,
+                "budget_credits_per_session": budget,
             }
         ),
         encoding="utf-8",
@@ -156,6 +157,52 @@ class TestFetch:
 
         assert qv.DataLoader().fetch(["AAPL.US"], "2024-01-01", "2024-01-31") == {}
         assert session.calls == []
+
+    def test_zero_budget_allows_search_but_blocks_paid_execute(self, monkeypatch):
+        _write_config(qv._CONFIG_PATH, budget=0.0)
+        session = _install_session(
+            monkeypatch,
+            [_FakeResponse({"search_id": "s_1", "results": [_capability()]})],
+        )
+
+        result = qv.DataLoader().fetch(
+            ["AAPL.US"], "2024-01-01", "2024-01-31"
+        )
+
+        assert result == {}
+        assert len(session.calls) == 1
+        assert session.calls[0]["url"].endswith("/search")
+
+    def test_budget_is_shared_across_symbols_in_one_fetch(self, monkeypatch):
+        _write_config(qv._CONFIG_PATH, budget=1.0)
+        rows = {
+            "data": [
+                {
+                    "date": "2024-01-02",
+                    "open": 100,
+                    "high": 101,
+                    "low": 99,
+                    "close": 100,
+                    "volume": 10,
+                }
+            ]
+        }
+        session = _install_session(
+            monkeypatch,
+            [
+                _FakeResponse({"search_id": "s_1", "results": [_capability()]}),
+                _FakeResponse({"success": True, "cost": 1.0, "result": rows}),
+                _FakeResponse({"search_id": "s_2", "results": [_capability()]}),
+            ],
+        )
+
+        result = qv.DataLoader().fetch(
+            ["AAPL.US", "MSFT.US"], "2024-01-01", "2024-01-31"
+        )
+
+        assert list(result) == ["AAPL.US"]
+        execute_calls = [call for call in session.calls if "/tools/execute" in call["url"]]
+        assert len(execute_calls) == 1
 
     def test_search_execute_happy_path_selects_best_capability(self, monkeypatch):
         _write_config(qv._CONFIG_PATH)


### PR DESCRIPTION
## Summary

- Load the existing QVeris session budget in the backtest loader.
- Share one spend ledger across symbols and capability candidates.
- Reject invalid or unaffordable quotes before paid execution.

## Why

Closes #677.

The backtest loader currently ignores the configured credit limit.

## Changes

- Parse and validate `budget_credits_per_session`.
- Reserve quoted credits before each execute request.
- Reconcile higher reported costs conservatively.
- Add zero-budget and multi-symbol regressions.

## Test Plan

- [x] New tests added
- [x] 43 relevant QVeris loader tests passed
- [x] Ruff, diff, DCO, and secret checks passed
- [x] All responses were fakes and no credits were spent

## Risk

Paid calls with invalid or over-budget quotes now stop. Search remains available. No real provider, key, or billable endpoint was used.

## Out of scope

This does not change the interactive QVeris tool ledger.

## Rollback

Revert this one commit to restore the previous loader behavior.

## Checklist

- [x] No hardcoded credentials or paths
- [x] Code follows `CONTRIBUTING.md`
- [x] No user-facing documentation change is needed