### PR TITLE
fix(loaders): accept lowercase 1d/1w in AKShare daily map

### DIFF
--- a/agent/backtest/loaders/akshare_loader.py
+++ b/agent/backtest/loaders/akshare_loader.py
@@ -19,7 +19,9 @@ logger = logging.getLogger(__name__)
 
 _INTERVAL_MAP_DAILY = {
     "1D": "daily",
+    "1d": "daily",
     "1W": "weekly",
+    "1w": "weekly",
     "1M": "monthly",
 }
 

--- a/agent/tests/test_akshare_daily_aliases.py
+++ b/agent/tests/test_akshare_daily_aliases.py
@@ -1,0 +1,15 @@
+"""AKShare daily map must accept connector-style lowercase 1d/1w aliases."""
+
+from __future__ import annotations
+
+from backtest.loaders.akshare_loader import _INTERVAL_MAP_DAILY
+
+
+def test_lowercase_1d_and_1w_map_like_project_tokens() -> None:
+    assert _INTERVAL_MAP_DAILY["1d"] == _INTERVAL_MAP_DAILY["1D"] == "daily"
+    assert _INTERVAL_MAP_DAILY["1w"] == _INTERVAL_MAP_DAILY["1W"] == "weekly"
+
+
+def test_hour_token_still_absent_from_daily_map() -> None:
+    assert "1H" not in _INTERVAL_MAP_DAILY
+    assert "1h" not in _INTERVAL_MAP_DAILY


### PR DESCRIPTION
The AKShare daily interval map listed 1D/1W but not 1d/1w, so lowercase day/week tokens missed the map.

Add the lowercase aliases.