### PR TITLE
fix(composite): fall back to first available sub-engine for unknown symbols

### DIFF
--- a/agent/backtest/engines/composite.py
+++ b/agent/backtest/engines/composite.py
@@ -92,6 +92,8 @@ class CompositeEngine(BaseEngine):
             market = "china_futures" if _is_china_futures(symbol) else "global_futures"
         engine = self._rule_engines.get(market)
         if engine is None:
+            if not self._rule_engines:
+                raise ValueError("No sub-engines available for composite backtest")
             engine = next(iter(self._rule_engines.values()))
         return engine
 

--- a/agent/backtest/engines/composite.py
+++ b/agent/backtest/engines/composite.py
@@ -90,7 +90,10 @@ class CompositeEngine(BaseEngine):
         market = self._symbol_market.get(symbol, "a_share")
         if market == "futures":
             market = "china_futures" if _is_china_futures(symbol) else "global_futures"
-        return self._rule_engines[market]
+        engine = self._rule_engines.get(market)
+        if engine is None:
+            engine = next(iter(self._rule_engines.values()))
+        return engine
 
     # ── Stateless method dispatch ──
 

--- a/agent/tests/test_composite_engine_fallback.py
+++ b/agent/tests/test_composite_engine_fallback.py
@@ -1,0 +1,52 @@
+"""Tests for CompositeEngine fallback when an unknown symbol is encountered."""
+
+from __future__ import annotations
+
+import pytest
+
+from backtest.engines.composite import CompositeEngine
+
+
+class TestCompositeEngineFallback:
+    """Verify that CompositeEngine does not crash on unknown symbols."""
+
+    def test_unknown_symbol_round_size(self):
+        """round_size for a symbol not in the original codes should not crash."""
+        config = {"initial_cash": 100_000}
+        engine = CompositeEngine(config, ["BTC-USDT", "ETH-USDT"])
+        result = engine.round_size(1.0, 100.0)
+        assert isinstance(result, float)
+        assert result >= 0.0
+
+    def test_unknown_symbol_calc_commission(self):
+        """calc_commission for a symbol not in the original codes should not crash."""
+        config = {"initial_cash": 100_000}
+        engine = CompositeEngine(config, ["BTC-USDT"])
+        fee = engine.calc_commission(1.0, 100.0, 1, True)
+        assert isinstance(fee, float)
+        assert fee >= 0.0
+
+    def test_unknown_symbol_leverage(self):
+        """_leverage_for_symbol for a symbol not in the original codes should not crash."""
+        config = {"initial_cash": 100_000}
+        engine = CompositeEngine(config, ["BTC-USDT"])
+        lev = engine._leverage_for_symbol("UNKNOWN-SYMBOL")
+        assert isinstance(lev, float)
+        assert lev > 0
+
+    def test_known_symbols_still_use_correct_engine(self):
+        """Known symbols should still route to their dedicated sub-engine."""
+        config = {"initial_cash": 100_000, "maker_rate": 0.001}
+        engine = CompositeEngine(config, ["BTC-USDT", "ETH-USDT"])
+        # BTC-USDT should use the crypto sub-engine (maker_rate=0.001 from config)
+        fee = engine.calc_commission(1.0, 50000.0, 1, False)
+        # Crypto maker rate is 0.0002 by default, but config overrides to 0.001
+        assert fee == pytest.approx(1.0 * 50000.0 * 0.001)
+
+    def test_empty_rule_engines_raises(self):
+        """If somehow _rule_engines is empty, should raise ValueError."""
+        config = {"initial_cash": 100_000}
+        engine = CompositeEngine(config, ["BTC-USDT"])
+        engine._rule_engines = {}
+        with pytest.raises(ValueError, match="No sub-engines available"):
+            engine._rule_for("UNKNOWN-SYMBOL")


### PR DESCRIPTION
## Summary

`CompositeEngine._rule_for()` defaults to `"a_share"` for any symbol whose market type is not in `_symbol_market`. When `_rule_engines` does not contain an `"a_share"` key (because no A-share codes were in the original request), the method raises `KeyError: 'a_share'` and the backtest crashes.

## Reproduction

```python
from backtest.engines.composite import CompositeEngine

config = {"initial_cash": 100_000}
engine = CompositeEngine(config, ["BTC-USDT", "ETH-USDT"])

# Any method that dispatches through _rule_for crashes:
engine.round_size(1.0, 100.0)  # KeyError: 'a_share'
```

## Root cause

`_rule_for()` uses `self._symbol_market.get(symbol, "a_share")` which maps unknown symbols to `"a_share"`, then indexes `self._rule_engines[market]` without checking if that key exists. When the engine was constructed only for crypto+forex codes, no `"a_share"` sub-engine was built.

## Fix

Replace the hard index `self._rule_engines[market]` with `.get(market)` and fall back to the first available sub-engine when the resolved market has no dedicated rule engine. This keeps the current behavior for all known markets while preventing a crash on unrecognised symbols.

## Testing

Verified in Docker environment:
- `round_size` for an unknown symbol returns a valid float instead of crashing
- `calc_commission` for an unknown symbol returns a valid float
- `_leverage_for_symbol` for an unknown symbol returns a positive float
- All existing engine imports and behaviors unchanged (no regressions)
