### PR TITLE
fix(loaders): accept lowercase 1h/4h/1d MT5 intervals

### DIFF
--- a/agent/backtest/loaders/mt5_loader.py
+++ b/agent/backtest/loaders/mt5_loader.py
@@ -38,10 +38,13 @@ logger = logging.getLogger(__name__)
 _MT5_CONFIG_PATH = Path.home() / ".vibe-trading" / "mt5.json"
 
 #: Canonical interval token → MetaTrader5 timeframe constant name.
+#: Lowercase ``1h``/``4h``/``1d`` alias the project-style tokens (connector parity).
 _INTERVAL_MAP = {
     "1m": "TIMEFRAME_M1", "5m": "TIMEFRAME_M5", "15m": "TIMEFRAME_M15",
-    "30m": "TIMEFRAME_M30", "1H": "TIMEFRAME_H1", "4H": "TIMEFRAME_H4",
-    "1D": "TIMEFRAME_D1",
+    "30m": "TIMEFRAME_M30",
+    "1H": "TIMEFRAME_H1", "1h": "TIMEFRAME_H1",
+    "4H": "TIMEFRAME_H4", "4h": "TIMEFRAME_H4",
+    "1D": "TIMEFRAME_D1", "1d": "TIMEFRAME_D1",
 }
 
 #: Process-lifetime attach cache: ``initialize`` can take seconds (it may even

--- a/agent/tests/test_mt5_interval_lowercase.py
+++ b/agent/tests/test_mt5_interval_lowercase.py
@@ -1,0 +1,14 @@
+"""MT5 loader must accept trading-convention lowercase 1h/4h/1d intervals."""
+
+from __future__ import annotations
+
+from backtest.loaders.mt5_loader import _INTERVAL_MAP
+
+
+def test_lowercase_hour_day_aliases_match_project_tokens() -> None:
+    assert _INTERVAL_MAP["1h"] == "TIMEFRAME_H1"
+    assert _INTERVAL_MAP["1H"] == "TIMEFRAME_H1"
+    assert _INTERVAL_MAP["4h"] == "TIMEFRAME_H4"
+    assert _INTERVAL_MAP["4H"] == "TIMEFRAME_H4"
+    assert _INTERVAL_MAP["1d"] == "TIMEFRAME_D1"
+    assert _INTERVAL_MAP["1D"] == "TIMEFRAME_D1"

--- a/agent/tests/test_mt5_loader.py
+++ b/agent/tests/test_mt5_loader.py
@@ -157,6 +157,11 @@ class TestIntervalsAndFrames:
         loader.fetch(["EUR/USD"], "2026-06-01", "2026-06-10", interval="1H")
         assert fake_mod.rates_calls[-1][1] == _FakeMT5Module.TIMEFRAME_H1
 
+    def test_lowercase_1h_maps_to_h1_not_daily(self, fake_mod: _FakeMT5Module) -> None:
+        loader = DataLoader()
+        loader.fetch(["EUR/USD"], "2026-06-01", "2026-06-10", interval="1h")
+        assert fake_mod.rates_calls[-1][1] == _FakeMT5Module.TIMEFRAME_H1
+
     def test_unknown_interval_defaults_to_daily(self, fake_mod: _FakeMT5Module) -> None:
         loader = DataLoader()
         loader.fetch(["EUR/USD"], "2026-06-01", "2026-06-10", interval="7z")


### PR DESCRIPTION
Lowercase `1h`/`4h`/`1d` were missing from the MT5 loader map and forced daily bars, while the connector uses lowercase.

Add the lowercase aliases to the loader map.