### PR TITLE
fix(journal): normalize stringified Excel serials in Futu dates

### DIFF
--- a/agent/src/tools/trade_journal_parsers.py
+++ b/agent/src/tools/trade_journal_parsers.py
@@ -328,7 +328,41 @@ def _futu_datetime(date_val: Any, time_val: Any) -> str:
                     return ts.strftime("%Y-%m-%d %H:%M:%S")
                 # Numeric Excel date + string/clock Time column.
                 return f"{ts.strftime('%Y-%m-%d')} {str(time_val).strip()}".strip()
-    date = "" if date_val is None or (isinstance(date_val, float) and pd.isna(date_val)) else str(date_val).strip()
+    # load_dataframe uses dtype=str; Excel serial dates arrive as "45321" / "45321.0".
+    date_text = (
+        ""
+        if date_val is None or (isinstance(date_val, float) and pd.isna(date_val))
+        else str(date_val).strip()
+    )
+    if date_text and not any(ch in date_text for ch in "/-:"):
+        try:
+            serial = float(date_text)
+        except ValueError:
+            serial = None
+        else:
+            if 1.0 <= serial < 100_000.0:
+                frac = 0.0
+                time_is_frac = False
+                time_text = (
+                    ""
+                    if time_val is None or (isinstance(time_val, float) and pd.isna(time_val))
+                    else str(time_val).strip()
+                )
+                if time_text and not any(ch in time_text for ch in "/-:"):
+                    try:
+                        candidate = float(time_text)
+                    except ValueError:
+                        candidate = None
+                    else:
+                        if 0.0 <= candidate < 1.0:
+                            frac = candidate
+                            time_is_frac = True
+                ts = pd.to_datetime(serial + frac, unit="D", origin="1899-12-30", errors="coerce")
+                if pd.notna(ts):
+                    if time_is_frac or not time_text:
+                        return ts.strftime("%Y-%m-%d %H:%M:%S")
+                    return f"{ts.strftime('%Y-%m-%d')} {time_text}".strip()
+    date = date_text
     time = "" if time_val is None or (isinstance(time_val, float) and pd.isna(time_val)) else str(time_val).strip()
     return f"{date} {time}".strip()
 

--- a/agent/tests/test_futu_stringified_excel_serial.py
+++ b/agent/tests/test_futu_stringified_excel_serial.py
@@ -1,0 +1,49 @@
+"""Futu Excel serial dates must survive load_dataframe dtype=str."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+
+from src.tools.trade_journal_parsers import load_dataframe, parse_file, parse_futu
+
+
+def test_parse_futu_stringified_excel_serial_date_and_time() -> None:
+    df = pd.DataFrame([{
+        "Date": "45321.0",
+        "Time": "0.375",
+        "Symbol": "AAPL",
+        "Name": "Apple",
+        "Side": "Buy",
+        "Quantity": "10",
+        "Price": "100",
+        "Amount": "1000",
+        "Commission": "1",
+        "Platform Fee": "0",
+    }])
+    rec = parse_futu(df)
+    assert len(rec) == 1
+    assert rec[0].datetime == "2024-01-30 09:00:00"
+
+
+def test_parse_file_xlsx_stringified_excel_serial() -> None:
+    path = Path(tempfile.mkdtemp()) / "futu.xlsx"
+    pd.DataFrame([{
+        "Date": 45321.0,
+        "Time": 0.375,
+        "Symbol": "AAPL",
+        "Name": "Apple",
+        "Side": "Buy",
+        "Quantity": 10,
+        "Price": 100,
+        "Amount": 1000,
+        "Commission": 1,
+        "Platform Fee": 0,
+    }]).to_excel(path, index=False)
+    loaded = load_dataframe(path)
+    assert isinstance(loaded["Date"].iloc[0], str)
+    fmt, recs = parse_file(path)
+    assert fmt == "futu"
+    assert recs[0].datetime == "2024-01-30 09:00:00"


### PR DESCRIPTION
Futu exports that stringify Excel Date/Time serials kept the raw number instead of a datetime.

Normalize stringified serials the same way as numeric ones.