### PR TITLE
fix(loaders): map MT5 1W/1M and reject unknown intervals

### DIFF
--- a/agent/backtest/loaders/mt5_loader.py
+++ b/agent/backtest/loaders/mt5_loader.py
@@ -200,8 +200,7 @@ class DataLoader:
         validate_date_range(start_date, end_date)
         timeframe_name = _INTERVAL_MAP.get(str(interval).strip())
         if timeframe_name is None:
-            # Never rewrite unknown intervals to daily — that caches day bars
-            # under the caller's timeframe key and poisons later sources.
+            # Reject unknown tokens; do not fetch TIMEFRAME_D1 under the caller's key.
             logger.warning("mt5 unsupported interval %r; rejecting", interval)
             return {}
 

--- a/agent/backtest/loaders/mt5_loader.py
+++ b/agent/backtest/loaders/mt5_loader.py
@@ -38,13 +38,16 @@ logger = logging.getLogger(__name__)
 _MT5_CONFIG_PATH = Path.home() / ".vibe-trading" / "mt5.json"
 
 #: Canonical interval token → MetaTrader5 timeframe constant name.
-#: Lowercase ``1h``/``4h``/``1d`` alias the project-style tokens (connector parity).
+#: Lowercase ``1h``/``4h``/``1d``/``1w`` alias project-style tokens (connector parity).
+#: ``1m`` (minute) and ``1M`` (month) differ by case.
 _INTERVAL_MAP = {
     "1m": "TIMEFRAME_M1", "5m": "TIMEFRAME_M5", "15m": "TIMEFRAME_M15",
     "30m": "TIMEFRAME_M30",
     "1H": "TIMEFRAME_H1", "1h": "TIMEFRAME_H1",
     "4H": "TIMEFRAME_H4", "4h": "TIMEFRAME_H4",
     "1D": "TIMEFRAME_D1", "1d": "TIMEFRAME_D1",
+    "1W": "TIMEFRAME_W1", "1w": "TIMEFRAME_W1",
+    "1M": "TIMEFRAME_MN1",
 }
 
 #: Process-lifetime attach cache: ``initialize`` can take seconds (it may even
@@ -195,10 +198,12 @@ class DataLoader:
         runtime fallback can engage for the missing symbols.
         """
         validate_date_range(start_date, end_date)
-        timeframe_name = _INTERVAL_MAP.get(interval)
+        timeframe_name = _INTERVAL_MAP.get(str(interval).strip())
         if timeframe_name is None:
-            logger.warning("unsupported MT5 interval %s, using 1D", interval)
-            interval, timeframe_name = "1D", "TIMEFRAME_D1"
+            # Never rewrite unknown intervals to daily — that caches day bars
+            # under the caller's timeframe key and poisons later sources.
+            logger.warning("mt5 unsupported interval %r; rejecting", interval)
+            return {}
 
         result: dict[str, pd.DataFrame] = {}
         for code in codes:

--- a/agent/tests/test_mt5_loader.py
+++ b/agent/tests/test_mt5_loader.py
@@ -162,10 +162,14 @@ class TestIntervalsAndFrames:
         loader.fetch(["EUR/USD"], "2026-06-01", "2026-06-10", interval="1h")
         assert fake_mod.rates_calls[-1][1] == _FakeMT5Module.TIMEFRAME_H1
 
-    def test_unknown_interval_defaults_to_daily(self, fake_mod: _FakeMT5Module) -> None:
+    def test_unknown_interval_is_rejected_not_rewritten_to_daily(
+        self, fake_mod: _FakeMT5Module
+    ) -> None:
         loader = DataLoader()
-        loader.fetch(["EUR/USD"], "2026-06-01", "2026-06-10", interval="7z")
-        assert fake_mod.rates_calls[-1][1] == _FakeMT5Module.TIMEFRAME_D1
+        before = len(fake_mod.rates_calls)
+        frames = loader.fetch(["EUR/USD"], "2026-06-01", "2026-06-10", interval="7z")
+        assert frames == {}
+        assert len(fake_mod.rates_calls) == before
 
     def test_frame_contract(self, fake_mod: _FakeMT5Module) -> None:
         loader = DataLoader()

--- a/agent/tests/test_mt5_loader_week_month_reject.py
+++ b/agent/tests/test_mt5_loader_week_month_reject.py
@@ -1,0 +1,37 @@
+"""MT5 loader must map week/month tokens and never rewrite unknown intervals to daily."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from backtest.loaders.mt5_loader import DataLoader, _INTERVAL_MAP
+
+
+def test_week_and_month_tokens_map_like_connector() -> None:
+    assert _INTERVAL_MAP["1W"] == "TIMEFRAME_W1"
+    assert _INTERVAL_MAP["1w"] == "TIMEFRAME_W1"
+    assert _INTERVAL_MAP["1M"] == "TIMEFRAME_MN1"
+    assert _INTERVAL_MAP["1m"] == "TIMEFRAME_M1"
+
+
+def test_unsupported_interval_returns_empty_without_daily_rewrite() -> None:
+    """``2H`` used to fall back to TIMEFRAME_D1 and fetch day bars."""
+    with patch.object(DataLoader, "_fetch_one") as mock_fetch:
+        out = DataLoader().fetch(
+            ["EURUSD"], "2024-01-01", "2024-01-31", interval="2H"
+        )
+    assert out == {}
+    mock_fetch.assert_not_called()
+
+
+def test_week_interval_uses_w1_not_daily() -> None:
+    frame = MagicMock()
+    frame.empty = False
+    with patch(
+        "backtest.loaders.mt5_loader.cached_loader_fetch", return_value=frame
+    ) as mock_cache:
+        out = DataLoader().fetch(
+            ["EURUSD"], "2024-01-01", "2024-01-31", interval="1W"
+        )
+    assert set(out) == {"EURUSD"}
+    assert mock_cache.call_args.kwargs["timeframe"] == "1W"


### PR DESCRIPTION
Unknown MT5 intervals silently fell back to daily bars, and week/month tokens were missing while the connector already exposes W1/MN1.

Map 1W/1w/1M and return empty instead of rewriting unknowns to daily.