### PR TITLE
fix(providers): force temperature=1 for the whole Kimi K-series

### DIFF
--- a/agent/src/providers/llm.py
+++ b/agent/src/providers/llm.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from collections.abc import Sequence
 from importlib import import_module
 from importlib.metadata import PackageNotFoundError, version
@@ -297,6 +298,11 @@ _ENV_CANDIDATES = [
 # which slot won - the entire P08 R1 signal - using compile-time
 # constants only.
 _ENV_LABELS = ("~/.vibe-trading/.env", "<AGENT_DIR>/.env", "<CWD>/.env")
+
+# Kimi reasoning models (K-series: kimi-k2*, kimi-k3, …, and the
+# kimi-for-coding alias) reject any temperature other than 1 with
+# "invalid temperature: only 1 is allowed for this model".
+_KIMI_FORCED_TEMPERATURE_RE = re.compile(r"kimi-(k\d+|for-coding)", re.IGNORECASE)
 
 logger = logging.getLogger(__name__)
 
@@ -625,7 +631,7 @@ def build_llm(*, model_name: Optional[str] = None, callbacks: Any = None) -> Any
     # ("invalid temperature: only 1 is allowed for this model").
     if (
         caps.name in {"moonshot", "kimi-coding"}
-        and name.lower().startswith(("kimi-k2", "kimi-for-coding"))
+        and _KIMI_FORCED_TEMPERATURE_RE.match(name)
         and temperature != 1.0
     ):
         logger.info("Forcing temperature=1.0 for %s (provider requirement)", name)

--- a/agent/tests/test_llm.py
+++ b/agent/tests/test_llm.py
@@ -263,6 +263,53 @@ class TestMinimaxTemperature:
         assert captured["temperature"] == 0.7
 
 
+# ---------------------------------------------------------------------------
+# Kimi K-series temperature forcing
+# ---------------------------------------------------------------------------
+
+
+class TestKimiTemperature:
+    """Kimi reasoning models reject any temperature other than 1."""
+
+    def _capture_temperature(self, model: str, configured_temp: str) -> float:
+        import src.providers.llm as llm_mod
+        llm_mod._dotenv_loaded = True
+
+        captured: dict[str, float] = {}
+
+        class _FakeChatOpenAI:
+            def __init__(self, **kwargs: object) -> None:
+                captured["temperature"] = float(kwargs.get("temperature", -1))
+
+        env = {
+            "LANGCHAIN_PROVIDER": "moonshot",
+            "MOONSHOT_API_KEY": "moonshot-key",
+            "MOONSHOT_BASE_URL": "https://api.kimi.com/coding/v1",
+            "LANGCHAIN_MODEL_NAME": model,
+            "LANGCHAIN_TEMPERATURE": configured_temp,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with patch.object(llm_mod, "ChatOpenAIWithReasoning", _FakeChatOpenAI):
+                build_llm()
+        return captured["temperature"]
+
+    def test_kimi_k3_temperature_forced_to_one(self) -> None:
+        """kimi-k3 must be forced to 1.0 (API rejects other values)."""
+        assert self._capture_temperature("kimi-k3", "0.0") == 1.0
+
+    def test_kimi_k2_temperature_forced_to_one(self) -> None:
+        """Regression: kimi-k2.x keeps the existing forcing behavior."""
+        assert self._capture_temperature("kimi-k2.6", "0.0") == 1.0
+
+    def test_kimi_for_coding_temperature_forced_to_one(self) -> None:
+        """Regression: kimi-for-coding alias keeps the existing behavior."""
+        assert self._capture_temperature("kimi-for-coding", "0.5") == 1.0
+
+    def test_non_k_series_temperature_preserved(self) -> None:
+        """Non-reasoning Moonshot models keep the configured temperature."""
+        assert self._capture_temperature("moonshot-v1-8k", "0.0") == 0.0
+
+
 class TestReasoningEffortPassthrough:
     """LANGCHAIN_REASONING_EFFORT is forwarded as extra_body.reasoning.effort
     to the underlying OpenAI-compatible client. Used for OpenRouter-style


### PR DESCRIPTION
kimi-k3 rejects any temperature other than 1 ("invalid temperature: only 1 is allowed for this model"), same as kimi-k2, but the forcing guard only matched the kimi-k2 prefix — so a default LANGCHAIN_TEMPERATURE=0.0 config fails on every request with kimi-k3.

Replace the hardcoded prefix tuple with a K-family regex (kimi-k<digits> + kimi-for-coding) so kimi-k3 and future K-series reasoning models are covered without another whack-a-mole patch.

Verified against the Kimi for Coding endpoint: both kimi-k3 and its k3 alias return the temperature error; moonshot-v1-* models are unaffected. Note: bare aliases like "k3" are intentionally out of scope for the name-based guard.

## Summary

<!-- What does this PR do? 1-3 bullet points. -->

-

## Why

<!-- What problem does it solve? Link related issues with "Closes #123". -->

## Changes

<!-- List key changes. For new skills/presets, describe what they cover. -->

-

## Test Plan

- [ ] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [ ] New tests added (if applicable)
- [ ] Tested manually (describe below)

## Checklist

- [ ] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [ ] No hardcoded values (API keys, file paths, magic numbers)
- [ ] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] Documentation updated (if user-facing change)
