### PR TITLE
fix(api): skip commented dotenv keys when upserting settings

### DIFF
--- a/agent/src/api/helpers.py
+++ b/agent/src/api/helpers.py
@@ -188,11 +188,12 @@ def _write_env_values(path: Path, updates: Dict[str, str]) -> None:
     seen: set[str] = set()
     for index, raw in enumerate(lines):
         stripped = raw.lstrip()
-        is_comment = stripped.startswith("#")
-        candidate = stripped[1:].lstrip() if is_comment else stripped
-        if "=" not in candidate:
+        # Active keys only; a leading `# KEY=` must not steal the upsert.
+        if stripped.startswith("#"):
             continue
-        key = candidate.split("=", 1)[0].strip()
+        if "=" not in stripped:
+            continue
+        key = stripped.split("=", 1)[0].strip()
         if key in updates and key not in seen:
             lines[index] = f"{key}={_format_env_value(updates[key])}"
             seen.add(key)

--- a/agent/tests/test_api_infrastructure.py
+++ b/agent/tests/test_api_infrastructure.py
@@ -228,6 +228,24 @@ def test_read_write_env_values_roundtrip(tmp_path):
     assert updated["BAZ"] == "qux"
 
 
+def test_write_env_values_skips_commented_keys(tmp_path):
+    """A commented `# KEY=` must not steal an upsert from a later active KEY."""
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "# LANGCHAIN_PROVIDER=openrouter\nLANGCHAIN_PROVIDER=deepseek\nOTHER=1\n",
+        encoding="utf-8",
+    )
+
+    helpers._write_env_values(env_file, {"LANGCHAIN_PROVIDER": "ollama"})
+
+    text = env_file.read_text(encoding="utf-8")
+    assert "# LANGCHAIN_PROVIDER=openrouter\n" in text
+    assert "LANGCHAIN_PROVIDER=ollama\n" in text
+    assert text.count("LANGCHAIN_PROVIDER=") == 2  # one comment + one active
+    assert helpers._read_env_values(env_file)["LANGCHAIN_PROVIDER"] == "ollama"
+    assert helpers._read_env_values(env_file)["OTHER"] == "1"
+
+
 def test_settings_default_to_user_writable_config_path() -> None:
     """Web settings must not target the installed package directory."""
     from pathlib import Path


### PR DESCRIPTION
Web UI settings writes matched `# KEY=...` before the active `KEY=` line, so the update could be overwritten on read and silently discarded when `.env` had commented examples.

Skip commented lines when matching keys; append missing keys as before.