### PR TITLE
fix(journal): treat numpy int serials as Excel days in Tonghuashun

### DIFF
--- a/agent/src/tools/trade_journal_parsers.py
+++ b/agent/src/tools/trade_journal_parsers.py
@@ -223,7 +223,7 @@ def parse_tonghuashun(df: pd.DataFrame) -> list[TradeRecord]:
         amount = _to_float(row.get("成交金额")) or qty * price
         fee = _to_float(row.get("手续费")) + _to_float(row.get("印花税")) + _to_float(row.get("过户费"))
         records.append(TradeRecord(
-            datetime=str(row.get("成交时间", "")).strip(),
+            datetime=_ths_datetime(row.get("成交时间", "")),
             symbol=_qualify_a_share(raw_code),
             name=str(row.get("证券名称", "")).strip(),
             side=_normalize_side(row.get("操作")),
@@ -234,6 +234,20 @@ def parse_tonghuashun(df: pd.DataFrame) -> list[TradeRecord]:
             market="china_a",
         ))
     return records
+
+
+def _ths_datetime(val: Any) -> str:
+    """Normalize 成交时间; Excel serial floats become ISO datetime."""
+    if val is None or (isinstance(val, float) and pd.isna(val)):
+        return ""
+    if isinstance(val, (int, float)) and not isinstance(val, bool):
+        ts = pd.to_datetime(float(val), unit="D", origin="1899-12-30", errors="coerce")
+        if pd.notna(ts):
+            return ts.strftime("%Y-%m-%d %H:%M:%S")
+    ts = pd.to_datetime(val, errors="coerce")
+    if pd.notna(ts):
+        return ts.strftime("%Y-%m-%d %H:%M:%S")
+    return str(val).strip()
 
 
 def parse_eastmoney(df: pd.DataFrame) -> list[TradeRecord]:

--- a/agent/src/tools/trade_journal_parsers.py
+++ b/agent/src/tools/trade_journal_parsers.py
@@ -240,7 +240,8 @@ def _ths_datetime(val: Any) -> str:
     """Normalize 成交时间; Excel serial floats become ISO datetime."""
     if val is None or (isinstance(val, float) and pd.isna(val)):
         return ""
-    if isinstance(val, (int, float)) and not isinstance(val, bool):
+    # iterrows yields numpy integer/float scalars; bare pd.to_datetime(int) is ns-epoch.
+    if pd.api.types.is_number(val) and not isinstance(val, (bool,)):
         ts = pd.to_datetime(float(val), unit="D", origin="1899-12-30", errors="coerce")
         if pd.notna(ts):
             return ts.strftime("%Y-%m-%d %H:%M:%S")

--- a/agent/tests/test_ths_excel_serial_dates.py
+++ b/agent/tests/test_ths_excel_serial_dates.py
@@ -26,6 +26,25 @@ def test_parse_tonghuashun_excel_serial_datetime() -> None:
     assert rec[0].datetime == "2024-01-30 09:00:00"
 
 
+def test_parse_tonghuashun_excel_serial_int64_datetime() -> None:
+    """iterrows yields np.int64 for int64 columns; must not treat as ns-epoch."""
+    df = pd.DataFrame({
+        "成交时间": pd.Series([45321], dtype="int64"),
+        "证券代码": ["600519"],
+        "证券名称": ["茅台"],
+        "操作": ["买入"],
+        "成交数量": ["100"],
+        "成交价格": ["100"],
+        "成交金额": ["10000"],
+        "手续费": ["1"],
+        "印花税": ["0"],
+        "过户费": ["0"],
+    })
+    rec = parse_tonghuashun(df)
+    assert len(rec) == 1
+    assert rec[0].datetime == "2024-01-30 00:00:00"
+
+
 def test_parse_tonghuashun_string_datetime_still_ok() -> None:
     df = pd.DataFrame([{
         "成交时间": "2024-01-01 10:00:00",

--- a/agent/tests/test_ths_excel_serial_dates.py
+++ b/agent/tests/test_ths_excel_serial_dates.py
@@ -1,0 +1,44 @@
+"""Tonghuashun 成交时间 Excel serial floats must normalize to ISO datetime."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from src.tools.trade_journal_parsers import parse_tonghuashun
+
+
+def test_parse_tonghuashun_excel_serial_datetime() -> None:
+    # Excel serial 45321.375 = 2024-01-30 09:00:00
+    df = pd.DataFrame([{
+        "成交时间": 45321.375,
+        "证券代码": "600519",
+        "证券名称": "茅台",
+        "操作": "买入",
+        "成交数量": "100",
+        "成交价格": "100",
+        "成交金额": "10000",
+        "手续费": "1",
+        "印花税": "0",
+        "过户费": "0",
+    }])
+    rec = parse_tonghuashun(df)
+    assert len(rec) == 1
+    assert rec[0].datetime == "2024-01-30 09:00:00"
+
+
+def test_parse_tonghuashun_string_datetime_still_ok() -> None:
+    df = pd.DataFrame([{
+        "成交时间": "2024-01-01 10:00:00",
+        "证券代码": "600519",
+        "证券名称": "茅台",
+        "操作": "买入",
+        "成交数量": "100",
+        "成交价格": "100",
+        "成交金额": "10000",
+        "手续费": "1",
+        "印花税": "0",
+        "过户费": "0",
+    }])
+    rec = parse_tonghuashun(df)
+    assert len(rec) == 1
+    assert rec[0].datetime == "2024-01-01 10:00:00"


### PR DESCRIPTION
Tonghuashun Excel `成交时间` serials stringified as `45321.5` instead of a datetime.

Convert Excel serial values before formatting.