### PR TITLE
Make QVeris credit accounting atomic

### DIFF
--- a/agent/src/tools/qveris_tool.py
+++ b/agent/src/tools/qveris_tool.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 import re
 import tempfile
+import threading
 import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -28,6 +30,8 @@ _LEGACY_MODE_MAP = {
 }
 
 _SESSION_SPEND: dict[str, float] = {}
+_SESSION_RESERVED: dict[str, float] = {}
+_SESSION_BUDGET_LOCK = threading.Lock()
 
 
 @dataclass
@@ -407,7 +411,7 @@ class QVerisExecuteTool(_QVerisBaseTool):
         "Execute a QVeris tool when paid QVeris routing is enabled. Enforces "
         "the per-session credit budget before sending a billable request."
     )
-    is_readonly = True
+    is_readonly = False
     parameters = {
         "type": "object",
         "properties": {
@@ -452,31 +456,65 @@ class QVerisExecuteTool(_QVerisBaseTool):
         tool_id = str(kwargs["tool_id"])
         quote = self._quote(client, tool_id, kwargs)
         session_id = str(kwargs.get("session_id") or "default")
-        spent = _SESSION_SPEND.get(session_id, 0.0)
         budget = max(float(cfg.budget_credits_per_session), 0.0)
         expected = _parse_expected_cost(quote.get("expected_cost"))
-        if spent >= budget or (expected is not None and spent + expected > budget):
-            return _json_response(
-                {
-                    "ok": False,
-                    "status": "budget_exceeded",
-                    "spent_credits": spent,
-                    "budget_credits_per_session": budget,
-                    "quote": quote,
-                }
+        with _SESSION_BUDGET_LOCK:
+            spent = _SESSION_SPEND.get(session_id, 0.0)
+            reserved = _SESSION_RESERVED.get(session_id, 0.0)
+            valid_quote = (
+                expected is not None and math.isfinite(expected) and expected >= 0.0
             )
+            if (
+                not valid_quote
+                or spent >= budget
+                or spent + reserved + expected > budget
+            ):
+                return _json_response(
+                    {
+                        "ok": False,
+                        "status": "budget_exceeded",
+                        "spent_credits": spent,
+                        "budget_credits_per_session": budget,
+                        "quote": quote,
+                    }
+                )
+            _SESSION_RESERVED[session_id] = reserved + expected
 
-        payload = client.execute(
-            tool_id,
-            parameters=dict(kwargs["parameters"]),
-            search_id=kwargs.get("search_id"),
-            session_id=kwargs.get("session_id"),
-            model=kwargs.get("model"),
-            max_response_size=int(kwargs.get("max_response_size", 20480)),
-        )
-        cost = float(payload.get("cost") or 0.0)
-        _SESSION_SPEND[session_id] = spent + max(cost, 0.0)
+        try:
+            payload = client.execute(
+                tool_id,
+                parameters=dict(kwargs["parameters"]),
+                search_id=kwargs.get("search_id"),
+                session_id=kwargs.get("session_id"),
+                model=kwargs.get("model"),
+                max_response_size=int(kwargs.get("max_response_size", 20480)),
+            )
+        except Exception:
+            with _SESSION_BUDGET_LOCK:
+                remaining = _SESSION_RESERVED.get(session_id, 0.0) - expected
+                if remaining > 1e-12:
+                    _SESSION_RESERVED[session_id] = remaining
+                else:
+                    _SESSION_RESERVED.pop(session_id, None)
+            raise
+
+        try:
+            cost = float(payload.get("cost"))
+        except (TypeError, ValueError):
+            cost = expected
+        if not math.isfinite(cost) or cost < 0.0:
+            cost = expected
+
+        with _SESSION_BUDGET_LOCK:
+            remaining = _SESSION_RESERVED.get(session_id, 0.0) - expected
+            if remaining > 1e-12:
+                _SESSION_RESERVED[session_id] = remaining
+            else:
+                _SESSION_RESERVED.pop(session_id, None)
+            _SESSION_SPEND[session_id] = _SESSION_SPEND.get(session_id, 0.0) + cost
+            session_spent = _SESSION_SPEND[session_id]
+
         payload["cost"] = cost
         payload["remaining_credits"] = payload.get("remaining_credits")
-        payload["session_spent_credits"] = _SESSION_SPEND[session_id]
+        payload["session_spent_credits"] = session_spent
         return _json_response({"ok": True, **payload})

--- a/agent/tests/test_qveris_tool.py
+++ b/agent/tests/test_qveris_tool.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import stat
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -15,6 +17,7 @@ def qveris_config_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv("QVERIS_API_KEY", raising=False)
     monkeypatch.delenv("QVERIS_BASE_URL", raising=False)
     qt._SESSION_SPEND.clear()
+    getattr(qt, "_SESSION_RESERVED", {}).clear()
     return tmp_path / "qveris.json"
 
 
@@ -138,6 +141,102 @@ def test_paid_mode_rejects_when_expected_cost_exceeds_budget(monkeypatch):
 
     assert payload["status"] == "budget_exceeded"
     assert payload["budget_credits_per_session"] == 1.0
+
+
+def test_parallel_execute_reserves_shared_session_budget(monkeypatch):
+    qt.save_qveris_config(
+        qt.QVerisConfig(
+            enabled=True,
+            api_key="sk-live",
+            mode="paid",
+            budget_credits_per_session=1.0,
+        )
+    )
+    entered = threading.Event()
+    release = threading.Event()
+
+    class FakeClient:
+        calls = 0
+        lock = threading.Lock()
+
+        def execute(self, *args, **kwargs):
+            del args, kwargs
+            with self.lock:
+                type(self).calls += 1
+                call_number = type(self).calls
+            if call_number == 1:
+                entered.set()
+                assert release.wait(timeout=2)
+            return {"success": True, "cost": 0.75, "result": {}}
+
+    client = FakeClient()
+    monkeypatch.setattr(qt.QVerisExecuteTool, "_client", lambda self: client)
+    tool = qt.QVerisExecuteTool()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(
+            tool.execute,
+            tool_id="tool_1",
+            parameters={},
+            session_id="shared",
+            expected_cost="0.75 credits",
+        )
+        assert entered.wait(timeout=2)
+        second = pool.submit(
+            tool.execute,
+            tool_id="tool_2",
+            parameters={},
+            session_id="shared",
+            expected_cost="0.75 credits",
+        )
+        second_payload = json.loads(second.result(timeout=2))
+        release.set()
+        first_payload = json.loads(first.result(timeout=2))
+
+    assert first_payload["ok"] is True
+    assert second_payload["status"] == "budget_exceeded"
+    assert FakeClient.calls == 1
+    assert qt._SESSION_SPEND["shared"] == pytest.approx(0.75)
+    assert qt._SESSION_RESERVED.get("shared", 0.0) == 0.0
+
+
+def test_failed_execute_releases_credit_reservation(monkeypatch):
+    qt.save_qveris_config(
+        qt.QVerisConfig(
+            enabled=True,
+            api_key="sk-live",
+            mode="paid",
+            budget_credits_per_session=1.0,
+        )
+    )
+
+    class FailOnceClient:
+        calls = 0
+
+        def execute(self, *args, **kwargs):
+            del args, kwargs
+            type(self).calls += 1
+            if type(self).calls == 1:
+                raise RuntimeError("provider failed")
+            return {"success": True, "cost": 1.0, "result": {}}
+
+    client = FailOnceClient()
+    monkeypatch.setattr(qt.QVerisExecuteTool, "_client", lambda self: client)
+    tool = qt.QVerisExecuteTool()
+    call = {
+        "tool_id": "tool_1",
+        "parameters": {},
+        "session_id": "retry",
+        "expected_cost": "1 credit",
+    }
+
+    with pytest.raises(RuntimeError, match="provider failed"):
+        tool.execute(**call)
+
+    assert qt._SESSION_RESERVED.get("retry", 0.0) == 0.0
+    payload = json.loads(tool.execute(**call))
+    assert payload["ok"] is True
+    assert payload["session_spent_credits"] == pytest.approx(1.0)
 
 
 def test_429_retries_after_retry_after(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
## Summary

- Mark paid QVeris execution as state-changing.
- Reserve quoted credits under a per-process lock.
- Reconcile actual cost and release failed reservations.

## Why

Closes #678.

Parallel calls can both pass the same budget check and overwrite the spend ledger.

## Changes

- Add per-session reserved-credit state.
- Require finite, nonnegative quotes.
- Include committed and outstanding credits in admission.
- Add deterministic contention and failure regressions.

## Test Plan

- [x] New tests added
- [x] 20 relevant QVeris tool tests passed
- [x] Ruff, diff, DCO, and secret checks passed
- [x] All provider calls were fakes and no credits were spent

## Risk

Paid execute calls are no longer parallelized by the AgentLoop. The ledger is process-local, matching current session execution. No real provider or credential was used.

## Out of scope

Cross-process credit accounting is not added.

## Rollback

Revert this one commit to restore unlocked accounting.

## Checklist

- [x] No hardcoded credentials or paths
- [x] Code follows `CONTRIBUTING.md`
- [x] No user-facing documentation change is needed