### PR TITLE
fix(tools): sync market data sources with loader registry

### DIFF
--- a/agent/src/tools/market_data_tool.py
+++ b/agent/src/tools/market_data_tool.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 from typing import Any
 
+from backtest.loaders.registry import VALID_SOURCES
 from src.agent.tools import BaseTool
 from src.market_data import DEFAULT_MAX_ROWS, fetch_market_data_json
+
+
+_MARKET_DATA_SOURCES = ["auto", *sorted(VALID_SOURCES - {"auto"})]
 
 
 class MarketDataTool(BaseTool):
@@ -35,31 +39,12 @@ class MarketDataTool(BaseTool):
             },
             "source": {
                 "type": "string",
-                "enum": [
-                    "auto",
-                    "yfinance",
-                    "yahoo",
-                    "okx",
-                    "ccxt",
-                    "tushare",
-                    "baostock",
-                    "tencent",
-                    "akshare",
-                    "mootdx",
-                    "eastmoney",
-                    "sina",
-                    "stooq",
-                    "finnhub",
-                    "alphavantage",
-                    "tiingo",
-                    "fmp",
-                ],
+                "enum": _MARKET_DATA_SOURCES,
                 "description": (
                     "Data source. 'auto' detects from symbol format with fallback. "
-                    "Free, no key: yfinance/yahoo (US/HK equities), okx/ccxt "
-                    "(crypto), baostock/tencent/eastmoney/sina/akshare/mootdx "
-                    "(China A-shares), stooq (global EOD). Key-gated REST: tushare "
-                    "(China A-shares), finnhub/alphavantage/tiingo/fmp (US/global)."
+                    "Explicit sources may require credentials, a local service, "
+                    "or paid quota. Being listed does not mean a source is "
+                    "configured in the current environment."
                 ),
                 "default": "auto",
             },

--- a/agent/tests/test_market_data_tool.py
+++ b/agent/tests/test_market_data_tool.py
@@ -1,14 +1,39 @@
 from __future__ import annotations
 
+import importlib
 import json
 
 import pandas as pd
+import pytest
 
+from backtest.loaders.registry import VALID_SOURCES
 from src.market_data import fetch_market_data_json
 from src.swarm.models import SwarmAgentSpec
 from src.swarm.presets import list_presets, load_preset
 from src.swarm.worker import build_worker_prompt
 from src.tools import build_swarm_registry
+from src.tools.market_data_tool import MarketDataTool
+
+
+def test_market_data_source_schema_matches_loader_registry():
+    source_enum = MarketDataTool.parameters["properties"]["source"]["enum"]
+
+    assert source_enum[0] == "auto"
+    assert set(source_enum) == VALID_SOURCES
+    assert source_enum[1:] == sorted(VALID_SOURCES - {"auto"})
+
+
+def test_market_data_source_schema_does_not_resolve_loaders(monkeypatch):
+    from backtest.loaders import registry as loader_registry
+    from src.tools import market_data_tool
+
+    def fail_if_called():
+        pytest.fail("schema construction must not resolve or instantiate loaders")
+
+    monkeypatch.setattr(loader_registry, "_ensure_registered", fail_if_called)
+    reloaded = importlib.reload(market_data_tool)
+
+    assert reloaded.MarketDataTool.parameters["properties"]["source"]["enum"]
 
 
 def test_market_data_json_is_strict_when_loader_returns_nan():


### PR DESCRIPTION
## Summary

- Derive the `get_market_data` tool's `source.enum` from the loader registry's canonical `VALID_SOURCES` set.
- Keep `auto` first and sort all explicit sources for a stable tool schema.
- Expose the registered `futu`, `qveris`, `india_broker`, `longbridge`, and `local` sources.
- Clarify that enum membership does not imply a source is configured in the current environment.

## Why

The runtime loader registry and the agent-facing tool schema maintained separate source lists. The hard-coded tool enum had drifted behind `VALID_SOURCES`, so five registered runtime sources could not be selected through the tool contract.

## Changes

- Import the canonical `VALID_SOURCES` set.
- Build a stable schema enum with `auto` first and all remaining sources sorted.
- Replace provider-specific description text with a stable availability contract.
- Add regression coverage for exact set equality, ordering, and schema construction without loader resolution.

## Impact

This is a schema-only consistency fix. It does not change loader resolution, fallback order, market/engine routing, provider behavior, return payloads, MCP behavior, or broker/order paths.

## Test Plan

- [x] `PYTHONPATH=agent pytest agent/tests/test_market_data.py agent/tests/test_registry.py agent/tests/test_data_routing_sources_subset.py -q` — **56 passed**.
- [x] Isolated schema-contract smoke — **22 sources**, `auto` first, exact set equality, stable sorting, and fail-fast proof that schema construction does not call `_ensure_registered()`.
- [x] `python3.11 -m py_compile agent/src/tools/market_data_tool.py agent/tests/test_market_data_tool.py`.
- [x] `ruff check agent/src/tools/market_data_tool.py agent/tests/test_market_data_tool.py`.
- [x] `git diff --check`.
- [x] New tests use no provider, loader instance, network, credentials, MCP, broker, or trading call.

The complete local non-E2E suite could not be collected in the available Anaconda environment because declared project dependencies such as `fastmcp`, `mcp`, `ccxt`, and `yfinance` are absent and its NumPy/SciPy binaries are ABI-incompatible. CI remains the authoritative full-suite run; the focused registry/market-data tests above are green.

## Risk and rollback

Risk is limited to the agent-visible JSON schema: callers can now choose sources already accepted by the runtime registry. Reverting this single commit restores the previous hard-coded enum.

## Out of scope

- market engine routing
- source fallback behavior
- provenance or loader return contracts
- session or Swarm changes
- live broker or order execution
- research-report and architecture changes

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`).
- [x] No hardcoded API keys, file paths, or environment-specific availability filtering.
- [x] Code follows `CONTRIBUTING.md`; the commit carries a DCO sign-off.
- [x] No user-facing documentation change is required for this contract sync.
