### PR TITLE
Fix circular-reference crash serializing dataclass tool results

### DIFF
--- a/agent/src/tools/mcp.py
+++ b/agent/src/tools/mcp.py
@@ -10,7 +10,8 @@ import os
 import re
 import threading
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, fields, is_dataclass
+from datetime import date, datetime
 from typing import Any, Awaitable, Callable, Coroutine, Iterable, Protocol, TypeVar
 
 from fastmcp.client import Client
@@ -1074,6 +1075,16 @@ def _format_exception_message(exc: Exception) -> str:
 def _make_jsonable(value: Any) -> Any:
     """Convert FastMCP response payloads into JSON-serializable objects.
 
+    ``fastmcp``'s client auto-types ``CallToolResult.data`` from a tool's
+    output schema via ``json_schema_to_type``, which produces a plain
+    ``dataclasses`` instance (not a Pydantic ``BaseModel``) for any object
+    schema that doesn't set ``additionalProperties: true`` -- the common
+    case. Without a dedicated branch here, such an instance falls through
+    to the final ``return value`` unconverted; ``json.dumps``'s ``default``
+    then receives the same unconvertible object back and raises
+    ``ValueError: Circular reference detected``, since its cycle detector
+    can't distinguish "default() gave up" from an actual cycle.
+
     Args:
         value: Arbitrary response value.
 
@@ -1082,6 +1093,10 @@ def _make_jsonable(value: Any) -> Any:
     """
     if hasattr(value, "model_dump"):
         return value.model_dump(mode="json", by_alias=True, exclude_none=True)
+    if is_dataclass(value) and not isinstance(value, type):
+        return {field.name: _make_jsonable(getattr(value, field.name)) for field in fields(value)}
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
     if isinstance(value, list):
         return [_make_jsonable(item) for item in value]
     if isinstance(value, dict):


### PR DESCRIPTION
## Goal

Fix a crash in `MCPRemoteTool.execute()` (`agent/src/tools/mcp.py`):
`ValueError: Circular reference detected` when serializing the result of
any MCP tool whose structured output schema doesn't set
`additionalProperties: true` -- the common case for a typical
Pydantic-model tool return type.

## Root cause

- `_normalize_call_tool_result()` sets `payload["data"] = _make_jsonable(result.data)`.
  `result.data` is `fastmcp`'s client-side auto-typed object, built from
  the tool's output JSON Schema via `json_schema_to_type()`.
- `json_schema_to_type()` only produces a Pydantic `BaseModel` when the
  schema sets `additionalProperties: true`; otherwise it produces a plain
  stdlib `dataclasses.dataclass` instance.
- `_make_jsonable()` only has branches for `hasattr(value, "model_dump")`
  (Pydantic models), `list`, and `dict`. A stdlib dataclass instance falls
  through to the final `return value`, unconverted.
- That unconverted object is then handed to
  `json.dumps(payload, default=_json_default)`. Since `_json_default`
  (via `_make_jsonable`) hands back the *same* unconvertible object,
  Python's encoder -- which tracks in-flight object ids specifically to
  catch a `default` callback that fails to converge -- raises
  `ValueError: Circular reference detected`. There's no actual data
  cycle; `default()` just never resolves to a JSON-serializable value.
- The same gap exists one level down for `datetime`/`date` fields: a
  schema property with `"format": "date-time"` validates to a real
  `datetime` object via `TypeAdapter`, which also has no branch in
  `_make_jsonable` and would hit the identical failure.

Encountered live via an unrelated local MCP server's `get_ticks_history`
tool -- its output schema (plain object properties, no
`additionalProperties`, with a nested `datetime` field) triggers this
exact path. This is a general serialization bug affecting any MCP server
with typical Pydantic-model tool outputs, not specific to that server.

## Fix

Adds a `dataclasses.is_dataclass(value)` branch to `_make_jsonable` that
recursively converts each field through `_make_jsonable` (rather than a
raw `dataclasses.asdict()`, which would leave nested `datetime`/dataclass
values unconverted), plus a `datetime`/`date` -> `.isoformat()` branch.

## Affected areas

- `agent/src/tools/mcp.py`: `_make_jsonable` only. No changes to tool
  discovery, invocation, retry, or auth logic.

## Out of scope

- No changes to broker, order-gate, mandate, or credential handling.
- No changes to the `fastmcp` dependency itself (the underlying
  `json_schema_to_type` behavior that produces dataclasses instead of
  Pydantic models is unchanged; this PR only fixes how this repo's own
  `_make_jsonable` handles that output).
- Didn't add a unit test in this PR since I couldn't get a full local
  clone of this repo to run its test suite in my environment (network
  issue on my end, unrelated to the repo) -- see Test plan below for how
  this was verified instead. Happy to add a test under
  `agent/tests/` if a maintainer points me to the right location/fixtures
  for MCP client-side tests.

## Test plan

- Reproduced the crash standalone against the real `fastmcp` dependency:
  built a dataclass-producing type via
  `fastmcp.utilities.json_schema_type.json_schema_to_type()` from a real
  MCP tool's output schema (object properties, no
  `additionalProperties`, nested `datetime` field), ran it through the
  old `_make_jsonable` -> `ValueError: Circular reference detected`,
  matching the originally reported traceback exactly.
- Ran the same object through the patched `_make_jsonable` -> serializes
  correctly.
- Verified the `datetime` branch specifically by constructing the
  instance through `pydantic.TypeAdapter(...).validate_python(...)` (the
  same validation path `fastmcp`'s client uses), confirming a
  `"format": "date-time"` field becomes a real `datetime.datetime` and
  still serializes correctly (`"2026-07-24T20:50:00+00:00"`).
- Not run: this repo's own pytest suite / `agent/tests/` (couldn't get a
  local clone of `Vibe-Trading` in my environment -- shallow and full
  `git clone` both hung/disconnected on this network). The change is
  scoped to a single pure function with no I/O, so this is a low-risk
  gap, but flagging it per the contributor guide rather than claiming a
  suite run that didn't happen.

## Risk

- No broker, order, credential, network, or deployment surface touched.
- `agent/src/tools/mcp.py` is the MCP client adapter, but this change only
  affects local JSON serialization of already-received tool results --
  it does not change what gets sent to, or trusted from, any MCP server.

## Rollback

Single-file, single-function change; `git revert` is sufficient if an
issue is found.
