### PR TITLE
fix(validation): accept equity.csv nav/value column aliases

### DIFF
--- a/agent/backtest/validation.py
+++ b/agent/backtest/validation.py
@@ -324,8 +324,6 @@ def _load_equity(run_dir: Path) -> pd.Series:
     for col in ("equity", "nav", "value"):
         if col in df.columns:
             return df[col]
-    if len(df.columns) == 1:
-        return df.iloc[:, 0]
     raise ValueError(
         f"equity.csv must contain an equity/nav/value column; got {list(df.columns)}"
     )

--- a/agent/backtest/validation.py
+++ b/agent/backtest/validation.py
@@ -321,7 +321,14 @@ def _load_equity(run_dir: Path) -> pd.Series:
     """Load equity curve from artifacts/equity.csv."""
     path = run_dir / "artifacts" / "equity.csv"
     df = pd.read_csv(path, index_col=0, parse_dates=True)
-    return df["equity"]
+    for col in ("equity", "nav", "value"):
+        if col in df.columns:
+            return df[col]
+    if len(df.columns) == 1:
+        return df.iloc[:, 0]
+    raise ValueError(
+        f"equity.csv must contain an equity/nav/value column; got {list(df.columns)}"
+    )
 
 
 def _load_trades(run_dir: Path) -> List[TradeRecord]:

--- a/agent/tests/test_load_equity_aliases.py
+++ b/agent/tests/test_load_equity_aliases.py
@@ -1,0 +1,39 @@
+"""Regression: equity.csv may use nav/value instead of equity."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from backtest.validation import _load_equity
+
+
+def test_load_equity_accepts_nav_column(tmp_path: Path) -> None:
+    arts = tmp_path / "artifacts"
+    arts.mkdir()
+    pd.DataFrame({"nav": [100.0, 101.0]}, index=pd.date_range("2024-01-01", periods=2)).to_csv(
+        arts / "equity.csv"
+    )
+    s = _load_equity(tmp_path)
+    assert list(s.values) == [100.0, 101.0]
+
+
+def test_load_equity_accepts_equity_column(tmp_path: Path) -> None:
+    arts = tmp_path / "artifacts"
+    arts.mkdir()
+    pd.DataFrame({"equity": [1.0, 2.0]}, index=pd.date_range("2024-01-01", periods=2)).to_csv(
+        arts / "equity.csv"
+    )
+    assert list(_load_equity(tmp_path).values) == [1.0, 2.0]
+
+
+def test_load_equity_unknown_columns_raise(tmp_path: Path) -> None:
+    arts = tmp_path / "artifacts"
+    arts.mkdir()
+    pd.DataFrame({"foo": [1.0], "bar": [2.0]}, index=pd.date_range("2024-01-01", periods=1)).to_csv(
+        arts / "equity.csv"
+    )
+    with pytest.raises(ValueError, match="equity/nav/value"):
+        _load_equity(tmp_path)

--- a/agent/tests/test_load_equity_aliases.py
+++ b/agent/tests/test_load_equity_aliases.py
@@ -29,10 +29,19 @@ def test_load_equity_accepts_equity_column(tmp_path: Path) -> None:
     assert list(_load_equity(tmp_path).values) == [1.0, 2.0]
 
 
+def test_load_equity_accepts_value_column(tmp_path: Path) -> None:
+    arts = tmp_path / "artifacts"
+    arts.mkdir()
+    pd.DataFrame({"value": [9.0, 10.0]}, index=pd.date_range("2024-01-01", periods=2)).to_csv(
+        arts / "equity.csv"
+    )
+    assert list(_load_equity(tmp_path).values) == [9.0, 10.0]
+
+
 def test_load_equity_unknown_columns_raise(tmp_path: Path) -> None:
     arts = tmp_path / "artifacts"
     arts.mkdir()
-    pd.DataFrame({"foo": [1.0], "bar": [2.0]}, index=pd.date_range("2024-01-01", periods=1)).to_csv(
+    pd.DataFrame({"foo": [1.0]}, index=pd.date_range("2024-01-01", periods=1)).to_csv(
         arts / "equity.csv"
     )
     with pytest.raises(ValueError, match="equity/nav/value"):


### PR DESCRIPTION
validation CLI hardcoded df['equity'], so artifacts that store nav or value raised KeyError. Accept equity/nav/value (or a single numeric column).