### PR TITLE
fix(connectors): map Binance 1H/4H periods to ccxt timeframes

### DIFF
--- a/agent/src/trading/connectors/binance/sdk.py
+++ b/agent/src/trading/connectors/binance/sdk.py
@@ -374,6 +374,14 @@ def get_quote(symbol: str, *, config: BinanceConfig | None = None, **_: Any) -> 
     }
 
 
+#: Project/canonical period token → ccxt unified timeframe (lowercase).
+_TIMEFRAME_MAP = {
+    "1m": "1m", "5m": "5m", "15m": "15m", "30m": "30m",
+    "1h": "1h", "1H": "1h", "4h": "4h", "4H": "4h",
+    "1d": "1d", "1D": "1d", "1w": "1w", "1W": "1w", "1M": "1M",
+}
+
+
 def get_historical_bars(
     symbol: str,
     *,
@@ -387,7 +395,8 @@ def get_historical_bars(
     _assert_host(cfg)
     ex = _exchange(cfg)
     clean = normalize_symbol(symbol)
-    bars = ex.fetch_ohlcv(clean, timeframe=period, limit=int(limit))
+    timeframe = _TIMEFRAME_MAP.get(period.strip(), "1d")
+    bars = ex.fetch_ohlcv(clean, timeframe=timeframe, limit=int(limit))
     return {
         "status": "ok",
         "symbol": clean,

--- a/agent/tests/test_binance_period_map.py
+++ b/agent/tests/test_binance_period_map.py
@@ -1,0 +1,42 @@
+"""Binance history must map project-style 1H/4H tokens to ccxt timeframes."""
+
+from __future__ import annotations
+
+from src.trading.connectors.binance import sdk as bn
+
+
+class _FakeEx:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def fetch_ohlcv(self, symbol, timeframe="1d", limit=90):
+        self.calls.append({"symbol": symbol, "timeframe": timeframe, "limit": limit})
+        return []
+
+
+def test_timeframe_map_covers_hour_tokens() -> None:
+    assert bn._TIMEFRAME_MAP["1H"] == "1h"
+    assert bn._TIMEFRAME_MAP["1h"] == "1h"
+    assert bn._TIMEFRAME_MAP["4H"] == "4h"
+    assert bn._TIMEFRAME_MAP["4h"] == "4h"
+
+
+def test_history_1H_uses_hour_timeframe(monkeypatch) -> None:
+    fake = _FakeEx()
+    cfg = bn.BinanceConfig(api_key="k", api_secret="s", profile="paper")
+    monkeypatch.setattr(bn, "_assert_host", lambda c: None)
+    monkeypatch.setattr(bn, "_exchange", lambda c: fake)
+    monkeypatch.setattr(bn, "normalize_symbol", lambda s: "BTC/USDT")
+    out = bn.get_historical_bars("BTC/USDT", config=cfg, period="1H", limit=10)
+    assert out["status"] == "ok"
+    assert fake.calls[0]["timeframe"] == "1h"
+
+
+def test_history_4H_uses_four_hour_timeframe(monkeypatch) -> None:
+    fake = _FakeEx()
+    cfg = bn.BinanceConfig(api_key="k", api_secret="s", profile="paper")
+    monkeypatch.setattr(bn, "_assert_host", lambda c: None)
+    monkeypatch.setattr(bn, "_exchange", lambda c: fake)
+    monkeypatch.setattr(bn, "normalize_symbol", lambda s: "BTC/USDT")
+    bn.get_historical_bars("BTC/USDT", config=cfg, period="4H", limit=10)
+    assert fake.calls[0]["timeframe"] == "4h"


### PR DESCRIPTION
Project-style `1H`/`4H` were passed raw to ccxt, which expects lowercase unified timeframes.

Map them before the history request.