### PR TITLE
fix(skills): parse frontmatter when closing fence is at EOF

### DIFF
--- a/agent/src/agent/frontmatter.py
+++ b/agent/src/agent/frontmatter.py
@@ -8,7 +8,7 @@ from typing import Any, Dict
 # Opening ---, optional meta lines, closing ---. The closing fence may be at
 # EOF (no trailing newline) or followed by a body; empty meta (---\n---) is ok.
 _FRONTMATTER_RE = re.compile(
-    r"^---[ \t]*\r?\n(.*?)(?:\r?\n)?---[ \t]*(?:\r?\n(.*))?$",
+    r"^---[ \t]*\r?\n(?:(.*?)\r?\n)?---[ \t]*(?:\r?\n(.*))?$",
     re.DOTALL,
 )
 
@@ -29,7 +29,7 @@ def parse_frontmatter(text: str) -> tuple[Dict[str, Any], str]:
         return {}, text.strip()
 
     meta: Dict[str, Any] = {}
-    for line in match.group(1).strip().split("\n"):
+    for line in (match.group(1) or "").strip().split("\n"):
         line = line.strip()
         if ":" not in line:
             continue

--- a/agent/src/agent/frontmatter.py
+++ b/agent/src/agent/frontmatter.py
@@ -5,6 +5,13 @@ from __future__ import annotations
 import re
 from typing import Any, Dict
 
+# Opening ---, optional meta lines, closing ---. The closing fence may be at
+# EOF (no trailing newline) or followed by a body; empty meta (---\n---) is ok.
+_FRONTMATTER_RE = re.compile(
+    r"^---[ \t]*\r?\n(.*?)(?:\r?\n)?---[ \t]*(?:\r?\n(.*))?$",
+    re.DOTALL,
+)
+
 
 def parse_frontmatter(text: str) -> tuple[Dict[str, Any], str]:
     """Parse YAML-like frontmatter and body from a markdown file.
@@ -17,7 +24,7 @@ def parse_frontmatter(text: str) -> tuple[Dict[str, Any], str]:
     Returns:
         Tuple of (metadata dict, body text).
     """
-    match = re.match(r"^---\s*\n(.*?)\n---\s*\n(.*)", text, re.DOTALL)
+    match = _FRONTMATTER_RE.match(text)
     if not match:
         return {}, text.strip()
 
@@ -37,4 +44,5 @@ def parse_frontmatter(text: str) -> tuple[Dict[str, Any], str]:
         else:
             meta[key] = value
 
-    return meta, match.group(2).strip()
+    body = match.group(2) or ""
+    return meta, body.strip()

--- a/agent/tests/test_skills.py
+++ b/agent/tests/test_skills.py
@@ -55,6 +55,20 @@ class TestParseFrontmatter:
         assert "Line 1" in body
         assert "Line 3" in body
 
+    def test_closing_fence_at_eof_without_trailing_newline(self) -> None:
+        # Skill/memory writers often omit the final newline after ---.
+        text = "---\nname: eof-skill\ndescription: no trailing newline\n---"
+        meta, body = _parse_frontmatter(text)
+        assert meta["name"] == "eof-skill"
+        assert meta["description"] == "no trailing newline"
+        assert body == ""
+
+    def test_empty_frontmatter_block(self) -> None:
+        text = "---\n---\nBody only."
+        meta, body = _parse_frontmatter(text)
+        assert meta == {}
+        assert body == "Body only."
+
 
 # ---------------------------------------------------------------------------
 # Skill dataclass

--- a/agent/tests/test_skills.py
+++ b/agent/tests/test_skills.py
@@ -68,6 +68,13 @@ class TestParseFrontmatter:
         meta, body = _parse_frontmatter(text)
         assert meta == {}
         assert body == "Body only."
+    def test_rejects_inline_fence_tail_false_positive(self) -> None:
+        # Fence must stand alone on its line; a trailing --- on a value line
+        # is not a fence.
+        text = "---\nname: foo---"
+        meta, body = _parse_frontmatter(text)
+        assert meta == {}
+        assert body == text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
SKILL.md files that end at the closing --- with no trailing newline were treated as plain text, so name and description never loaded. Empty --- / --- blocks had the same miss. Accept EOF and empty meta between fences, with tests.