### PR TITLE
fix(mcp): align factor_analysis wrapper with the registered tool contract

### DIFF
--- a/agent/mcp_server.py
+++ b/agent/mcp_server.py
@@ -466,39 +466,30 @@ def backtest(run_dir: str) -> str:
 
 @mcp.tool
 def factor_analysis(
-    codes: list[str],
-    factor_name: str,
-    start_date: str,
-    end_date: str,
-    source: str = "auto",
-    top_n: int = 10,
-    bottom_n: int = 10,
+    factor_csv: str,
+    return_csv: str,
+    output_dir: str,
+    n_groups: int = 5,
 ) -> str:
-    """Compute factor IC/IR analysis and layered backtest for a cross-section of stocks.
+    """Compute factor IC/IR analysis and layered backtest from prepared CSVs.
 
     Analyzes factor predictive power using Spearman rank IC, IR (IC/std),
-    and top/bottom quintile return spreads.
+    and quantile group return spreads.
 
     Args:
-        codes: List of stock codes (e.g. ["000001.SZ", "600519.SH"]).
-        factor_name: Factor column name in daily_basic data (e.g. "pe_ttm", "pb", "turnover_rate").
-        start_date: Start date (YYYY-MM-DD).
-        end_date: End date (YYYY-MM-DD).
-        source: Data source ("tushare", "yfinance", "auto").
-        top_n: Number of top-ranked stocks per period.
-        bottom_n: Number of bottom-ranked stocks per period.
+        factor_csv: Path to factor values CSV (index=date, columns=codes).
+        return_csv: Path to returns CSV (same structure as factor_csv).
+        output_dir: Directory for output files (ic_series.csv, ic_summary.json, group_equity.csv).
+        n_groups: Number of quantile groups (default 5).
     """
     registry = _get_registry()
     return registry.execute(
         "factor_analysis",
         {
-            "codes": codes,
-            "factor_name": factor_name,
-            "start_date": start_date,
-            "end_date": end_date,
-            "source": source,
-            "top_n": top_n,
-            "bottom_n": bottom_n,
+            "factor_csv": factor_csv,
+            "return_csv": return_csv,
+            "output_dir": output_dir,
+            "n_groups": n_groups,
         },
     )
 

--- a/agent/tests/test_mcp_factor_analysis_contract.py
+++ b/agent/tests/test_mcp_factor_analysis_contract.py
@@ -1,0 +1,114 @@
+"""Regression tests for issue #635 — MCP ``factor_analysis`` contract mismatch.
+
+Pre-fix: the MCP wrapper forwarded ``codes``/``factor_name``/``start_date``/
+``end_date``/``source``/``top_n``/``bottom_n``, but the registered
+``FactorAnalysisTool`` requires ``factor_csv``/``return_csv``/``output_dir`` —
+every MCP call died on ``KeyError: 'factor_csv'`` before any analysis ran.
+Post-fix: the wrapper mirrors the registered tool's real contract, and these
+tests pin that contract so future drift fails loudly.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+
+import pandas as pd
+
+import mcp_server
+from src.tools.factor_analysis_tool import FactorAnalysisTool
+
+# fastmcp wraps the tool; reach the raw callable.
+_fa = getattr(mcp_server.factor_analysis, "fn", None) or getattr(
+    mcp_server.factor_analysis, "__wrapped__", mcp_server.factor_analysis
+)
+
+
+class _RecordingRegistry:
+    """Registry stub that captures execute() calls."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+
+    def execute(self, name: str, args: dict) -> str:
+        self.calls.append((name, args))
+        return json.dumps({"status": "ok"})
+
+
+def test_wrapper_forwards_registered_contract(monkeypatch) -> None:
+    """The wrapper must forward exactly the registered tool's argument keys."""
+    rec = _RecordingRegistry()
+    monkeypatch.setattr(mcp_server, "_get_registry", lambda: rec)
+
+    _fa(factor_csv="f.csv", return_csv="r.csv", output_dir="out", n_groups=3)
+
+    assert rec.calls == [
+        (
+            "factor_analysis",
+            {
+                "factor_csv": "f.csv",
+                "return_csv": "r.csv",
+                "output_dir": "out",
+                "n_groups": 3,
+            },
+        )
+    ]
+
+
+def test_wrapper_signature_matches_registered_tool() -> None:
+    """Drift guard: wrapper params must equal FactorAnalysisTool.parameters."""
+    spec = FactorAnalysisTool.parameters
+    sig = inspect.signature(_fa)
+
+    assert set(sig.parameters) == set(spec["properties"])
+    wrapper_required = {
+        name for name, p in sig.parameters.items() if p.default is inspect.Parameter.empty
+    }
+    assert wrapper_required == set(spec["required"])
+
+
+def _write_synthetic_csvs(tmp_path) -> tuple[str, str]:
+    """Build minimal factor/return CSVs (6 codes x 12 days, perfectly ranked)."""
+    dates = pd.date_range("2026-01-01", periods=12, freq="D")
+    codes = [f"C{i}" for i in range(6)]
+    factor = pd.DataFrame(
+        [[float(i * 10 + j) for j in range(6)] for i in range(12)],
+        index=dates,
+        columns=codes,
+    )
+    returns = pd.DataFrame(
+        [[0.01 * (j + 1) for j in range(6)] for _ in range(12)],
+        index=dates,
+        columns=codes,
+    )
+    factor_csv = tmp_path / "factor.csv"
+    return_csv = tmp_path / "return.csv"
+    factor.to_csv(factor_csv)
+    returns.to_csv(return_csv)
+    return str(factor_csv), str(return_csv)
+
+
+def test_well_formed_call_runs_end_to_end(tmp_path) -> None:
+    """The issue scenario: a well-formed MCP call reaches the implementation.
+
+    Uses the real tool registry against synthetic CSVs. Pre-fix this raised
+    ``KeyError: 'factor_csv'``; post-fix it returns ``status == "ok"`` and
+    writes the analysis artifacts.
+    """
+    factor_csv, return_csv = _write_synthetic_csvs(tmp_path)
+    output_dir = tmp_path / "out"
+
+    result = json.loads(
+        _fa(
+            factor_csv=factor_csv,
+            return_csv=return_csv,
+            output_dir=str(output_dir),
+            n_groups=3,
+        )
+    )
+
+    assert result["status"] == "ok"
+    assert result["ic_count"] == 12
+    assert (output_dir / "ic_series.csv").exists()
+    assert (output_dir / "ic_summary.json").exists()
+    assert (output_dir / "group_equity.csv").exists()


### PR DESCRIPTION
## Summary

The MCP `factor_analysis` tool could never succeed: the wrapper forwarded `codes`/`factor_name`/`start_date`/`end_date`/`source`/`top_n`/`bottom_n`, but the only registered implementation (`FactorAnalysisTool`) requires pre-built CSV artifact paths (`factor_csv`, `return_csv`, `output_dir`). Every MCP call died on `KeyError: 'factor_csv'` before any analysis ran.

This PR mirrors the registered tool's real contract in the wrapper and pins it with regression tests.

Closes #635

## Why

The wrapper advertised a fetch-by-codes capability that no registered tool implements, so the MCP schema was 100% broken — any well-formed call raised `KeyError` inside `execute()`. The registered tool's CSV contract is the source of truth (it is what the agent loop uses), so the minimal honest repair is to align the wrapper to it. Implementing fetch-by-codes would be a separate feature.

## Changes

- `agent/mcp_server.py`: `factor_analysis` wrapper now takes `(factor_csv, return_csv, output_dir, n_groups=5)` and forwards exactly those keys to the registry; docstring rewritten for the CSV-based contract.
- `agent/tests/test_mcp_factor_analysis_contract.py`: 3 regression tests — forwarded-keys pinning, wrapper↔`FactorAnalysisTool.parameters` drift guard, and an end-to-end call through the real registry on synthetic CSVs (the exact issue scenario).

## Test Plan

- [x] ruff check — clean
- [x] pytest (new regression tests) — 3 passed
- [x] pytest (mcp + factor related) — 1193 passed
- [x] pytest (full suite excl e2e) — 5539 passed, 9 skipped; 2 failures reproduce on a clean `main` worktree (`test_bottleneck_available` env check, `test_factor_gate_fund_prefix` runner test) and are unrelated to this change

## Checklist

- [x] No changes to protected areas without prior discussion
- [x] No hardcoded values
- [x] Code follows CONTRIBUTING.md guidelines
- [x] Documentation updated (if user-facing change)
