### PR TITLE
fix(backtest): consume historical USD-M funding + round settlement jitter

### DIFF
--- a/agent/backtest/engines/_market_hooks.py
+++ b/agent/backtest/engines/_market_hooks.py
@@ -164,7 +164,8 @@ def calc_crypto_funding_fee(
         bar: Current bar data.
         timestamp: Bar timestamp.
         positions: Shared positions dict.
-        funding_rate: Fixed rate per settlement.
+        funding_rate: Fallback fixed rate per settlement, used when the bar
+            carries no historical ``funding_rate`` column.
         applied_set: (symbol, date, hour) dedup set — mutated.
         daily_done_set: (symbol, date) dedup set — mutated.
 
@@ -194,6 +195,12 @@ def calc_crypto_funding_fee(
 
     mark_price = float(bar.get("close", pos.entry_price))
     notional = pos.size * mark_price
+    # Prefer the bar's historical funding rate when the loader supplied one
+    # (USD-M perpetual data via BASE-USDT-PERP); fall back to the fixed
+    # config rate otherwise so spot-proxy runs keep their behaviour.
+    hist = bar.get("funding_rate")
+    if hist is not None and pd.notna(hist):
+        funding_rate = float(hist)
     return notional * funding_rate * pos.direction
 
 

--- a/agent/backtest/loaders/ccxt_loader.py
+++ b/agent/backtest/loaders/ccxt_loader.py
@@ -408,9 +408,12 @@ class DataLoader:
             )
 
         frame = pd.DataFrame({
+            # Binance settlement timestamps carry millisecond jitter
+            # (e.g. 08:00:00.011); round to the second so they align with
+            # bar timestamps instead of failing the missing-settlement check.
             "trade_date": pd.to_datetime(
                 [row["timestamp"] for row in rows], unit="ms"
-            ),
+            ).round("s"),
             "funding_rate": pd.to_numeric(
                 [row["fundingRate"] for row in rows], errors="raise"
             ),

--- a/agent/tests/test_ccxt_perpetual_loader.py
+++ b/agent/tests/test_ccxt_perpetual_loader.py
@@ -353,3 +353,27 @@ def test_bracket_artifact_rejects_non_monotonic_brackets() -> None:
     ])
     with pytest.raises(ValueError, match="not strictly increasing"):
         _validate_bracket_artifact(artifact, expected_symbol="BTC/USDT:USDT")
+
+
+def test_perpetual_fetch_rounds_funding_settlement_jitter(monkeypatch) -> None:
+    """Binance returns settlement timestamps with millisecond jitter
+    (e.g. ``08:00:00.011``); the loader must round them to the second so
+    they align with bar timestamps instead of raising the
+    missing-settlement error."""
+    start = int(pd.Timestamp("2024-01-01 00:00:00").timestamp() * 1000)
+    exchange = _PerpetualExchange(
+        funding_rows=[{"timestamp": start + 11, "fundingRate": 0.0003}]
+    )
+    monkeypatch.setattr(
+        "backtest.loaders.ccxt_loader.DataLoader._get_exchange",
+        lambda _self, instrument_type="spot": exchange,
+    )
+
+    from backtest.loaders.ccxt_loader import DataLoader
+
+    frame = DataLoader().fetch(
+        ["BTC-USDT-PERP"], "2024-01-01", "2024-01-01", interval="1H"
+    )["BTC-USDT-PERP"]
+
+    assert frame["funding_rate"].tolist() == [0.0003, 0.0]
+    assert frame["funding_settlement_time"].iloc[0] == pd.Timestamp("2024-01-01")

--- a/agent/tests/test_crypto_engine.py
+++ b/agent/tests/test_crypto_engine.py
@@ -327,3 +327,44 @@ class TestMaintenanceRate:
 
     def test_maximum_tier(self) -> None:
         assert _maintenance_rate(100_000_000) == 0.10
+
+
+class TestHistoricalFundingRate:
+    def test_bar_funding_rate_overrides_fixed_rate(self) -> None:
+        """A bar carrying a historical ``funding_rate`` column (USD-M perp
+        data) must be charged at that rate, not the fixed config rate."""
+        engine = _make_engine(funding_rate=0.0001)
+        engine.positions["BTC-USDT-PERP"] = Position(
+            "BTC-USDT-PERP", 1, 60000.0, pd.Timestamp("2025-01-01"), 1.0, leverage=10.0,
+        )
+        initial_capital = engine.capital
+        bar = pd.Series({"close": 60000.0, "open": 60000.0, "funding_rate": 0.0005})
+        ts = pd.Timestamp("2025-01-01 08:00:00")
+        engine.on_bar("BTC-USDT-PERP", bar, ts)
+        # Historical rate: 1.0 × 60000 × 0.0005 = $30 (not $6 from the fixed rate)
+        assert engine.capital == pytest.approx(initial_capital - 30.0)
+
+    def test_negative_historical_funding_pays_longs(self) -> None:
+        engine = _make_engine(funding_rate=0.0001)
+        engine.positions["BTC-USDT-PERP"] = Position(
+            "BTC-USDT-PERP", 1, 60000.0, pd.Timestamp("2025-01-01"), 1.0, leverage=10.0,
+        )
+        initial_capital = engine.capital
+        bar = pd.Series({"close": 60000.0, "open": 60000.0, "funding_rate": -0.0002})
+        ts = pd.Timestamp("2025-01-01 08:00:00")
+        engine.on_bar("BTC-USDT-PERP", bar, ts)
+        # Negative funding: longs receive
+        assert engine.capital == pytest.approx(initial_capital + 12.0)
+
+    def test_nan_funding_rate_falls_back_to_fixed(self) -> None:
+        """Non-settlement bars carry NaN funding_rate — must fall back to
+        the fixed config rate (daily-fallback path), not charge NaN."""
+        engine = _make_engine(funding_rate=0.0001)
+        engine.positions["BTC-USDT-PERP"] = Position(
+            "BTC-USDT-PERP", 1, 60000.0, pd.Timestamp("2025-01-01"), 1.0, leverage=10.0,
+        )
+        initial_capital = engine.capital
+        bar = pd.Series({"close": 60000.0, "open": 60000.0, "funding_rate": float("nan")})
+        ts = pd.Timestamp("2025-01-01 08:00:00")
+        engine.on_bar("BTC-USDT-PERP", bar, ts)
+        assert engine.capital == pytest.approx(initial_capital - 6.0)


### PR DESCRIPTION
## What

Two related fixes that make the v0.1.12 historical USD-M funding feature actually flow into backtest PnL. Follows up on #716 / #462.

### 1. Loader: settlement-timestamp millisecond jitter breaks alignment

Binance returns funding settlement timestamps with millisecond jitter — real examples from `binanceusdm.fetch_funding_rate_history('BTC/USDT:USDT')`:

```
2026-05-05T08:00:00.011Z  -4.626e-05
2026-05-06T00:00:00.010Z  -9.153e-05
2026-05-06T16:00:00.002Z  -3.756e-05
```

`_fetch_funding_history` builds its index from the raw timestamps, so most settlements never intersect the bar index and the missing-settlement guard raises `funding settlement data is missing for BTC-USDT-PERP: <hundreds of slots>` on real fetches. Fix: `.round("s")` on the settlement index before aligning.

### 2. Engine: fetched funding data is never consumed

The loader writes `funding_rate` / `funding_settlement_time` columns into the frame, but `calc_crypto_funding_fee` only ever charges the fixed config rate (default `0.0001`) — the historical data is fetched, validated, aligned, and then ignored. Fix: prefer the bar's historical `funding_rate` when present and finite; fall back to the fixed config rate otherwise, so spot-proxy runs and the daily-fallback path (NaN on non-settlement bars) keep their existing behaviour.

If you'd rather gate the engine change behind an explicit config flag (e.g. `funding_source: historical`), happy to rework — the loader fix stands alone either way.

## Verification

- Live Binance USD-M data, BTC/ETH `-USDT-PERP`, 4H bars, Jan–Jul 2026: before fix 1, the fetch hard-errors; after both fixes, an always-short strategy returns +39.1% with historical funding vs +44.5% with the fixed rate — the ~5pp drag matches 2026's predominantly negative funding regime (shorts pay).
- `pytest tests/test_ccxt_perpetual_loader.py tests/test_crypto_engine.py tests/test_ccxt_loader_bounded.py` → 66 passed
- `pytest -k 'composite or market_hooks or engine'` → 353 passed, 2 skipped
- Not run: full suite, e2e harness, frontend build (unrelated to these paths).

## Tests added

- `test_perpetual_fetch_rounds_funding_settlement_jitter` — jittered settlement aligns to the bar and carries its rate
- `TestHistoricalFundingRate` (3 tests) — historical rate overrides fixed, negative funding pays longs, NaN falls back to fixed

AI-assisted contribution (Claude, supervised); verified against live exchange data as described above. DCO signed.