### PR TITLE
fix(journal): treat numpy int serials as Excel days in Futu Date

### DIFF
--- a/agent/src/tools/trade_journal_parsers.py
+++ b/agent/src/tools/trade_journal_parsers.py
@@ -284,6 +284,22 @@ def _futu_market(symbol: str, market_hint: str) -> str:
     return "other"
 
 
+def _futu_datetime(date_val: Any, time_val: Any) -> str:
+    """Combine Futu Date+Time cells; Excel serial floats become ISO datetime."""
+    if isinstance(date_val, (int, float)) and not isinstance(date_val, bool) and pd.notna(date_val):
+        serial = float(date_val)
+        if isinstance(time_val, (int, float)) and not isinstance(time_val, bool) and pd.notna(time_val):
+            frac = float(time_val)
+            if 0.0 <= frac < 1.0:
+                serial += frac
+        ts = pd.to_datetime(serial, unit="D", origin="1899-12-30", errors="coerce")
+        if pd.notna(ts):
+            return ts.strftime("%Y-%m-%d %H:%M:%S")
+    date = "" if date_val is None or (isinstance(date_val, float) and pd.isna(date_val)) else str(date_val).strip()
+    time = "" if time_val is None or (isinstance(time_val, float) and pd.isna(time_val)) else str(time_val).strip()
+    return f"{date} {time}".strip()
+
+
 def parse_futu(df: pd.DataFrame) -> list[TradeRecord]:
     """Parse 富途 exports (English headers, HK+US mix).
 
@@ -295,9 +311,7 @@ def parse_futu(df: pd.DataFrame) -> list[TradeRecord]:
         raw_symbol = row.get("Symbol", "")
         if _is_empty_code(raw_symbol):
             continue
-        date = str(row.get("Date", "")).strip()
-        time = str(row.get("Time", "")).strip()
-        dt = f"{date} {time}".strip()
+        dt = _futu_datetime(row.get("Date", ""), row.get("Time", ""))
         symbol = str(raw_symbol).strip().upper()
         qty = _to_float(row.get("Quantity"))
         price = _to_float(row.get("Price"))

--- a/agent/src/tools/trade_journal_parsers.py
+++ b/agent/src/tools/trade_journal_parsers.py
@@ -286,15 +286,26 @@ def _futu_market(symbol: str, market_hint: str) -> str:
 
 def _futu_datetime(date_val: Any, time_val: Any) -> str:
     """Combine Futu Date+Time cells; Excel serial floats become ISO datetime."""
-    if isinstance(date_val, (int, float)) and not isinstance(date_val, bool) and pd.notna(date_val):
-        serial = float(date_val)
-        if isinstance(time_val, (int, float)) and not isinstance(time_val, bool) and pd.notna(time_val):
-            frac = float(time_val)
-            if 0.0 <= frac < 1.0:
-                serial += frac
-        ts = pd.to_datetime(serial, unit="D", origin="1899-12-30", errors="coerce")
-        if pd.notna(ts):
-            return ts.strftime("%Y-%m-%d %H:%M:%S")
+    # iterrows yields numpy integer/float scalars; bare pd.to_datetime(int) is ns-epoch.
+    if pd.api.types.is_number(date_val) and not isinstance(date_val, (bool,)):
+        if not (isinstance(date_val, float) and pd.isna(date_val)):
+            serial = float(date_val)
+            frac = 0.0
+            time_is_frac = False
+            if pd.api.types.is_number(time_val) and not isinstance(time_val, (bool,)):
+                if not (isinstance(time_val, float) and pd.isna(time_val)):
+                    candidate = float(time_val)
+                    if 0.0 <= candidate < 1.0:
+                        frac = candidate
+                        time_is_frac = True
+            ts = pd.to_datetime(serial + frac, unit="D", origin="1899-12-30", errors="coerce")
+            if pd.notna(ts):
+                if time_is_frac or time_val is None or (
+                    isinstance(time_val, float) and pd.isna(time_val)
+                ):
+                    return ts.strftime("%Y-%m-%d %H:%M:%S")
+                # Numeric Excel date + string/clock Time column.
+                return f"{ts.strftime('%Y-%m-%d')} {str(time_val).strip()}".strip()
     date = "" if date_val is None or (isinstance(date_val, float) and pd.isna(date_val)) else str(date_val).strip()
     time = "" if time_val is None or (isinstance(time_val, float) and pd.isna(time_val)) else str(time_val).strip()
     return f"{date} {time}".strip()

--- a/agent/tests/test_futu_excel_serial_dates.py
+++ b/agent/tests/test_futu_excel_serial_dates.py
@@ -1,0 +1,44 @@
+"""Futu Date/Time Excel serial floats must normalize to ISO datetime."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from src.tools.trade_journal_parsers import parse_futu
+
+
+def test_parse_futu_excel_serial_date_and_time() -> None:
+    # Excel serial 45321.0 + 0.375 day = 2024-01-30 09:00:00
+    df = pd.DataFrame([{
+        "Date": 45321.0,
+        "Time": 0.375,
+        "Symbol": "AAPL",
+        "Name": "Apple",
+        "Side": "Buy",
+        "Quantity": 10,
+        "Price": 100,
+        "Amount": 1000,
+        "Commission": 1,
+        "Platform Fee": 0,
+    }])
+    rec = parse_futu(df)
+    assert len(rec) == 1
+    assert rec[0].datetime == "2024-01-30 09:00:00"
+
+
+def test_parse_futu_string_date_time_still_ok() -> None:
+    df = pd.DataFrame([{
+        "Date": "2024-02-04",
+        "Time": "09:00:00",
+        "Symbol": "AAPL",
+        "Name": "Apple",
+        "Side": "Buy",
+        "Quantity": 10,
+        "Price": 100,
+        "Amount": 1000,
+        "Commission": 1,
+        "Platform Fee": 0,
+    }])
+    rec = parse_futu(df)
+    assert len(rec) == 1
+    assert rec[0].datetime == "2024-02-04 09:00:00"

--- a/agent/tests/test_futu_excel_serial_dates.py
+++ b/agent/tests/test_futu_excel_serial_dates.py
@@ -26,6 +26,25 @@ def test_parse_futu_excel_serial_date_and_time() -> None:
     assert rec[0].datetime == "2024-01-30 09:00:00"
 
 
+def test_parse_futu_excel_serial_int64_date() -> None:
+    """iterrows yields np.int64 for int64 columns; must not treat as ns-epoch."""
+    df = pd.DataFrame({
+        "Date": pd.Series([45321], dtype="int64"),
+        "Time": ["09:00:00"],
+        "Symbol": ["AAPL"],
+        "Name": ["Apple"],
+        "Side": ["Buy"],
+        "Quantity": [10],
+        "Price": [100],
+        "Amount": [1000],
+        "Commission": [1],
+        "Platform Fee": [0],
+    })
+    rec = parse_futu(df)
+    assert len(rec) == 1
+    assert rec[0].datetime == "2024-01-30 09:00:00"
+
+
 def test_parse_futu_string_date_time_still_ok() -> None:
     df = pd.DataFrame([{
         "Date": "2024-02-04",


### PR DESCRIPTION
Futu Excel exports can store Date/Time as serial numbers; stringifying them produced `45321.0 0.375` instead of a real datetime.

Convert Excel serial day/fraction values before formatting.