### PR TITLE
fix(loaders): reject unsupported Tiingo history intervals

### DIFF
--- a/agent/backtest/loaders/tiingo_loader.py
+++ b/agent/backtest/loaders/tiingo_loader.py
@@ -177,6 +177,14 @@ class DataLoader:
         del fields
         validate_date_range(start_date, end_date)
 
+        # Daily-only EOD endpoint; do not silently return day bars for ``1H``.
+        if str(interval).strip().lower() not in {"1d", "d", "day", "daily"}:
+            logger.warning(
+                "tiingo supports daily bars only; rejecting interval=%r",
+                interval,
+            )
+            return {}
+
         key = _resolve_key()
         if not key:
             logger.warning("tiingo skipped: %s not configured", _AUTH_ENV)

--- a/agent/tests/test_tiingo_interval_reject.py
+++ b/agent/tests/test_tiingo_interval_reject.py
@@ -1,0 +1,48 @@
+"""Tiingo must reject non-daily intervals instead of silently returning day bars."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from backtest.loaders import tiingo_loader as tg
+
+
+def test_unsupported_interval_does_not_hit_api() -> None:
+    """Runner ``1H`` must not fall through to Tiingo daily EOD."""
+    with patch.object(tg, "throttled_get_json") as mock_get:
+        with patch.object(tg, "_resolve_key", return_value="KEY"):
+            out = tg.DataLoader().fetch(
+                ["AAPL"], "2024-01-01", "2024-01-31", interval="1H"
+            )
+    assert out == {}
+    mock_get.assert_not_called()
+
+
+def test_four_hour_interval_also_rejected() -> None:
+    with patch.object(tg, "throttled_get_json") as mock_get:
+        with patch.object(tg, "_resolve_key", return_value="KEY"):
+            out = tg.DataLoader().fetch(
+                ["AAPL"], "2024-01-01", "2024-01-31", interval="4H"
+            )
+    assert out == {}
+    mock_get.assert_not_called()
+
+
+def test_daily_interval_still_fetches() -> None:
+    payload = [
+        {
+            "date": "2024-01-02T00:00:00.000Z",
+            "open": 100,
+            "high": 110,
+            "low": 99,
+            "close": 105,
+            "volume": 1000,
+        }
+    ]
+    with patch.object(tg, "throttled_get_json", return_value=payload) as mock_get:
+        with patch.object(tg, "_resolve_key", return_value="KEY"):
+            out = tg.DataLoader().fetch(
+                ["AAPL"], "2024-01-01", "2024-01-31", interval="1D"
+            )
+    assert "AAPL" in out
+    mock_get.assert_called_once()


### PR DESCRIPTION
Tiingo always fetched EOD daily bars for unsupported intervals like 1H, so intraday runs silently got day bars.

Reject unsupported intervals like the other daily-only loaders.
