### PR TITLE
fix(factors): reject non-positive n_groups in factor analysis

### DIFF
--- a/agent/src/factors/factor_analysis_core.py
+++ b/agent/src/factors/factor_analysis_core.py
@@ -60,6 +60,10 @@ def compute_group_equity(
     Returns:
         DataFrame with index=date and columns Group_1 ... Group_N holding cumulative NAV.
     """
+    if n_groups < 1:
+        # qcut/cut reject non-positive bins; range(n_groups) is also empty for <=0
+        raise ValueError(f"n_groups must be >= 1, got {n_groups}")
+
     common_dates = sorted(factor_df.index.intersection(return_df.index))
     common_codes = factor_df.columns.intersection(return_df.columns)
     if len(common_dates) == 0 or len(common_codes) == 0:

--- a/agent/src/tools/factor_analysis_tool.py
+++ b/agent/src/tools/factor_analysis_tool.py
@@ -67,7 +67,10 @@ def run_factor_analysis(
         json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8"
     )
 
-    equity_df = compute_group_equity(factor_df, return_df, n_groups)
+    try:
+        equity_df = compute_group_equity(factor_df, return_df, n_groups)
+    except ValueError as e:
+        return json.dumps({"status": "error", "error": str(e)}, ensure_ascii=False)
     if equity_df.empty:
         return json.dumps(
             {"status": "error", "error": "Layered backtest failed: insufficient valid cross-section dates"},

--- a/agent/src/tools/factor_analysis_tool.py
+++ b/agent/src/tools/factor_analysis_tool.py
@@ -42,6 +42,12 @@ def run_factor_analysis(
     if factor_df.empty or return_df.empty:
         return json.dumps({"status": "error", "error": "Factor or return data is empty"}, ensure_ascii=False)
 
+    if n_groups < 1:
+        return json.dumps(
+            {"status": "error", "error": f"n_groups must be >= 1, got {n_groups}"},
+            ensure_ascii=False,
+        )
+
     ic_series = compute_ic_series(factor_df, return_df)
     if ic_series.empty:
         return json.dumps(
@@ -67,10 +73,7 @@ def run_factor_analysis(
         json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8"
     )
 
-    try:
-        equity_df = compute_group_equity(factor_df, return_df, n_groups)
-    except ValueError as e:
-        return json.dumps({"status": "error", "error": str(e)}, ensure_ascii=False)
+    equity_df = compute_group_equity(factor_df, return_df, n_groups)
     if equity_df.empty:
         return json.dumps(
             {"status": "error", "error": "Layered backtest failed: insufficient valid cross-section dates"},

--- a/agent/tests/factors/test_factor_analysis_core.py
+++ b/agent/tests/factors/test_factor_analysis_core.py
@@ -1,0 +1,54 @@
+"""Regression tests for factor analysis core helpers."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.factors.factor_analysis_core import compute_group_equity
+from src.tools.factor_analysis_tool import run_factor_analysis
+
+
+def _panel(n_dates: int = 30, n_codes: int = 10, seed: int = 0) -> tuple[pd.DataFrame, pd.DataFrame]:
+    dates = pd.date_range("2020-01-01", periods=n_dates, freq="B")
+    codes = [f"C{i:02d}" for i in range(n_codes)]
+    rng = np.random.default_rng(seed)
+    factor = pd.DataFrame(rng.normal(size=(n_dates, n_codes)), index=dates, columns=codes)
+    ret = pd.DataFrame(
+        rng.normal(scale=0.01, size=(n_dates, n_codes)), index=dates, columns=codes
+    )
+    return factor, ret
+
+
+def test_compute_group_equity_rejects_nonpositive_n_groups() -> None:
+    factor, ret = _panel()
+    with pytest.raises(ValueError, match="n_groups"):
+        compute_group_equity(factor, ret, -1)
+    with pytest.raises(ValueError, match="n_groups"):
+        compute_group_equity(factor, ret, 0)
+    eq = compute_group_equity(factor, ret, 1)
+    assert not eq.empty
+    assert list(eq.columns) == ["Group_1"]
+
+
+def test_run_factor_analysis_nonpositive_n_groups_returns_json_error() -> None:
+    factor, ret = _panel()
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        factor.to_csv(root / "f.csv")
+        ret.to_csv(root / "r.csv")
+        out = json.loads(
+            run_factor_analysis(
+                str(root / "f.csv"),
+                str(root / "r.csv"),
+                str(root / "out"),
+                n_groups=-1,
+            )
+        )
+        assert out["status"] == "error"
+        assert "n_groups" in out["error"]


### PR DESCRIPTION
compute_group_equity passed n_groups=-1 into pandas.qcut and raised IndexError. Require n_groups >= 1 and return a JSON error from the factor_analysis tool instead of crashing.