### PR TITLE
fix(connectors): reject unsupported Dhan history periods

### DIFF
--- a/agent/src/trading/connectors/dhan/sdk.py
+++ b/agent/src/trading/connectors/dhan/sdk.py
@@ -343,6 +343,10 @@ def get_quote(
     }
 
 
+#: Periods Dhan can serve without silently remapping to a different bar size.
+_SUPPORTED_PERIODS = frozenset({"1m", "5m", "15m", "30m", "1d", "1D"})
+
+
 def get_historical_bars(
     symbol: str,
     *,
@@ -356,26 +360,38 @@ def get_historical_bars(
     """Fetch historical OHLCV bars.
 
     ``period`` tokens: ``1m``, ``5m``, ``15m``, ``30m`` → intraday candles.
-    ``1d`` → daily candles. Dhan's intraday data is limited to last 5 trading
-    days; daily goes back much further.
+    ``1d`` / ``1D`` → daily candles. Dhan's intraday data is limited to last 5
+    trading days; daily goes back much further. Unsupported periods (including
+    ``1H`` / ``4H``) fail closed instead of silently substituting daily bars.
     """
     cfg = config or load_config()
     client = _dhan_client(cfg)
 
     sec_id = str(security_id or symbol).strip()
     segment = exchange_segment.strip().upper()
+    token = period.strip()
+    if token not in _SUPPORTED_PERIODS:
+        return {
+            "status": "error",
+            "error": (
+                f"unsupported period: {period!r}; "
+                f"supported: {sorted(_SUPPORTED_PERIODS)}"
+            ),
+            "symbol": symbol,
+        }
+    intraday = token in ("1m", "5m", "15m", "30m")
 
     from datetime import datetime, timedelta, timezone
 
     to_date = datetime.now(timezone.utc)
     # Intraday: max 5 days back; daily: use limit
-    if period in ("1m", "5m", "15m", "30m"):
+    if intraday:
         from_date = to_date - timedelta(days=5)
     else:
         from_date = to_date - timedelta(days=min(limit * 2, 365))
 
     try:
-        if period in ("1m", "5m", "15m", "30m"):
+        if intraday:
             data = client.intraday_daily_candle_data(
                 security_id=sec_id,
                 exchange_segment=segment,

--- a/agent/tests/test_dhan_period_reject.py
+++ b/agent/tests/test_dhan_period_reject.py
@@ -1,0 +1,42 @@
+"""Dhan history must reject unsupported periods instead of serving daily bars."""
+
+from __future__ import annotations
+
+from src.trading.connectors.dhan import sdk as dhan_sdk
+
+
+class _FakeDhanClient:
+    def __init__(self) -> None:
+        self.daily_calls = 0
+        self.intraday_calls = 0
+
+    def historical_daily_candle_data(self, **kwargs):
+        self.daily_calls += 1
+        return {"data": {"candles": []}}
+
+    def intraday_daily_candle_data(self, **kwargs):
+        self.intraday_calls += 1
+        return {"data": {"candles": []}}
+
+
+def test_dhan_rejects_hour_period_instead_of_daily(monkeypatch) -> None:
+    fake = _FakeDhanClient()
+    monkeypatch.setattr(dhan_sdk, "_dhan_client", lambda cfg: fake)
+    cfg = dhan_sdk.DhanConfig(client_id="x", access_token="y", profile="paper")
+    out = dhan_sdk.get_historical_bars("RELIANCE", config=cfg, period="1H", limit=24)
+    assert out["status"] == "error"
+    assert "unsupported period" in out["error"]
+    assert fake.daily_calls == 0
+    assert fake.intraday_calls == 0
+
+
+def test_dhan_keeps_supported_daily_and_intraday(monkeypatch) -> None:
+    fake = _FakeDhanClient()
+    monkeypatch.setattr(dhan_sdk, "_dhan_client", lambda cfg: fake)
+    cfg = dhan_sdk.DhanConfig(client_id="x", access_token="y", profile="paper")
+    daily = dhan_sdk.get_historical_bars("RELIANCE", config=cfg, period="1D", limit=10)
+    assert daily["status"] == "ok"
+    assert fake.daily_calls == 1
+    minute = dhan_sdk.get_historical_bars("RELIANCE", config=cfg, period="5m", limit=10)
+    assert minute["status"] == "ok"
+    assert fake.intraday_calls == 1


### PR DESCRIPTION
Unsupported Dhan history periods silently became daily bars.

Reject them with a clear error, matching Shoonya.