### PR TITLE
fix(loaders): reject non-daily intervals for AKShare US/HK/ETF/forex

### DIFF
--- a/agent/backtest/loaders/akshare_loader.py
+++ b/agent/backtest/loaders/akshare_loader.py
@@ -23,6 +23,18 @@ _INTERVAL_MAP_DAILY = {
     "1M": "monthly",
 }
 
+# US / HK / ETF / forex endpoints only serve daily bars. Accept the same
+# daily aliases as sina/tencent so ``1d`` still works; reject ``1H``/``4H``.
+_DAILY_ONLY_ALIASES = frozenset({"1d", "d", "day", "daily"})
+
+
+def _require_daily_interval(interval: str, market: str) -> None:
+    """Raise when a daily-only AKShare market is asked for non-daily bars."""
+    if str(interval).strip().lower() not in _DAILY_ONLY_ALIASES:
+        raise ValueError(
+            f"Unsupported interval {interval!r}; akshare {market} supports daily bars only"
+        )
+
 
 def _is_a_share(code: str) -> bool:
     return code.upper().endswith((".SZ", ".SH", ".BJ"))
@@ -127,14 +139,18 @@ class DataLoader:
 
         # ETF check must precede A-share — 518880.SH ends with .SH but is an ETF.
         if _is_etf_listed(code):
+            _require_daily_interval(interval, "etf")
             return self._fetch_etf(ak, code, start_date, end_date)
         if _is_a_share(code):
             return self._fetch_a_share(ak, code, start_date, end_date, interval)
         if _is_us(code):
+            _require_daily_interval(interval, "us")
             return self._fetch_us(ak, code, start_date, end_date)
         if _is_hk(code):
+            _require_daily_interval(interval, "hk")
             return self._fetch_hk(ak, code, start_date, end_date)
         if _is_forex(code):
+            _require_daily_interval(interval, "forex")
             return self._fetch_forex(ak, code, start_date, end_date)
         # Default: try A-share
         return self._fetch_a_share(ak, code, start_date, end_date, interval)

--- a/agent/backtest/loaders/akshare_loader.py
+++ b/agent/backtest/loaders/akshare_loader.py
@@ -23,13 +23,11 @@ _INTERVAL_MAP_DAILY = {
     "1M": "monthly",
 }
 
-# US / HK / ETF / forex endpoints only serve daily bars. Accept the same
-# daily aliases as sina/tencent so ``1d`` still works; reject ``1H``/``4H``.
+# US/HK/ETF/forex serve daily bars only.
 _DAILY_ONLY_ALIASES = frozenset({"1d", "d", "day", "daily"})
 
 
 def _require_daily_interval(interval: str, market: str) -> None:
-    """Raise when a daily-only AKShare market is asked for non-daily bars."""
     if str(interval).strip().lower() not in _DAILY_ONLY_ALIASES:
         raise ValueError(
             f"Unsupported interval {interval!r}; akshare {market} supports daily bars only"

--- a/agent/tests/test_akshare_nona_share_interval.py
+++ b/agent/tests/test_akshare_nona_share_interval.py
@@ -1,0 +1,63 @@
+"""AKShare US/HK/ETF/forex must not return daily bars for intraday intervals."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from backtest.loaders.akshare_loader import DataLoader
+
+
+def _us_daily_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "日期": ["2024-01-02", "2024-01-03"],
+            "开盘": [1.0, 2.0],
+            "最高": [2.0, 3.0],
+            "最低": [0.5, 1.0],
+            "收盘": [1.5, 2.5],
+            "成交量": [10.0, 20.0],
+        }
+    )
+
+
+def test_us_intraday_interval_does_not_hit_daily_endpoint() -> None:
+    """Runner ``1H`` used to fetch stock_us_hist daily bars under a 1H cache key."""
+    ak = MagicMock()
+    ak.stock_us_hist.return_value = _us_daily_frame()
+    loader = DataLoader()
+    with patch.dict("sys.modules", {"akshare": ak}):
+        with pytest.raises(ValueError, match="Unsupported interval"):
+            loader._fetch_one("AAPL.US", "2024-01-01", "2024-01-31", "1H")
+    ak.stock_us_hist.assert_not_called()
+
+
+def test_hk_four_hour_interval_rejected() -> None:
+    ak = MagicMock()
+    loader = DataLoader()
+    with patch.dict("sys.modules", {"akshare": ak}):
+        with pytest.raises(ValueError, match="Unsupported interval"):
+            loader._fetch_one("0700.HK", "2024-01-01", "2024-01-31", "4H")
+    ak.stock_hk_hist.assert_not_called()
+
+
+def test_etf_intraday_interval_rejected() -> None:
+    ak = MagicMock()
+    loader = DataLoader()
+    with patch.dict("sys.modules", {"akshare": ak}):
+        with pytest.raises(ValueError, match="Unsupported interval"):
+            loader._fetch_one("510050.SH", "2024-01-01", "2024-01-31", "1H")
+    ak.fund_etf_hist_sina.assert_not_called()
+
+
+def test_us_daily_interval_still_fetches() -> None:
+    ak = MagicMock()
+    ak.stock_us_hist.return_value = _us_daily_frame()
+    loader = DataLoader()
+    with patch.dict("sys.modules", {"akshare": ak}):
+        frame = loader._fetch_one("AAPL.US", "2024-01-01", "2024-01-31", "1D")
+    assert frame is not None
+    assert len(frame) == 2
+    ak.stock_us_hist.assert_called()


### PR DESCRIPTION
A-share already raised on unsupported intervals, but US/HK/ETF/forex always called the daily endpoints, so interval=1H returned day bars under a 1H cache key and stopped the fallback chain.

Reject non-daily intervals for those markets (daily aliases like 1d still work).