### PR TITLE
fix(pattern): reject non-positive detection window

### DIFF
--- a/agent/src/tools/pattern_tool.py
+++ b/agent/src/tools/pattern_tool.py
@@ -30,6 +30,8 @@ def find_peaks_valleys(close: pd.Series, window: int = 5) -> dict:
     Returns:
         Dict with keys "peaks" and "valleys", each a list of integer indices.
     """
+    if window < 1:
+        raise ValueError(f"window must be >= 1, got {window}")
     n = len(close)
     if n < 2 * window + 1:
         return {"peaks": [], "valleys": []}
@@ -138,6 +140,8 @@ def trend_line_slope(close: pd.Series, window: int = 20) -> pd.Series:
     Returns:
         Series of slope values; first window-1 entries are NaN.
     """
+    if window < 1:
+        raise ValueError(f"window must be >= 1, got {window}")
     n = len(close)
     slopes = np.full(n, np.nan)
     values = close.values.astype(float)
@@ -329,6 +333,12 @@ def run_pattern(run_dir: str, patterns: str = "all", window: int = 10) -> str:
         selected = [p.strip() for p in patterns.split(",") if p.strip() in _PATTERN_FUNCS]
         if not selected:
             return json.dumps({"status": "error", "error": f"Invalid pattern name(s). Available: {', '.join(_PATTERN_FUNCS.keys())}"}, ensure_ascii=False)
+
+    if window < 1:
+        return json.dumps(
+            {"status": "error", "error": f"window must be >= 1, got {window}"},
+            ensure_ascii=False,
+        )
 
     results: Dict[str, Any] = {}
     for f in ohlcv_files:

--- a/agent/tests/test_pattern_tool.py
+++ b/agent/tests/test_pattern_tool.py
@@ -252,3 +252,30 @@ def _write_ohlcv(path: Path) -> None:
         index=idx,
     )
     df.to_csv(path)
+
+
+def test_find_peaks_valleys_rejects_nonpositive_window() -> None:
+    close = pd.Series(range(30), dtype=float)
+    with pytest.raises(ValueError, match="window"):
+        find_peaks_valleys(close, window=-1)
+    with pytest.raises(ValueError, match="window"):
+        find_peaks_valleys(close, window=0)
+
+
+def test_trend_line_slope_rejects_nonpositive_window() -> None:
+    close = pd.Series(range(30), dtype=float)
+    with pytest.raises(ValueError, match="window"):
+        trend_line_slope(close, window=0)
+
+
+def test_run_pattern_nonpositive_window_returns_json_error(allow_runs: Path) -> None:
+    run_dir = allow_runs / "run1"
+    arts = run_dir / "artifacts"
+    arts.mkdir(parents=True)
+    pd.DataFrame(
+        {"open": range(30), "high": range(30), "low": range(30), "close": range(30), "volume": 1},
+        index=pd.date_range("2024-01-01", periods=30),
+    ).to_csv(arts / "ohlcv_TEST.csv")
+    out = json.loads(run_pattern(str(run_dir), patterns="peaks_valleys", window=-1))
+    assert out["status"] == "error"
+    assert "window" in out["error"]


### PR DESCRIPTION
pattern detectors passed window<=0 into peak scans and polyfit, causing IndexError, TypeError, or every-bar peak/valley garbage. Require window >= 1 and return a JSON error from run_pattern.