### PR TITLE
fix(channels): keep empty edge columns in Slack md tables

### DIFF
--- a/agent/src/channels/slack.py
+++ b/agent/src/channels/slack.py
@@ -723,16 +723,30 @@ class SlackChannel(BaseChannel):
         return text
 
     @staticmethod
-    def _convert_table(match: re.Match) -> str:
+    def _split_md_row(line: str) -> list[str]:
+        """Split a markdown table row, keeping empty leading/trailing cells.
+
+        ``str.strip("|")`` would also drop empty edge cells (``||Name|`` → ``Name``,
+        ``|a|b||`` → ``a|b``), so only peel the row's bounding pipes.
+        """
+        parts = line.strip().split("|")
+        if parts and parts[0] == "":
+            parts = parts[1:]
+        if parts and parts[-1] == "":
+            parts = parts[:-1]
+        return [c.strip() for c in parts]
+
+    @classmethod
+    def _convert_table(cls, match: re.Match) -> str:
         """Convert a Markdown table to a Slack-readable list."""
         lines = [ln.strip() for ln in match.group(0).strip().splitlines() if ln.strip()]
         if len(lines) < 2:
             return match.group(0)
-        headers = [h.strip() for h in lines[0].strip("|").split("|")]
+        headers = cls._split_md_row(lines[0])
         start = 2 if re.fullmatch(r"[|\s:\-]+", lines[1]) else 1
         rows: list[str] = []
         for line in lines[start:]:
-            cells = [c.strip() for c in line.strip("|").split("|")]
+            cells = cls._split_md_row(line)
             cells = (cells + [""] * len(headers))[: len(headers)]
             parts = [f"**{headers[i]}**: {cells[i]}" for i in range(len(headers)) if cells[i]]
             if parts:

--- a/agent/tests/test_slack_table_edge_columns.py
+++ b/agent/tests/test_slack_table_edge_columns.py
@@ -1,0 +1,68 @@
+"""Slack markdown tables must keep empty leading/trailing columns."""
+
+from __future__ import annotations
+
+import re
+import sys
+import types
+
+
+def _stub_slack_deps() -> None:
+    """Install minimal stubs so slack.py imports without slack_sdk/slackify."""
+
+    def _mod(name: str) -> types.ModuleType:
+        mod = types.ModuleType(name)
+        sys.modules[name] = mod
+        return mod
+
+    for name in (
+        "slack_sdk",
+        "slack_sdk.socket_mode",
+        "slack_sdk.socket_mode.request",
+        "slack_sdk.socket_mode.response",
+        "slack_sdk.socket_mode.websockets",
+        "slack_sdk.web",
+        "slack_sdk.web.async_client",
+    ):
+        _mod(name)
+
+    sys.modules["slack_sdk.socket_mode.request"].SocketModeRequest = object
+    sys.modules["slack_sdk.socket_mode.response"].SocketModeResponse = object
+    sys.modules["slack_sdk.socket_mode.websockets"].SocketModeClient = object
+    sys.modules["slack_sdk.web.async_client"].AsyncWebClient = object
+
+    sm = _mod("slackify_markdown")
+    sm.slackify_markdown = lambda text: text
+
+
+_stub_slack_deps()
+
+from src.channels.slack import SlackChannel  # noqa: E402
+
+
+def test_split_md_row_keeps_empty_edge_cells() -> None:
+    assert SlackChannel._split_md_row("|Name|Qty||") == ["Name", "Qty", ""]
+    assert SlackChannel._split_md_row("||Name|Qty|") == ["", "Name", "Qty"]
+    assert SlackChannel._split_md_row("|a|1|note|") == ["a", "1", "note"]
+
+
+def test_convert_table_keeps_leading_empty_header_row_labels() -> None:
+    md = "||Name|Qty|\n|---|---|---|\n|row1|a|1|\n|row2|b|2|\n"
+    match = SlackChannel._TABLE_RE.search(md)
+    assert match is not None
+    out = SlackChannel._convert_table(match)
+    assert out == (
+        "****: row1 · **Name**: a · **Qty**: 1\n"
+        "****: row2 · **Name**: b · **Qty**: 2"
+    )
+
+
+def test_convert_table_keeps_trailing_empty_header_slot() -> None:
+    md = "|Name|Qty||\n|---|---|---|\n|a|1|note|\n|b|2|other|\n"
+    match = SlackChannel._TABLE_RE.search(md)
+    assert match is not None
+    out = SlackChannel._convert_table(match)
+    assert out == (
+        "**Name**: a · **Qty**: 1 · ****: note\n"
+        "**Name**: b · **Qty**: 2 · ****: other"
+    )


### PR DESCRIPTION
Markdown tables with empty leading or trailing cells lost those columns in Slack output, shifting later fields.

Keep empty edge cells when splitting rows so column alignment matches the source table.