### PR TITLE
fix(cli): forward universe meta into alpha bench JSON/HTML output

### DIFF
--- a/agent/src/factors/cli_handlers.py
+++ b/agent/src/factors/cli_handlers.py
@@ -659,6 +659,10 @@ def cmd_alpha_bench(args: argparse.Namespace) -> int:
 
         top_rows = [_normalise_row(r) for r in top_rows_raw]
         failures_for_report = [_normalise_skipped(s) for s in skipped[:10]]
+        # Universe metadata (e.g. the sp500 loader's survivorship_bias flag),
+        # forwarded by bench_runner.run_bench as result["meta"] and already
+        # kept by alpha_routes._result_for_wire for the SSE/frontend path.
+        universe_meta = result.get("meta")
 
         report_path: Path | None = None
         try:
@@ -684,6 +688,8 @@ def cmd_alpha_bench(args: argparse.Namespace) -> int:
                 "top": top_rows,
                 "failures": failures_for_report,
             }
+            if universe_meta:
+                context["meta"] = universe_meta
             report_path.write_text(_render_html(context), encoding="utf-8")
         except Exception as exc:  # noqa: BLE001 — report is nice-to-have
             _err(f"warning: could not write HTML report: {exc}")
@@ -706,6 +712,8 @@ def cmd_alpha_bench(args: argparse.Namespace) -> int:
                     envelope[key] = result[key]
             if result.get("oos_split") is not None:
                 envelope["oos_split"] = result["oos_split"]
+        if universe_meta:
+            envelope["meta"] = universe_meta
         if report_path is not None:
             envelope["report_path"] = str(report_path)
         print(json.dumps(envelope, indent=2, default=str))

--- a/agent/tests/test_alpha_bench_meta_survivorship.py
+++ b/agent/tests/test_alpha_bench_meta_survivorship.py
@@ -1,0 +1,138 @@
+"""``alpha bench`` must forward result["meta"] (issue #797).
+
+bench_runner.run_bench forwards the sp500 loader's survivorship_bias flag as
+result["meta"], and alpha_routes._result_for_wire already keeps it for the
+SSE/frontend path. cmd_alpha_bench's own JSON envelope and HTML report
+context were built from hand-enumerated dict literals that never included
+that key, so the CLI/HTML path silently dropped the disclosure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+import pytest
+
+from src.factors import cli_handlers
+
+
+def _ns(**overrides):
+    base = dict(
+        zoo="alpha101",
+        universe="sp500",
+        period="2020-2025",
+        top=20,
+        yes=True,
+        strict=False,
+        oos_split=None,
+        random_seeds=5,
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def _result(**overrides):
+    base = {
+        "status": "ok",
+        "alive": 1,
+        "rows": [
+            {
+                "id": "alpha001",
+                "ic_mean": 0.05,
+                "ic_std": 0.01,
+                "ir": 0.9,
+                "ic_positive_ratio": 0.7,
+                "ic_count": 100,
+                "theme": ["momentum"],
+                "formula_latex": "x",
+                "_category": "alive",
+            }
+        ],
+        "skipped": [],
+        "wall_seconds": 1.0,
+    }
+    base.update(overrides)
+    return base
+
+
+_UNIVERSE_META = {
+    "universe": "sp500",
+    "survivorship_bias": True,
+    "constituent_source": "current wiki S&P 500 list",
+    "constituent_source_date": "2026-01-01",
+    "constituent_count": 500,
+}
+
+
+class _FakeReg:
+    def list(self, zoo=None):
+        return ["alpha001"]
+
+    def get(self, aid):
+        class _Entry:
+            zoo = "alpha101"
+            meta = {"theme": ["momentum"], "formula_latex": "x"}
+
+        return _Entry()
+
+
+def _envelope(out: str) -> dict:
+    start = out.find("\n{")
+    if start < 0:
+        start = out.find("{") if out.lstrip().startswith("{") else -1
+        if start < 0:
+            raise AssertionError(f"no JSON envelope in stdout: {out[:200]!r}")
+    else:
+        start += 1
+    return json.loads(out[start:])
+
+
+@pytest.fixture()
+def _reg(monkeypatch):
+    monkeypatch.setattr(cli_handlers, "Registry", _FakeReg)
+
+
+@pytest.fixture()
+def _captured_html_context(monkeypatch):
+    """Capture the context dict handed to the HTML renderer, write nothing."""
+    import src.tools.alpha_bench_tool as tool
+
+    captured = {}
+
+    def fake_render_html(context):
+        captured.update(context)
+        return "<html></html>"
+
+    monkeypatch.setattr(tool, "_render_html", fake_render_html)
+    return captured
+
+
+def _run(monkeypatch, capsys, args, result):
+    import src.factors.bench_runner as legacy_mod
+
+    monkeypatch.setattr(legacy_mod, "run_bench", lambda **kw: result)
+    rc = cli_handlers.cmd_alpha_bench(args)
+    return rc, capsys.readouterr()
+
+
+def test_envelope_includes_universe_meta_when_present(capsys, monkeypatch, _reg, _captured_html_context):
+    rc, cap = _run(monkeypatch, capsys, _ns(), _result(meta=dict(_UNIVERSE_META)))
+    assert rc == 0
+    envelope = _envelope(cap.out)
+    assert envelope["meta"] == _UNIVERSE_META
+
+
+def test_html_context_includes_universe_meta_when_present(capsys, monkeypatch, _reg, _captured_html_context):
+    rc, _cap = _run(monkeypatch, capsys, _ns(), _result(meta=dict(_UNIVERSE_META)))
+    assert rc == 0
+    assert _captured_html_context["meta"] == _UNIVERSE_META
+
+
+def test_meta_key_absent_from_envelope_and_context_when_loader_has_none(capsys, monkeypatch, _reg, _captured_html_context):
+    """csi300/other loaders return no _meta; final envelope/context must not gain a stray key."""
+    rc, cap = _run(monkeypatch, capsys, _ns(universe="csi300"), _result())
+    assert rc == 0
+    envelope = _envelope(cap.out)
+    assert "meta" not in envelope
+    assert "meta" not in _captured_html_context


### PR DESCRIPTION
## Summary

- `vibe-trading alpha bench` silently drops the sp500 loader's `survivorship_bias`
  disclosure from both its JSON envelope and its HTML report, even though the
  web UI's SSE path already keeps it.

## Why

`bench_runner.run_bench` forwards the sp500 loader's universe metadata as
`result["meta"]` (`bench_runner.py:319-347`), and `alpha_routes._result_for_wire`
explicitly keeps `"meta"` in the keys it forwards to the frontend
(`alpha_routes.py:757-777`, comment: "so users see degraded runs clearly"). But
`cmd_alpha_bench` builds its own JSON envelope and HTML report context from
hand-enumerated dict literals (`cli_handlers.py:676-701`), and `"meta"` was not
among the keys in either one. Anyone running `vibe-trading alpha bench --universe
sp500` from the CLI, or reading the generated HTML report, gets no
survivorship-bias signal at all, while the same run through the web UI does.

Fixes #797.

## Changes

- `cli_handlers.py`: read `result.get("meta")` once and forward it into both the
  HTML report context and the JSON envelope when present, the same opaque
  passthrough the wire path already uses.

## Test Plan

- [x] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`,
      6299 passed, 13 skipped; the one unrelated pre-existing failure,
      `test_redaction.py::test_no_over_redaction_of_external_or_caller_paths`,
      reproduces identically on unmodified `main` and is untouched by this diff)
- [x] New tests added: `agent/tests/test_alpha_bench_meta_survivorship.py`, 3 cases
      (envelope carries `meta` when present, HTML context carries `meta` when
      present, both stay free of the key when the loader supplies none). All three
      fail on `main` (`KeyError: 'meta'` for the first two) and pass on this branch.
- [x] Tested manually: drove `cmd_alpha_bench` directly (the real registered
      handler) in a clean `python:3.11-slim` Docker container against fresh
      `origin/main` HEAD, with a fake `run_bench` returning a `meta` payload;
      confirmed the key was missing pre-fix and present post-fix in both outputs.
- [x] `bash tools/ci_grep_gates.sh`, `pytest tools/test_ci_env_var_gate.py`, and
      the `compileall`/`py_compile` syntax checks all pass.
- [x] Not touched: frontend build and `vitest run` (35 files, 310 tests) pass
      unmodified; this diff has no frontend-visible surface, verified only as a
      completeness check since neither file changed.

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`)
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows CONTRIBUTING.md guidelines
- [ ] Documentation updated (not user-facing beyond the bug itself; no README/CLI
      help text describes this field today)
