### PR TITLE
perf(swarm): cache MCP tool discovery specs to avoid redundant RPC calls

### DIFF
--- a/agent/src/swarm/runtime.py
+++ b/agent/src/swarm/runtime.py
@@ -8,7 +8,6 @@ with cancellation and event callback support.
 from __future__ import annotations
 
 import logging
-import os
 import threading
 from concurrent.futures import (
     Future,
@@ -40,6 +39,7 @@ from src.swarm.task_store import (
     topological_layers,
     validate_dag,
 )
+from src.tools.mcp import invalidate_mcp_specs_cache
 from src.tools.redaction import redact_internal_paths
 from src.swarm.worker import run_worker
 
@@ -233,6 +233,10 @@ class SwarmRuntime:
         """
         run_id = run.id
         run_dir = self._store.run_dir(run_id)
+
+        # Ensure fresh MCP tool discovery for this run — prior run's cached
+        # specs may be stale if operator edited mcp_servers config between runs.
+        invalidate_mcp_specs_cache()
 
         # Mark as running
         run.status = RunStatus.running

--- a/agent/src/tools/mcp.py
+++ b/agent/src/tools/mcp.py
@@ -68,6 +68,7 @@ def _make_cache_key(server_name: str, server_config: "MCPServerConfig") -> tuple
         server_config.command,
         str(server_config.args or []),
         str(sorted((server_config.env or {}).items())),
+        str(sorted(server_config.enabled_tools or [])),
     )
 
 

--- a/agent/src/tools/mcp.py
+++ b/agent/src/tools/mcp.py
@@ -57,6 +57,29 @@ _TRANSIENT_ERROR_TOKENS = (
 
 ResultT = TypeVar("ResultT")
 
+_MCP_SPECS_CACHE: dict[tuple[str, ...], list["MCPRemoteToolSpec"]] = {}
+_MCP_SPECS_LOCK = threading.Lock()
+
+
+def _make_cache_key(server_name: str, server_config: "MCPServerConfig") -> tuple[str, ...]:
+    """Build a content-based cache key for MCP tool discovery results."""
+    return (
+        server_name,
+        server_config.command,
+        str(server_config.args or []),
+        str(sorted((server_config.env or {}).items())),
+    )
+
+
+def invalidate_mcp_specs_cache() -> None:
+    """Clear the MCP tool discovery cache.
+
+    Called by SwarmRuntime at the start of each run to ensure fresh
+    discovery when operator config may have changed between runs.
+    """
+    with _MCP_SPECS_LOCK:
+        _MCP_SPECS_CACHE.clear()
+
 
 class AsyncMCPClient(Protocol):
     """Protocol for async MCP clients used by the adapter."""
@@ -145,6 +168,24 @@ def build_mcp_tool_wrappers(
         Exception: Propagates discovery failures so callers can decide whether
             to warn, skip, or abort.
     """
+    # --- Cache lookup (thread-safe) ---
+    # Skip cache when a custom client_factory is provided (test injection).
+    cache_key: tuple[str, ...] | None = None
+    if client_factory is None:
+        cache_key = _make_cache_key(server_name, server_config)
+        with _MCP_SPECS_LOCK:
+            cached_specs = _MCP_SPECS_CACHE.get(cache_key)
+        if cached_specs is not None:
+            adapter = MCPServerAdapter(
+                server_name,
+                server_config,
+                local_server_name=local_server_name,
+                client_factory=client_factory,
+                max_list_tools_attempts=max_list_tools_attempts,
+            )
+            return [MCPRemoteTool(adapter=adapter, spec=spec) for spec in cached_specs]
+
+    # --- Original logic (cache miss) ---
     adapter = MCPServerAdapter(
         server_name,
         server_config,
@@ -152,7 +193,14 @@ def build_mcp_tool_wrappers(
         client_factory=client_factory,
         max_list_tools_attempts=max_list_tools_attempts,
     )
-    return [MCPRemoteTool(adapter=adapter, spec=spec) for spec in adapter.discover_tools()]
+    specs = adapter.discover_tools()
+
+    # Store in cache (only for production path, not test injection)
+    if cache_key is not None:
+        with _MCP_SPECS_LOCK:
+            _MCP_SPECS_CACHE[cache_key] = specs
+
+    return [MCPRemoteTool(adapter=adapter, spec=spec) for spec in specs]
 
 
 def make_mcp_tool_name(server_name: str, tool_name: str) -> str:
@@ -1073,6 +1121,7 @@ __all__ = [
     "MCPServerAdapter",
     "build_mcp_tool_wrappers",
     "format_mcp_server_name_collision_warning",
+    "invalidate_mcp_specs_cache",
     "make_mcp_tool_name",
     "normalize_mcp_tool_schema",
     "resolve_mcp_server_tool_name_segments",

--- a/agent/tests/test_mcp_specs_cache.py
+++ b/agent/tests/test_mcp_specs_cache.py
@@ -1,0 +1,282 @@
+"""Unit tests for MCP tool discovery specs cache.
+
+Tests verify that :func:`build_mcp_tool_wrappers` caches tool specs to
+avoid redundant ``list_tools`` RPC calls across Swarm workers.
+"""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.tools.mcp import (
+    MCPRemoteToolSpec,
+    MCPServerAdapter,
+    _MCP_SPECS_CACHE,
+    _make_cache_key,
+    build_mcp_tool_wrappers,
+    invalidate_mcp_specs_cache,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """Ensure each test starts with a clean cache."""
+    invalidate_mcp_specs_cache()
+    yield
+    invalidate_mcp_specs_cache()
+
+
+def _make_server_config(command="mcp-server", args=None, env=None, enabled_tools=None):
+    """Create a minimal MCPServerConfig-like object for testing."""
+    config = MagicMock()
+    config.command = command
+    config.args = args or ["--port", "8080"]
+    config.env = env or {}
+    config.enabled_tools = enabled_tools or ["*"]
+    config.url = None
+    config.tool_timeout = 30.0
+    config.init_timeout = None
+    config.headers = {}
+    config.auth = None
+    return config
+
+
+def _make_specs(server_name: str, tool_names: list[str]) -> list[MCPRemoteToolSpec]:
+    """Build a list of fake MCPRemoteToolSpec for testing."""
+    return [
+        MCPRemoteToolSpec(
+            server_name=server_name,
+            remote_name=name,
+            local_name=f"mcp_{server_name}_{name}",
+            description=f"Tool {name}",
+            parameters={"type": "object", "properties": {}, "required": []},
+            annotations=None,
+        )
+        for name in tool_names
+    ]
+
+
+class TestMakeCacheKey:
+    """Tests for _make_cache_key determinism and isolation."""
+
+    def test_same_config_produces_same_key(self):
+        """Identical server_name and config should yield the same cache key."""
+        config = _make_server_config()
+        key1 = _make_cache_key("srv", config)
+        key2 = _make_cache_key("srv", config)
+        assert key1 == key2
+
+    def test_different_server_name_produces_different_key(self):
+        """Different server_name should produce different cache keys."""
+        config = _make_server_config()
+        key1 = _make_cache_key("srv1", config)
+        key2 = _make_cache_key("srv2", config)
+        assert key1 != key2
+
+    def test_different_command_produces_different_key(self):
+        """Different command should produce different cache keys."""
+        config1 = _make_server_config(command="cmd-a")
+        config2 = _make_server_config(command="cmd-b")
+        key1 = _make_cache_key("srv", config1)
+        key2 = _make_cache_key("srv", config2)
+        assert key1 != key2
+
+    def test_different_args_produces_different_key(self):
+        """Different args should produce different cache keys."""
+        config1 = _make_server_config(args=["--port", "8080"])
+        config2 = _make_server_config(args=["--port", "9090"])
+        key1 = _make_cache_key("srv", config1)
+        key2 = _make_cache_key("srv", config2)
+        assert key1 != key2
+
+    def test_different_env_produces_different_key(self):
+        """Different env should produce different cache keys."""
+        config1 = _make_server_config(env={"KEY": "val1"})
+        config2 = _make_server_config(env={"KEY": "val2"})
+        key1 = _make_cache_key("srv", config1)
+        key2 = _make_cache_key("srv", config2)
+        assert key1 != key2
+
+
+class TestMCPSpecsCache:
+    """Tests for the MCP tool discovery specs cache."""
+
+    def test_cache_hit_avoids_repeated_rpc(self):
+        """Second call to build_mcp_tool_wrappers should use cached specs."""
+        config = _make_server_config()
+        fake_specs = _make_specs("srv1", ["tool_a", "tool_b"])
+
+        with patch.object(MCPServerAdapter, "discover_tools", return_value=fake_specs) as mock_discover:
+            # First call — cache miss, triggers discover_tools
+            tools1 = build_mcp_tool_wrappers("srv1", config, client_factory=None)
+            assert mock_discover.call_count == 1
+            assert len(tools1) == 2
+
+            # Second call — cache hit, no additional RPC
+            tools2 = build_mcp_tool_wrappers("srv1", config, client_factory=None)
+            assert mock_discover.call_count == 1
+            assert len(tools2) == 2
+
+    def test_cache_key_isolation(self):
+        """Different server_name should have separate cache entries."""
+        config = _make_server_config()
+        specs_a = _make_specs("srv_a", ["tool_x"])
+        specs_b = _make_specs("srv_b", ["tool_y", "tool_z"])
+
+        with patch.object(MCPServerAdapter, "discover_tools") as mock_discover:
+            mock_discover.return_value = specs_a
+            tools_a = build_mcp_tool_wrappers("srv_a", config, client_factory=None)
+
+            mock_discover.return_value = specs_b
+            tools_b = build_mcp_tool_wrappers("srv_b", config, client_factory=None)
+
+            # Both should have called discover_tools (different cache keys)
+            assert mock_discover.call_count == 2
+            assert len(tools_a) == 1
+            assert len(tools_b) == 2
+
+    def test_thread_safety(self):
+        """Concurrent calls from multiple threads should not raise."""
+        config = _make_server_config()
+        fake_specs = _make_specs("srv_thread", ["tool_t"])
+        errors: list[Exception] = []
+
+        with patch.object(MCPServerAdapter, "discover_tools", return_value=fake_specs):
+
+            def worker(idx: int):
+                try:
+                    # Use a unique server name per thread to stress the write path
+                    build_mcp_tool_wrappers(f"srv_{idx}", config, client_factory=None)
+                except Exception as exc:
+                    errors.append(exc)
+
+            with ThreadPoolExecutor(max_workers=8) as executor:
+                futures = [executor.submit(worker, i) for i in range(20)]
+                for f in futures:
+                    f.result()
+
+        assert errors == [], f"Thread safety violation: {errors}"
+
+    def test_thread_safety_same_key(self):
+        """Concurrent calls with the same cache key should not raise or corrupt."""
+        config = _make_server_config()
+        fake_specs = _make_specs("srv_same", ["tool_s"])
+        call_count = 0
+        lock = threading.Lock()
+
+        def counting_discover(self_adapter):
+            nonlocal call_count
+            with lock:
+                call_count += 1
+            return fake_specs
+
+        with patch.object(MCPServerAdapter, "discover_tools", counting_discover):
+
+            def worker():
+                build_mcp_tool_wrappers("srv_same", config, client_factory=None)
+
+            with ThreadPoolExecutor(max_workers=8) as executor:
+                futures = [executor.submit(worker) for _ in range(20)]
+                for f in futures:
+                    f.result()
+
+        # At least one call must have happened; due to races, more than one
+        # thread may execute discover_tools before any writes to cache.
+        assert call_count >= 1
+
+    def test_client_factory_bypasses_cache(self):
+        """When client_factory is provided, cache is not used."""
+        config = _make_server_config()
+        fake_specs = _make_specs("srv_cf", ["tool_cf"])
+
+        # Pre-fill cache to prove it's not consulted
+        cache_key = _make_cache_key("srv_cf", config)
+        _MCP_SPECS_CACHE[cache_key] = _make_specs("srv_cf", ["cached_tool"])
+
+        # A custom client_factory (non-None) should bypass the cache
+        with patch.object(MCPServerAdapter, "discover_tools", return_value=fake_specs) as mock_discover:
+            dummy_factory = MagicMock()
+            tools = build_mcp_tool_wrappers("srv_cf", config, client_factory=dummy_factory)
+            # discover_tools is called despite cache being populated
+            assert mock_discover.call_count == 1
+            assert len(tools) == 1
+            assert tools[0].name == "mcp_srv_cf_tool_cf"
+
+    def test_client_factory_does_not_write_cache(self):
+        """When client_factory is provided, results are not stored in cache."""
+        config = _make_server_config()
+        fake_specs = _make_specs("srv_no_write", ["tool_nw"])
+
+        with patch.object(MCPServerAdapter, "discover_tools", return_value=fake_specs):
+            dummy_factory = MagicMock()
+            build_mcp_tool_wrappers("srv_no_write", config, client_factory=dummy_factory)
+
+        cache_key = _make_cache_key("srv_no_write", config)
+        assert cache_key not in _MCP_SPECS_CACHE
+
+    def test_invalidate_clears_cache(self):
+        """invalidate_mcp_specs_cache() should clear all cached entries."""
+        config = _make_server_config()
+        fake_specs = _make_specs("srv_inv", ["tool_inv"])
+
+        with patch.object(MCPServerAdapter, "discover_tools", return_value=fake_specs) as mock_discover:
+            build_mcp_tool_wrappers("srv_inv", config, client_factory=None)
+            assert mock_discover.call_count == 1
+            assert len(_MCP_SPECS_CACHE) == 1
+
+            # Invalidate and verify cache is empty
+            invalidate_mcp_specs_cache()
+            assert len(_MCP_SPECS_CACHE) == 0
+
+            # Next call should trigger discover_tools again
+            build_mcp_tool_wrappers("srv_inv", config, client_factory=None)
+            assert mock_discover.call_count == 2
+
+    def test_exception_not_cached(self):
+        """When discover_tools raises, result should not be stored in cache."""
+        config = _make_server_config()
+        cache_key = _make_cache_key("srv_err", config)
+
+        with patch.object(MCPServerAdapter, "discover_tools", side_effect=RuntimeError("connection failed")):
+            with pytest.raises(RuntimeError, match="connection failed"):
+                build_mcp_tool_wrappers("srv_err", config, client_factory=None)
+
+        # Cache should remain empty after failure
+        assert cache_key not in _MCP_SPECS_CACHE
+
+    def test_exception_does_not_poison_subsequent_success(self):
+        """A failed discovery should not prevent a later successful one."""
+        config = _make_server_config()
+        fake_specs = _make_specs("srv_recover", ["tool_ok"])
+
+        with patch.object(MCPServerAdapter, "discover_tools") as mock_discover:
+            # First call fails
+            mock_discover.side_effect = RuntimeError("temporary failure")
+            with pytest.raises(RuntimeError):
+                build_mcp_tool_wrappers("srv_recover", config, client_factory=None)
+
+            # Second call succeeds
+            mock_discover.side_effect = None
+            mock_discover.return_value = fake_specs
+            tools = build_mcp_tool_wrappers("srv_recover", config, client_factory=None)
+            assert len(tools) == 1
+
+    def test_cached_specs_produce_valid_tools(self):
+        """Tools built from cache should have correct name and description."""
+        config = _make_server_config()
+        fake_specs = _make_specs("srv_valid", ["alpha", "beta"])
+
+        with patch.object(MCPServerAdapter, "discover_tools", return_value=fake_specs):
+            build_mcp_tool_wrappers("srv_valid", config, client_factory=None)
+
+            # Second call (from cache)
+            tools = build_mcp_tool_wrappers("srv_valid", config, client_factory=None)
+
+        assert tools[0].name == "mcp_srv_valid_alpha"
+        assert tools[1].name == "mcp_srv_valid_beta"
+        assert "Tool alpha" in tools[0].description
+        assert "Tool beta" in tools[1].description


### PR DESCRIPTION
## Summary

- Add module-level thread-safe MCP tool specs cache to eliminate redundant `tools/list` RPC calls across Swarm workers
- Reduce tool discovery overhead from O(Workers × Layers × Servers) to O(Servers)
- ~6× speedup in typical 3-layer DAG scenarios (from ~44s to ~7.4s for tool discovery)

## Why

Closes #703

During Swarm DAG execution, every Worker independently calls `MCPServerAdapter.discover_tools()` which issues a `list_tools` RPC to each configured MCP server. A single RPC takes ~7.4s. In a 3-layer DAG with 2 workers/layer and 1 MCP server, this adds ~44s of pure discovery overhead before any LLM reasoning begins.

## Changes

- `agent/src/tools/mcp.py`: Added `_MCP_SPECS_CACHE`, `_MCP_SPECS_LOCK`, `_make_cache_key()`, `invalidate_mcp_specs_cache()`. Modified `build_mcp_tool_wrappers()` to check cache before creating adapter and executing discovery RPC.
- `agent/src/swarm/runtime.py`: Call `invalidate_mcp_specs_cache()` at the start of `_execute_run()` to ensure per-run cache freshness.
- `agent/tests/test_mcp_specs_cache.py`: 15 unit tests covering cache hit, key isolation, thread safety, client_factory bypass, invalidation, and exception-not-cached scenarios.

## Test Plan

- [x] Existing tests pass (`pytest agent/tests/test_mcp_client_adapter.py agent/tests/test_swarm_m2_registry_assembly.py` — 29 tests pass)
- [x] New tests added (`pytest agent/tests/test_mcp_specs_cache.py` — 15 tests pass)
- [x] Tested manually: verified import succeeds and cache behavior via Python REPL

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows CONTRIBUTING.md guidelines
- [ ] Documentation updated (if user-facing change)
