### PR TITLE
fix(journal): normalize stringified Excel serials in Tonghuashun dates

### DIFF
--- a/agent/src/tools/trade_journal_parsers.py
+++ b/agent/src/tools/trade_journal_parsers.py
@@ -245,10 +245,23 @@ def _ths_datetime(val: Any) -> str:
         ts = pd.to_datetime(float(val), unit="D", origin="1899-12-30", errors="coerce")
         if pd.notna(ts):
             return ts.strftime("%Y-%m-%d %H:%M:%S")
+    # load_dataframe uses dtype=str; Excel serials arrive as "44927" / "44927.5".
+    text = str(val).strip()
+    if text and not any(ch in text for ch in "/-:"):
+        try:
+            serial = float(text)
+        except ValueError:
+            serial = None
+        else:
+            # Civil day serials; YYYYMMDD ints are >= 19_000_001.
+            if 1.0 <= serial < 100_000.0:
+                ts = pd.to_datetime(serial, unit="D", origin="1899-12-30", errors="coerce")
+                if pd.notna(ts):
+                    return ts.strftime("%Y-%m-%d %H:%M:%S")
     ts = pd.to_datetime(val, errors="coerce")
     if pd.notna(ts):
         return ts.strftime("%Y-%m-%d %H:%M:%S")
-    return str(val).strip()
+    return text
 
 
 def parse_eastmoney(df: pd.DataFrame) -> list[TradeRecord]:

--- a/agent/tests/test_ths_stringified_excel_serial.py
+++ b/agent/tests/test_ths_stringified_excel_serial.py
@@ -1,0 +1,49 @@
+"""Tonghuashun Excel serials must survive load_dataframe dtype=str."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+
+from src.tools.trade_journal_parsers import load_dataframe, parse_file, parse_tonghuashun
+
+
+def test_parse_tonghuashun_stringified_excel_serial() -> None:
+    df = pd.DataFrame([{
+        "成交时间": "45321.375",
+        "证券代码": "600519",
+        "证券名称": "茅台",
+        "操作": "买入",
+        "成交数量": "100",
+        "成交价格": "100",
+        "成交金额": "10000",
+        "手续费": "1",
+        "印花税": "0",
+        "过户费": "0",
+    }])
+    rec = parse_tonghuashun(df)
+    assert len(rec) == 1
+    assert rec[0].datetime == "2024-01-30 09:00:00"
+
+
+def test_parse_file_xlsx_stringified_excel_serial() -> None:
+    path = Path(tempfile.mkdtemp()) / "ths.xlsx"
+    pd.DataFrame([{
+        "成交时间": 45321.375,
+        "证券代码": "600519",
+        "证券名称": "茅台",
+        "操作": "买入",
+        "成交数量": 100,
+        "成交价格": 100,
+        "成交金额": 10000,
+        "手续费": 1,
+        "印花税": 0,
+        "过户费": 0,
+    }]).to_excel(path, index=False)
+    loaded = load_dataframe(path)
+    assert isinstance(loaded["成交时间"].iloc[0], str)
+    fmt, recs = parse_file(path)
+    assert fmt == "tonghuashun"
+    assert recs[0].datetime == "2024-01-30 09:00:00"


### PR DESCRIPTION
Tonghuashun exports that stringify Excel serials (for example `45321.5`) kept the raw number instead of a datetime.

Normalize stringified serials the same way as numeric ones.