### PR TITLE
fix(mt5): convert numpy scalars to native Python types for JSON serialization

### DIFF
--- a/agent/src/trading/connectors/mt5/reads.py
+++ b/agent/src/trading/connectors/mt5/reads.py
@@ -259,6 +259,20 @@ def get_historical_bars(
     )
 
 
+def _int_or_none(value: Any) -> int | None:
+    """Cast *value* to a plain Python int (handles numpy scalars). Return None for None."""
+    if value is None:
+        return None
+    return int(value)
+
+
+def _float_or_none(value: Any) -> float | None:
+    """Cast *value* to a plain Python float (handles numpy scalars). Return None for None."""
+    if value is None:
+        return None
+    return float(value)
+
+
 def _rate_to_dict(rate: Any) -> dict[str, Any]:
     """Map one rates row (numpy structured row, mapping, or object) defensively."""
 
@@ -270,12 +284,12 @@ def _rate_to_dict(rate: Any) -> dict[str, Any]:
 
     volume = _get("tick_volume")
     return {
-        "time": _get("time"),
-        "open": _get("open"),
-        "high": _get("high"),
-        "low": _get("low"),
-        "close": _get("close"),
-        "volume": volume,
-        "spread": _get("spread"),
-        "real_volume": _get("real_volume"),
+        "time": _int_or_none(_get("time")),
+        "open": _float_or_none(_get("open")),
+        "high": _float_or_none(_get("high")),
+        "low": _float_or_none(_get("low")),
+        "close": _float_or_none(_get("close")),
+        "volume": _int_or_none(volume),
+        "spread": _int_or_none(_get("spread")),
+        "real_volume": _int_or_none(_get("real_volume")),
     }

--- a/agent/tests/test_mt5_connector.py
+++ b/agent/tests/test_mt5_connector.py
@@ -739,6 +739,99 @@ class TestCancelOrder:
 
 
 # --------------------------------------------------------------------------- #
+# _rate_to_dict numpy serialization regression (Issue #774)                     #
+# --------------------------------------------------------------------------- #
+
+
+class TestRateToDictSerialization:
+    def test_rate_to_dict_numpy_serializable(self) -> None:
+        """Verify _rate_to_dict converts numpy scalars to native Python types."""
+        import json
+
+        import numpy as np
+
+        from src.trading.connectors.mt5.reads import _rate_to_dict
+
+        # Simulate a numpy structured array row as returned by MT5 SDK.
+        dt = np.dtype([
+            ("time", "<i8"), ("open", "<f8"), ("high", "<f8"),
+            ("low", "<f8"), ("close", "<f8"), ("tick_volume", "<i8"),
+            ("spread", "<i4"), ("real_volume", "<i8"),
+        ])
+        row = np.array(
+            [(1_750_000_000, 1.0700, 1.0900, 1.0600, 1.0800, 1200, 6, 0)],
+            dtype=dt,
+        )[0]
+
+        result = _rate_to_dict(row)
+
+        # Must be JSON-serializable without raising.
+        serialized = json.dumps(result)
+        assert serialized  # non-empty string
+
+        # All numeric values must be native Python types, not numpy scalars.
+        for key in ("time", "volume", "spread", "real_volume"):
+            assert type(result[key]) is int, f"{key} should be int, got {type(result[key])}"
+        for key in ("open", "high", "low", "close"):
+            assert type(result[key]) is float, f"{key} should be float, got {type(result[key])}"
+
+        # Verify values are correct.
+        assert result["time"] == 1_750_000_000
+        assert result["close"] == 1.08
+        assert result["volume"] == 1200
+
+    def test_rate_to_dict_mapping_types(self) -> None:
+        """Plain dict input produces native Python types and is JSON-serializable."""
+        import json
+
+        from src.trading.connectors.mt5.reads import _rate_to_dict
+
+        rate = {
+            "time": 1_750_000_000,
+            "open": 1.07,
+            "high": 1.09,
+            "low": 1.06,
+            "close": 1.08,
+            "tick_volume": 1200,
+            "spread": 6,
+            "real_volume": 0,
+        }
+
+        result = _rate_to_dict(rate)
+        json.dumps(result)  # must not raise
+
+        assert type(result["time"]) is int
+        assert type(result["close"]) is float
+        assert type(result["volume"]) is int
+        assert type(result["spread"]) is int
+        assert type(result["real_volume"]) is int
+
+    def test_rate_to_dict_handles_none_values(self) -> None:
+        """None values pass through without raising and remain JSON-serializable."""
+        import json
+
+        from src.trading.connectors.mt5.reads import _rate_to_dict
+
+        rate = {
+            "time": None,
+            "open": None,
+            "high": None,
+            "low": None,
+            "close": None,
+            "tick_volume": None,
+            "spread": None,
+            "real_volume": None,
+        }
+
+        result = _rate_to_dict(rate)
+        json.dumps(result)  # must not raise
+
+        assert result["time"] is None
+        assert result["open"] is None
+        assert result["volume"] is None
+
+
+# --------------------------------------------------------------------------- #
 # Profiles, classification, service registration                               #
 # --------------------------------------------------------------------------- #
 


### PR DESCRIPTION
## Summary

Fix MT5 connector `trading_history` JSON serialization failure caused by numpy scalar types.

## Why

MetaTrader5 SDK `copy_rates_from_pos()` returns numpy structured arrays containing `numpy.int64`/`numpy.float64` scalars. These types are not natively JSON-serializable, causing `TypeError: Object of type int64 is not JSON serializable` whenever `trading_history` responses are serialized downstream. All other MT5 read operations (`get_account`, `get_positions`, `get_quote`, `check_status`) work correctly because they don't interact with numpy arrays.

Closes #774

## Changes

- Add `_int_or_none()` and `_float_or_none()` type-conversion helpers in `reads.py`
- Apply conversions to all numeric fields in `_rate_to_dict()`
- Add regression tests covering numpy structured rows, plain-dict, and None-value inputs

## Test Plan

- [x] Existing 86 MT5 connector tests pass
- [x] New regression test `test_rate_to_dict_numpy_serializable` verifies numpy scalars are converted
- [x] New test `test_rate_to_dict_mapping_types` verifies plain dict inputs
- [x] New test `test_rate_to_dict_handles_none_values` verifies None handling

## Checklist

- [x] No changes to protected areas
- [x] No hardcoded values (tokens, paths, URLs)
- [x] Follows CONTRIBUTING.md guidelines
- [ ] Documentation updated (N/A - no user-facing doc changes needed)