### PR TITLE
docs: fix broken Contributing nav anchor in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
   <a href="#-examples">Examples</a> &nbsp;&middot;&nbsp;
   <a href="#-api-server">API / MCP</a> &nbsp;&middot;&nbsp;
   <a href="#-roadmap">Roadmap</a> &nbsp;&middot;&nbsp;
-  <a href="#-contributing">Contributing</a>
+  <a href="#contributing">Contributing</a>
 </p>
 
 <p align="center">

--- a/README_zh.md
+++ b/README_zh.md
@@ -39,7 +39,7 @@
   <a href="#-examples">Examples</a> &nbsp;&middot;&nbsp;
   <a href="#-api-server">API / MCP</a> &nbsp;&middot;&nbsp;
   <a href="#-roadmap">Roadmap</a> &nbsp;&middot;&nbsp;
-  <a href="#-contributing">Contributing</a>
+  <a href="#contributing">Contributing</a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
The header navigation links "Contributing" to `#-contributing`, but the `## Contributing` heading has no leading emoji, so GitHub generates its anchor as `#contributing` (no leading hyphen). As a result, clicking "Contributing" in the top nav doesn't scroll to the section.

Every other nav entry points at an emoji heading (e.g. `## 📰 News` → `#-news`), so their leading-hyphen anchors are correct. `README_ja.md` already uses the correct `#contributing`; this aligns `README.md` and `README_zh.md` with it.

Docs-only, no functional changes.
