### PR TITLE
fix(pattern): reject window=1 for trend_line_slope

### DIFF
--- a/agent/src/tools/pattern_tool.py
+++ b/agent/src/tools/pattern_tool.py
@@ -140,8 +140,9 @@ def trend_line_slope(close: pd.Series, window: int = 20) -> pd.Series:
     Returns:
         Series of slope values; first window-1 entries are NaN.
     """
-    if window < 1:
-        raise ValueError(f"window must be >= 1, got {window}")
+    # polyfit needs >=2 points; window=1 raises LinAlgError.
+    if window < 2:
+        raise ValueError(f"window must be >= 2, got {window}")
     n = len(close)
     slopes = np.full(n, np.nan)
     values = close.values.astype(float)
@@ -337,6 +338,11 @@ def run_pattern(run_dir: str, patterns: str = "all", window: int = 10) -> str:
     if window < 1:
         return json.dumps(
             {"status": "error", "error": f"window must be >= 1, got {window}"},
+            ensure_ascii=False,
+        )
+    if "trend_slope" in selected and window < 2:
+        return json.dumps(
+            {"status": "error", "error": f"window must be >= 2 for trend_slope, got {window}"},
             ensure_ascii=False,
         )
 

--- a/agent/tests/test_pattern_tool.py
+++ b/agent/tests/test_pattern_tool.py
@@ -268,6 +268,20 @@ def test_trend_line_slope_rejects_nonpositive_window() -> None:
         trend_line_slope(close, window=0)
 
 
+def test_trend_line_slope_rejects_window_one() -> None:
+    """window=1 passes the old >=1 guard then polyfit raises LinAlgError."""
+    close = pd.Series(range(30), dtype=float)
+    with pytest.raises(ValueError, match="window must be >= 2"):
+        trend_line_slope(close, window=1)
+
+
+def test_trend_line_slope_window_two_is_finite() -> None:
+    slopes = trend_line_slope(pd.Series([0.0, 1.0, 2.0, 3.0]), window=2)
+    assert pd.isna(slopes.iloc[0])
+    assert slopes.iloc[1] == pytest.approx(1.0)
+    assert slopes.iloc[2] == pytest.approx(1.0)
+
+
 def test_run_pattern_nonpositive_window_returns_json_error(allow_runs: Path) -> None:
     run_dir = allow_runs / "run1"
     arts = run_dir / "artifacts"
@@ -279,3 +293,17 @@ def test_run_pattern_nonpositive_window_returns_json_error(allow_runs: Path) -> 
     out = json.loads(run_pattern(str(run_dir), patterns="peaks_valleys", window=-1))
     assert out["status"] == "error"
     assert "window" in out["error"]
+
+
+def test_run_pattern_trend_slope_window_one_returns_json_error(allow_runs: Path) -> None:
+    run_dir = allow_runs / "run_trend"
+    arts = run_dir / "artifacts"
+    arts.mkdir(parents=True)
+    pd.DataFrame(
+        {"open": range(30), "high": range(30), "low": range(30), "close": range(30), "volume": 1},
+        index=pd.date_range("2024-01-01", periods=30),
+    ).to_csv(arts / "ohlcv_TEST.csv")
+    out = json.loads(run_pattern(str(run_dir), patterns="trend_slope", window=1))
+    assert out["status"] == "error"
+    assert "window" in out["error"]
+    assert "trend_slope" in out["error"] or ">= 2" in out["error"]


### PR DESCRIPTION
trend_line_slope accepted window=1, then polyfit on a single point raised LinAlgError. Require window>=2 (and return a JSON error from run_pattern for trend_slope).

Repro: trend_line_slope(pd.Series(range(30), dtype=float), window=1)