### PR TITLE
fix(metrics): avoid OverflowError annualizing explosive equity paths

### DIFF
--- a/agent/backtest/metrics.py
+++ b/agent/backtest/metrics.py
@@ -267,7 +267,14 @@ def calc_metrics(
     if growth <= 0:
         ann_ret = -1.0
     else:
-        ann_ret = float(growth ** (bpy / max(n, 1)) - 1)
+        # Explosive equity paths (e.g. 1 → 1e6 in a few bars) overflow
+        # ``float(growth ** …)`` on CPython; treat as non-finite annualisation.
+        try:
+            ann_ret = float(growth ** (bpy / max(n, 1)) - 1)
+        except OverflowError:
+            ann_ret = float("inf")
+        if not np.isfinite(ann_ret):
+            ann_ret = float("inf")
     # ``Series.std()`` uses ddof=1, so a single-observation return series
     # (e.g. a one-bar backtest) yields NaN and poisons the Sharpe ratio.
     # Guard the small sample the same way ``downside_std`` is guarded below.

--- a/agent/tests/test_metrics.py
+++ b/agent/tests/test_metrics.py
@@ -327,6 +327,16 @@ class TestCalcMetrics:
         assert m["annual_return"] == pytest.approx(-1.0)
         assert m["final_value"] == pytest.approx(-500_000)
 
+    def test_explosive_equity_annualization_does_not_overflow(self) -> None:
+        """A 1 → 1e6 two-bar path overflows ``growth ** factor`` on CPython.
+
+        Metrics must stay defined (non-finite annual_return is acceptable).
+        """
+        eq = pd.Series([1.0, 1_000_000.0])
+        m = calc_metrics(eq, [], 1.0, 252)
+        assert m["total_return"] == pytest.approx(999_999.0)
+        assert m["annual_return"] == float("inf")
+
 
 # ---------------------------------------------------------------------------
 # turnover


### PR DESCRIPTION
calc_metrics annualised with float(growth ** (bars_per_year / n) - 1). Short crypto 1m windows (bars_per_year=525600) overflow that power on CPython for ordinary gains like 2x over a few hundred bars, crashing the metrics step after an otherwise successful backtest.

Catch OverflowError and treat annual_return as +inf (run_card already sanitizes non-finite values to null).

Repro: calc_metrics(pd.Series([1.0, 1_000_000.0]), [], 1.0, 252) raised OverflowError on main and now returns annual_return=inf.