### PR TITLE
fix(loaders): keep lowercase 1h/4h/1w as ccxt hour/week bars

### DIFF
--- a/agent/backtest/loaders/ccxt_loader.py
+++ b/agent/backtest/loaders/ccxt_loader.py
@@ -31,7 +31,8 @@ logger = logging.getLogger(__name__)
 
 _INTERVAL_MAP = {
     "1m": "1m", "5m": "5m", "15m": "15m", "30m": "30m",
-    "1H": "1h", "4H": "4h", "1D": "1d", "1W": "1w", "1M": "1M",
+    "1H": "1h", "1h": "1h", "4H": "4h", "4h": "4h",
+    "1D": "1d", "1d": "1d", "1W": "1w", "1w": "1w", "1M": "1M",
 }
 
 _TIMEFRAME_DELTA = {

--- a/agent/tests/test_ccxt_interval_map.py
+++ b/agent/tests/test_ccxt_interval_map.py
@@ -10,3 +10,12 @@ def test_ccxt_interval_map_keeps_week_and_month() -> None:
     assert _INTERVAL_MAP["1M"] == "1M"
     assert _INTERVAL_MAP["1D"] == "1d"
     assert _INTERVAL_MAP["1m"] == "1m"
+
+
+def test_ccxt_interval_map_keeps_lowercase_hour_and_week() -> None:
+    # Lowercase project-style tokens must not fall through to silent daily.
+    assert _INTERVAL_MAP["1h"] == "1h"
+    assert _INTERVAL_MAP["4h"] == "4h"
+    assert _INTERVAL_MAP["1w"] == "1w"
+    assert _INTERVAL_MAP["1H"] == "1h"
+    assert _INTERVAL_MAP["4H"] == "4h"

--- a/agent/tests/test_ccxt_interval_map.py
+++ b/agent/tests/test_ccxt_interval_map.py
@@ -13,7 +13,6 @@ def test_ccxt_interval_map_keeps_week_and_month() -> None:
 
 
 def test_ccxt_interval_map_keeps_lowercase_hour_and_week() -> None:
-    # Lowercase project-style tokens must not fall through to silent daily.
     assert _INTERVAL_MAP["1h"] == "1h"
     assert _INTERVAL_MAP["4h"] == "4h"
     assert _INTERVAL_MAP["1w"] == "1w"


### PR DESCRIPTION
Fleet-style lowercase `1h`/`4h`/`1w` fell through to daily on the ccxt loader.

Alias them to the hour/week bars (same class as the MT5 loader aliases).