### PR TITLE
fix(alpha): reject inverted period ranges in _parse_period

### DIFF
--- a/agent/src/tools/alpha_bench_tool.py
+++ b/agent/src/tools/alpha_bench_tool.py
@@ -77,13 +77,19 @@ def _parse_period(period: str) -> tuple[str, str]:
         raise ValueError(f"period must be string, got {type(period).__name__}")
     m = _PERIOD_DATE.match(period)
     if m:
-        return m.group(1), m.group(2)
-    m = _PERIOD_YEAR.match(period)
-    if m:
-        return f"{m.group(1)}-01-01", f"{m.group(2)}-12-31"
-    raise ValueError(
-        f"period {period!r} must be YYYY-YYYY or YYYY-MM-DD/YYYY-MM-DD"
-    )
+        start, end = m.group(1), m.group(2)
+    else:
+        m = _PERIOD_YEAR.match(period)
+        if m:
+            start, end = f"{m.group(1)}-01-01", f"{m.group(2)}-12-31"
+        else:
+            raise ValueError(
+                f"period {period!r} must be YYYY-YYYY or YYYY-MM-DD/YYYY-MM-DD"
+            )
+    # Match backtest loaders.validate_date_range: reject inverted ranges.
+    if pd.Timestamp(start) > pd.Timestamp(end):
+        raise ValueError(f"start_date ({start}) > end_date ({end})")
+    return start, end
 
 
 def _load_universe_panel(

--- a/agent/tests/test_parse_period_inverted.py
+++ b/agent/tests/test_parse_period_inverted.py
@@ -1,0 +1,22 @@
+"""Regression: inverted period strings must raise ValueError."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.tools.alpha_bench_tool import _parse_period
+
+
+def test_parse_period_rejects_inverted_year_range() -> None:
+    with pytest.raises(ValueError, match="start_date"):
+        _parse_period("2024-2020")
+
+
+def test_parse_period_rejects_inverted_date_range() -> None:
+    with pytest.raises(ValueError, match="start_date"):
+        _parse_period("2020-01-02/2020-01-01")
+
+
+def test_parse_period_normal_ranges_still_work() -> None:
+    assert _parse_period("2020-2024") == ("2020-01-01", "2024-12-31")
+    assert _parse_period("2020-01-01/2020-12-31") == ("2020-01-01", "2020-12-31")


### PR DESCRIPTION
_parse_period accepted inverted ranges like 2024-2020 and returned a reversed (start, end) pair. Reject start > end with ValueError, matching validate_date_range.