### PR TITLE
fix(loaders): reject unsupported Stooq history intervals

### DIFF
--- a/agent/backtest/loaders/stooq_loader.py
+++ b/agent/backtest/loaders/stooq_loader.py
@@ -101,8 +101,8 @@ class DataLoader:
             codes: Project-side symbols (e.g. ``["AAPL.US", "MSFT.US"]``).
             start_date: Inclusive start date (``YYYY-MM-DD``).
             end_date: Inclusive end date (``YYYY-MM-DD``).
-            interval: Bar size; only daily (``"1D"``) is supported by the
-                endpoint and any other value is fetched as daily.
+            interval: Bar size; only daily (``"1D"``) is supported. Other
+                intervals return an empty map so the fallback chain can continue.
             fields: Unused — the CSV always carries the full OHLCV set.
 
         Returns:
@@ -115,6 +115,14 @@ class DataLoader:
             ValueError: If ``start_date > end_date`` or a date is unparseable.
         """
         validate_date_range(start_date, end_date)
+
+        # Daily-only CSV endpoint; do not silently return day bars for ``1H``.
+        if str(interval).strip().lower() not in {"1d", "d", "day", "daily"}:
+            logger.warning(
+                "stooq supports daily bars only; rejecting interval=%r",
+                interval,
+            )
+            return {}
 
         result: Dict[str, pd.DataFrame] = {}
         for code in codes:

--- a/agent/tests/test_stooq_interval_reject.py
+++ b/agent/tests/test_stooq_interval_reject.py
@@ -1,0 +1,43 @@
+"""Stooq must reject non-daily intervals instead of silently returning day bars."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from backtest.loaders import stooq_loader as sq
+
+
+def test_unsupported_interval_does_not_hit_api() -> None:
+    """Runner ``1H`` must not fall through to Stooq daily CSV."""
+    with patch.object(sq, "throttled_get") as mock_get:
+        out = sq.DataLoader().fetch(
+            ["AAPL.US"], "2024-01-01", "2024-01-31", interval="1H"
+        )
+    assert out == {}
+    mock_get.assert_not_called()
+
+
+def test_four_hour_interval_also_rejected() -> None:
+    with patch.object(sq, "throttled_get") as mock_get:
+        out = sq.DataLoader().fetch(
+            ["AAPL.US"], "2024-01-01", "2024-01-31", interval="4H"
+        )
+    assert out == {}
+    mock_get.assert_not_called()
+
+
+def test_daily_interval_still_fetches() -> None:
+    csv = (
+        "Date,Open,High,Low,Close,Volume\n"
+        "2024-01-02,100,110,99,105,1000\n"
+    )
+    mock_resp = MagicMock()
+    mock_resp.text = csv
+    mock_resp.status_code = 200
+    mock_resp.raise_for_status = lambda: None
+    with patch.object(sq, "throttled_get", return_value=mock_resp) as mock_get:
+        out = sq.DataLoader().fetch(
+            ["AAPL.US"], "2024-01-01", "2024-01-31", interval="1D"
+        )
+    assert "AAPL.US" in out
+    mock_get.assert_called_once()


### PR DESCRIPTION
Stooq always returned daily CSV bars for unsupported intervals like 1H, so intraday runs silently got day bars.

Reject unsupported intervals like the other daily-only loaders.
