### PR TITLE
feat: expose MiniMax regional API endpoints

### DIFF
--- a/agent/.env.example
+++ b/agent/.env.example
@@ -89,7 +89,8 @@ OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 # LANGCHAIN_PROVIDER=minimax
 # LANGCHAIN_MODEL_NAME=MiniMax-M3              # or MiniMax-M2.7 / MiniMax-M2.7-highspeed
 # MINIMAX_API_KEY=xxx
-# MINIMAX_BASE_URL=https://api.minimax.io/v1
+# MINIMAX_BASE_URL=https://api.minimax.io/v1  # Global
+# MINIMAX_BASE_URL=https://api.minimaxi.com/v1  # China
 # Note: MiniMax requires temperature > 0. Set LANGCHAIN_TEMPERATURE=1.0 (default when using MiniMax)
 
 # --- Xiaomi MIMO ---

--- a/agent/src/api/settings_routes.py
+++ b/agent/src/api/settings_routes.py
@@ -35,6 +35,7 @@ class LLMProviderOption(BaseModel):
     base_url_env: str
     default_model: str
     default_base_url: str
+    base_url_options: List[str] = Field(default_factory=list)
     api_key_required: bool = True
     auth_type: str = "api_key"
     login_command: Optional[str] = None

--- a/agent/src/providers/llm_providers.json
+++ b/agent/src/providers/llm_providers.json
@@ -134,6 +134,10 @@
     "base_url_env": "MINIMAX_BASE_URL",
     "default_model": "MiniMax-M3",
     "default_base_url": "https://api.minimax.io/v1",
+    "base_url_options": [
+      "https://api.minimax.io/v1",
+      "https://api.minimaxi.com/v1"
+    ],
     "api_key_required": true
   },
   {

--- a/agent/tests/test_llm_provider_defaults.py
+++ b/agent/tests/test_llm_provider_defaults.py
@@ -40,6 +40,17 @@ def test_llm_provider_registry_uses_current_default_models() -> None:
     assert defaults["openai"] != "gpt-5.5-instant"
 
 
+def test_minimax_provider_lists_regional_endpoints() -> None:
+    providers_path = Path(__file__).resolve().parents[1] / "src" / "providers" / "llm_providers.json"
+    providers = json.loads(providers_path.read_text(encoding="utf-8"))
+    minimax = next(item for item in providers if item["name"] == "minimax")
+
+    assert minimax["base_url_options"] == [
+        "https://api.minimax.io/v1",
+        "https://api.minimaxi.com/v1",
+    ]
+
+
 def test_interactive_onboard_openai_defaults_to_available_model() -> None:
     provider = next(provider for provider in ONBOARD_PROVIDERS if provider.key == "openai")
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -265,6 +265,7 @@ export interface LLMProviderOption {
   base_url_env: string;
   default_model: string;
   default_base_url: string;
+  base_url_options?: string[];
   api_key_required: boolean;
   auth_type?: string;
   login_command?: string | null;

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -462,8 +462,16 @@ export function Settings() {
                 onChange={(event) => setForm({ ...form, base_url: event.target.value })}
                 className={fieldClass}
                 placeholder={selectedProvider?.default_base_url}
+                list={selectedProvider?.base_url_options?.length ? "llm-base-url-options" : undefined}
                 disabled={selectedProvider?.auth_type === "oauth"}
               />
+              {selectedProvider?.base_url_options?.length ? (
+                <datalist id="llm-base-url-options">
+                  {selectedProvider.base_url_options.map((baseUrl) => (
+                    <option key={baseUrl} value={baseUrl} />
+                  ))}
+                </datalist>
+              ) : null}
             </label>
 
             <label className="grid gap-2">


### PR DESCRIPTION
Reason: MiniMax registry and documentation only exposed the global OpenAI-compatible endpoint, leaving the current China endpoint unavailable in provider configuration.

## Summary
- add the current global and China OpenAI-compatible MiniMax endpoints to provider metadata
- offer registered endpoint choices in the settings UI while keeping the global endpoint as the default
- document both regional `MINIMAX_BASE_URL` values in the environment example

## Testing
- `npm ci && npm run build`
- `python3 -m py_compile agent/src/api/settings_routes.py agent/tests/test_llm_provider_defaults.py`
- targeted registry assertion (the focused pytest module could not collect because the environment lacks the `rich` dependency)