### PR TITLE
fix(loaders): accept lowercase 1h/1d in India broker interval map

### DIFF
--- a/agent/backtest/loaders/india_broker_loader.py
+++ b/agent/backtest/loaders/india_broker_loader.py
@@ -34,7 +34,17 @@ logger = logging.getLogger(__name__)
 
 _OUTPUT_COLUMNS = ["open", "high", "low", "close", "volume"]
 # Project interval -> broker ``period`` token (both connectors share this set).
-_PERIOD_MAP = {"1D": "1d", "1H": "1h", "5m": "5m", "15m": "15m", "30m": "30m", "1m": "1m"}
+# ``1h``/``1d`` alias the project-style tokens; ``1m`` vs ``1M`` stays case-sensitive.
+_PERIOD_MAP = {
+    "1D": "1d",
+    "1d": "1d",
+    "1H": "1h",
+    "1h": "1h",
+    "5m": "5m",
+    "15m": "15m",
+    "30m": "30m",
+    "1m": "1m",
+}
 
 
 def _resolve_broker():

--- a/agent/tests/test_india_broker_loader.py
+++ b/agent/tests/test_india_broker_loader.py
@@ -97,3 +97,22 @@ def test_supported_1h_still_maps(monkeypatch) -> None:
     out = loader.fetch(["RELIANCE.NS"], "2024-04-01", "2024-04-30", interval="1H")
     assert "RELIANCE.NS" in out
     assert fake.calls[0]["period"] == "1h"
+
+
+def test_lowercase_1h_maps_like_project_token(monkeypatch) -> None:
+    """Connector-style ``1h`` must map the same as project ``1H``."""
+    fake = _FakeSDK()
+    monkeypatch.setattr(mod, "_resolve_broker", lambda: ("shoonya", fake))
+    loader = DataLoader()
+    out = loader.fetch(["RELIANCE.NS"], "2024-04-01", "2024-04-30", interval="1h")
+    assert "RELIANCE.NS" in out
+    assert fake.calls[0]["period"] == "1h"
+
+
+def test_lowercase_1d_maps_to_daily(monkeypatch) -> None:
+    fake = _FakeSDK()
+    monkeypatch.setattr(mod, "_resolve_broker", lambda: ("shoonya", fake))
+    loader = DataLoader()
+    out = loader.fetch(["RELIANCE.NS"], "2024-04-01", "2024-04-30", interval="1d")
+    assert "RELIANCE.NS" in out
+    assert fake.calls[0]["period"] == "1d"


### PR DESCRIPTION
The India broker interval map listed 1H/1D but not 1h/1d, so lowercase hours fell through.

Add the lowercase aliases next to the existing uppercase keys.