### PR TITLE
fix(loaders): map OKX lowercase 1h/4h instead of silent daily

### DIFF
--- a/agent/backtest/loaders/okx.py
+++ b/agent/backtest/loaders/okx.py
@@ -31,6 +31,21 @@ import requests
 
 logger = logging.getLogger(__name__)
 
+# Project / connector period tokens -> OKX candle ``bar`` strings.
+# ``1m`` vs ``1M`` stays case-sensitive; hour/day accept either case.
+_INTERVAL_MAP = {
+    "1m": "1m",
+    "5m": "5m",
+    "15m": "15m",
+    "30m": "30m",
+    "1h": "1H",
+    "1H": "1H",
+    "4h": "4H",
+    "4H": "4H",
+    "1d": "1D",
+    "1D": "1D",
+}
+
 from backtest.loaders.base import (
     cached_loader_fetch,
     check_budget,
@@ -129,7 +144,7 @@ class DataLoader:
             start_date: Start date (YYYY-MM-DD).
             end_date: End date (YYYY-MM-DD).
             fields: Ignored (OKX has no extra fields).
-            interval: Bar size (1m/5m/15m/30m/1H/4H/1D), default ``1D``.
+            interval: Bar size (1m/5m/15m/30m/1h/1H/4h/4H/1d/1D), default ``1D``.
 
         Returns:
             Mapping symbol -> DataFrame.
@@ -139,10 +154,16 @@ class DataLoader:
         if fields:
             logger.warning("OKX ignores extra fields: %s", fields)
 
-        valid_intervals = {"1m", "5m", "15m", "30m", "1H", "4H", "1D"}
-        if interval not in valid_intervals:
-            logger.warning("unsupported OKX interval %s, using 1D", interval)
-            interval = "1D"
+        # Case aliases: connector-style ``1h``/``4h`` must not fall through to daily.
+        mapped = _INTERVAL_MAP.get(interval.strip())
+        if mapped is None:
+            logger.warning(
+                "unsupported OKX interval %r; rejecting (supported: %s)",
+                interval,
+                sorted(set(_INTERVAL_MAP.values())),
+            )
+            return {}
+        interval = mapped
 
         codes = [c.replace("/", "-").upper() for c in codes]
 

--- a/agent/tests/test_okx_loader_interval_case.py
+++ b/agent/tests/test_okx_loader_interval_case.py
@@ -1,0 +1,40 @@
+"""OKX loader must keep lowercase 1h/4h as hour bars, not silent daily."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from backtest.loaders import okx as okx_mod
+
+
+def _fetch_with_interval(interval: str) -> list[str]:
+    seen: list[str] = []
+
+    def fake_fetch(self, session, symbol, start_ts, end_ts, bar, max_pages, prefer_history=False):
+        seen.append(bar)
+        return None
+
+    with patch.object(okx_mod.DataLoader, "_fetch_candles", fake_fetch):
+        with patch.object(okx_mod.DataLoader, "_should_use_history", return_value=False):
+            with patch.object(okx_mod, "_okx_session", return_value=MagicMock()):
+                okx_mod.DataLoader().fetch(
+                    ["BTC-USDT"], "2024-01-01", "2024-01-02", interval=interval
+                )
+    return seen
+
+
+def test_lowercase_one_hour_fetches_hour_bars_not_daily() -> None:
+    assert _fetch_with_interval("1h") == ["1H"]
+
+
+def test_lowercase_four_hour_fetches_four_hour_bars() -> None:
+    assert _fetch_with_interval("4h") == ["4H"]
+
+
+def test_project_style_one_hour_still_works() -> None:
+    assert _fetch_with_interval("1H") == ["1H"]
+
+
+def test_unsupported_interval_rejects_without_daily_fallback() -> None:
+    seen = _fetch_with_interval("2H")
+    assert seen == []


### PR DESCRIPTION
OKX mapped lowercase 1h/4h to daily instead of hour bars, so intraday runs silently got day bars.

Map 1h/4h like 1H/4H.
