### PR TITLE
fix(ui): skip non-positive MA periods in indicator overlays

### DIFF
--- a/agent/src/ui_services.py
+++ b/agent/src/ui_services.py
@@ -166,9 +166,11 @@ def infer_indicator_periods(run_dir: Path) -> List[int]:
     for key, value in signal_params.items():
         if "ma" in str(key).lower():
             try:
-                periods.add(int(value))
+                period = int(value)
             except (TypeError, ValueError):
                 continue
+            if period > 0:
+                periods.add(period)
 
     design = load_json_file(run_dir / "design_spec.json") or {}
     defaults = design.get("defaults_and_tunables") or {}
@@ -176,9 +178,11 @@ def infer_indicator_periods(run_dir: Path) -> List[int]:
     for key, value in assumptions.items():
         if "ma" in str(key).lower():
             try:
-                periods.add(int(value))
+                period = int(value)
             except (TypeError, ValueError):
                 continue
+            if period > 0:
+                periods.add(period)
 
     if not periods:
         return list(DEFAULT_ANALYSIS_PERIODS)
@@ -331,6 +335,8 @@ def build_indicator_series(
         closes = [float(row["close"]) for row in ordered_rows]
         code_series: Dict[str, List[Dict[str, Any]]] = {}
         for period in indicator_periods:
+            if period <= 0:
+                continue
             label = f"ma{period}"
             values: List[Dict[str, Any]] = []
             for index, row in enumerate(ordered_rows):

--- a/agent/tests/test_indicator_period_nonpositive.py
+++ b/agent/tests/test_indicator_period_nonpositive.py
@@ -1,0 +1,47 @@
+"""Reject non-positive MA periods in run-detail indicator overlays."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.ui_services import build_indicator_series, infer_indicator_periods
+
+
+def _rows():
+    return [
+        {
+            "time": f"2020-01-0{i}",
+            "code": "AAPL",
+            "close": float(i),
+            "open": 1,
+            "high": 1,
+            "low": 1,
+            "volume": 1,
+        }
+        for i in range(1, 6)
+    ]
+
+
+def test_build_indicator_series_skips_zero_period() -> None:
+    series = build_indicator_series(_rows(), [0, 5])
+    assert "ma0" not in series["AAPL"]
+    assert "ma5" in series["AAPL"]
+    assert len(series["AAPL"]["ma5"]) == 5
+
+
+def test_infer_indicator_periods_drops_nonpositive(tmp_path: Path) -> None:
+    (tmp_path / "planner_output.json").write_text(
+        json.dumps(
+            {
+                "coding_contract": {
+                    "input_logic": {
+                        "parameters": {
+                            "signal_params": {"ma_window": 0, "ma_fast": 5, "ma_slow": -3}
+                        }
+                    }
+                }
+            }
+        )
+    )
+    assert infer_indicator_periods(tmp_path) == [5]


### PR DESCRIPTION
Run-detail MA overlays infer periods from planner/design JSON. A zero `ma_window` made `sum(window)/period` raise `ZeroDivisionError`.

Skip non-positive periods when inferring and when building the series.