### PR TITLE
fix(api): keep hash characters inside quoted dotenv values

### DIFF
--- a/agent/src/api/helpers.py
+++ b/agent/src/api/helpers.py
@@ -133,11 +133,13 @@ def _ensure_agent_env_file(path: Path | None = None) -> Path:
 def _strip_env_value(value: str) -> str:
     """Remove basic dotenv quotes and inline comments."""
     value = value.strip()
-    # Unquote first so "secret # still" keeps the hash (dotenv quotes shield comments).
+    # Fully quote-wrapped: keep interior `#` (do not treat as comment).
     if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
         return value[1:-1].strip()
     if " #" in value:
         value = value.split(" #", 1)[0].rstrip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        value = value[1:-1]
     return value.strip()
 
 

--- a/agent/src/api/helpers.py
+++ b/agent/src/api/helpers.py
@@ -133,10 +133,11 @@ def _ensure_agent_env_file(path: Path | None = None) -> Path:
 def _strip_env_value(value: str) -> str:
     """Remove basic dotenv quotes and inline comments."""
     value = value.strip()
+    # Unquote first so "secret # still" keeps the hash (dotenv quotes shield comments).
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1].strip()
     if " #" in value:
         value = value.split(" #", 1)[0].rstrip()
-    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
-        value = value[1:-1]
     return value.strip()
 
 

--- a/agent/src/api/helpers.py
+++ b/agent/src/api/helpers.py
@@ -133,13 +133,19 @@ def _ensure_agent_env_file(path: Path | None = None) -> Path:
 def _strip_env_value(value: str) -> str:
     """Remove basic dotenv quotes and inline comments."""
     value = value.strip()
-    # Fully quote-wrapped: keep interior `#` (do not treat as comment).
-    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
-        return value[1:-1].strip()
+    if value[:1] in {"'", '"'}:
+        q = value[0]
+        i = 1
+        while i < len(value):
+            if value[i] == "\\" and i + 1 < len(value):
+                i += 2
+                continue
+            if value[i] == q:
+                return value[1:i].strip()
+            i += 1
+        return value
     if " #" in value:
         value = value.split(" #", 1)[0].rstrip()
-    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
-        value = value[1:-1]
     return value.strip()
 
 

--- a/agent/tests/test_api_infrastructure.py
+++ b/agent/tests/test_api_infrastructure.py
@@ -262,6 +262,12 @@ def test_strip_env_value_quoted_hash_preserves_value():
     assert helpers._strip_env_value("'secret # still-part-of-value'") == "secret # still-part-of-value"
 
 
+def test_strip_env_value_quoted_then_inline_comment():
+    """Trailing comments after a closed quote must still be stripped."""
+    assert helpers._strip_env_value('"secret" # comment') == "secret"
+    assert helpers._strip_env_value("'secret' # comment") == "secret"
+
+
 def test_read_write_env_quoted_hash_roundtrip(tmp_path):
     env_file = tmp_path / ".env"
     secret = "secret # still-part-of-value"

--- a/agent/tests/test_api_infrastructure.py
+++ b/agent/tests/test_api_infrastructure.py
@@ -256,6 +256,24 @@ def test_strip_env_value_inline_comment():
     assert helpers._strip_env_value("value # comment") == "value"
 
 
+def test_strip_env_value_quoted_hash_preserves_value():
+    """Quoted dotenv values may contain ' #'; do not treat as comment."""
+    assert helpers._strip_env_value('"secret # still-part-of-value"') == "secret # still-part-of-value"
+    assert helpers._strip_env_value("'secret # still-part-of-value'") == "secret # still-part-of-value"
+
+
+def test_read_write_env_quoted_hash_roundtrip(tmp_path):
+    env_file = tmp_path / ".env"
+    secret = "secret # still-part-of-value"
+    helpers._write_env_values(env_file, {"K": secret})
+    assert helpers._read_env_values(env_file)["K"] == secret
+    # Re-read the formatted line directly through strip
+    raw = env_file.read_text(encoding="utf-8")
+    assert ' #' in raw
+    line = [ln for ln in raw.splitlines() if ln.startswith("K=")][0]
+    assert helpers._strip_env_value(line.split("=", 1)[1]) == secret
+
+
 # ============================================================================
 # state._get_session_service writeback
 # ============================================================================

--- a/agent/tests/test_api_infrastructure.py
+++ b/agent/tests/test_api_infrastructure.py
@@ -266,6 +266,8 @@ def test_strip_env_value_quoted_then_inline_comment():
     """Trailing comments after a closed quote must still be stripped."""
     assert helpers._strip_env_value('"secret" # comment') == "secret"
     assert helpers._strip_env_value("'secret' # comment") == "secret"
+    assert helpers._strip_env_value('"a # b" # outer') == "a # b"
+    assert helpers._strip_env_value("'a # b' # outer") == "a # b"
 
 
 def test_read_write_env_quoted_hash_roundtrip(tmp_path):


### PR DESCRIPTION
Settings quotes dotenv values that contain `#`. On read, `_strip_env_value` stripped ` #` comments before handling quotes, so values like `secret # still-part-of-value` were truncated on reload.

Parse a leading quote through to its closing quote (skip escapes), then strip unquoted ` #` comments only.

Repro: `_strip_env_value('"secret # still-part-of-value"')` returned `"secret` on main.