### PR TITLE
fix(factors): keep single-day IC std finite in factor analysis JSON

### DIFF
--- a/agent/src/tools/factor_analysis_tool.py
+++ b/agent/src/tools/factor_analysis_tool.py
@@ -58,7 +58,9 @@ def run_factor_analysis(
     ic_series.to_csv(out_path / "ic_series.csv", header=["IC"])
 
     ic_mean = float(ic_series.mean())
-    ic_std = float(ic_series.std())
+    # ``Series.std()`` uses ddof=1, so a single IC observation yields NaN and
+    # poisons the JSON summary (sibling to metrics.py's single-bar vol guard).
+    ic_std = float(ic_series.std()) if len(ic_series) > 1 else 0.0
     ir = ic_mean / ic_std if ic_std > 0 else 0.0
     ic_positive_ratio = float((ic_series > 0).mean())
 
@@ -70,7 +72,8 @@ def run_factor_analysis(
         "ic_count": len(ic_series),
     }
     (out_path / "ic_summary.json").write_text(
-        json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8"
+        json.dumps(summary, ensure_ascii=False, indent=2, allow_nan=False),
+        encoding="utf-8",
     )
 
     equity_df = compute_group_equity(factor_df, return_df, n_groups)
@@ -99,7 +102,7 @@ def run_factor_analysis(
         "output_dir": str(out_path),
         "files": ["ic_series.csv", "ic_summary.json", "group_equity.csv"],
     }
-    return json.dumps(result, ensure_ascii=False, indent=2)
+    return json.dumps(result, ensure_ascii=False, indent=2, allow_nan=False)
 
 
 class FactorAnalysisTool(BaseTool):

--- a/agent/tests/factors/test_factor_analysis_core.py
+++ b/agent/tests/factors/test_factor_analysis_core.py
@@ -52,3 +52,29 @@ def test_run_factor_analysis_nonpositive_n_groups_returns_json_error() -> None:
         )
         assert out["status"] == "error"
         assert "n_groups" in out["error"]
+
+
+def test_run_factor_analysis_single_day_ic_std_is_finite_json() -> None:
+    """One IC date must not emit NaN ic_std (ddof=1) into the JSON summary."""
+    factor, ret = _panel(n_dates=1, n_codes=8, seed=3)
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        factor.to_csv(root / "f.csv")
+        ret.to_csv(root / "r.csv")
+        raw = run_factor_analysis(
+            str(root / "f.csv"),
+            str(root / "r.csv"),
+            str(root / "out"),
+            n_groups=5,
+        )
+        out = json.loads(raw)
+        assert out["status"] == "ok"
+        assert out["ic_count"] == 1
+        assert out["ic_std"] == 0.0
+        assert out["ir"] == 0.0
+        summary = json.loads(
+            (root / "out" / "ic_summary.json").read_text(encoding="utf-8")
+        )
+        assert summary["ic_std"] == 0.0
+        json.dumps(out, allow_nan=False)
+        json.dumps(summary, allow_nan=False)


### PR DESCRIPTION
A factor panel with only one IC date makes `Series.std()` (ddof=1) NaN, which leaked into `ic_summary.json` and the tool envelope as invalid JSON. Metrics already treat single-observation std as 0.

Repro: one-date factor/return frames with enough names produced `"ic_std": NaN` on main.

Treat single-sample IC std as 0.0 and dump with `allow_nan=False`.