### PR TITLE
fix(session): skip schema-bad messages.jsonl lines when reading

### DIFF
--- a/agent/src/session/store.py
+++ b/agent/src/session/store.py
@@ -169,8 +169,13 @@ class SessionStore:
         for line in path.read_text(encoding="utf-8").strip().splitlines():
             if line.strip():
                 try:
-                    messages.append(Message.from_dict(json.loads(line)))
-                except json.JSONDecodeError:
+                    payload = json.loads(line)
+                    if not isinstance(payload, dict):
+                        raise TypeError(
+                            f"message line must be a JSON object, got {type(payload).__name__}"
+                        )
+                    messages.append(Message.from_dict(payload))
+                except (json.JSONDecodeError, TypeError, ValueError, KeyError):
                     logger.warning(
                         "Skipping corrupted message line in session %s: %s",
                         session_id,

--- a/agent/tests/test_session_store_messages_corrupt.py
+++ b/agent/tests/test_session_store_messages_corrupt.py
@@ -1,0 +1,72 @@
+"""Schema-bad messages.jsonl lines must be skipped like JSONDecodeError lines."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.session.models import Message, Session
+from src.session.store import SessionStore
+
+
+def _seed(store: SessionStore, session_id: str) -> Path:
+    store.create_session(Session(session_id=session_id, title="t"))
+    store.append_message(
+        Message(session_id=session_id, role="user", content="keep-before")
+    )
+    return store._messages_file(session_id)
+
+
+def test_get_messages_skips_non_object_json_and_keeps_siblings(tmp_path: Path) -> None:
+    store = SessionStore(tmp_path / "sessions")
+    sid = "abc123def456"
+    path = _seed(store, sid)
+    path.write_text(
+        path.read_text(encoding="utf-8")
+        + "null\n"
+        + json.dumps(
+            {
+                "message_id": "2",
+                "session_id": sid,
+                "role": "user",
+                "content": "keep-after",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    contents = [m.content for m in store.get_messages(sid)]
+    assert contents == ["keep-before", "keep-after"]
+
+
+def test_get_messages_skips_unexpected_keys_and_keeps_siblings(tmp_path: Path) -> None:
+    store = SessionStore(tmp_path / "sessions")
+    sid = "abc123def789"
+    path = _seed(store, sid)
+    path.write_text(
+        path.read_text(encoding="utf-8")
+        + json.dumps(
+            {
+                "message_id": "2",
+                "session_id": sid,
+                "role": "user",
+                "content": "bad",
+                "tool_calls": [],
+            }
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "message_id": "3",
+                "session_id": sid,
+                "role": "user",
+                "content": "keep-after",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    contents = [m.content for m in store.get_messages(sid)]
+    assert contents == ["keep-before", "keep-after"]


### PR DESCRIPTION
`get_messages` already skipped `JSONDecodeError` lines, but a complete JSON line that was not a mapping (or had unexpected keys) raised `TypeError` and dropped later good messages.

Repro: a `messages.jsonl` with a valid user line, then `[1,2,3]` or `null`, then a valid assistant line aborted on the middle line.

Catch schema errors on the same skip path so later messages still load.