### PR TITLE
fix(options): treat non-positive spot/strike as intrinsic in BS helpers

### DIFF
--- a/agent/backtest/engines/options_portfolio.py
+++ b/agent/backtest/engines/options_portfolio.py
@@ -46,8 +46,8 @@ def bs_price(S: float, K: float, T: float, r: float, sigma: float,
         >>> round(bs_price(100, 100, 1.0, 0.05, 0.2, "call"), 2)
         10.45
     """
-    # Non-positive spot/strike makes log(S/K) undefined; match options_pricing_tool
-    # and iv_smile_adjustment by falling back to intrinsic value.
+    # Non-positive S/K makes log(S/K) undefined; reuse the intrinsic fallback
+    # (iv_smile_adjustment already soft-guards non-positive S/K).
     if T <= 0 or sigma <= 0 or S <= 0 or K <= 0:
         if option_type == "call":
             return max(S - K, 0.0)

--- a/agent/backtest/engines/options_portfolio.py
+++ b/agent/backtest/engines/options_portfolio.py
@@ -46,8 +46,9 @@ def bs_price(S: float, K: float, T: float, r: float, sigma: float,
         >>> round(bs_price(100, 100, 1.0, 0.05, 0.2, "call"), 2)
         10.45
     """
-    if T <= 0 or sigma <= 0:
-        # Expired: return intrinsic value
+    # Non-positive spot/strike makes log(S/K) undefined; match options_pricing_tool
+    # and iv_smile_adjustment by falling back to intrinsic value.
+    if T <= 0 or sigma <= 0 or S <= 0 or K <= 0:
         if option_type == "call":
             return max(S - K, 0.0)
         return max(K - S, 0.0)
@@ -78,7 +79,7 @@ def bs_greeks(S: float, K: float, T: float, r: float, sigma: float,
     Returns:
         Dict containing delta, gamma, theta, vega.
     """
-    if T <= 0 or sigma <= 0:
+    if T <= 0 or sigma <= 0 or S <= 0 or K <= 0:
         intrinsic_call = 1.0 if S > K else 0.0
         delta = intrinsic_call if option_type == "call" else intrinsic_call - 1.0
         return {"delta": delta, "gamma": 0.0, "theta": 0.0, "vega": 0.0}

--- a/agent/tests/test_options_bs_nonpositive_strike.py
+++ b/agent/tests/test_options_bs_nonpositive_strike.py
@@ -1,4 +1,4 @@
-"""Reject non-positive spot/strike in Black-Scholes pricing helpers."""
+"""Treat non-positive spot/strike as intrinsic in Black-Scholes helpers."""
 
 from __future__ import annotations
 

--- a/agent/tests/test_options_bs_nonpositive_strike.py
+++ b/agent/tests/test_options_bs_nonpositive_strike.py
@@ -1,0 +1,24 @@
+"""Reject non-positive spot/strike in Black-Scholes pricing helpers."""
+
+from __future__ import annotations
+
+from backtest.engines.options_portfolio import bs_greeks, bs_price
+
+
+def test_bs_price_zero_strike_returns_intrinsic() -> None:
+    # Call with K=0 is deep ITM; intrinsic is max(S-K, 0) == S.
+    assert bs_price(100.0, 0.0, 1.0, 0.05, 0.2, "call") == 100.0
+    assert bs_price(100.0, 0.0, 1.0, 0.05, 0.2, "put") == 0.0
+
+
+def test_bs_greeks_zero_strike_returns_degenerate_greeks() -> None:
+    g = bs_greeks(100.0, 0.0, 1.0, 0.05, 0.2, "call")
+    assert g["delta"] == 1.0
+    assert g["gamma"] == 0.0
+    assert g["theta"] == 0.0
+    assert g["vega"] == 0.0
+
+
+def test_bs_price_positive_strike_unchanged() -> None:
+    price = bs_price(100.0, 100.0, 1.0, 0.05, 0.2, "call")
+    assert abs(price - 10.45) < 0.05


### PR DESCRIPTION
bs_price/bs_greeks raise ZeroDivisionError when a signal leg uses strike 0, because S/K is undefined before log. Fall back to intrinsic value the same way the expired/zero-vol path already does; iv_smile_adjustment already soft-guards non-positive S/K.

Repro: bs_price(100.0, 0, 1.0, 0.05, 0.2, "call")