### PR TITLE
Reject mootdx history that does not reach the requested start

### DIFF
--- a/agent/backtest/loaders/mootdx_loader.py
+++ b/agent/backtest/loaders/mootdx_loader.py
@@ -191,9 +191,10 @@ class DataLoader:
             if first_dt <= start_ts:
                 break
         else:
-            logger.warning(
-                "mootdx: %s %s pagination hit cap (%d pages) without reaching %s",
-                symbol, freq, _MAX_PAGES, start_date,
+            raise ValueError(
+                "incomplete mootdx history: "
+                f"{symbol} frequency={freq} hit {_MAX_PAGES} pages "
+                f"without reaching {start_date}"
             )
         if not chunks:
             return None

--- a/agent/tests/test_mootdx_loader.py
+++ b/agent/tests/test_mootdx_loader.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import pandas as pd
 import pytest
 
+import backtest.loaders.mootdx_loader as ml
 from backtest.loaders.mootdx_loader import DataLoader, _is_a_share, _is_bj
 
 
@@ -135,6 +136,36 @@ def test_fetch_intraday_empty_window_returns_no_entry(
     loader = DataLoader()
     out = loader.fetch(["600519"], "2030-01-01", "2030-01-02", interval="5m")
     assert out == {}
+
+
+def test_intraday_page_cap_rejects_incomplete_history(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class NeverReachesStart:
+        def bars(self, symbol, frequency, start=0, offset=800):
+            del symbol, frequency, start, offset
+            timestamp = pd.Timestamp("2025-01-02 09:30")
+            return pd.DataFrame(
+                {
+                    "open": [10.0],
+                    "close": [10.0],
+                    "high": [10.0],
+                    "low": [10.0],
+                    "datetime": [timestamp],
+                    "volume": [100.0],
+                }
+            )
+
+    monkeypatch.setattr(ml, "_MAX_PAGES", 3)
+
+    with pytest.raises(ValueError, match="incomplete"):
+        DataLoader._fetch_bars_paginated(
+            NeverReachesStart(),
+            "600519",
+            8,
+            "2020-01-01",
+            "2025-01-03",
+        )
 
 
 def test_fetch_skips_non_a_share_symbols(fake_client: _FakeStdQuotes) -> None:


### PR DESCRIPTION
## Summary

- Keep the existing mootdx page cap.
- Raise an incomplete-history error when the cap cannot reach the requested start.
- Add a small fake-client regression.

## Why

Closes #684.

The loader currently warns but returns a shorter date range as success.

## Changes

- Convert page-cap exhaustion into a typed failure.
- Preserve successful behavior when a page reaches the start boundary.

## Test Plan

- [x] New tests added
- [x] 96 relevant mootdx loader tests passed
- [x] Ruff, diff, DCO, and secret checks passed
- [x] No TCP or provider access occurred

## Risk

Requests beyond the bounded history now fail visibly instead of running on partial data.

## Out of scope

This does not change page size or symbol support.

## Rollback

Revert this one commit to restore warning-only behavior.

## Checklist

- [x] No hardcoded credentials or local paths
- [x] Code follows `CONTRIBUTING.md`
- [x] No user-facing documentation change is needed