### PR TITLE
fix(cli): accept Longbridge broker key names in positions and account renderers

### DIFF
--- a/agent/cli/_legacy.py
+++ b/agent/cli/_legacy.py
@@ -3912,22 +3912,42 @@ def _print_connector_account(result: dict[str, Any]) -> int:
     accounts = ", ".join(result.get("accounts", [])) or "(none)"
     console.print(f"Accounts: [cyan]{rich_escape(accounts)}[/cyan]")
     rows = result.get("summary", [])
-    if not rows:
-        console.print("[dim]No account summary returned.[/dim]")
+    if rows:
+        table = Table(title=f"Account Summary · {result.get('profile_id')}", box=box.SIMPLE_HEAVY, show_lines=False)
+        table.add_column("Account")
+        table.add_column("Tag")
+        table.add_column("Value", justify="right")
+        table.add_column("Currency")
+        for row in rows:
+            table.add_row(
+                str(row.get("account") or ""),
+                str(row.get("tag") or ""),
+                str(row.get("value") or ""),
+                str(row.get("currency") or ""),
+            )
+        console.print(table)
         return EXIT_SUCCESS
-    table = Table(title=f"Account Summary · {result.get('profile_id')}", box=box.SIMPLE_HEAVY, show_lines=False)
-    table.add_column("Account")
-    table.add_column("Tag")
-    table.add_column("Value", justify="right")
-    table.add_column("Currency")
-    for row in rows:
-        table.add_row(
-            str(row.get("account") or ""),
-            str(row.get("tag") or ""),
-            str(row.get("value") or ""),
-            str(row.get("currency") or ""),
-        )
-    console.print(table)
+    balances = result.get("balances", [])
+    if balances:
+        table = Table(title=f"Balances · {result.get('profile_id')}", box=box.SIMPLE_HEAVY, show_lines=False)
+        table.add_column("Currency")
+        table.add_column("Total Cash", justify="right")
+        table.add_column("Net Assets", justify="right")
+        table.add_column("Buy Power", justify="right")
+        table.add_column("Init Margin", justify="right")
+        table.add_column("Maint Margin", justify="right")
+        for row in balances:
+            table.add_row(
+                str(row.get("currency") or ""),
+                str(row.get("total_cash") or ""),
+                str(row.get("net_assets") or ""),
+                str(row.get("buy_power") or ""),
+                str(row.get("init_margin") or ""),
+                str(row.get("maintenance_margin") or ""),
+            )
+        console.print(table)
+        return EXIT_SUCCESS
+    console.print("[dim]No account summary returned.[/dim]")
     return EXIT_SUCCESS
 
 
@@ -3987,9 +4007,9 @@ def cmd_connector_positions(
         table.add_row(
             str(row.get("account") or ""),
             str(row.get("local_symbol") or row.get("symbol") or ""),
-            str(row.get("sec_type") or ""),
-            str(row.get("position") or ""),
-            str(row.get("avg_cost") or ""),
+            str(row.get("sec_type") or row.get("market") or ""),
+            str(row.get("position") or row.get("quantity") or ""),
+            str(row.get("avg_cost") or row.get("cost_price") or ""),
             str(row.get("currency") or ""),
         )
     console.print(table)

--- a/agent/tests/test_connector_cli_renderer.py
+++ b/agent/tests/test_connector_cli_renderer.py
@@ -1,0 +1,181 @@
+"""Tests for connector CLI renderers with schema-tolerant key fallbacks.
+
+Refs #735 — Longbridge connector returns its own key schema
+(quantity/cost_price/market/balances) instead of the IBKR-style keys
+(position/avg_cost/sec_type/summary) assumed by the CLI renderers.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# _print_connector_account — balances fallback
+# ---------------------------------------------------------------------------
+
+class TestPrintConnectorAccount:
+    def test_renders_ibkr_summary(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """IBKR-style summary rows render as before."""
+        from cli._legacy import EXIT_SUCCESS, _print_connector_account
+
+        result = {
+            "accounts": ["U1234567"],
+            "summary": [
+                {"account": "U1234567", "tag": "NetLiquidation", "value": "100000.00", "currency": "USD"},
+                {"account": "U1234567", "tag": "Cash", "value": "5000.00", "currency": "USD"},
+            ],
+            "profile_id": "ibkr-test",
+        }
+        assert _print_connector_account(result) == EXIT_SUCCESS
+        out = capsys.readouterr().out
+        assert "U1234567" in out
+        assert "NetLiquidation" in out
+        assert "100000.00" in out
+
+    def test_renders_longbridge_balances(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Longbridge-style balances rows render as a balances table."""
+        from cli._legacy import EXIT_SUCCESS, _print_connector_account
+
+        result = {
+            "status": "ok",
+            "profile": "longbridge-paper-trade",
+            "paper_guard": "config_declared",
+            "profile_id": "longbridge-paper-trade",
+            "balances": [
+                {"currency": "USD", "total_cash": "5000.00", "net_assets": "50000.00",
+                 "buy_power": "10000.00", "init_margin": "0.00", "maintenance_margin": "0.00"},
+                {"currency": "HKD", "total_cash": "100000.00", "net_assets": "200000.00",
+                 "buy_power": "200000.00", "init_margin": "0.00", "maintenance_margin": "0.00"},
+            ],
+        }
+        assert _print_connector_account(result) == EXIT_SUCCESS
+        out = capsys.readouterr().out
+        assert "Balances" in out
+        assert "USD" in out
+        assert "HKD" in out
+        assert "5000.00" in out
+        assert "50000.00" in out
+        assert "Total Cash" in out
+        assert "Net Assets" in out
+
+    def test_renders_no_data_message_when_empty(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """When neither summary nor balances is present, show the no-data message."""
+        from cli._legacy import EXIT_SUCCESS, _print_connector_account
+
+        result = {
+            "accounts": [],
+            "profile_id": "empty-test",
+        }
+        assert _print_connector_account(result) == EXIT_SUCCESS
+        out = capsys.readouterr().out
+        assert "No account summary returned" in out
+
+    def test_balances_show_accounts_label(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Balances rendering still shows the Accounts line."""
+        from cli._legacy import _print_connector_account
+
+        result = {
+            "accounts": [],
+            "profile_id": "test",
+            "balances": [{"currency": "USD"}],
+        }
+        _print_connector_account(result)
+        out = capsys.readouterr().out
+        assert "Accounts:" in out
+
+
+# ---------------------------------------------------------------------------
+# cmd_connector_positions — key-aliased rendering
+# ---------------------------------------------------------------------------
+
+_SERVICE_PATH = "src.trading.service.get_positions"
+
+
+class TestCmdConnectorPositions:
+    def test_renders_ibkr_keys(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """IBKR-style position keys render as before (backward compat)."""
+        from cli._legacy import EXIT_SUCCESS, cmd_connector_positions
+
+        ibkr_positions = {
+            "status": "ok",
+            "profile_id": "ibkr-test",
+            "positions": [
+                {"account": "U1234567", "symbol": "AAPL", "local_symbol": "AAPL",
+                 "sec_type": "STK", "position": "100", "avg_cost": "150.00", "currency": "USD"},
+            ],
+        }
+        with patch(_SERVICE_PATH, return_value=ibkr_positions):
+            assert cmd_connector_positions("ibkr-test") == EXIT_SUCCESS
+        out = capsys.readouterr().out
+        assert "AAPL" in out
+        assert "100" in out
+        assert "150.00" in out
+        assert "STK" in out
+
+    def test_renders_longbridge_keys(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Longbridge-style keys (quantity/cost_price/market) render through fallback aliases."""
+        from cli._legacy import EXIT_SUCCESS, cmd_connector_positions
+
+        longbridge_positions = {
+            "status": "ok",
+            "profile_id": "longbridge-paper-trade",
+            "positions": [
+                {"symbol": "AAPL.US", "symbol_name": "Apple Inc", "quantity": 20.0,
+                 "available_quantity": 20.0, "cost_price": 185.50,
+                 "currency": "USD", "market": "US"},
+                {"symbol": "0700.HK", "symbol_name": "Tencent", "quantity": 100.0,
+                 "available_quantity": 100.0, "cost_price": 350.0,
+                 "currency": "HKD", "market": "HK"},
+            ],
+        }
+        with patch(_SERVICE_PATH, return_value=longbridge_positions):
+            assert cmd_connector_positions("longbridge-paper-trade") == EXIT_SUCCESS
+        out = capsys.readouterr().out
+        assert "AAPL.US" in out
+        assert "0700.HK" in out
+        assert "20.0" in out
+        assert "100.0" in out
+        assert "185.5" in out
+        assert "350.0" in out
+        assert "HK" in out  # market fallback for sec_type
+        assert "US" in out
+
+    def test_renders_symbol_fallback_for_local_symbol(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """When local_symbol is missing, symbol is used."""
+        from cli._legacy import cmd_connector_positions
+
+        result = {
+            "status": "ok",
+            "profile_id": "test",
+            "positions": [
+                {"symbol": "TSLA", "sec_type": "STK", "position": "50",
+                 "avg_cost": "200.00", "currency": "USD"},
+            ],
+        }
+        with patch(_SERVICE_PATH, return_value=result):
+            cmd_connector_positions("test")
+        out = capsys.readouterr().out
+        assert "TSLA" in out
+
+    def test_empty_positions_shows_no_data_message(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Empty positions list renders the no-data message."""
+        from cli._legacy import cmd_connector_positions
+
+        result = {"status": "ok", "profile_id": "test", "positions": []}
+        with patch(_SERVICE_PATH, return_value=result):
+            cmd_connector_positions("test")
+        out = capsys.readouterr().out
+        assert "No positions returned" in out
+
+    def test_error_status_renders_error_message(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Error status renders the error text."""
+        from cli._legacy import EXIT_RUN_FAILED, cmd_connector_positions
+
+        result = {"status": "error", "error": "Connection refused"}
+        with patch(_SERVICE_PATH, return_value=result):
+            assert cmd_connector_positions("test") == EXIT_RUN_FAILED
+        out = capsys.readouterr().out
+        assert "Connection refused" in out


### PR DESCRIPTION
## Summary

The CLI renderers for `connector positions` and `connector account` read IBKR-style dict keys (`position`, `avg_cost`, `sec_type`, `summary`), while the Longbridge broker connector returns its own schema (`quantity`, `cost_price`, `market`, `balances`). This makes positions show empty Qty/Avg Cost/Type columns and the account command claim "No account summary returned" even though the data layer returns complete data.

## Why

Fixes #735. Without this, Longbridge users get silently empty CLI output for positions and account commands. The root cause is a key-schema mismatch between the CLI renderers (which assume IBKR data shapes) and the Longbridge connector.

## Changes

- `agent/cli/_legacy.py`:
  - `cmd_connector_positions`: fall back from `position`→`quantity`, `avg_cost`→`cost_price`, `sec_type`→`market` so Longbridge position rows populate all columns
  - `_print_connector_account`: render a balances table when `result["balances"]` is present instead of only looking for IBKR-style `summary` rows
- `agent/tests/test_connector_cli_renderer.py` (new): 9 tests covering IBKR backward compat, Longbridge key aliases, empty/error edges

## Test Plan

- [x] ruff check — clean
- [x] pytest agent/tests/test_connector_cli_renderer.py — 9 passed

## Checklist

- [x] No changes to protected areas without prior discussion
- [x] No hardcoded values
- [x] Code follows CONTRIBUTING.md guidelines
- [x] Documentation updated (if user-facing change)
