### PR TITLE
fix(journal): normalize Excel serials in generic datetime columns

### DIFF
--- a/agent/src/tools/trade_journal_parsers.py
+++ b/agent/src/tools/trade_journal_parsers.py
@@ -402,9 +402,11 @@ def parse_generic(df: pd.DataFrame) -> list[TradeRecord]:
         if sym_col and _is_empty_code(row.get(sym_col)):
             continue
         if dt_col:
-            dt = str(row.get(dt_col, "")).strip()
+            raw_dt = row.get(dt_col, "")
+            dt = _generic_datetime_cell(raw_dt)
         elif date_col:
-            dt = str(row.get(date_col, "")).strip()
+            raw_dt = row.get(date_col, "")
+            dt = _generic_datetime_cell(raw_dt)
         else:
             dt = ""
         symbol = str(row.get(sym_col, "")).strip() if sym_col else ""
@@ -425,6 +427,33 @@ def parse_generic(df: pd.DataFrame) -> list[TradeRecord]:
             market=market,
         ))
     return records
+
+
+def _generic_datetime_cell(val: Any) -> str:
+    """Normalize a generic datetime/date cell; Excel serials become ISO datetime."""
+    if val is None or (isinstance(val, float) and pd.isna(val)):
+        return ""
+    if pd.api.types.is_number(val) and not isinstance(val, (bool,)):
+        serial = float(val)
+        if 1.0 <= serial < 100_000.0:
+            ts = pd.to_datetime(serial, unit="D", origin="1899-12-30", errors="coerce")
+            if pd.notna(ts):
+                return ts.strftime("%Y-%m-%d %H:%M:%S")
+    text = str(val).strip()
+    if text and not any(ch in text for ch in "/-:"):
+        try:
+            serial = float(text)
+        except ValueError:
+            serial = None
+        else:
+            if 1.0 <= serial < 100_000.0:
+                ts = pd.to_datetime(serial, unit="D", origin="1899-12-30", errors="coerce")
+                if pd.notna(ts):
+                    return ts.strftime("%Y-%m-%d %H:%M:%S")
+    ts = pd.to_datetime(val, errors="coerce")
+    if pd.notna(ts):
+        return ts.strftime("%Y-%m-%d %H:%M:%S")
+    return text
 
 
 def _infer_market_from_symbol(symbol: str) -> str:

--- a/agent/tests/test_generic_stringified_excel_serial.py
+++ b/agent/tests/test_generic_stringified_excel_serial.py
@@ -1,0 +1,46 @@
+"""Generic journal datetime cells must normalize Excel serials from dtype=str loads."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+
+from src.tools.trade_journal_parsers import (
+    load_dataframe,
+    parse_file,
+    parse_generic,
+    records_to_dataframe,
+)
+
+
+def test_parse_generic_stringified_excel_serial_datetime() -> None:
+    df = pd.DataFrame({
+        "datetime": ["45321.375", "45322.0"],
+        "symbol": ["AAPL", "MSFT"],
+        "side": ["buy", "sell"],
+        "quantity": ["10", "5"],
+        "price": ["150", "200"],
+    })
+    recs = parse_generic(df)
+    assert [r.datetime for r in recs] == [
+        "2024-01-30 09:00:00",
+        "2024-01-31 00:00:00",
+    ]
+    out = records_to_dataframe(recs)
+    assert out["datetime"].notna().all()
+
+
+def test_parse_file_generic_csv_excel_serial() -> None:
+    path = Path(tempfile.mkdtemp()) / "generic.csv"
+    path.write_text(
+        "datetime,symbol,side,quantity,price\n"
+        "45321.375,AAPL,buy,10,150\n",
+        encoding="utf-8",
+    )
+    loaded = load_dataframe(path)
+    assert isinstance(loaded["datetime"].iloc[0], str)
+    fmt, recs = parse_file(path)
+    assert fmt == "generic"
+    assert recs[0].datetime == "2024-01-30 09:00:00"


### PR DESCRIPTION
Generic journal datetime columns that arrive as stringified Excel serials kept the raw number.

Normalize those serials before formatting.