### PR TITLE
fix(session): skip corrupt session.json when listing sessions

### DIFF
--- a/agent/src/session/store.py
+++ b/agent/src/session/store.py
@@ -132,8 +132,17 @@ class SessionStore:
                 continue
             session_file = session_dir / "session.json"
             data = self._read_json(session_file)
-            if data:
+            if not isinstance(data, dict):
+                continue
+            try:
                 sessions.append(Session.from_dict(data))
+            except (TypeError, ValueError, KeyError) as exc:
+                # One bad session.json must not abort listing siblings.
+                logger.warning(
+                    "Skipping corrupt session.json in %s: %s",
+                    session_dir.name,
+                    exc,
+                )
         sessions.sort(key=lambda s: s.updated_at, reverse=True)
         return sessions[:limit]
 

--- a/agent/tests/test_session_store_list_corrupt.py
+++ b/agent/tests/test_session_store_list_corrupt.py
@@ -1,0 +1,44 @@
+"""One corrupt session.json must not abort SessionStore.list_sessions."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.session.models import Session
+from src.session.store import SessionStore
+
+
+def test_list_sessions_skips_invalid_status_and_keeps_siblings(tmp_path: Path) -> None:
+    store = SessionStore(tmp_path / "sessions")
+    store.create_session(Session(session_id="goodsession01", title="good"))
+
+    bad = store.base_dir / "badsession02"
+    bad.mkdir()
+    (bad / "session.json").write_text(
+        json.dumps(
+            {
+                "session_id": "badsession02",
+                "title": "broken",
+                "status": "not-a-status",
+                "created_at": "2020-01-01T00:00:00+00:00",
+                "updated_at": "2020-01-01T00:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    listed = store.list_sessions()
+    assert [s.session_id for s in listed] == ["goodsession01"]
+
+
+def test_list_sessions_skips_non_object_session_json(tmp_path: Path) -> None:
+    store = SessionStore(tmp_path / "sessions")
+    store.create_session(Session(session_id="goodsession01", title="good"))
+
+    bad = store.base_dir / "listsess"
+    bad.mkdir()
+    (bad / "session.json").write_text('"not-an-object"', encoding="utf-8")
+
+    listed = store.list_sessions()
+    assert [s.session_id for s in listed] == ["goodsession01"]


### PR DESCRIPTION
One invalid `session.json` (bad status enum or non-object) raised in `list_sessions` and aborted the whole listing, hiding sibling sessions. Search rebuild already skips bad session files.

Repro: a store with one good session and one `session.json` with status `not-a-status` raised `ValueError` and returned nothing.

Skip unreadable/invalid session files with a warning and keep the good ones.