### PR TITLE
fix(backtest): print scalar metrics as strict JSON

### DIFF
--- a/agent/backtest/engines/base.py
+++ b/agent/backtest/engines/base.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import importlib
 import json
 import logging
+import math
 import re as _re
 import sys
 from abc import ABC, abstractmethod
@@ -38,6 +39,15 @@ from backtest.metrics import (
     calc_metrics,
     calc_trade_turnover_series,
 )
+
+
+def _json_safe_scalar_metrics(metrics: Dict[str, Any]) -> Dict[str, Any]:
+    """Scalar metrics for stdout JSON; non-finite floats become null."""
+    return {
+        k: (None if isinstance(v, float) and not math.isfinite(v) else v)
+        for k, v in metrics.items()
+        if not isinstance(v, dict)
+    }
 from backtest.models import EquitySnapshot, Position, TradeRecord
 
 logger = logging.getLogger(__name__)
@@ -599,8 +609,10 @@ class BaseEngine(ABC):
             warnings=config.get("content_filter_warnings") or None,
         )
 
-        # Print scalar metrics (skip nested dicts for JSON compat)
-        print(json.dumps({k: v for k, v in m.items() if not isinstance(v, dict)}, indent=2))
+        # Print scalar metrics (skip nested dicts for JSON compat).
+        # Explosive annual_return may be +inf; match options/run_card and emit
+        # null instead of a bare Infinity token (invalid RFC-8259 JSON).
+        print(json.dumps(_json_safe_scalar_metrics(m), indent=2, allow_nan=False))
         return m
 
     # ── Execution loop ──

--- a/agent/tests/test_engine_metrics_json.py
+++ b/agent/tests/test_engine_metrics_json.py
@@ -1,0 +1,30 @@
+"""Strict JSON for BaseEngine scalar metrics stdout."""
+
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+
+import backtest.engines.base as base_mod
+from backtest.metrics import calc_metrics
+
+
+def test_engine_scalar_metrics_stdout_is_strict_json() -> None:
+    """Explosive equity sets annual_return=inf; stdout must not emit Infinity."""
+    eq = pd.Series([1.0, 1_000_000.0, 500_000.0])
+    m = calc_metrics(eq, [], 1.0, bars_per_year=525_600)
+    assert m["annual_return"] == float("inf")
+
+    scrub = getattr(base_mod, "_json_safe_scalar_metrics", None)
+    if scrub is None:
+        # Pristine engine printed scalars with default allow_nan=True.
+        payload = {k: v for k, v in m.items() if not isinstance(v, dict)}
+    else:
+        payload = scrub(m)
+
+    raw = json.dumps(payload, allow_nan=False)
+    assert "Infinity" not in raw and "NaN" not in raw
+    loaded = json.loads(raw, parse_constant=lambda c: (_ for _ in ()).throw(ValueError(c)))
+    assert loaded["annual_return"] is None
+    assert loaded["total_return"] == m["total_return"]


### PR DESCRIPTION
After annualization overflow is clamped, `annual_return` can still be `+inf`. `BaseEngine` printed metrics with default `json.dumps`, which emits bare `Infinity` and breaks consumers that expect RFC JSON.

Repro: printing metrics with an infinite annual return raised under `allow_nan=False`.

Sanitize non-finite scalar metrics and print with `allow_nan=False`.