### PR TITLE
fix(journal): normalize Excel day-count serials in Eastmoney dates

### DIFF
--- a/agent/src/tools/trade_journal_parsers.py
+++ b/agent/src/tools/trade_journal_parsers.py
@@ -264,10 +264,15 @@ def parse_eastmoney(df: pd.DataFrame) -> list[TradeRecord]:
             continue
         raw_date = str(row.get("成交日期", "")).strip()
         # Excel numeric YYYYMMDD cells stringify as "20260115.0".
+        # Day-count serials (dtype=str load) arrive as "44941" / "44941.0".
         try:
             as_float = float(raw_date)
             if as_float.is_integer() and 19_000_001 <= int(as_float) <= 21_001_231:
                 raw_date = f"{int(as_float):08d}"
+            elif 1.0 <= as_float < 100_000.0:
+                ts = pd.to_datetime(as_float, unit="D", origin="1899-12-30", errors="coerce")
+                if pd.notna(ts):
+                    raw_date = ts.strftime("%Y-%m-%d")
         except (ValueError, OverflowError):
             pass
         raw_time = str(row.get("成交时间", "")).strip()

--- a/agent/tests/test_eastmoney_excel_day_serial.py
+++ b/agent/tests/test_eastmoney_excel_day_serial.py
@@ -1,0 +1,86 @@
+"""Eastmoney Excel day-count serials must normalize to ISO dates."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+
+from src.tools.trade_journal_parsers import load_dataframe, parse_eastmoney, parse_file
+
+
+def test_parse_eastmoney_stringified_excel_day_serial() -> None:
+    # 2023-01-15 as an Excel day-count serial (not YYYYMMDD).
+    df = pd.DataFrame([{
+        "成交日期": "44941.0",
+        "成交时间": "09:35:00",
+        "股票代码": "600519",
+        "股票名称": "贵州茅台",
+        "买卖标志": "B",
+        "成交数量": "100",
+        "成交均价": "1800",
+        "成交金额": "180000",
+        "佣金": "5",
+        "印花税": "0",
+    }])
+    rec = parse_eastmoney(df)
+    assert len(rec) == 1
+    assert rec[0].datetime == "2023-01-15 09:35:00"
+
+
+def test_parse_eastmoney_numeric_excel_day_serial() -> None:
+    df = pd.DataFrame([{
+        "成交日期": 44941.0,
+        "成交时间": "09:35:00",
+        "股票代码": "600519",
+        "股票名称": "贵州茅台",
+        "买卖标志": "B",
+        "成交数量": 100,
+        "成交均价": 1800,
+        "成交金额": 180000,
+        "佣金": 5,
+        "印花税": 0,
+    }])
+    rec = parse_eastmoney(df)
+    assert len(rec) == 1
+    assert rec[0].datetime == "2023-01-15 09:35:00"
+
+
+def test_parse_eastmoney_yyyymmdd_float_still_ok() -> None:
+    df = pd.DataFrame([{
+        "成交日期": "20230115.0",
+        "成交时间": "09:35:00",
+        "股票代码": "600519",
+        "股票名称": "贵州茅台",
+        "买卖标志": "B",
+        "成交数量": "100",
+        "成交均价": "1800",
+        "成交金额": "180000",
+        "佣金": "5",
+        "印花税": "0",
+    }])
+    rec = parse_eastmoney(df)
+    assert len(rec) == 1
+    assert rec[0].datetime == "2023-01-15 09:35:00"
+
+
+def test_parse_file_xlsx_eastmoney_excel_day_serial() -> None:
+    path = Path(tempfile.mkdtemp()) / "em.xlsx"
+    pd.DataFrame([{
+        "成交日期": 44941.0,
+        "成交时间": "09:35:00",
+        "股票代码": "600519",
+        "股票名称": "贵州茅台",
+        "买卖标志": "B",
+        "成交数量": 100,
+        "成交均价": 1800,
+        "成交金额": 180000,
+        "佣金": 5,
+        "印花税": 0,
+    }]).to_excel(path, index=False)
+    loaded = load_dataframe(path)
+    assert isinstance(loaded["成交日期"].iloc[0], str)
+    fmt, recs = parse_file(path)
+    assert fmt == "eastmoney"
+    assert recs[0].datetime == "2023-01-15 09:35:00"


### PR DESCRIPTION
Eastmoney exports that store `成交日期` as a General-format day serial (for example `44941`) kept the raw number after `dtype=str`, so the journal row became `NaT`.

Normalize those day-count serials the same way as the Tonghuashun/Futu path.