### PR TITLE
fix(channels): avoid hang in split_message when max_len <= 0

### DIFF
--- a/agent/src/channels/utils.py
+++ b/agent/src/channels/utils.py
@@ -62,6 +62,9 @@ def split_message(content: str, max_len: int = 2000) -> list[str]:
     """
     if not content:
         return []
+    # Non-positive max_len cannot advance the cut pointer; return unsplit.
+    if max_len <= 0:
+        return [content]
     if len(content) <= max_len:
         return [content]
     chunks: list[str] = []

--- a/agent/tests/test_split_message_nonpositive.py
+++ b/agent/tests/test_split_message_nonpositive.py
@@ -1,0 +1,17 @@
+"""Regression: split_message must not hang on non-positive max_len."""
+
+from __future__ import annotations
+
+from src.channels.utils import split_message
+
+
+def test_split_message_nonpositive_max_len_returns_unsplit() -> None:
+    content = "hello world"
+    assert split_message(content, max_len=0) == [content]
+    assert split_message(content, max_len=-1) == [content]
+
+
+def test_split_message_normal_path() -> None:
+    chunks = split_message("aaa\nbbb\nccc", max_len=5)
+    assert chunks
+    assert all(len(c) <= 5 for c in chunks)


### PR DESCRIPTION
When max_len is 0 or negative, the cut pointer never advances and split_message loops forever. Return the content unsplit so outbound IM adapters cannot wedge.

Repro: split_message("hello world", max_len=0).