### PR TITLE
fix(cli): show a meaningful account label in the broker_sdk balances view

### DIFF
--- a/agent/cli/_legacy.py
+++ b/agent/cli/_legacy.py
@@ -4021,6 +4021,8 @@ def _print_connector_account(result: dict[str, Any]) -> int:
     # broker_sdk connectors (Longbridge, …) return a ``balances`` list instead of
     # IBKR-style ``summary`` tag/value rows; render that when present (#735).
     if not rows and result.get("balances"):
+        label = accounts if accounts != "(none)" else result.get("profile_id", result.get("profile", "unknown"))
+        console.print(f"Accounts: [cyan]{rich_escape(str(label))}[/cyan]")
         return _print_connector_balances(result)
     if not rows:
         # Not the broker_sdk flat shape — try the remote-MCP nested shape.


### PR DESCRIPTION
### Problem

The `_print_connector_account` CLI renderer has a broker_sdk fast-path for connectors
that return `balances` instead of the IBKR-style `summary` rows (introduced in #726).
When that path is taken, the header always prints

```
Accounts: (none)
```

because `accounts` is derived from `result.get("accounts", [])` — a key that
Longbridge and other broker_sdk connectors do not include in their response.

### Fix

When `accounts` is empty and the renderer falls into the `balances` fast-path, fall
back to `result.get("profile_id")` — which `_with_profile()` (service.py:426)
always injects into every account result — so the label is informative:

```
Accounts: longbridge-paper-trade
```

### Why a separate follow-up (not part of #735)

#726 fixed the core rendering bug (#735): broker_sdk schemas were not decoded at
all. This is a cosmetic gap left behind: the header label that was always `(none)`
in the only path the fix introduced.

### Manual verification

- Ran `agent/tests/test_cli_connector_renderers.py` — 4/4 pass, including the
  balances-table test whose code path is the one being changed.
- Traced the full call chain: `get_account_snapshot()` → `_with_profile()` →
  `_print_connector_account()` — `profile_id` is guaranteed to be present.

Closes #846