### PR TITLE
Derive China-futures leverage per contract

### DIFF
--- a/agent/backtest/engines/base.py
+++ b/agent/backtest/engines/base.py
@@ -376,6 +376,11 @@ class BaseEngine(ABC):
         """Convert target notional exposure to number of units/contracts."""
         return target_notional / price
 
+    def _leverage_for_symbol(self, symbol: str) -> float:
+        """Return leverage used to size and margin one symbol."""
+        del symbol
+        return self.default_leverage
+
     # ── Main entry ──
 
     def run_backtest(
@@ -810,7 +815,7 @@ class BaseEngine(ABC):
         if open_price <= 0:
             return None
         price = self.apply_slippage(open_price, direction)
-        leverage = self.default_leverage
+        leverage = self._leverage_for_symbol(symbol)
         target_notional = abs(target_weight) * equity * leverage
         size = self.round_size(
             self._calc_raw_size(symbol, target_notional, price), price

--- a/agent/backtest/engines/china_futures.py
+++ b/agent/backtest/engines/china_futures.py
@@ -152,6 +152,7 @@ class ChinaFuturesEngine(FuturesBaseEngine):
         config = {**config, "leverage": leverage}
         super().__init__(config)
         self.slippage_rate: float = config.get("slippage", 0.0005)
+        self._margin_rate_override = margin_override if margin_override else None
         self._commission_override = config.get("commission_override")
 
     def can_execute(self, symbol: str, direction: int, bar: pd.Series) -> bool:
@@ -242,6 +243,12 @@ class ChinaFuturesEngine(FuturesBaseEngine):
         """
         product = _extract_product(symbol)
         return _MARGIN_RATE.get(product, 0.10)
+
+    def _leverage_for_symbol(self, symbol: str) -> float:
+        """Derive leverage from this contract's own margin requirement."""
+        if self._margin_rate_override is not None:
+            return 1.0 / float(self._margin_rate_override)
+        return 1.0 / self.get_margin_rate(symbol)
 
 
 # ── Helpers ──

--- a/agent/backtest/engines/composite.py
+++ b/agent/backtest/engines/composite.py
@@ -155,6 +155,9 @@ class CompositeEngine(BaseEngine):
     ) -> float:
         return self._rule_for(symbol)._calc_raw_size(symbol, target_notional, price)
 
+    def _leverage_for_symbol(self, symbol: str) -> float:
+        return self._rule_for(symbol)._leverage_for_symbol(symbol)
+
     # ── Stateful hooks (implemented directly, NO delegation) ──
 
     def on_bar(self, symbol: str, bar: pd.Series, timestamp: pd.Timestamp) -> None:

--- a/agent/tests/test_china_futures_engine.py
+++ b/agent/tests/test_china_futures_engine.py
@@ -283,3 +283,35 @@ class TestLeverageFromMargin:
     def test_override_margin_rate(self) -> None:
         engine = _make_engine(margin_rate_override=0.20)
         assert engine.default_leverage == pytest.approx(5.0)
+
+    def test_order_sizing_does_not_depend_on_symbol_order(self) -> None:
+        timestamp = pd.Timestamp("2026-01-05")
+        frame = pd.DataFrame(
+            {"open": [5_000.0], "close": [5_000.0]},
+            index=pd.DatetimeIndex([timestamp]),
+        )
+        first = _make_engine(codes=["IF2406.CFFEX", "T2406.CFFEX"])
+        second = _make_engine(codes=["T2406.CFFEX", "IF2406.CFFEX"])
+
+        first_order = first._plan_open_order(
+            "IF2406.CFFEX", 0.5, frame, timestamp, 1_000_000.0
+        )
+        second_order = second._plan_open_order(
+            "IF2406.CFFEX", 0.5, frame, timestamp, 1_000_000.0
+        )
+
+        assert first_order is not None
+        assert second_order is not None
+        assert first_order.size == second_order.size
+        assert first_order.leverage == pytest.approx(1 / 0.12)
+        assert second_order.leverage == pytest.approx(1 / 0.12)
+
+    def test_composite_delegates_symbol_leverage(self) -> None:
+        from backtest.engines.composite import CompositeEngine
+
+        engine = CompositeEngine(
+            {"initial_cash": 1_000_000, "codes": ["AAPL.US", "IF2406.CFFEX"]},
+            ["AAPL.US", "IF2406.CFFEX"],
+        )
+
+        assert engine._leverage_for_symbol("IF2406.CFFEX") == pytest.approx(1 / 0.12)


### PR DESCRIPTION
## Summary

- Derive China futures leverage from each contract's margin rate.
- Delegate symbol-aware leverage through composite portfolios.
- Preserve the explicit margin override.

## Why

Closes #679.

The first configured symbol currently controls sizing for every China futures contract.

## Changes

- Add a symbol-aware leverage hook to the base engine.
- Implement contract margin lookup in the China futures engine.
- Add order-invariance and composite regressions.

## Test Plan

- [x] New tests added
- [x] 100 relevant engine tests passed
- [x] Source Ruff, diff, DCO, and secret checks passed
- [x] Tests used synthetic prices only

## Risk

Multi-product China futures sizes can change to match each product's margin. The explicit override remains unchanged. No broker or exchange was contacted.

## Out of scope

This does not update the margin-rate table.

## Rollback

Revert this one commit to restore first-symbol leverage.

## Checklist

- [x] No hardcoded credentials or local paths
- [x] Code follows `CONTRIBUTING.md`
- [x] No user-facing documentation change is needed