### PR TITLE
fix(loaders): treat QVeris 1m/5m/15m/30m as intraday granularity

### DIFF
--- a/agent/backtest/loaders/qveris_loader.py
+++ b/agent/backtest/loaders/qveris_loader.py
@@ -414,16 +414,25 @@ def _capability_text(item: dict[str, Any]) -> str:
 
 
 def _granularity_tokens(interval: str) -> tuple[tuple[str, ...], tuple[str, ...]]:
-    """Return (wanted, unwanted) capability-text tokens for a bar interval."""
-    norm = interval.strip().lower()
+    """Return (wanted, unwanted) capability-text tokens for a bar interval.
+
+    ``1m``/``5m``/``15m``/``30m`` are case-sensitive minute tokens; ``1M`` is
+    month. Lowercasing first would collapse ``1m`` into an empty match and let
+    daily capabilities outrank minute ones.
+    """
+    token = interval.strip()
+    norm = token.lower()
     intraday = ("intraday", "minute", "1min", "5min", "15min", "30min", "60min", "hourly")
     if norm in ("", "1d", "d", "day", "daily"):
         return ("daily", "eod", "end-of-day", "end of day"), ("monthly", "weekly") + intraday
-    if "min" in norm or norm in ("1h", "4h") or "hour" in norm:
+    # Case-sensitive: ``1M`` (month) must not be treated as ``1m`` (minute).
+    if token == "1M" or "month" in norm:
+        return ("monthly",), ("weekly",) + intraday
+    if token in {"1m", "5m", "15m", "30m"} or "min" in norm or norm in ("1h", "4h") or "hour" in norm:
         return intraday, ("monthly", "weekly")
     if "w" in norm or "week" in norm:
         return ("weekly",), ("monthly",) + intraday
-    if "mo" in norm or "month" in norm:
+    if "mo" in norm:
         return ("monthly",), ("weekly",) + intraday
     return (), ()
 

--- a/agent/tests/test_qveris_minute_granularity_tokens.py
+++ b/agent/tests/test_qveris_minute_granularity_tokens.py
@@ -1,0 +1,47 @@
+"""QVeris must rank minute intervals as intraday, not fall through to daily."""
+
+from __future__ import annotations
+
+from backtest.loaders.qveris_loader import _granularity_tokens, _select_capabilities
+
+
+def _sample_results() -> list[dict]:
+    return [
+        {
+            "tool_id": "daily-ohlcv",
+            "name": "Daily OHLCV historical",
+            "description": "end-of-day daily open high low close volume for symbol ticker",
+            "stats": {"success_rate": 0.99},
+            "expected_cost": 0.01,
+        },
+        {
+            "tool_id": "intraday-1min",
+            "name": "1min intraday candles",
+            "description": "minute bar ohlcv historical price for symbol ticker",
+            "stats": {"success_rate": 0.90},
+            "expected_cost": 0.02,
+        },
+    ]
+
+
+def test_one_minute_tokens_are_intraday() -> None:
+    wanted, unwanted = _granularity_tokens("1m")
+    assert "minute" in wanted
+    assert "monthly" in unwanted
+
+
+def test_five_minute_tokens_are_intraday() -> None:
+    wanted, _ = _granularity_tokens("5m")
+    assert "minute" in wanted
+
+
+def test_month_token_stays_monthly_not_minute() -> None:
+    wanted, unwanted = _granularity_tokens("1M")
+    assert "monthly" in wanted
+    assert "minute" in unwanted
+
+
+def test_one_minute_prefers_intraday_capability_over_daily() -> None:
+    selected = _select_capabilities(_sample_results(), "1m")
+    assert selected
+    assert selected[0]["tool_id"] == "intraday-1min"


### PR DESCRIPTION
QVeris left 1m/5m/15m/30m with empty granularity tokens, so the daily path won.

Treat those minute intervals as intraday tokens.
