### PR TITLE
fix(loaders): accept lowercase 1d/1w in Eastmoney KLT map

### DIFF
--- a/agent/backtest/loaders/eastmoney_client.py
+++ b/agent/backtest/loaders/eastmoney_client.py
@@ -42,7 +42,9 @@ _DEFAULT_MIN_INTERVAL = 1.0
 # Eastmoney kline period codes (``klt``) keyed by our interval labels.
 KLT_BY_INTERVAL: dict[str, int] = {
     "1D": 101,
+    "1d": 101,
     "1W": 102,
+    "1w": 102,
     "1M": 103,
     "1m": 1,
     "5m": 5,

--- a/agent/tests/test_eastmoney_daily_week_aliases.py
+++ b/agent/tests/test_eastmoney_daily_week_aliases.py
@@ -1,0 +1,15 @@
+"""Eastmoney KLT map must accept lowercase 1d/1w like project 1D/1W tokens."""
+
+from __future__ import annotations
+
+from backtest.loaders.eastmoney_client import KLT_BY_INTERVAL
+
+
+def test_lowercase_1d_and_1w_map_like_project_tokens() -> None:
+    assert KLT_BY_INTERVAL["1d"] == KLT_BY_INTERVAL["1D"] == 101
+    assert KLT_BY_INTERVAL["1w"] == KLT_BY_INTERVAL["1W"] == 102
+
+
+def test_month_vs_minute_case_preserved() -> None:
+    assert KLT_BY_INTERVAL["1M"] == 103
+    assert KLT_BY_INTERVAL["1m"] == 1


### PR DESCRIPTION
The Eastmoney KLT map missed lowercase 1d/1w, so those intervals did not resolve.

Add the lowercase aliases next to the existing keys.