### PR TITLE
fix(loaders): map Yahoo 4H to 1h like yfinance

### DIFF
--- a/agent/backtest/loaders/yahoo_loader.py
+++ b/agent/backtest/loaders/yahoo_loader.py
@@ -33,6 +33,8 @@ _OHLCV_COLUMNS = ("open", "high", "low", "close", "volume")
 _INTERVAL_MAP = {
     "1D": "1d",
     "1H": "1h",
+    # Yahoo chart has no 4h bar; match yfinance's 4H → 1h approximation.
+    "4H": "1h",
     "1W": "1wk",
     "1M": "1mo",
 }

--- a/agent/tests/test_yahoo_loader.py
+++ b/agent/tests/test_yahoo_loader.py
@@ -84,6 +84,10 @@ class TestIntervalMap:
     def test_hourly(self):
         assert _to_yahoo_interval("1H") == "1h"
 
+    def test_four_hour_maps_like_yfinance(self):
+        # Yahoo has no 4h interval; project 4H must not pass through as "4h".
+        assert _to_yahoo_interval("4H") == "1h"
+
     def test_unknown_lowercased(self):
         assert _to_yahoo_interval("5m") == "5m"
 


### PR DESCRIPTION
Project `4H` fell through to unsupported Yahoo chart interval `4h`, so symbols were omitted or empty.

Map `4H` to `1h` like the yfinance loader.