### PR TITLE
fix(tools): reject inverted trade-journal date filters

### DIFF
--- a/agent/src/tools/trade_journal_tool.py
+++ b/agent/src/tools/trade_journal_tool.py
@@ -389,10 +389,15 @@ def _apply_filter(df: pd.DataFrame, expr: str) -> pd.DataFrame:
                 if hi_month
                 else hi_base + pd.Timedelta(days=1)
             )
-            return df[(df["datetime"] >= lo) & (df["datetime"] < hi)]
+        except ValueError:
+            raise
         except Exception as exc:
             logger.warning("filter date parse failed: %s", exc)
             return df
+        # Mirror alpha_bench _parse_period: reject inverted ranges.
+        if lo >= hi:
+            raise ValueError(f"inverted date filter: {expr!r}")
+        return df[(df["datetime"] >= lo) & (df["datetime"] < hi)]
 
     if "=" in expr:
         key, val = (p.strip() for p in expr.split("=", 1))

--- a/agent/tests/test_journal_inverted_date_filter.py
+++ b/agent/tests/test_journal_inverted_date_filter.py
@@ -23,5 +23,5 @@ def test_inverted_month_filter_raises() -> None:
 
 
 def test_normal_month_filter_keeps_rows() -> None:
-    out = _apply_filter(_frame(), "2026-01 to 2026-03")
-    assert len(out) == 2
+    out = _apply_filter(_frame(), "2026-01 to 2026-02")
+    assert list(out["datetime"].dt.strftime("%Y-%m")) == ["2026-01", "2026-02"]

--- a/agent/tests/test_journal_inverted_date_filter.py
+++ b/agent/tests/test_journal_inverted_date_filter.py
@@ -1,0 +1,27 @@
+"""Inverted journal date filters must raise, not silently empty the frame."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from src.tools.trade_journal_tool import _apply_filter
+
+
+def _frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "datetime": pd.to_datetime(["2026-01-15", "2026-02-15", "2026-03-15"]),
+            "symbol": ["A", "A", "A"],
+        }
+    )
+
+
+def test_inverted_month_filter_raises() -> None:
+    with pytest.raises(ValueError, match="inverted date filter"):
+        _apply_filter(_frame(), "2026-03 to 2026-01")
+
+
+def test_normal_month_filter_keeps_rows() -> None:
+    out = _apply_filter(_frame(), "2026-01 to 2026-03")
+    assert len(out) == 2


### PR DESCRIPTION
Trade journal `filter_expr` values like `2026-03 to 2026-01` parsed cleanly but selected zero rows, so analysis ran on an empty frame with no error. Ascending ranges are the documented examples, and alpha_bench already rejects inverted periods.

`_apply_filter` now raises `ValueError` when the lower bound is not before the upper bound.

Repro: `_apply_filter(df, "2026-03 to 2026-01")` returned an empty frame on main and now raises.