### PR TITLE
fix(connectors): map MT5 1H/4H/1D periods to hour/day bars

### DIFF
--- a/agent/src/trading/connectors/mt5/reads.py
+++ b/agent/src/trading/connectors/mt5/reads.py
@@ -29,10 +29,15 @@ _MT5_ERRORS = (MT5DependencyError, MT5ConfigError, MT5ConnectionError, MT5Profil
 #: Canonical period token → MetaTrader5 timeframe constant name. Resolved via
 #: ``getattr`` on the module so fakes only need the integers. NOTE ``1m``
 #: (minute) and ``1M`` (month) differ by case, matching the other connectors.
+#: ``1H``/``4H``/``1D``/``1W`` alias the lowercase forms (project-style tokens).
 _TIMEFRAME_MAP = {
     "1m": "TIMEFRAME_M1", "5m": "TIMEFRAME_M5", "15m": "TIMEFRAME_M15",
-    "30m": "TIMEFRAME_M30", "1h": "TIMEFRAME_H1", "4h": "TIMEFRAME_H4",
-    "1d": "TIMEFRAME_D1", "1w": "TIMEFRAME_W1", "1M": "TIMEFRAME_MN1",
+    "30m": "TIMEFRAME_M30",
+    "1h": "TIMEFRAME_H1", "1H": "TIMEFRAME_H1",
+    "4h": "TIMEFRAME_H4", "4H": "TIMEFRAME_H4",
+    "1d": "TIMEFRAME_D1", "1D": "TIMEFRAME_D1",
+    "1w": "TIMEFRAME_W1", "1W": "TIMEFRAME_W1",
+    "1M": "TIMEFRAME_MN1",
 }
 
 

--- a/agent/tests/test_mt5_connector_project_period_aliases.py
+++ b/agent/tests/test_mt5_connector_project_period_aliases.py
@@ -1,0 +1,23 @@
+"""MT5 connector must map project-style 1H/4H/1D periods to hour/day bars."""
+
+from __future__ import annotations
+
+from src.trading.connectors.mt5.reads import _TIMEFRAME_MAP
+
+
+def test_timeframe_map_accepts_project_hour_day_tokens() -> None:
+    assert _TIMEFRAME_MAP["1H"] == "TIMEFRAME_H1"
+    assert _TIMEFRAME_MAP["1h"] == "TIMEFRAME_H1"
+    assert _TIMEFRAME_MAP["4H"] == "TIMEFRAME_H4"
+    assert _TIMEFRAME_MAP["4h"] == "TIMEFRAME_H4"
+    assert _TIMEFRAME_MAP["1D"] == "TIMEFRAME_D1"
+    assert _TIMEFRAME_MAP["1d"] == "TIMEFRAME_D1"
+    assert _TIMEFRAME_MAP["1W"] == "TIMEFRAME_W1"
+    assert _TIMEFRAME_MAP["1w"] == "TIMEFRAME_W1"
+    assert _TIMEFRAME_MAP["1m"] == "TIMEFRAME_M1"
+    assert _TIMEFRAME_MAP["1M"] == "TIMEFRAME_MN1"
+
+
+def test_project_1H_does_not_fall_back_to_daily() -> None:
+    assert _TIMEFRAME_MAP.get("1H".strip(), "TIMEFRAME_D1") == "TIMEFRAME_H1"
+    assert _TIMEFRAME_MAP.get("4H".strip(), "TIMEFRAME_D1") == "TIMEFRAME_H4"


### PR DESCRIPTION
Project-style `1H`/`4H`/`1D` periods fell through to daily on the MT5 connector.

Map them to hour/day bars.