### PR TITLE
fix(shoonya): map 4h/1H periods and reject unknown intervals

### DIFF
--- a/agent/src/trading/connectors/shoonya/sdk.py
+++ b/agent/src/trading/connectors/shoonya/sdk.py
@@ -116,6 +116,21 @@ class ShoonyaConfig:
 
 _OVERRIDE_KEYS = ("user_id", "password", "vendor_code", "api_secret", "totp_secret", "profile")
 
+#: Canonical period token → Noren interval (minutes as str, or ``D`` for daily).
+#: ``1H``/``4H``/``1D`` alias the lowercase forms; ``1w``/``1M`` are unsupported.
+_INTERVAL_MAP = {
+    "1m": "1",
+    "5m": "5",
+    "15m": "15",
+    "30m": "30",
+    "1h": "60",
+    "1H": "60",
+    "4h": "240",
+    "4H": "240",
+    "1d": "D",
+    "1D": "D",
+}
+
 
 def build_config(
     profile_config: Mapping[str, Any] | None = None,
@@ -346,8 +361,18 @@ def get_historical_bars(
     else:
         start = end - timedelta(days=min(limit * 2, 365))
 
-    interval_map = {"1m": "1", "5m": "5", "15m": "15", "30m": "30", "1h": "60", "1d": "D"}
-    interval = interval_map.get(period, "D")
+    # Noren TP series minutes: 1/3/5/10/15/30/60/120/240; daily via get_daily_price_series.
+    # Reject unknown (incl. 1w/1M) instead of silently substituting daily bars.
+    interval = _INTERVAL_MAP.get(period.strip())
+    if interval is None:
+        return {
+            "status": "error",
+            "error": (
+                f"unsupported period: {period!r}; "
+                f"supported: {sorted(_INTERVAL_MAP)}"
+            ),
+            "symbol": clean,
+        }
 
     try:
         if interval == "D":

--- a/agent/tests/test_shoonya_interval_map.py
+++ b/agent/tests/test_shoonya_interval_map.py
@@ -1,0 +1,73 @@
+"""Shoonya period map must not silently collapse 4h/1H/1w/1M to daily."""
+
+from __future__ import annotations
+
+from src.trading.connectors.shoonya import sdk as sh
+
+
+class _FakeApi:
+    def __init__(self) -> None:
+        self.daily_calls: list[dict] = []
+        self.time_calls: list[dict] = []
+
+    def get_daily_price_series(self, **kwargs):
+        self.daily_calls.append(kwargs)
+        return []
+
+    def get_time_price_series(self, **kwargs):
+        self.time_calls.append(kwargs)
+        return []
+
+
+def _cfg() -> sh.ShoonyaConfig:
+    return sh.ShoonyaConfig(
+        user_id="u", password="p", vendor_code="v", api_secret="s", totp_secret="t",
+    )
+
+
+def test_interval_map_covers_documented_hour_tokens() -> None:
+    assert sh._INTERVAL_MAP["1H"] == "60"
+    assert sh._INTERVAL_MAP["4h"] == "240"
+    assert sh._INTERVAL_MAP["4H"] == "240"
+    assert sh._INTERVAL_MAP["1h"] == "60"
+    assert sh._INTERVAL_MAP["1d"] == "D"
+    assert "1w" not in sh._INTERVAL_MAP
+    assert "1M" not in sh._INTERVAL_MAP
+
+
+def test_history_4h_uses_minute_series_not_daily(monkeypatch) -> None:
+    fake = _FakeApi()
+    monkeypatch.setattr(sh, "_login", lambda cfg: fake)
+    out = sh.get_historical_bars("RELIANCE", config=_cfg(), period="4h", limit=10)
+    assert out["status"] == "ok"
+    assert fake.daily_calls == []
+    assert fake.time_calls[-1]["interval"] == "240"
+
+
+def test_history_1H_maps_to_60_not_daily(monkeypatch) -> None:
+    fake = _FakeApi()
+    monkeypatch.setattr(sh, "_login", lambda cfg: fake)
+    out = sh.get_historical_bars("RELIANCE", config=_cfg(), period="1H", limit=10)
+    assert out["status"] == "ok"
+    assert fake.daily_calls == []
+    assert fake.time_calls[-1]["interval"] == "60"
+
+
+def test_history_1w_rejected_not_silent_daily(monkeypatch) -> None:
+    fake = _FakeApi()
+    monkeypatch.setattr(sh, "_login", lambda cfg: fake)
+    out = sh.get_historical_bars("RELIANCE", config=_cfg(), period="1w", limit=10)
+    assert out["status"] == "error"
+    assert "unsupported period" in out["error"]
+    assert fake.daily_calls == []
+    assert fake.time_calls == []
+
+
+def test_history_1M_rejected_not_silent_daily(monkeypatch) -> None:
+    fake = _FakeApi()
+    monkeypatch.setattr(sh, "_login", lambda cfg: fake)
+    out = sh.get_historical_bars("RELIANCE", config=_cfg(), period="1M", limit=10)
+    assert out["status"] == "error"
+    assert "unsupported period" in out["error"]
+    assert fake.daily_calls == []
+    assert fake.time_calls == []


### PR DESCRIPTION
Documented periods such as `4h`/`1H`/`1w`/`1M` fell through to daily (`D`) on Shoonya history.

Map those tokens to the SDK periods and reject unknown intervals instead of silent daily.