### PR TITLE
fix(loaders): treat lowercase 1d as Tushare daily bars

### DIFF
--- a/agent/backtest/loaders/tushare.py
+++ b/agent/backtest/loaders/tushare.py
@@ -93,7 +93,11 @@ class DataLoader:
         """
         validate_date_range(start_date, end_date)
 
-        if interval != "1D":
+        # Daily aliases (sina/tencent/market_data style); bare ``1d`` must not
+        # fall into the minute path and return empty.
+        if str(interval).strip().lower() in {"1d", "d", "day", "daily"}:
+            interval = "1D"
+        elif interval != "1D":
             return self._fetch_minutes(codes, start_date, end_date, interval)
 
         sd = start_date.replace("-", "")

--- a/agent/backtest/loaders/tushare.py
+++ b/agent/backtest/loaders/tushare.py
@@ -93,8 +93,7 @@ class DataLoader:
         """
         validate_date_range(start_date, end_date)
 
-        # Daily aliases (sina/tencent/market_data style); bare ``1d`` must not
-        # fall into the minute path and return empty.
+        # Tencent/sina-style daily aliases; bare ``1d`` must not take the minute path.
         if str(interval).strip().lower() in {"1d", "d", "day", "daily"}:
             interval = "1D"
         elif interval != "1D":

--- a/agent/tests/test_tushare_daily_alias_1d.py
+++ b/agent/tests/test_tushare_daily_alias_1d.py
@@ -1,0 +1,55 @@
+"""Tushare daily fetch must accept lowercase 1d instead of falling into minutes."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+from backtest.loaders.tushare import DataLoader
+
+
+def _daily_frame() -> pd.DataFrame:
+    idx = pd.to_datetime(["2024-01-02"])
+    return pd.DataFrame(
+        {
+            "open": [1.0],
+            "high": [2.0],
+            "low": [0.5],
+            "close": [1.5],
+            "volume": [100.0],
+        },
+        index=idx,
+    )
+
+
+def test_lowercase_1d_uses_daily_path_not_minutes() -> None:
+    """``1d`` used to miss ``!= "1D"`` and return empty from minute freq_map."""
+    loader = DataLoader.__new__(DataLoader)
+    loader.api = MagicMock()
+    daily = _daily_frame()
+    with patch.object(loader, "_fetch_daily_frame", return_value=daily) as mock_daily:
+        with patch.object(loader, "_fetch_minutes") as mock_mins:
+            with patch(
+                "backtest.loaders.tushare.cached_loader_fetch",
+                side_effect=lambda **kw: kw["fetch"](),
+            ):
+                out = loader.fetch(
+                    ["000001.SZ"], "2024-01-01", "2024-01-31", interval="1d"
+                )
+    assert set(out) == {"000001.SZ"}
+    mock_daily.assert_called()
+    mock_mins.assert_not_called()
+
+
+def test_hour_interval_still_uses_minutes() -> None:
+    loader = DataLoader.__new__(DataLoader)
+    loader.api = MagicMock()
+    with patch.object(loader, "_fetch_minutes", return_value={}) as mock_mins:
+        with patch.object(loader, "_fetch_daily_frame") as mock_daily:
+            out = loader.fetch(
+                ["000001.SZ"], "2024-01-01", "2024-01-31", interval="1H"
+            )
+    assert out == {}
+    mock_mins.assert_called_once()
+    mock_daily.assert_not_called()


### PR DESCRIPTION
Tushare treated lowercase 1d as non-daily while 1D already selected the daily path.

Treat 1d as daily like 1D.