### PR TITLE
fix(channels): keep empty edge columns in Signal md tables

### DIFF
--- a/agent/src/channels/signal.py
+++ b/agent/src/channels/signal.py
@@ -72,6 +72,20 @@ def _sig_strip_cell(s: str) -> str:
     return s.strip()
 
 
+def _sig_split_row(line: str) -> list[str]:
+    """Split a markdown table row, keeping empty leading/trailing cells.
+
+    ``str.strip("|")`` would also drop empty edge cells (``||Name|`` → ``Name``,
+    ``|a|b||`` → ``a|b``), so only peel the row's bounding pipes.
+    """
+    parts = line.strip().split("|")
+    if parts and parts[0] == "":
+        parts = parts[1:]
+    if parts and parts[-1] == "":
+        parts = parts[:-1]
+    return [_sig_strip_cell(c) for c in parts]
+
+
 def _sig_render_table(table_lines: list[str]) -> str:
     """Render a markdown pipe-table as fixed-width plain text."""
 
@@ -81,7 +95,7 @@ def _sig_render_table(table_lines: list[str]) -> str:
     rows: list[list[str]] = []
     has_sep = False
     for line in table_lines:
-        cells = [_sig_strip_cell(c) for c in line.strip().strip("|").split("|")]
+        cells = _sig_split_row(line)
         if all(re.match(r"^:?-+:?$", c) for c in cells if c):
             has_sep = True
             continue

--- a/agent/tests/test_signal_table_edge_columns.py
+++ b/agent/tests/test_signal_table_edge_columns.py
@@ -1,0 +1,34 @@
+"""Signal markdown tables must keep empty leading/trailing columns."""
+
+from __future__ import annotations
+
+from src.channels.signal import _sig_render_table
+
+
+def test_sig_render_table_keeps_trailing_empty_column() -> None:
+    box = _sig_render_table(
+        [
+            "|Name|Qty||",
+            "|---|---|---|",
+            "|a|1||",
+            "|b|2||",
+        ]
+    )
+    rule = box.split("\n")[1]
+    assert rule.count("  ") == 2
+
+
+def test_sig_render_table_keeps_leading_empty_header_with_row_labels() -> None:
+    box = _sig_render_table(
+        [
+            "||Name|Qty|",
+            "|---|---|---|",
+            "|row1|a|1|",
+            "|row2|b|2|",
+        ]
+    )
+    header, _rule, data_row = box.split("\n")[:3]
+    assert data_row.startswith("row1")
+    # Empty leading header must keep Name aligned over the second data cell.
+    assert header.index("Name") == data_row.index("a")
+    assert "1" in data_row


### PR DESCRIPTION
Markdown tables with empty leading or trailing cells lost those columns in Signal output, shifting later fields.

Keep empty edge cells when splitting rows so column alignment matches the source table.