### PR TITLE
fix(journal): normalize Excel float-stringified A-share codes

### DIFF
--- a/agent/src/tools/trade_journal_parsers.py
+++ b/agent/src/tools/trade_journal_parsers.py
@@ -178,7 +178,16 @@ def _qualify_a_share(code: str) -> str:
     """Append .SH/.SZ/.BJ suffix to a bare A-share ticker."""
     if _is_empty_code(code):
         raise ValueError("empty securities code")
-    code = str(code).strip().zfill(6)
+    code = str(code).strip()
+    # Numeric Excel/CSV cells often stringify as "600519.0" or "6.00519E+5".
+    # Those contain "." but are not exchange-qualified; normalize first.
+    try:
+        as_float = float(code)
+        if as_float.is_integer() and abs(as_float) < 10_000_000:
+            code = str(int(as_float))
+    except (ValueError, OverflowError):
+        pass
+    code = code.zfill(6)
     if "." in code:
         return code.upper()
     first = code[0]

--- a/agent/src/tools/trade_journal_parsers.py
+++ b/agent/src/tools/trade_journal_parsers.py
@@ -179,8 +179,7 @@ def _qualify_a_share(code: str) -> str:
     if _is_empty_code(code):
         raise ValueError("empty securities code")
     code = str(code).strip()
-    # Numeric Excel/CSV cells often stringify as "600519.0" or "6.00519E+5".
-    # Those contain "." but are not exchange-qualified; normalize first.
+    # Excel/CSV numeric cells stringify as "600519.0"/sci — not exchange suffixes.
     try:
         as_float = float(code)
         if as_float.is_integer() and abs(as_float) < 10_000_000:

--- a/agent/tests/test_trade_journal.py
+++ b/agent/tests/test_trade_journal.py
@@ -611,3 +611,32 @@ def test_parse_generic_skips_nan_symbol_rows() -> None:
     rec = parse_generic(df)
     assert len(rec) == 1
     assert rec[0].symbol == "AAPL"
+
+
+@pytest.mark.parametrize(
+    "code,expected",
+    [
+        (600519.0, "600519.SH"),
+        ("600519.0", "600519.SH"),
+        ("6.00519E+5", "600519.SH"),
+        ("6.00519e5", "600519.SH"),
+        ("000001.0", "000001.SZ"),
+        ("600519.SH", "600519.SH"),  # still passthrough
+    ],
+)
+def test_qualify_a_share_normalizes_float_stringified_codes(
+    code: object, expected: str
+) -> None:
+    """Excel/CSV float forms must not be treated as exchange-qualified."""
+    assert _qualify_a_share(code) == expected  # type: ignore[arg-type]
+
+
+def test_parse_tonghuashun_float_code_cell() -> None:
+    df = pd.DataFrame([{
+        "成交时间": "2024-01-01 10:00:00", "证券代码": 600519.0, "证券名称": "茅台",
+        "操作": "买入", "成交数量": 100, "成交价格": 10.0, "成交金额": 1000,
+        "手续费": 0, "印花税": 0, "过户费": 0,
+    }])
+    rec = parse_tonghuashun(df)
+    assert len(rec) == 1
+    assert rec[0].symbol == "600519.SH"


### PR DESCRIPTION
Numeric Excel/CSV cells often stringify as `600519.0` or scientific notation. `_qualify_a_share` saw `.` and treated them as already exchange-qualified, so `.SH`/`.SZ` never attached.

Repro: `_qualify_a_share(600519.0)` returned `600519.0` on main instead of `600519.SH`.

Normalize integer-valued float forms before the suffix logic; real `600519.SH` still passes through.