### PR TITLE
fix(tools): reject inverted PDF page ranges in doc_reader

### DIFF
--- a/agent/src/tools/doc_reader_tool.py
+++ b/agent/src/tools/doc_reader_tool.py
@@ -111,8 +111,13 @@ def _parse_pages(pages_str: str, total: int) -> list[int]:
             continue
         if "-" in part:
             start, end = part.split("-", 1)
-            s = max(int(start.strip()) - 1, 0)
-            e = min(int(end.strip()), total)
+            start_1 = int(start.strip())
+            end_1 = int(end.strip())
+            # Mirror alpha_bench_tool._parse_period: reject inverted ranges.
+            if start_1 > end_1:
+                raise ValueError(f"inverted page range: {part!r}")
+            s = max(start_1 - 1, 0)
+            e = min(end_1, total)
             out.extend(range(s, e))
         elif part.isdigit():
             out.append(int(part) - 1)

--- a/agent/tests/test_doc_reader_inverted_pages.py
+++ b/agent/tests/test_doc_reader_inverted_pages.py
@@ -1,0 +1,20 @@
+"""Inverted PDF page ranges must raise, not silently read nothing."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.tools.doc_reader_tool import _parse_pages
+
+
+def test_inverted_page_range_raises() -> None:
+    with pytest.raises(ValueError, match="inverted page range"):
+        _parse_pages("10-5", 20)
+
+
+def test_normal_page_range_ok() -> None:
+    assert _parse_pages("1-3", 20) == [0, 1, 2]
+
+
+def test_comma_list_ok() -> None:
+    assert _parse_pages("1,3,5", 20) == [0, 2, 4]


### PR DESCRIPTION
`doc_reader` page specs like `10-5` produced an empty index list, so the PDF path returned success with no text. Ascending ranges are the documented grammar, and `alpha_bench` already rejects inverted periods.

`_parse_pages` now raises `ValueError` for inverted ranges.

Repro: `_parse_pages("10-5", 20)` returned `[]` on main and now raises.