### PR TITLE
fix: Robinhood connector account_number wiring + remote-MCP display shape

### DIFF
--- a/agent/cli/_legacy.py
+++ b/agent/cli/_legacy.py
@@ -3908,13 +3908,89 @@ def cmd_connector_check(
     return EXIT_SUCCESS
 
 
+def _normalize_mcp_value(value: Any) -> Any:
+    """Unwrap a value from a remote MCP call into plain JSON-safe data.
+
+    Remote connectors (e.g. Robinhood) return their payload as an instance of
+    ``fastmcp``'s auto-generated ``Root`` type — a *dataclass* built at runtime
+    via ``dataclasses.make_dataclass`` from the tool's JSON Schema, not a
+    Pydantic model. ``dataclasses.asdict()`` is the correct unwrap (it also
+    recurses into nested dataclass fields, e.g. ``buying_power``); a stray
+    Pydantic model elsewhere falls back to ``model_dump()``. Anything else
+    (already a dict/list/scalar) is returned as-is.
+    """
+    import dataclasses
+
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return dataclasses.asdict(value)
+    if hasattr(value, "model_dump"):
+        return value.model_dump()
+    return value
+
+
+def _flatten_account_fields(data: dict[str, Any], prefix: str = "") -> list[tuple[str, str]]:
+    """Flatten a remote-MCP account payload into (tag, value) rows.
+
+    Nested one level (e.g. ``buying_power.buying_power``) rather than
+    recursing arbitrarily deep, since broker account payloads are shallow.
+    Skips ``None`` and zero-valued numeric-looking fields, matching the
+    guidance the broker's own response typically includes (zero means no
+    holdings in that asset class — noise to omit, not a real 0.00 balance).
+    """
+    rows: list[tuple[str, str]] = []
+    for key, value in data.items():
+        if key == "currency" or value is None:
+            continue
+        label = f"{prefix}{key}"
+        normalized = _normalize_mcp_value(value)
+        if isinstance(normalized, dict):
+            rows.extend(_flatten_account_fields(normalized, prefix=f"{label}."))
+            continue
+        text = str(normalized)
+        try:
+            if float(text) == 0.0:
+                continue
+        except (TypeError, ValueError):
+            pass
+        rows.append((label, text))
+    return rows
+
+
 def _print_connector_account(result: dict[str, Any]) -> int:
     accounts = ", ".join(result.get("accounts", [])) or "(none)"
-    console.print(f"Accounts: [cyan]{rich_escape(accounts)}[/cyan]")
     rows = result.get("summary", [])
     if not rows:
+        # Not the broker_sdk flat shape — try the remote-MCP nested shape.
+        # Robinhood's tool result double-wraps: result["data"] unwraps to
+        # {"data": <actual account fields>, "guide": "<advisory text>"},
+        # not the fields directly — drill one more level in when present.
+        wrapper = _normalize_mcp_value(result.get("data"))
+        raw_data = wrapper
+        guide = result.get("guide")
+        if isinstance(wrapper, dict) and "data" in wrapper and "guide" in wrapper:
+            raw_data = _normalize_mcp_value(wrapper.get("data"))
+            guide = wrapper.get("guide") or guide
+        if isinstance(raw_data, dict):
+            currency = raw_data.get("currency", "")
+            account_label = result.get("account_number") or accounts
+            table = Table(
+                title=f"Account Summary · {result.get('profile_id')}", box=box.SIMPLE_HEAVY, show_lines=False
+            )
+            table.add_column("Field")
+            table.add_column("Value", justify="right")
+            for tag, value in _flatten_account_fields(raw_data):
+                is_currency_code = tag.endswith("currency") or tag.endswith("_currency")
+                display = value if is_currency_code else f"{value} {currency}".strip()
+                table.add_row(tag, display)
+            console.print(f"Account: [cyan]{rich_escape(str(account_label))}[/cyan]")
+            console.print(table)
+            if guide:
+                console.print(f"[dim]{rich_escape(str(guide))}[/dim]")
+            return EXIT_SUCCESS
+        console.print(f"Accounts: [cyan]{rich_escape(accounts)}[/cyan]")
         console.print("[dim]No account summary returned.[/dim]")
         return EXIT_SUCCESS
+    console.print(f"Accounts: [cyan]{rich_escape(accounts)}[/cyan]")
     table = Table(title=f"Account Summary · {result.get('profile_id')}", box=box.SIMPLE_HEAVY, show_lines=False)
     table.add_column("Account")
     table.add_column("Tag")
@@ -3929,7 +4005,6 @@ def _print_connector_account(result: dict[str, Any]) -> int:
         )
     console.print(table)
     return EXIT_SUCCESS
-
 
 def cmd_connector_account(
     profile_id: Optional[str] = None,
@@ -3974,6 +4049,41 @@ def cmd_connector_positions(
         return EXIT_RUN_FAILED
     rows = result.get("positions", [])
     if not rows:
+        # Not the broker_sdk flat shape — try the remote-MCP nested shape
+        # (same double-wrap as account: result["data"] -> {"data": {"positions":
+        # [...], "next": ...}, "guide": "..."}).
+        wrapper = _normalize_mcp_value(result.get("data"))
+        inner = wrapper
+        guide = result.get("guide")
+        if isinstance(wrapper, dict) and "data" in wrapper and "guide" in wrapper:
+            inner = _normalize_mcp_value(wrapper.get("data"))
+            guide = wrapper.get("guide") or guide
+        remote_positions = inner.get("positions") if isinstance(inner, dict) else None
+        if remote_positions:
+            account_label = result.get("account_number") or "(none)"
+            table = Table(title=f"Positions · {result.get('profile_id')}", box=box.SIMPLE_HEAVY, show_lines=False)
+            table.add_column("Symbol")
+            table.add_column("Type")
+            table.add_column("Qty", justify="right")
+            table.add_column("Avail. Sell", justify="right")
+            table.add_column("Avg Buy Price", justify="right")
+            for pos in remote_positions:
+                pos = _normalize_mcp_value(pos)
+                table.add_row(
+                    str(pos.get("symbol") or pos.get("local_symbol") or ""),
+                    str(pos.get("type") or pos.get("sec_type") or ""),
+                    str(pos.get("quantity") or pos.get("position") or ""),
+                    str(pos.get("shares_available_for_sells") or ""),
+                    str(pos.get("average_buy_price") or pos.get("avg_cost") or ""),
+                )
+            console.print(f"Account: [cyan]{rich_escape(str(account_label))}[/cyan]")
+            console.print(table)
+            if guide:
+                console.print(f"[dim]{rich_escape(str(guide))}[/dim]")
+            next_cursor = inner.get("next") if isinstance(inner, dict) else None
+            if next_cursor:
+                console.print(f"[dim]More results available (next={rich_escape(str(next_cursor))}).[/dim]")
+            return EXIT_SUCCESS
         console.print("[dim]No positions returned.[/dim]")
         return EXIT_SUCCESS
     table = Table(title=f"Positions · {result.get('profile_id')}", box=box.SIMPLE_HEAVY, show_lines=False)
@@ -3994,7 +4104,6 @@ def cmd_connector_positions(
         )
     console.print(table)
     return EXIT_SUCCESS
-
 
 def cmd_connector_orders(
     profile_id: Optional[str] = None,

--- a/agent/src/trading/connectors/robinhood/mcp.py
+++ b/agent/src/trading/connectors/robinhood/mcp.py
@@ -37,4 +37,13 @@ def remote_arguments(operation: str, arguments: dict[str, Any]) -> dict[str, Any
         symbol = arguments.get("symbol")
         symbols = arguments.get("symbols")
         return {"symbols": symbols or ([symbol] if symbol else [])}
+    if operation in ("account", "positions", "orders"):
+        # Robinhood's get_portfolio / get_equity_positions / get_equity_orders
+        # MCP tools require account_number. The generic trading service passes
+        # the CLI/agent-supplied account code in under the "account" key; map
+        # it to the field name Robinhood's schema actually expects.
+        account_number = arguments.get("account_number") or arguments.get("account")
+        if account_number:
+            return {"account_number": account_number}
+        return {}
     return {}

--- a/agent/src/trading/service.py
+++ b/agent/src/trading/service.py
@@ -72,7 +72,7 @@ def get_account(profile_id: str | None = None, **overrides: Any) -> dict[str, An
     if profile.transport == "broker_sdk":
         module = _sdk_module(profile.connector)
         return _with_profile(profile, module.get_account_snapshot(module.build_config(profile.config, overrides)))
-    return _call_remote(profile, "account", {})
+    return _call_remote(profile, "account", _account_arg(overrides))
 
 
 def get_positions(profile_id: str | None = None, **overrides: Any) -> dict[str, Any]:
@@ -85,7 +85,7 @@ def get_positions(profile_id: str | None = None, **overrides: Any) -> dict[str, 
     if profile.transport == "broker_sdk":
         module = _sdk_module(profile.connector)
         return _with_profile(profile, module.get_positions(module.build_config(profile.config, overrides)))
-    return _call_remote(profile, "positions", {})
+    return _call_remote(profile, "positions", _account_arg(overrides))
 
 
 def get_open_orders(
@@ -111,7 +111,7 @@ def get_open_orders(
                 module.build_config(profile.config, overrides), include_executions=include_executions
             ),
         )
-    return _call_remote(profile, "orders", {})
+    return _call_remote(profile, "orders", _account_arg(overrides))
 
 
 def get_quote(
@@ -462,6 +462,18 @@ def _remote_status(profile: TradingProfile) -> dict[str, Any]:
     }
 
 
+def _account_arg(overrides: dict[str, Any]) -> dict[str, Any]:
+    """Build the arguments dict a remote MCP account/positions/orders call needs.
+
+    The CLI ``--account`` flag and the agent-facing tools both surface as an
+    ``account`` key in ``overrides``. Remote connectors (e.g. Robinhood) expect
+    ``account_number`` on the wire; this normalizes that once here instead of
+    duplicating the mapping at each call site.
+    """
+    account = overrides.get("account") or overrides.get("account_number")
+    return {"account_number": account} if account else {}
+
+
 def _call_remote(profile: TradingProfile, operation: str, arguments: dict[str, Any]) -> dict[str, Any]:
     """Call a known read operation on a remote MCP connector profile."""
     from src.config.loader import load_agent_config
@@ -520,10 +532,12 @@ def _call_remote(profile: TradingProfile, operation: str, arguments: dict[str, A
         }
 
     adapter = MCPServerAdapter(server_name, server)
-    return _with_profile(
-        profile,
-        adapter.call_tool(remote_name, _remote_arguments(profile.connector, operation, arguments)),
-    )
+    call_result = adapter.call_tool(remote_name, _remote_arguments(profile.connector, operation, arguments))
+    account_number = arguments.get("account_number")
+    if account_number:
+        call_result = dict(call_result)
+        call_result.setdefault("account_number", account_number)
+    return _with_profile(profile, call_result)
 
 
 def _remote_tool_name(connector: str, operation: str) -> str | None:


### PR DESCRIPTION
## Summary

Two compounding bugs that made the Robinhood remote MCP connector's read tools (`connector account` / `connector positions`) non-functional even on a fully authorized, healthy connection.

---

## Bug 1 — `account_number` silently dropped

**What was happening**

`get_account` / `get_positions` / `get_open_orders` in `service.py` always called `_call_remote(profile, op, {})` — a hardcoded empty dict, ignoring any `account` override passed in via the CLI `--account` flag or an agent tool call. `robinhood/mcp.py`'s `remote_arguments()` also returned `{}` for every operation except `quote`.

Robinhood's `get_portfolio` / `get_equity_positions` / `get_equity_orders` tools require `account_number` as a parameter, so every read call failed with:

```
invalid params: validating "arguments": validating root:
required: missing properties: ["account_number"]
```

**Fix**

- `remote_arguments()` now maps `account`/`account_number` into the field Robinhood's schema expects.
- `service.py` adds `_account_arg()` and wires it into all three read functions.
- `_call_remote` now also echoes `account_number` back into the result, so callers can display which account was actually queried (previously always showed as unknown).

---

## Bug 2 — CLI printer didn't understand the remote-MCP response shape

**What was happening**

Even after fixing Bug 1, `connector account` / `connector positions` still printed "No account summary returned" / "No positions returned" on a working connection. Two issues:

1. `fastmcp`'s auto-generated `Root` response type is a **dataclass** (built via `dataclasses.make_dataclass` from the tool's JSON Schema), not a Pydantic model — code checking `hasattr(value, "model_dump")` never matched, so the raw dataclass instance fell through unconverted.
2. Robinhood's response is **double-wrapped**:
   `result["data"] → Root(data=Root(<actual fields>), guide="<text>")`
   The real fields are one level deeper than `result["data"]`, alongside a sibling `guide` field containing the broker's own advisory text (e.g. "use `buying_power.buying_power`, not `cash`, as the authoritative spendable figure").

**Fix**

- `_normalize_mcp_value` now checks `dataclasses.is_dataclass()` and uses `dataclasses.asdict()` (which also recurses into nested dataclass fields like `buying_power`), falling back to `model_dump()` for any Pydantic-model shape.
- Both printers drill into the `data.data` / `data.guide` double-wrap when present, before falling back to the flat `broker_sdk` shape.
- The positions table now uses Robinhood's actual field names (`symbol`, `type`, `quantity`, `shares_available_for_sells`, `average_buy_price`) instead of the IBKR-style names it previously assumed.

---

## Verification

Reproduced and fixed against a live, read-only-authorized Robinhood Agentic Trading connector profile. Values below are illustrative placeholders, not real account data.

**Before:**
```
$ vibe-trading connector account --account XXXXXXXX
Session termination failed: 400
invalid params: validating "arguments": validating root:
required: missing properties: ["account_number"]
```

**After:**
```
$ vibe-trading connector account --account XXXXXXXX
Account: XXXXXXXX
                 Account Summary · robinhood-live-mcp
  Field                                    Value
  total_value                        12345.678901 USD
  equity_value                          2345.670000 USD
  crypto_value                          1000.000000 USD
  cash                                  9000.000000 USD
  buying_power.buying_power             9000.000000 USD
  ...
```

```
$ vibe-trading connector positions --account XXXXXXXX
Account: XXXXXXXX
              Positions · robinhood-live-mcp
  Symbol   Type        Qty   Avail. Sell   Avg Buy Price
  ABCD     long   10.000000     10.000000       42.500000
```

**No changes to any write/order-placement path** — both fixes are confined to read operations (`account`, `positions`, `orders`).