### PR TITLE
fix(tools): accept unicode dashes in PDF page ranges

### DIFF
--- a/agent/src/tools/doc_reader_tool.py
+++ b/agent/src/tools/doc_reader_tool.py
@@ -104,6 +104,12 @@ def _envelope(path: Path, fmt: str, text: str, **extra: Any) -> str:
 
 def _parse_pages(pages_str: str, total: int) -> list[int]:
     """Parse '1-10' / '5' / '1,3,5-8' into zero-based indices."""
+    # Word/LLM paste often uses en/em/minus dashes; treat as ASCII hyphen.
+    pages_str = (
+        pages_str.replace("\u2013", "-")
+        .replace("\u2014", "-")
+        .replace("\u2212", "-")
+    )
     out: list[int] = []
     for part in pages_str.split(","):
         part = part.strip()

--- a/agent/tests/test_doc_reader_unicode_page_dashes.py
+++ b/agent/tests/test_doc_reader_unicode_page_dashes.py
@@ -1,0 +1,28 @@
+"""Unicode dash page ranges must parse like ASCII hyphens, not yield empty."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.tools.doc_reader_tool import _parse_pages
+
+
+def test_en_dash_page_range_parses() -> None:
+    assert _parse_pages("1\u201310", 20) == list(range(10))
+
+
+def test_em_dash_page_range_parses() -> None:
+    assert _parse_pages("2\u20144", 20) == [1, 2, 3]
+
+
+def test_minus_sign_page_range_parses() -> None:
+    assert _parse_pages("5\u22127", 20) == [4, 5, 6]
+
+
+def test_ascii_hyphen_still_ok() -> None:
+    assert _parse_pages("1-3", 20) == [0, 1, 2]
+
+
+def test_inverted_en_dash_range_still_raises() -> None:
+    with pytest.raises(ValueError, match="inverted page range"):
+        _parse_pages("10\u20135", 20)


### PR DESCRIPTION
`read_document` page ranges copied from Word/LLMs often use en/em/minus dashes. `_parse_pages` on `1–10` matched neither `-` nor `isdigit`, returned `[]`, and silently extracted no pages.

Repro: `_parse_pages` with a unicode en-dash range returned `[]` while ASCII `1-10` returned pages 1-10.

Normalize unicode dashes to ASCII `-` before parsing; inverted ranges still raise.