### PR TITLE
fix(cli): forward survivorship_bias meta to JSON envelope and HTML report

### DIFF
--- a/agent/src/factors/cli_handlers.py
+++ b/agent/src/factors/cli_handlers.py
@@ -662,6 +662,7 @@ def cmd_alpha_bench(args: argparse.Namespace) -> int:
                 "n_skipped": len(skipped),
                 "top": top_rows,
                 "failures": failures_for_report,
+                "meta": result.get("meta"),
             }
             report_path.write_text(_render_html(context), encoding="utf-8")
         except Exception as exc:  # noqa: BLE001 — report is nice-to-have
@@ -676,6 +677,7 @@ def cmd_alpha_bench(args: argparse.Namespace) -> int:
             "n_alphas_tested": len(rows),
             "n_skipped": len(skipped),
             "top": top_rows,
+            "meta": result.get("meta"),
             "wall_seconds": result.get("wall_seconds"),
         }
         if report_path is not None:

--- a/agent/src/tools/alpha_bench_tool.py
+++ b/agent/src/tools/alpha_bench_tool.py
@@ -690,10 +690,18 @@ def _render_html_manual(ctx: dict[str, Any]) -> str:
         _esc(ctx["period"]),
         f" &middot; {int(ctx['n_alphas_tested'])} tested, {int(ctx['n_skipped'])} skipped",
         "</div>",
-        f"<h2>Top {len(ctx['top'])} by IR</h2><table>",
-        "<tr><th>#</th><th>Alpha ID</th><th>Zoo</th><th>Theme</th>"
-        "<th>IC mean</th><th>IC std</th><th>IR</th><th>IC+ ratio</th><th>N</th></tr>",
     ]
+    meta = ctx.get("meta") or {}
+    if meta.get("survivorship_bias"):
+        parts.append(
+            "<div class=\"warning\">&#9888; Survivorship-biased universe: "
+            "constituents are the current index members, not the point-in-time "
+            "roster. IC statistics may be overstated."
+            "</div>"
+        )
+    parts.append(f"<h2>Top {len(ctx['top'])} by IR</h2><table>")
+    parts.append("<tr><th>#</th><th>Alpha ID</th><th>Zoo</th><th>Theme</th>"
+        "<th>IC mean</th><th>IC std</th><th>IR</th><th>IC+ ratio</th><th>N</th></tr>")
     for i, row in enumerate(ctx["top"], start=1):
         ic_mean = _esc(f"{row['ic_mean']:.4f}")
         ic_std = _esc(f"{row['ic_std']:.4f}")


### PR DESCRIPTION
The sp500 loader sets `_meta.survivorship_bias` on the panel so downstream surfaces can warn users about inflated IC stats, but the CLI JSON envelope and HTML report both dropped it — only the API SSE path preserved it. Include meta in both the envelope and report context, and render a warning banner in the HTML when survivorship_bias is true.

Closes #797