### PR TITLE
fix(loaders): reject unsupported Alpha Vantage history intervals

### DIFF
--- a/agent/backtest/loaders/alphavantage_loader.py
+++ b/agent/backtest/loaders/alphavantage_loader.py
@@ -134,6 +134,14 @@ class DataLoader:
         """
         validate_date_range(start_date, end_date)
 
+        # Daily-only TIME_SERIES_DAILY; do not silently return day bars for ``1H``.
+        if str(interval).strip().lower() not in {"1d", "d", "day", "daily"}:
+            logger.warning(
+                "alphavantage supports daily bars only; rejecting interval=%r",
+                interval,
+            )
+            return {}
+
         api_key = _resolve_api_key()
         if not api_key:
             logger.warning("alphavantage skipped: %s not set", _API_KEY_ENV)

--- a/agent/tests/test_alphavantage_interval_reject.py
+++ b/agent/tests/test_alphavantage_interval_reject.py
@@ -1,0 +1,43 @@
+"""Alpha Vantage must reject non-daily intervals instead of silently returning day bars."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from backtest.loaders import alphavantage_loader as av
+
+
+def test_unsupported_interval_does_not_hit_api(monkeypatch) -> None:
+    """Runner ``1H`` must not fall through to TIME_SERIES_DAILY."""
+    monkeypatch.setenv("ALPHAVANTAGE_API_KEY", "ABC123")
+    with patch.object(av, "throttled_get_json") as mock_get:
+        out = av.DataLoader().fetch(["AAPL"], "2024-01-01", "2024-01-31", interval="1H")
+    assert out == {}
+    mock_get.assert_not_called()
+
+
+def test_four_hour_interval_also_rejected(monkeypatch) -> None:
+    monkeypatch.setenv("ALPHAVANTAGE_API_KEY", "ABC123")
+    with patch.object(av, "throttled_get_json") as mock_get:
+        out = av.DataLoader().fetch(["AAPL"], "2024-01-01", "2024-01-31", interval="4H")
+    assert out == {}
+    mock_get.assert_not_called()
+
+
+def test_daily_interval_still_fetches(monkeypatch) -> None:
+    monkeypatch.setenv("ALPHAVANTAGE_API_KEY", "ABC123")
+    payload = {
+        "Time Series (Daily)": {
+            "2024-01-02": {
+                "1. open": "100",
+                "2. high": "110",
+                "3. low": "99",
+                "4. close": "105",
+                "5. volume": "1000",
+            }
+        }
+    }
+    with patch.object(av, "throttled_get_json", return_value=payload) as mock_get:
+        out = av.DataLoader().fetch(["AAPL"], "2024-01-01", "2024-01-31", interval="1D")
+    assert "AAPL" in out
+    mock_get.assert_called_once()


### PR DESCRIPTION
Alpha Vantage always called `TIME_SERIES_DAILY` even for `1H`/`4H`, so intraday runs silently got day bars and stopped the fallback chain.

Reject unsupported intervals like the other daily-only loaders.