### PR TITLE
fix(api): add fundamental zoo to _VALID_ZOOS whitelist

### DIFF
--- a/agent/src/api/alpha_routes.py
+++ b/agent/src/api/alpha_routes.py
@@ -101,7 +101,7 @@ _ALPHA_ID_RE = re.compile(r"^[a-z][a-z0-9]+_[a-z0-9_]{1,64}$")
 _JOB_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
 
 # Filter enums — keep in sync with src.factors.registry.Theme / Universe.
-_VALID_ZOOS = {"alpha101", "gtja191", "qlib158", "academic"}
+_VALID_ZOOS = {"alpha101", "gtja191", "qlib158", "academic", "fundamental"}
 _VALID_THEMES = {
     "momentum", "reversal", "volume", "volatility", "quality", "value",
     "liquidity", "microstructure", "sentiment", "growth", "leverage",


### PR DESCRIPTION
The fundamental factor zoo (zoo/fundamental/, 4 PIT-safe alphas) shipped in v0.1.11 and has a frontend card in AlphaZoo, but the API whitelist was never updated — GET /alpha/list?zoo=fundamental and POST /alpha/bench both reject it with 400 "unknown zoo 'fundamental'".

Add "fundamental" to _VALID_ZOOS so both endpoints accept it.

## Summary

<!-- What does this PR do? 1-3 bullet points. -->

-

## Why

<!-- What problem does it solve? Link related issues with "Closes #123". -->

## Changes

<!-- List key changes. For new skills/presets, describe what they cover. -->

-

## Test Plan

- [ ] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [ ] New tests added (if applicable)
- [ ] Tested manually (describe below)

## Checklist

- [ ] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [ ] No hardcoded values (API keys, file paths, magic numbers)
- [ ] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] Documentation updated (if user-facing change)
