### PR TITLE
Verify CCXT coverage after bounded pagination

### DIFF
--- a/agent/backtest/loaders/ccxt_loader.py
+++ b/agent/backtest/loaders/ccxt_loader.py
@@ -32,6 +32,16 @@ _INTERVAL_MAP = {
     "1H": "1h", "4H": "4h", "1D": "1d",
 }
 
+_TIMEFRAME_DELTA = {
+    "1m": pd.Timedelta(minutes=1),
+    "5m": pd.Timedelta(minutes=5),
+    "15m": pd.Timedelta(minutes=15),
+    "30m": pd.Timedelta(minutes=30),
+    "1h": pd.Timedelta(hours=1),
+    "4h": pd.Timedelta(hours=4),
+    "1d": pd.Timedelta(days=1),
+}
+
 # P12-b: ccxt had no request timeout and an unbounded paginated fetch with
 # no retry budget, so a transient disconnect hung get_market_data for 10+
 # minutes. Cap each HTTP call, bound transient retries, and enforce a hard
@@ -228,6 +238,7 @@ class DataLoader:
         limit = 1000
         deadline = time.monotonic() + _CCXT_FETCH_BUDGET_S
         label = f"ccxt fetch for {symbol}"
+        hit_page_cap = True
 
         for _ in range(200):
             check_budget(deadline, label, budget_s=_CCXT_FETCH_BUDGET_S)
@@ -247,10 +258,12 @@ class DataLoader:
                 label=label,
             )
             if not ohlcv:
+                hit_page_cap = False
                 break
             all_rows.extend(ohlcv)
             last_ts = ohlcv[-1][0]
             if last_ts >= end_ms or len(ohlcv) < limit:
+                hit_page_cap = False
                 break
             cursor = last_ts + 1
 
@@ -271,4 +284,15 @@ class DataLoader:
         df = df[["open", "high", "low", "close", "volume"]].dropna(
             subset=["open", "high", "low", "close"]
         )
-        return df if not df.empty else None
+        if df.empty:
+            return None
+
+        tolerance = _TIMEFRAME_DELTA.get(timeframe)
+        if tolerance is None:
+            raise ValueError(f"unsupported CCXT timeframe: {timeframe}")
+        if hit_page_cap and df.index[-1] < end_dt - tolerance:
+            raise ValueError(
+                f"incomplete CCXT history for {symbol}: requested "
+                f"[{start_dt}, {end_dt}), received [{df.index[0]}, {df.index[-1]}]"
+            )
+        return df

--- a/agent/tests/test_ccxt_loader_bounded.py
+++ b/agent/tests/test_ccxt_loader_bounded.py
@@ -25,7 +25,7 @@ SINCE = int(pd.Timestamp("2026-05-01").timestamp() * 1000)
 END = int((pd.Timestamp("2026-05-05") + pd.Timedelta(days=1)).timestamp() * 1000)
 
 
-def _bars(n: int = 4) -> list:
+def _bars(n: int = 5) -> list:
     base = int(pd.Timestamp("2026-05-01").timestamp() * 1000)
     day = 86_400_000
     return [[base + i * day, 100 + i, 101 + i, 99 + i, 100 + i, 10 + i] for i in range(n)]
@@ -87,6 +87,25 @@ def test_wallclock_budget_enforced(monkeypatch):
     ex = _FakeEx([ccxt.NetworkError("slow")])
     with pytest.raises(TimeoutError):
         DataLoader._fetch_one(ex, "BTC/USDT", "1d", SINCE, END)
+
+
+def test_page_cap_rejects_incomplete_requested_history():
+    minute_ms = 60_000
+
+    class FullPageExchange:
+        def fetch_ohlcv(self, symbol, timeframe, since=None, limit=None):
+            del symbol, timeframe
+            assert since is not None
+            assert limit == 1000
+            return [
+                [since + i * minute_ms, 100.0, 101.0, 99.0, 100.0, 10.0]
+                for i in range(limit)
+            ]
+
+    end = int((pd.Timestamp("2027-05-01") + pd.Timedelta(days=1)).timestamp() * 1000)
+
+    with pytest.raises(ValueError, match="incomplete"):
+        DataLoader._fetch_one(FullPageExchange(), "BTC/USDT", "1m", SINCE, end)
 
 
 def test_get_exchange_sets_explicit_timeout():


### PR DESCRIPTION
## Summary

- Keep the existing 200-page safety cap.
- Reject a full-cap result that does not reach the requested end.
- Add a deterministic incomplete-range regression.

## Why

Closes #683.

CCXT pagination can hit its cap and return a truncated date range as success.

## Changes

- Track whether pagination stopped because of the cap.
- Compare the final bar with the requested end using interval tolerance.
- Raise a clear incomplete-history error when coverage is missing.

## Test Plan

- [x] New tests added
- [x] 40 relevant CCXT loader tests passed
- [x] Ruff, diff, DCO, and secret checks passed
- [x] The exchange client was a fake

## Risk

Long requests that exceed bounded coverage now fail so fallback or the user can respond. The cap and normal short responses are unchanged.

## Out of scope

This does not increase the pagination or wall-clock budget.

## Rollback

Revert this one commit to restore capped partial results.

## Checklist

- [x] No hardcoded credentials or local paths
- [x] Code follows `CONTRIBUTING.md`
- [x] No user-facing documentation change is needed