### PR TITLE
fix(providers): omit temperature for Claude Opus 4.7

### DIFF
--- a/agent/src/providers/llm.py
+++ b/agent/src/providers/llm.py
@@ -464,20 +464,26 @@ def _build_anthropic(
             'extra: pip install "vibe-trading-ai[anthropic]" (or pip install langchain-anthropic).'
         ) from exc
 
-    return chat_anthropic(
-        model=model,
-        max_tokens=get_env_config().llm.anthropic_max_tokens,
-        temperature=temperature,
-        timeout=get_env_config().llm.timeout_seconds,
-        max_retries=get_env_config().llm.max_retries,
-        callbacks=callbacks,
-        api_key=os.getenv("ANTHROPIC_API_KEY") or None,  # noqa: env-gate — native provider credential
-        base_url=(
+    kwargs: dict[str, Any] = {
+        "model": model,
+        "max_tokens": get_env_config().llm.anthropic_max_tokens,
+        "timeout": get_env_config().llm.timeout_seconds,
+        "max_retries": get_env_config().llm.max_retries,
+        "callbacks": callbacks,
+        "api_key": os.getenv("ANTHROPIC_API_KEY") or None,  # noqa: env-gate — native provider credential
+        "base_url": (
             os.getenv("ANTHROPIC_BASE_URL")  # noqa: env-gate — native provider endpoint
             or os.getenv("ANTHROPIC_API_URL")  # noqa: env-gate — SDK-compatible alias
             or None
         ),
+    }
+    is_opus_4_7 = re.search(
+        r"(?:^|[.:/])claude-opus-4-7(?:-|$)", model.lower()
     )
+    if not is_opus_4_7:
+        kwargs["temperature"] = temperature
+
+    return chat_anthropic(**kwargs)
 
 
 def _load_env_file(path: Path) -> None:

--- a/agent/tests/test_anthropic_provider.py
+++ b/agent/tests/test_anthropic_provider.py
@@ -1,0 +1,75 @@
+"""Regression coverage for Anthropic model-specific request parameters."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.providers import llm
+
+
+def _capture_anthropic_kwargs(monkeypatch, model: str, temperature: float) -> dict:
+    captured: dict = {}
+
+    def fake_chat_anthropic(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    fake_module = SimpleNamespace(ChatAnthropic=fake_chat_anthropic)
+    fake_config = SimpleNamespace(
+        llm=SimpleNamespace(
+            anthropic_max_tokens=None,
+            timeout_seconds=120,
+            max_retries=2,
+        )
+    )
+    monkeypatch.setattr(llm, "import_module", lambda _name: fake_module)
+    monkeypatch.setattr(llm, "get_env_config", lambda: fake_config)
+
+    llm._build_anthropic(model=model, temperature=temperature)
+    return captured
+
+
+def test_opus_4_7_omits_deprecated_temperature(monkeypatch) -> None:
+    """Claude Opus 4.7 rejects requests that include temperature."""
+    kwargs = _capture_anthropic_kwargs(monkeypatch, "claude-opus-4-7", 0.3)
+
+    assert "temperature" not in kwargs
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "claude-opus-4-7-20260725",
+        "anthropic.claude-opus-4-7-v1:0",
+    ],
+)
+def test_opus_4_7_model_variants_omit_deprecated_temperature(
+    monkeypatch, model: str
+) -> None:
+    """Dated and provider-qualified Opus 4.7 IDs follow the same restriction."""
+    kwargs = _capture_anthropic_kwargs(monkeypatch, model, 0.3)
+
+    assert "temperature" not in kwargs
+
+
+def test_older_anthropic_models_keep_configured_temperature(monkeypatch) -> None:
+    """Existing Anthropic model behavior remains unchanged."""
+    kwargs = _capture_anthropic_kwargs(monkeypatch, "claude-sonnet-4-6", 0.3)
+
+    assert kwargs["temperature"] == 0.3
+
+
+def test_older_opus_models_keep_configured_temperature(monkeypatch) -> None:
+    """The restriction does not change older Opus request behavior."""
+    kwargs = _capture_anthropic_kwargs(monkeypatch, "claude-opus-4-6", 0.3)
+
+    assert kwargs["temperature"] == 0.3
+
+
+def test_other_opus_versions_keep_configured_temperature(monkeypatch) -> None:
+    """Do not infer the Opus 4.7 restriction for unreported model versions."""
+    kwargs = _capture_anthropic_kwargs(monkeypatch, "claude-opus-4-8", 0.3)
+
+    assert kwargs["temperature"] == 0.3


### PR DESCRIPTION
## Summary

- Omit the `temperature` request key for Claude Opus 4.7 model IDs.
- Preserve existing temperature behavior for Sonnet, older Opus releases, and unreported future Opus versions.
- Add provider-factory regressions for canonical, dated, and provider-qualified model IDs.

## Why

Closes #856.

`_build_anthropic()` currently forwards `temperature` unconditionally. Claude Opus 4.7 rejects requests containing this deprecated parameter, causing every worker to fail before its first iteration.

This draft is intentionally narrow because `src/providers` is protected by the contribution guide. It is open for maintainer confirmation of the model matching boundary before being marked ready.

## Changes

- Build Anthropic kwargs before constructing `ChatAnthropic`.
- Leave out `temperature` only when the model ID identifies Claude Opus 4.7.
- Keep the original parameter for existing unaffected model families.

## Test Plan

- [x] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [x] New tests added
- [ ] Tested manually against the live Anthropic API

Validation performed:

- Full `agent/tests` suite: `6355 passed, 13 skipped`.
- Focused provider/config audit tests: `41 passed`.
- Ruff passes for both changed files.
- Black passes for the new test file. The existing `llm.py` already fails repository Black formatting on the unchanged base revision, so this PR avoids unrelated whole-file formatting churn.
- The environment-variable gate reports only its pre-existing `os.environ.pop()` warning; the credential reads touched by this change retain their required suppressions.

## Checklist

- [ ] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion — protected provider change; proposal posted on #856 and PR remains draft pending maintainer direction
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Documentation updated (if user-facing change) — no documentation surface changed

## Contributor review note

I reviewed the final diff, verified the model-ID boundaries explicitly, ran the full agent test suite, and kept the change limited to the reported provider failure. No live API credential was used during testing.
