### PR TITLE
Preserve requested crypto symbols after provider normalization

### DIFF
--- a/agent/backtest/runner.py
+++ b/agent/backtest/runner.py
@@ -584,6 +584,16 @@ def _normalize_codes(codes: List[str], source: str) -> List[str]:
     return codes
 
 
+def _restore_original_codes(
+    data_map: dict,
+    original_codes: List[str],
+    normalized_codes: List[str],
+) -> dict:
+    """Map provider-normalized result keys back to requested symbols."""
+    aliases = dict(zip(normalized_codes, original_codes))
+    return {aliases.get(code, code): frame for code, frame in data_map.items()}
+
+
 def _columns_required_from_factor_spec(spec: Any) -> list[str]:
     """Extract ``columns_required`` from supported factor spec shapes.
 
@@ -1042,6 +1052,7 @@ def _fetch_auto(codes: List[str], config: dict, interval: str = "1D") -> dict:
 
         src_name = getattr(loader, "name", "unknown")
         normalized_codes = _normalize_codes(market_codes, src_name)
+        result_codes = normalized_codes
         fields = config.get("extra_fields") if src_name == "tushare" else None
         result = loader.fetch(normalized_codes, start_date, end_date, fields=fields, interval=interval)
 
@@ -1056,10 +1067,11 @@ def _fetch_auto(codes: List[str], config: dict, interval: str = "1D") -> dict:
                 fb_codes = _normalize_codes(market_codes, fb_name)
                 result = fb_loader.fetch(fb_codes, start_date, end_date, interval=interval)
                 if result:
+                    result_codes = fb_codes
                     logger.info("Runtime fallback: %s -> %s for %s", src_name, fb_name, market)
                     break
 
-        merged.update(result)
+        merged.update(_restore_original_codes(result, market_codes, result_codes))
 
     return merged
 

--- a/agent/tests/test_ui_services.py
+++ b/agent/tests/test_ui_services.py
@@ -174,3 +174,29 @@ def test_fetch_data_map_delegates_auto_routing(
     assert calls == [(["AAPL.US"], config, "1D")]
     assert result.source == "auto"
     assert result.effective_sources == ["yfinance"]
+
+
+def test_fetch_auto_restores_original_crypto_symbol(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    frame = pd.DataFrame(
+        {"open": [1.0], "high": [1.0], "low": [1.0], "close": [1.0]},
+        index=pd.DatetimeIndex([pd.Timestamp("2026-01-01")]),
+    )
+
+    class OkxLoader:
+        name = "okx"
+
+        def fetch(self, codes, start_date, end_date, **kwargs):
+            del start_date, end_date, kwargs
+            assert codes == ["BTC-USDT"]
+            return {"BTC-USDT": frame}
+
+    monkeypatch.setattr(runner, "resolve_loader", lambda market: OkxLoader())
+
+    result = runner._fetch_auto(
+        ["BTC/USDT"],
+        {"start_date": "2026-01-01", "end_date": "2026-01-02"},
+    )
+
+    assert list(result) == ["BTC/USDT"]


### PR DESCRIPTION
## Summary

- Track provider-normalized crypto aliases.
- Restore original request keys before merging data.
- Add a slash-form OKX regression.

## Why

Closes #680.

Auto routing can fetch `BTC-USDT` successfully but lose it because downstream code requests `BTC/USDT`.

## Changes

- Pair normalized codes with their original symbols.
- Restore keys for both primary and fallback results.
- Keep provider-facing formats unchanged.

## Test Plan

- [x] New tests added
- [x] 89 relevant routing tests passed
- [x] Ruff, diff, DCO, and secret checks passed
- [x] No provider was contacted

## Risk

Only returned map keys change, back to the caller's requested form.

## Out of scope

This does not change symbol detection or provider symbol formats.

## Rollback

Revert this one commit to restore normalized result keys.

## Checklist

- [x] No hardcoded credentials or local paths
- [x] Code follows `CONTRIBUTING.md`
- [x] No user-facing documentation change is needed