### PR TITLE
Keep Tencent routing daily-only

### DIFF
--- a/agent/backtest/loaders/tencent_loader.py
+++ b/agent/backtest/loaders/tencent_loader.py
@@ -52,6 +52,14 @@ class DataLoader:
         fields: Optional[List[str]] = None,
     ) -> Dict[str, pd.DataFrame]:
         validate_date_range(start_date, end_date)
+        del fields
+
+        if interval.strip().lower() not in {"1d", "d", "day", "daily"}:
+            logger.warning(
+                "tencent supports daily bars only; rejecting interval=%s",
+                interval,
+            )
+            return {}
 
         result: Dict[str, pd.DataFrame] = {}
         for code in codes:

--- a/agent/tests/test_tencent_loader.py
+++ b/agent/tests/test_tencent_loader.py
@@ -1,0 +1,42 @@
+"""Tests for Tencent's daily-only market-data contract."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from backtest.loaders import tencent_loader
+
+
+def test_intraday_request_does_not_return_daily_bars(monkeypatch) -> None:
+    calls: list[str] = []
+    daily = pd.DataFrame(
+        {
+            "open": [10.0],
+            "high": [11.0],
+            "low": [9.0],
+            "close": [10.5],
+            "volume": [100.0],
+        },
+        index=pd.DatetimeIndex([pd.Timestamp("2026-01-05")]),
+    )
+    loader = tencent_loader.DataLoader()
+    monkeypatch.setattr(
+        tencent_loader,
+        "cached_loader_fetch",
+        lambda **kwargs: kwargs["fetch"](),
+    )
+    monkeypatch.setattr(
+        loader,
+        "_fetch_one",
+        lambda code, start, end: calls.append(code) or daily,
+    )
+
+    result = loader.fetch(
+        ["600519.SH"],
+        "2026-01-01",
+        "2026-01-31",
+        interval="1m",
+    )
+
+    assert result == {}
+    assert calls == []


### PR DESCRIPTION
## Summary

- Reject non-daily Tencent intervals before network access.
- Leave supported daily aliases unchanged.
- Add an intraday no-call regression.

## Why

Closes #682.

The daily-only Tencent endpoint currently returns daily rows for intraday requests.

## Changes

- Validate the interval at the loader entry point.
- Return no data for unsupported frequencies so fallback can run.

## Test Plan

- [x] New tests added
- [x] 53 relevant loader tests passed
- [x] Ruff, diff, DCO, and secret checks passed
- [x] No Tencent request was made

## Risk

Intraday requests now use fallback or fail instead of receiving mislabeled daily bars.

## Out of scope

This does not implement Tencent intraday retrieval.

## Rollback

Revert this one commit to restore permissive interval handling.

## Checklist

- [x] No hardcoded credentials or local paths
- [x] Code follows `CONTRIBUTING.md`
- [x] No user-facing documentation change is needed