### PR TITLE
fix(longbridge): accept project-style 1H/4H period tokens

### DIFF
--- a/agent/src/trading/connectors/longbridge/sdk.py
+++ b/agent/src/trading/connectors/longbridge/sdk.py
@@ -677,23 +677,31 @@ def _quote_context(cfg: LongbridgeConfig):
     return getattr(openapi, "QuoteContext")(_build_config(cfg))
 
 
+#: Canonical period token → Longbridge ``Period`` attribute name.
+#: ``1H``/``4H``/``1D``/``1W`` alias lowercase; ``1m`` vs ``1M`` stays case-sensitive.
+_PERIOD_MAP = {
+    "1m": "Min_1",
+    "5m": "Min_5",
+    "15m": "Min_15",
+    "30m": "Min_30",
+    "1h": "Min_60",
+    "1H": "Min_60",
+    "4h": "Min_60",
+    "4H": "Min_60",
+    "1d": "Day",
+    "1D": "Day",
+    "1w": "Week",
+    "1W": "Week",
+    "1M": "Month",
+}
+
+
 def _candlestick_enums(period: str):
     """Map a period string to the SDK ``Period`` and ``AdjustType`` enums."""
     openapi = _require_openapi()
     period_cls = getattr(openapi, "Period")
     adjust_cls = getattr(openapi, "AdjustType")
-    period_map = {
-        "1m": "Min_1",
-        "5m": "Min_5",
-        "15m": "Min_15",
-        "30m": "Min_30",
-        "1h": "Min_60",
-        "4h": "Min_60",
-        "1d": "Day",
-        "1w": "Week",
-        "1M": "Month",
-    }
-    attr = period_map.get(period.strip(), "Day")
+    attr = _PERIOD_MAP.get(period.strip(), "Day")
     period_enum = getattr(period_cls, attr, getattr(period_cls, "Day"))
     adjust_enum = getattr(adjust_cls, "NoAdjust", getattr(adjust_cls, "ForwardAdjust", None))
     return period_enum, adjust_enum

--- a/agent/tests/test_longbridge_period_hour_case.py
+++ b/agent/tests/test_longbridge_period_hour_case.py
@@ -1,0 +1,31 @@
+"""Longbridge connector period map must treat 1H/4H like the loader."""
+
+from __future__ import annotations
+
+from src.trading.connectors.longbridge import sdk as lb
+
+
+def test_period_map_accepts_project_hour_tokens() -> None:
+    assert lb._PERIOD_MAP["1H"] == "Min_60"
+    assert lb._PERIOD_MAP["4H"] == "Min_60"
+    assert lb._PERIOD_MAP["1h"] == "Min_60"
+    assert lb._PERIOD_MAP["4h"] == "Min_60"
+    assert lb._PERIOD_MAP["1m"] == "Min_1"
+    assert lb._PERIOD_MAP["1M"] == "Month"
+
+
+def test_candlestick_enums_1H_not_day(monkeypatch) -> None:
+    class _Period:
+        Min_60 = "Min_60"
+        Day = "Day"
+
+    class _Adjust:
+        NoAdjust = "NoAdjust"
+
+    class _OpenApi:
+        Period = _Period
+        AdjustType = _Adjust
+
+    monkeypatch.setattr(lb, "_require_openapi", lambda: _OpenApi)
+    period_enum, _ = lb._candlestick_enums("1H")
+    assert period_enum == "Min_60"


### PR DESCRIPTION
The Longbridge connector mapped only lowercase `1h`, so project-style `1H` became Day while the loader already accepts `1H`.

Accept `1H`/`4H` in the connector period map.