### PR TITLE
fix(loaders): accept lowercase 1h/4h/1d in Futu interval map

### DIFF
--- a/agent/backtest/loaders/futu.py
+++ b/agent/backtest/loaders/futu.py
@@ -25,9 +25,13 @@ _INTERVAL_MAP: dict[str, str] = {
     "15m": "K_15M",
     "30m": "K_30M",
     "1D": "K_DAY",
+    "1d": "K_DAY",
     "1H": "K_60M",
+    "1h": "K_60M",
     "4H": "K_240M",
+    "4h": "K_240M",
     "1W": "K_WEEK",
+    "1w": "K_WEEK",
     "1M": "K_MON",
 }
 

--- a/agent/tests/test_futu_loader_interval_case.py
+++ b/agent/tests/test_futu_loader_interval_case.py
@@ -1,0 +1,26 @@
+"""Futu loader interval map must accept connector-style hour/day aliases."""
+
+from __future__ import annotations
+
+from backtest.loaders.futu import _INTERVAL_MAP, _to_futu_ktype
+
+
+def test_lowercase_hour_aliases_match_project_tokens() -> None:
+    assert _INTERVAL_MAP["1h"] == _INTERVAL_MAP["1H"] == "K_60M"
+    assert _INTERVAL_MAP["4h"] == _INTERVAL_MAP["4H"] == "K_240M"
+    assert _INTERVAL_MAP["1d"] == _INTERVAL_MAP["1D"] == "K_DAY"
+
+
+def test_to_futu_ktype_accepts_lowercase_1h(monkeypatch) -> None:
+    class _KL:
+        K_60M = "K_60M"
+        K_240M = "K_240M"
+        K_DAY = "K_DAY"
+
+    import sys
+    from types import SimpleNamespace
+
+    fake = SimpleNamespace(KLType=_KL)
+    monkeypatch.setitem(sys.modules, "futu", fake)
+    assert _to_futu_ktype("1h") == "K_60M"
+    assert _to_futu_ktype("4h") == "K_240M"


### PR DESCRIPTION
The Futu loader interval map accepted 1H/4H/1D but not the lowercase forms used elsewhere in the project.

Map 1h/4h/1d like their uppercase siblings.