### PR TITLE
fix(api): treat export KEY= as KEY in dotenv settings helpers

### DIFF
--- a/agent/src/api/helpers.py
+++ b/agent/src/api/helpers.py
@@ -149,6 +149,18 @@ def _strip_env_value(value: str) -> str:
     return value.strip()
 
 
+def _dotenv_key(raw_key: str) -> str:
+    """Return the canonical env key, stripping an optional ``export `` prefix.
+
+    python-dotenv accepts ``export KEY=value``; Settings must too so reads and
+    upserts hit the same key users set when sourcing a shell-style dotenv.
+    """
+    key = raw_key.strip()
+    if key.lower().startswith("export "):
+        key = key[7:].strip()
+    return key
+
+
 def _read_env_values(path: Path) -> Dict[str, str]:
     """Read active KEY=value entries from a dotenv file."""
     values: Dict[str, str] = {}
@@ -159,7 +171,7 @@ def _read_env_values(path: Path) -> Dict[str, str]:
         if not line or line.startswith("#") or "=" not in line:
             continue
         key, value = line.split("=", 1)
-        key = key.strip()
+        key = _dotenv_key(key)
         if key:
             values[key] = _strip_env_value(value)
     return values
@@ -200,12 +212,14 @@ def _write_env_values(path: Path, updates: Dict[str, str]) -> None:
         stripped = raw.lstrip()
         if stripped.startswith("#") or "=" not in stripped:
             continue
-        key = stripped.split("=", 1)[0].strip()
+        key = _dotenv_key(stripped.split("=", 1)[0])
         if key in updates:
             last_active[key] = index
     seen: set[str] = set()
     for key, index in last_active.items():
-        lines[index] = f"{key}={_format_env_value(updates[key])}"
+        stripped = lines[index].lstrip()
+        prefix = "export " if stripped.lower().startswith("export ") else ""
+        lines[index] = f"{prefix}{key}={_format_env_value(updates[key])}"
         seen.add(key)
     missing = [key for key in updates if key not in seen]
     if missing:

--- a/agent/tests/test_api_infrastructure.py
+++ b/agent/tests/test_api_infrastructure.py
@@ -312,6 +312,33 @@ def test_read_write_env_quoted_hash_roundtrip(tmp_path):
     assert helpers._strip_env_value(line.split("=", 1)[1]) == secret
 
 
+def test_read_env_values_strips_export_prefix(tmp_path):
+    """Shell-style ``export KEY=`` must read as KEY (python-dotenv parity)."""
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "export OPENAI_API_KEY=sk-real\nLANGCHAIN_PROVIDER=openai\n",
+        encoding="utf-8",
+    )
+    values = helpers._read_env_values(env_file)
+    assert values["OPENAI_API_KEY"] == "sk-real"
+    assert values["LANGCHAIN_PROVIDER"] == "openai"
+    assert "export OPENAI_API_KEY" not in values
+
+
+def test_write_env_values_updates_export_prefixed_key(tmp_path):
+    """Upsert must rewrite ``export KEY=`` in place, not append a duplicate KEY=."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("export TUSHARE_TOKEN=old-token\nOTHER=1\n", encoding="utf-8")
+
+    helpers._write_env_values(env_file, {"TUSHARE_TOKEN": "new-token"})
+
+    text = env_file.read_text(encoding="utf-8")
+    assert "export TUSHARE_TOKEN=new-token\n" in text
+    assert text.count("TUSHARE_TOKEN=") == 1
+    assert helpers._read_env_values(env_file)["TUSHARE_TOKEN"] == "new-token"
+    assert helpers._read_env_values(env_file)["OTHER"] == "1"
+
+
 # ============================================================================
 # state._get_session_service writeback
 # ============================================================================


### PR DESCRIPTION
Settings helpers treated `export FOO=bar` as key `export FOO`, so `load_dotenv` saw the value but Settings read/upsert missed it and could append a duplicate `FOO=` line.

Repro: `_read_env_values` on a file with `export OPENAI_API_KEY=sk-test` returned key `export OPENAI_API_KEY`.

Strip a leading `export ` on read and preserve it on in-place rewrite.