### PR TITLE
fix(loaders): keep yahoo 1m as minute bars, not monthly

### DIFF
--- a/agent/backtest/loaders/yahoo_loader.py
+++ b/agent/backtest/loaders/yahoo_loader.py
@@ -59,6 +59,11 @@ def _to_yahoo_interval(interval: str) -> str:
         Yahoo-compatible interval string (e.g. ``1d``).
     """
     normalized = str(interval or "1D").strip()
+    if not normalized:
+        return "1d"
+    # Bare trailing ``m`` is minutes; do not uppercase into monthly ``1M`` → ``1mo``.
+    if normalized.endswith("m") and not normalized.endswith("M"):
+        return normalized.lower()
     return _INTERVAL_MAP.get(normalized.upper(), normalized.lower())
 
 

--- a/agent/tests/test_yahoo_loader.py
+++ b/agent/tests/test_yahoo_loader.py
@@ -87,6 +87,12 @@ class TestIntervalMap:
     def test_unknown_lowercased(self):
         assert _to_yahoo_interval("5m") == "5m"
 
+    def test_one_minute_not_mapped_to_month(self):
+        assert _to_yahoo_interval("1m") == "1m"
+        assert _to_yahoo_interval("1M") == "1mo"
+        assert _to_yahoo_interval("15m") == "15m"
+        assert _to_yahoo_interval("30m") == "30m"
+
     def test_empty_defaults_daily(self):
         assert _to_yahoo_interval("") == "1d"
 


### PR DESCRIPTION
`_to_yahoo_interval("1m")` uppercased the token to `1M`, which the Yahoo map treats as monthly (`1mo`). Minute backtests silently fetched monthly bars.

Repro: `_to_yahoo_interval("1m")` returned `1mo` on main. Longbridge already maps `1m` and `1M` separately.

Keep case for known minute tokens before the uppercase monthly map, and cover `1m`/`1M`/`15m`/`30m` in the interval tests.