### PR TITLE
feat(data): decouple maintenance-bracket acquisition from the historical fetch path

### DIFF
--- a/agent/backtest/loaders/ccxt_loader.py
+++ b/agent/backtest/loaders/ccxt_loader.py
@@ -89,6 +89,95 @@ def _ccxt_proxy_config() -> dict[str, str]:
     return proxies
 
 
+_BRACKET_SCHEMA_VERSION = 1
+
+
+def _validate_bracket_artifact(artifact: dict, *, expected_symbol: str) -> tuple[list[dict], str]:
+    """Validate a caller-supplied maintenance-bracket artifact.
+
+    ``binanceusdm.fetch_leverage_tiers()`` routes to Binance's signed
+    ``GET /fapi/v1/leverageBracket`` USER_DATA endpoint — it requires an API
+    key even though the response carries no account-specific data. This
+    loader no longer calls it: maintenance brackets are supplied out of band
+    as a versioned artifact and validated here, never fetched live. Fails
+    closed (raises ``ValueError``) on any schema, symbol, provenance,
+    ordering, or content-hash problem.
+    """
+    if not isinstance(artifact, dict):
+        raise ValueError("bracket artifact must be a dict")
+
+    schema_version = artifact.get("schema_version")
+    if schema_version != _BRACKET_SCHEMA_VERSION:
+        raise ValueError(
+            f"bracket artifact schema_version must be {_BRACKET_SCHEMA_VERSION}, "
+            f"got {schema_version!r}"
+        )
+
+    symbol = artifact.get("symbol")
+    if symbol != expected_symbol:
+        raise ValueError(
+            f"bracket artifact symbol mismatch: expected {expected_symbol!r}, got {symbol!r}"
+        )
+
+    provenance_timestamp = artifact.get("provenance_timestamp")
+    if not provenance_timestamp:
+        raise ValueError("bracket artifact is missing provenance_timestamp")
+    try:
+        pd.Timestamp(provenance_timestamp)
+    except (ValueError, TypeError) as exc:
+        raise ValueError(
+            f"bracket artifact provenance_timestamp is not a valid timestamp: "
+            f"{provenance_timestamp!r}"
+        ) from exc
+
+    brackets = artifact.get("brackets")
+    if not brackets:
+        raise ValueError("bracket artifact has no brackets")
+
+    normalized: list[dict] = []
+    for tier in brackets:
+        try:
+            record = {
+                "bracket_tier": int(tier["bracket_tier"]),
+                "notional_cap": float(tier["notional_cap"]),
+                "maintenance_rate": float(tier["maintenance_rate"]),
+                "cumulative_maintenance_amount": float(tier["cumulative_maintenance_amount"]),
+            }
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError(
+                f"bracket artifact tier for {expected_symbol} is missing a required field: {exc}"
+            ) from exc
+        # Optional: reserved for future risk-model calibration, not part of
+        # Binance's own bracket schema. Validated only if present.
+        coefficient = tier.get("notional_coefficient")
+        if coefficient is not None:
+            try:
+                record["notional_coefficient"] = float(coefficient)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"bracket artifact notional_coefficient must be numeric: {coefficient!r}"
+                ) from exc
+        normalized.append(record)
+
+    normalized.sort(key=lambda row: row["bracket_tier"])
+    caps = [row["notional_cap"] for row in normalized]
+    if caps != sorted(caps) or len(caps) != len(set(caps)):
+        raise ValueError(
+            f"bracket artifact notional caps for {expected_symbol} are not strictly increasing"
+        )
+
+    blob = json.dumps(normalized, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    computed_hash = hashlib.sha256(blob).hexdigest()[:16]
+    content_hash = artifact.get("content_hash")
+    if content_hash != computed_hash:
+        raise ValueError(
+            f"bracket artifact content_hash mismatch for {expected_symbol}: "
+            f"expected {computed_hash}, artifact declares {content_hash!r}"
+        )
+
+    return normalized, computed_hash
+
+
 @register
 class DataLoader:
     """CCXT-backed crypto OHLCV loader (100+ exchanges)."""
@@ -139,6 +228,8 @@ class DataLoader:
         *,
         interval: str = "1D",
         fields: Optional[List[str]] = None,
+        bracket_artifacts: Optional[Dict[str, dict]] = None,
+        require_brackets: bool = False,
     ) -> Dict[str, pd.DataFrame]:
         """Fetch crypto OHLCV via CCXT.
 
@@ -148,6 +239,17 @@ class DataLoader:
             end_date: End date (YYYY-MM-DD).
             interval: Bar size.
             fields: Ignored.
+            bracket_artifacts: Optional ``{code: artifact}`` map of caller-supplied,
+                versioned maintenance-bracket artifacts (see
+                ``_validate_bracket_artifact``) for ``-PERP`` codes. Normal
+                execution/mark/funding data never needs this — it stays
+                zero-credential regardless. This loader does not fetch brackets
+                live: ``binanceusdm.fetch_leverage_tiers()`` requires a Binance
+                API key, which this historical/backtest path never carries.
+            require_brackets: When True, a ``-PERP`` code without a matching,
+                valid artifact in ``bracket_artifacts`` fails closed instead of
+                silently returning data without bracket columns. Intended for
+                strict margin-risk consumers.
 
         Returns:
             Mapping symbol -> OHLCV DataFrame.
@@ -173,11 +275,13 @@ class DataLoader:
             try:
                 ccxt_symbol, instrument_type = _parse_ccxt_symbol(code)
                 exchange = get_exchange(instrument_type)
+                artifact = (bracket_artifacts or {}).get(code)
 
                 def fetch_frame():
                     if instrument_type == "swap":
                         return self._fetch_perpetual(
-                            exchange, ccxt_symbol, timeframe, since_ms, end_ms
+                            exchange, ccxt_symbol, timeframe, since_ms, end_ms,
+                            bracket_artifact=artifact, require_brackets=require_brackets,
                         )
                     return self._fetch_one(
                         exchange, ccxt_symbol, timeframe, since_ms, end_ms
@@ -203,8 +307,24 @@ class DataLoader:
     @classmethod
     def _fetch_perpetual(
         cls, exchange, symbol: str, timeframe: str, since_ms: int, end_ms: int,
+        *, bracket_artifact: dict | None = None, require_brackets: bool = False,
     ) -> pd.DataFrame:
-        """Fetch aligned trade-price and mark-price candles for one USD-M swap."""
+        """Fetch aligned trade-price and mark-price candles for one USD-M swap.
+
+        Maintenance brackets are never fetched live (see
+        ``_validate_bracket_artifact``): they're attached only when the caller
+        supplies a validated artifact. A strict caller (``require_brackets``)
+        fails closed before any network call when no artifact is supplied.
+        """
+        if require_brackets and bracket_artifact is None:
+            raise ValueError(
+                f"strict margin-risk fetch for {symbol} requires a maintenance-bracket "
+                "artifact, but none was supplied. This loader does not perform a live "
+                "authenticated bracket fetch (binanceusdm.fetch_leverage_tiers requires "
+                "a Binance API key this backtest path does not carry) — pass a validated "
+                "artifact via DataLoader.fetch(bracket_artifacts={code: artifact})."
+            )
+
         trade = cls._fetch_one(exchange, symbol, timeframe, since_ms, end_ms)
         mark = cls._fetch_one(
             exchange,
@@ -240,9 +360,12 @@ class DataLoader:
             result.loc[aligned, "funding_rate"] = funding.loc[aligned, "funding_rate"]
             result.loc[aligned, "funding_settlement_time"] = aligned
 
-        brackets, version = cls._fetch_maintenance_brackets(exchange, symbol)
-        result["maintenance_brackets"] = json.dumps(brackets)
-        result["maintenance_bracket_version"] = version
+        if bracket_artifact is not None:
+            brackets, version = _validate_bracket_artifact(
+                bracket_artifact, expected_symbol=symbol
+            )
+            result["maintenance_brackets"] = json.dumps(brackets)
+            result["maintenance_bracket_version"] = version
         return result
 
     @staticmethod
@@ -293,62 +416,6 @@ class DataLoader:
         start_dt = pd.Timestamp(since_ms, unit="ms")
         end_dt = pd.Timestamp(end_ms, unit="ms")
         return frame[(frame.index >= start_dt) & (frame.index < end_dt)]
-
-    @staticmethod
-    def _fetch_maintenance_brackets(exchange, symbol: str) -> tuple[list[dict], str]:
-        """Fetch the current versioned maintenance-margin bracket schedule.
-
-        CCXT/Binance expose only the *current* bracket table (no history), so
-        each bracket record is stamped with a content hash rather than an
-        exchange-provided version: any change to the schedule changes the
-        hash, giving downstream consumers a fail-closed way to detect a stale
-        or mismatched bracket set.
-        """
-        import ccxt
-
-        try:
-            raw = retry_with_budget(
-                lambda: exchange.fetch_leverage_tiers([symbol]),
-                transient=ccxt.NetworkError,
-                deadline=time.monotonic() + _CCXT_FETCH_BUDGET_S,
-                label=f"ccxt bracket fetch for {symbol}",
-            )
-            tiers = raw.get(symbol) if raw else None
-        except Exception as exc:
-            raise ValueError(f"maintenance bracket fetch failed for {symbol}: {exc}") from exc
-
-        if not tiers:
-            raise ValueError(f"maintenance bracket data is missing for {symbol}")
-
-        brackets: list[dict] = []
-        for tier in tiers:
-            info = tier.get("info") or {}
-            try:
-                bracket_tier = int(info["bracket"])
-                notional_cap = float(info["notionalCap"])
-                maintenance_rate = float(info["maintMarginRatio"])
-                cumulative_maintenance_amount = float(info["cum"])
-            except (KeyError, TypeError, ValueError) as exc:
-                raise ValueError(
-                    f"maintenance bracket for {symbol} is missing a required field: {exc}"
-                ) from exc
-            brackets.append({
-                "bracket_tier": bracket_tier,
-                "notional_cap": notional_cap,
-                "maintenance_rate": maintenance_rate,
-                "cumulative_maintenance_amount": cumulative_maintenance_amount,
-            })
-
-        brackets.sort(key=lambda row: row["bracket_tier"])
-        caps = [row["notional_cap"] for row in brackets]
-        if caps != sorted(caps) or len(caps) != len(set(caps)):
-            raise ValueError(
-                f"maintenance bracket notional caps for {symbol} are not strictly increasing"
-            )
-
-        blob = json.dumps(brackets, sort_keys=True, separators=(",", ":")).encode("utf-8")
-        version = hashlib.sha256(blob).hexdigest()[:16]
-        return brackets, version
 
     @staticmethod
     def _fetch_one(

--- a/agent/tests/test_ccxt_perpetual_loader.py
+++ b/agent/tests/test_ccxt_perpetual_loader.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 
 import pytest
 import pandas as pd
 
 from backtest.loaders.base import make_loader_cache_key
-from backtest.loaders.ccxt_loader import _parse_ccxt_symbol
+from backtest.loaders.ccxt_loader import _parse_ccxt_symbol, _validate_bracket_artifact
 
 
 def _hourly_rows(opens: list[float]) -> list[list[float]]:
@@ -20,19 +21,18 @@ def _hourly_rows(opens: list[float]) -> list[list[float]]:
     ]
 
 
-_DEFAULT_BRACKETS = [
-    {"bracket": 1, "notionalCap": 50_000, "maintMarginRatio": 0.004, "cum": 0.0},
-    {"bracket": 2, "notionalCap": 250_000, "maintMarginRatio": 0.005, "cum": 50.0},
-]
-
-
 class _PerpetualExchange:
+    """Fake exchange with no ``fetch_leverage_tiers`` — proves the loader
+    never calls the authenticated bracket endpoint. If any code path tried
+    to, this fake would raise ``AttributeError`` instead of silently
+    succeeding.
+    """
+
     def __init__(
         self,
         *,
         mark_rows: list[list[float]] | None = None,
         funding_rows: list[dict[str, object]] | None = None,
-        brackets: list[dict[str, object]] | None = None,
     ) -> None:
         self.trade_rows = _hourly_rows([100.0, 101.0])
         self.mark_rows = mark_rows if mark_rows is not None else _hourly_rows([99.0, 100.0])
@@ -42,7 +42,6 @@ class _PerpetualExchange:
             if funding_rows is not None
             else [{"timestamp": start, "fundingRate": 0.0}]
         )
-        self.brackets = _DEFAULT_BRACKETS if brackets is None else brackets
         self.calls: list[dict[str, object]] = []
 
     def fetch_ohlcv(self, symbol, timeframe, since=None, limit=None, params=None):
@@ -63,22 +62,42 @@ class _PerpetualExchange:
         })
         return self.funding_rows
 
-    def fetch_leverage_tiers(self, symbols):
-        self.calls.append({"bracket_symbols": symbols})
-        [symbol] = symbols
-        return {
-            symbol: [
-                {
-                    "tier": row["bracket"],
-                    "minNotional": 0,
-                    "maxNotional": row["notionalCap"],
-                    "maintenanceMarginRate": row["maintMarginRatio"],
-                    "maxLeverage": 1,
-                    "info": row,
-                }
-                for row in self.brackets
-            ]
-        }
+
+_DEFAULT_BRACKET_RECORDS = [
+    {
+        "bracket_tier": 1,
+        "notional_cap": 50_000.0,
+        "maintenance_rate": 0.004,
+        "cumulative_maintenance_amount": 0.0,
+    },
+    {
+        "bracket_tier": 2,
+        "notional_cap": 250_000.0,
+        "maintenance_rate": 0.005,
+        "cumulative_maintenance_amount": 50.0,
+    },
+]
+
+
+def _bracket_content_hash(records: list[dict]) -> str:
+    """Mirror ``_validate_bracket_artifact``'s canonical hashing exactly."""
+    blob = json.dumps(records, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()[:16]
+
+
+def _make_bracket_artifact(
+    *, symbol: str = "BTC/USDT:USDT", brackets: list[dict] | None = None, **overrides,
+) -> dict:
+    records = _DEFAULT_BRACKET_RECORDS if brackets is None else brackets
+    artifact = {
+        "schema_version": 1,
+        "symbol": symbol,
+        "provenance_timestamp": "2024-01-01T00:00:00Z",
+        "brackets": records,
+        "content_hash": _bracket_content_hash(records),
+    }
+    artifact.update(overrides)
+    return artifact
 
 
 def test_spot_symbol_keeps_existing_ccxt_contract() -> None:
@@ -200,7 +219,10 @@ def test_perpetual_fetch_rejects_duplicate_funding_settlement(monkeypatch) -> No
         )
 
 
-def test_perpetual_fetch_attaches_versioned_maintenance_brackets(monkeypatch) -> None:
+def test_perpetual_fetch_has_no_bracket_columns_without_artifact(monkeypatch) -> None:
+    """Normal perpetual fetch stays zero-credential: no artifact in, no
+    bracket columns out, and no bracket-endpoint call ever attempted (the
+    fake exchange has no ``fetch_leverage_tiers`` at all)."""
     exchange = _PerpetualExchange()
     monkeypatch.setattr(
         "backtest.loaders.ccxt_loader.DataLoader._get_exchange",
@@ -213,102 +235,121 @@ def test_perpetual_fetch_attaches_versioned_maintenance_brackets(monkeypatch) ->
         ["BTC-USDT-PERP"], "2024-01-01", "2024-01-01", interval="1H"
     )["BTC-USDT-PERP"]
 
-    versions = frame["maintenance_bracket_version"].unique().tolist()
-    assert len(versions) == 1
-    assert isinstance(versions[0], str) and versions[0]
+    assert "maintenance_brackets" not in frame.columns
+    assert "maintenance_bracket_version" not in frame.columns
+    assert all("bracket" not in str(call) for call in exchange.calls)
 
-    brackets = json.loads(frame["maintenance_brackets"].iloc[0])
-    assert brackets == [
-        {
-            "bracket_tier": 1,
-            "notional_cap": 50_000.0,
-            "maintenance_rate": 0.004,
-            "cumulative_maintenance_amount": 0.0,
-        },
-        {
-            "bracket_tier": 2,
-            "notional_cap": 250_000.0,
-            "maintenance_rate": 0.005,
-            "cumulative_maintenance_amount": 50.0,
-        },
-    ]
+
+def test_perpetual_fetch_attaches_valid_bracket_artifact(monkeypatch) -> None:
+    exchange = _PerpetualExchange()
+    monkeypatch.setattr(
+        "backtest.loaders.ccxt_loader.DataLoader._get_exchange",
+        lambda _self, instrument_type="spot": exchange,
+    )
+
+    from backtest.loaders.ccxt_loader import DataLoader
+
+    artifact = _make_bracket_artifact()
+    frame = DataLoader().fetch(
+        ["BTC-USDT-PERP"], "2024-01-01", "2024-01-01", interval="1H",
+        bracket_artifacts={"BTC-USDT-PERP": artifact},
+    )["BTC-USDT-PERP"]
+
+    versions = frame["maintenance_bracket_version"].unique().tolist()
+    assert versions == [artifact["content_hash"]]
+    assert json.loads(frame["maintenance_brackets"].iloc[0]) == _DEFAULT_BRACKET_RECORDS
     assert frame["maintenance_brackets"].nunique() == 1
 
 
-def test_perpetual_fetch_bracket_version_changes_with_bracket_contents(monkeypatch) -> None:
-    from backtest.loaders.ccxt_loader import DataLoader
-
-    exchange_a = _PerpetualExchange()
+def test_strict_perpetual_fetch_without_artifact_fails_closed_before_any_call(monkeypatch) -> None:
+    exchange = _PerpetualExchange()
     monkeypatch.setattr(
         "backtest.loaders.ccxt_loader.DataLoader._get_exchange",
-        lambda _self, instrument_type="spot": exchange_a,
+        lambda _self, instrument_type="spot": exchange,
     )
-    frame_a = DataLoader().fetch(
-        ["BTC-USDT-PERP"], "2024-01-01", "2024-01-01", interval="1H"
+
+    from backtest.loaders.ccxt_loader import DataLoader
+
+    with pytest.raises(ValueError, match="requires a maintenance-bracket artifact"):
+        DataLoader().fetch(
+            ["BTC-USDT-PERP"], "2024-01-01", "2024-01-01", interval="1H",
+            require_brackets=True,
+        )
+    assert exchange.calls == []
+
+
+def test_strict_perpetual_fetch_with_valid_artifact_succeeds(monkeypatch) -> None:
+    exchange = _PerpetualExchange()
+    monkeypatch.setattr(
+        "backtest.loaders.ccxt_loader.DataLoader._get_exchange",
+        lambda _self, instrument_type="spot": exchange,
+    )
+
+    from backtest.loaders.ccxt_loader import DataLoader
+
+    artifact = _make_bracket_artifact()
+    frame = DataLoader().fetch(
+        ["BTC-USDT-PERP"], "2024-01-01", "2024-01-01", interval="1H",
+        bracket_artifacts={"BTC-USDT-PERP": artifact}, require_brackets=True,
     )["BTC-USDT-PERP"]
 
-    exchange_b = _PerpetualExchange(brackets=[
-        {"bracket": 1, "notionalCap": 50_000, "maintMarginRatio": 0.005, "cum": 0.0},
+    assert frame["maintenance_bracket_version"].iloc[0] == artifact["content_hash"]
+
+
+def test_bracket_artifact_accepts_optional_notional_coefficient() -> None:
+    records = [
+        {**_DEFAULT_BRACKET_RECORDS[0], "notional_coefficient": 1.5},
+        _DEFAULT_BRACKET_RECORDS[1],
+    ]
+    artifact = _make_bracket_artifact(brackets=records)
+    brackets, version = _validate_bracket_artifact(artifact, expected_symbol="BTC/USDT:USDT")
+    assert brackets[0]["notional_coefficient"] == 1.5
+    assert "notional_coefficient" not in brackets[1]
+    assert version == artifact["content_hash"]
+
+
+@pytest.mark.parametrize(
+    ("overrides", "match"),
+    [
+        ({"schema_version": 2}, "schema_version"),
+        ({"symbol": "ETH/USDT:USDT"}, "symbol mismatch"),
+        ({"provenance_timestamp": ""}, "provenance_timestamp"),
+        ({"provenance_timestamp": "not-a-timestamp"}, "provenance_timestamp"),
+        ({"brackets": []}, "no brackets"),
+        ({"content_hash": "deadbeefdeadbeef"}, "content_hash mismatch"),
+    ],
+)
+def test_bracket_artifact_rejects_invalid_fields(overrides: dict, match: str) -> None:
+    artifact = _make_bracket_artifact(**overrides)
+    with pytest.raises(ValueError, match=match):
+        _validate_bracket_artifact(artifact, expected_symbol="BTC/USDT:USDT")
+
+
+def test_bracket_artifact_rejects_tier_missing_required_field() -> None:
+    artifact = _make_bracket_artifact(brackets=[
+        {"bracket_tier": 1, "notional_cap": 50_000.0, "maintenance_rate": 0.004},
     ])
-    monkeypatch.setattr(
-        "backtest.loaders.ccxt_loader.DataLoader._get_exchange",
-        lambda _self, instrument_type="spot": exchange_b,
-    )
-    frame_b = DataLoader().fetch(
-        ["BTC-USDT-PERP"], "2024-01-01", "2024-01-01", interval="1H"
-    )["BTC-USDT-PERP"]
-
-    assert (
-        frame_a["maintenance_bracket_version"].iloc[0]
-        != frame_b["maintenance_bracket_version"].iloc[0]
-    )
+    with pytest.raises(ValueError, match="missing a required field"):
+        _validate_bracket_artifact(artifact, expected_symbol="BTC/USDT:USDT")
 
 
-def test_perpetual_fetch_rejects_empty_maintenance_brackets(monkeypatch) -> None:
-    exchange = _PerpetualExchange(brackets=[])
-    monkeypatch.setattr(
-        "backtest.loaders.ccxt_loader.DataLoader._get_exchange",
-        lambda _self, instrument_type="spot": exchange,
-    )
-
-    from backtest.loaders.ccxt_loader import DataLoader
-
-    with pytest.raises(ValueError, match="maintenance bracket"):
-        DataLoader().fetch(
-            ["BTC-USDT-PERP"], "2024-01-01", "2024-01-01", interval="1H"
-        )
+def test_bracket_artifact_rejects_non_numeric_notional_coefficient() -> None:
+    records = [{**_DEFAULT_BRACKET_RECORDS[0], "notional_coefficient": "not-a-number"}]
+    artifact = _make_bracket_artifact(brackets=records)
+    with pytest.raises(ValueError, match="notional_coefficient must be numeric"):
+        _validate_bracket_artifact(artifact, expected_symbol="BTC/USDT:USDT")
 
 
-def test_perpetual_fetch_rejects_maintenance_bracket_missing_field(monkeypatch) -> None:
-    exchange = _PerpetualExchange(brackets=[
-        {"bracket": 1, "notionalCap": 50_000, "maintMarginRatio": 0.004},
+def test_bracket_artifact_rejects_non_monotonic_brackets() -> None:
+    artifact = _make_bracket_artifact(brackets=[
+        {
+            "bracket_tier": 1, "notional_cap": 250_000.0,
+            "maintenance_rate": 0.004, "cumulative_maintenance_amount": 0.0,
+        },
+        {
+            "bracket_tier": 2, "notional_cap": 50_000.0,
+            "maintenance_rate": 0.005, "cumulative_maintenance_amount": 50.0,
+        },
     ])
-    monkeypatch.setattr(
-        "backtest.loaders.ccxt_loader.DataLoader._get_exchange",
-        lambda _self, instrument_type="spot": exchange,
-    )
-
-    from backtest.loaders.ccxt_loader import DataLoader
-
-    with pytest.raises(ValueError, match="maintenance bracket"):
-        DataLoader().fetch(
-            ["BTC-USDT-PERP"], "2024-01-01", "2024-01-01", interval="1H"
-        )
-
-
-def test_perpetual_fetch_rejects_non_monotonic_maintenance_brackets(monkeypatch) -> None:
-    exchange = _PerpetualExchange(brackets=[
-        {"bracket": 1, "notionalCap": 250_000, "maintMarginRatio": 0.004, "cum": 0.0},
-        {"bracket": 2, "notionalCap": 50_000, "maintMarginRatio": 0.005, "cum": 50.0},
-    ])
-    monkeypatch.setattr(
-        "backtest.loaders.ccxt_loader.DataLoader._get_exchange",
-        lambda _self, instrument_type="spot": exchange,
-    )
-
-    from backtest.loaders.ccxt_loader import DataLoader
-
-    with pytest.raises(ValueError, match="maintenance bracket"):
-        DataLoader().fetch(
-            ["BTC-USDT-PERP"], "2024-01-01", "2024-01-01", interval="1H"
-        )
+    with pytest.raises(ValueError, match="not strictly increasing"):
+        _validate_bracket_artifact(artifact, expected_symbol="BTC/USDT:USDT")


### PR DESCRIPTION
## Summary

- Remove the unconditional `fetch_leverage_tiers()` call `#716` added — it routes to Binance's signed `GET /fapi/v1/leverageBracket` USER_DATA endpoint and requires an API key, so every `-PERP` fetch on merged `main` currently hard-crashes for callers without a Binance key.
- Execution/mark OHLC and funding settlements go back to zero-credential.
- Maintenance brackets are now supplied as an explicit, versioned artifact rather than fetched live. A strict margin-risk consumer can require one and fail closed when it's missing.

## Why

Follow-up to `#716` per post-merge validation discussed on `#462` — see the [empirical finding](https://github.com/HKUDS/Vibe-Trading/issues/462#issuecomment-5029633402) and [maintainer's conditional go-ahead](https://github.com/HKUDS/Vibe-Trading/issues/462#issuecomment-5030458834) (historical/sandbox only, no live endpoint/connector/order code, backward compatible, independently reviewable). This PR is scoped to exactly that: decouple bracket *acquisition* without removing bracket *support*.

## Changes

`agent/backtest/loaders/ccxt_loader.py`:

- Deleted `_fetch_maintenance_brackets` (the live, authenticated fetch) entirely — not just its call site.
- Added `_validate_bracket_artifact(artifact, *, expected_symbol)`: validates a caller-supplied dict — `schema_version`, `symbol` (must match the requested CCXT symbol), `provenance_timestamp` (must parse), `brackets` (per-tier `bracket_tier`/`notional_cap`/`maintenance_rate`/`cumulative_maintenance_amount`, optional `notional_coefficient`, strictly increasing notional caps), and `content_hash` (must match the SHA-256 of the canonical bracket JSON — catches a tampered or hand-edited artifact). Fails closed on any mismatch. Never touches the network.
- `DataLoader.fetch(..., bracket_artifacts=None, require_brackets=False)`: two new keyword-only params, both defaulting to today's behavior minus the crash — i.e. a plain `-PERP` fetch now succeeds with zero credentials and no bracket columns. Passing a matching artifact in `bracket_artifacts={code: artifact}` attaches `maintenance_brackets`/`maintenance_bracket_version`, same column shape as `#716`. `require_brackets=True` makes a `-PERP` code without a matching valid artifact fail closed *before* any network call, with a message that names the actual constraint (no live authenticated fetch, supply an artifact).
- Existing callers (`engines/base.py`, `runner.py`, etc.) never pass these new kwargs, so nothing outside this file changes.

## Test Plan

- [x] `pytest agent/tests/test_ccxt_perpetual_loader.py -q` — 25 passed (11 pre-existing unchanged + 14 new: no-artifact zero-credential path, valid-artifact attach, strict-without-artifact fail-closed-before-any-call, strict-with-artifact success, optional `notional_coefficient`, and 7 artifact-validation rejection cases).
- [x] `pytest agent/tests/test_ccxt_perpetual_loader.py agent/tests/test_ccxt_loader_bounded.py agent/tests/test_ccxt_loader_proxy.py agent/tests/test_crypto_engine.py agent/tests/test_base_engine.py -q` — 85 passed (default-path regression, unchanged).
- [x] `ruff check agent/backtest/loaders/ccxt_loader.py agent/tests/test_ccxt_perpetual_loader.py` — all checks passed (one pre-existing noqa-format warning, unrelated to this change, present on unmodified `main` too).
- [x] `bash tools/ci_grep_gates.sh` — all 5 gates pass (zero raw `os.getenv`/`os.environ` in new code; the one WARN is pre-existing and unrelated).
- [x] `git diff --stat main` — 2 files, 261(+)/153(-), 414 lines total.
- [x] **Live confirmation, zero credentials**: `DataLoader().fetch(["BTC-USDT-PERP"], "2026-07-01", "2026-07-02", interval="1H")` against real `binanceusdm` — 48 rows, `execution_open`/`mark_*`/`funding_rate` all populated, no `maintenance_brackets` columns, **no `AuthenticationError`**. This is the regression #716 introduced; confirmed fixed against the live endpoint, not just the mocked test suite.

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`)
- [x] No hardcoded values; no raw env reads (AST-gated)
- [x] Follows CONTRIBUTING.md (DCO sign-off on the commit)
- [x] No market data files committed; no real bracket snapshot committed; test fixtures are synthetic/mocked
- [x] No live-endpoint imports reachable from the backtest path
- [x] No Binance credentials added to the backtest path
- [x] Opt-in only: default `-PERP` fetch behavior is zero-credential; bracket attachment and strict-fail-closed are both opt-in via new keyword args

## Safety and network risk

- Runtime access is public, read-only CCXT market data (OHLCV, funding rate history) — no API key accepted or required by any code path in this file.
- The bracket artifact is caller-supplied data validated in memory; this PR adds no fetcher, exporter, or credential surface for it. (A separate, optional, read-only exporter to *produce* such an artifact outside the backtest runtime may be proposed later — out of scope here.)
- Tests use fake exchanges and hand-built artifacts — no network requests in the test suite, no committed market data.

## Out of scope

- Producing real bracket artifacts (a future optional exporter tool).
- The non-8h funding-interval completeness gap found during the same validation pass — kept separate so this PR stays focused; will be proposed as its own small follow-up.
- PR 2 (margin-risk model) — stays paused until this merges, since it's the bracket consumer.

## Rollback

Revert this commit. Spot symbols and the pre-#716 execution/mark/funding perpetual path are unaffected either way; a caller who was relying on automatic (but broken, credential-requiring) bracket attachment gets the same `ValueError` shape as before, just earlier and with a clearer message, when `require_brackets=True` is set explicitly.
