### PR TITLE
fix(loaders): map yfinance lowercase 4h/1w like 4H/1W

### DIFF
--- a/agent/backtest/loaders/yfinance_loader.py
+++ b/agent/backtest/loaders/yfinance_loader.py
@@ -36,7 +36,9 @@ _INTERVAL_MAP = {
     "1D": "1d",
     "1H": "1h",
     "4H": "1h",
+    "4h": "1h",  # yfinance has no 4h; match project ``4H`` → ``1h``
     "1W": "1wk",
+    "1w": "1wk",
     "1M": "1mo",
     # Minute tokens stay lowercase; do not fold ``1M`` (month) via ``.lower()``.
     "1m": "1m",

--- a/agent/tests/test_yfinance_lowercase_4h_1w.py
+++ b/agent/tests/test_yfinance_lowercase_4h_1w.py
@@ -1,0 +1,22 @@
+"""yfinance interval map must not leave lowercase 4h/1w as invalid Yahoo tokens."""
+
+from __future__ import annotations
+
+from backtest.loaders.yfinance_loader import _to_yfinance_interval
+
+
+def test_lowercase_4h_maps_like_4H() -> None:
+    """``4h`` used to fall through to ``.lower()`` and become invalid ``4h``."""
+    assert _to_yfinance_interval("4H") == "1h"
+    assert _to_yfinance_interval("4h") == "1h"
+
+
+def test_lowercase_1w_maps_like_1W() -> None:
+    """``1w`` used to become ``1w``; yfinance expects ``1wk``."""
+    assert _to_yfinance_interval("1W") == "1wk"
+    assert _to_yfinance_interval("1w") == "1wk"
+
+
+def test_month_vs_minute_case_preserved() -> None:
+    assert _to_yfinance_interval("1M") == "1mo"
+    assert _to_yfinance_interval("1m") == "1m"


### PR DESCRIPTION
Lowercase 4h/1w fell through to .lower() as invalid Yahoo tokens while 4H/1W already mapped to 1h/1wk.

Map 4h→1h and 1w→1wk like the uppercase keys.