### PR TITLE
fix(journal): accept UTF-16 BOM CSV exports in load_dataframe

### DIFF
--- a/agent/src/tools/trade_journal_parsers.py
+++ b/agent/src/tools/trade_journal_parsers.py
@@ -104,12 +104,13 @@ def load_dataframe(path: str | Path) -> pd.DataFrame:
         raise ValueError(f"Unsupported extension: {ext}")
 
     last_err: Exception | None = None
-    for enc in ("utf-8", "utf-8-sig", "gbk", "gb2312"):
+    # utf-16 covers Excel "CSV UTF-16" / Unicode exports (BOM required).
+    for enc in ("utf-8-sig", "utf-8", "utf-16", "gbk", "gb2312"):
         try:
             return pd.read_csv(p, dtype=str, encoding=enc)
         except UnicodeDecodeError as exc:
             last_err = exc
-    raise ValueError(f"Failed to decode CSV with utf-8/gbk/gb2312: {last_err}")
+    raise ValueError(f"Failed to decode CSV with utf-8/utf-16/gbk/gb2312: {last_err}")
 
 
 # ---------------- Format detection ----------------

--- a/agent/tests/test_trade_journal.py
+++ b/agent/tests/test_trade_journal.py
@@ -19,6 +19,7 @@ from src.tools.trade_journal_parsers import (
     _infer_market_from_symbol,
     _normalize_side,
     _qualify_a_share,
+    load_dataframe,
     parse_tonghuashun,
     parse_eastmoney,
     parse_futu,
@@ -202,6 +203,18 @@ def test_parse_file_unknown_raises(tmp_path: Path) -> None:
     csv.write_text("foo,bar\n1,2\n", encoding="utf-8")
     with pytest.raises(ValueError, match="Unrecognized"):
         parse_file(csv)
+
+
+def test_load_dataframe_accepts_utf16_bom_csv(tmp_path: Path) -> None:
+    # Excel "CSV UTF-16" / Unicode CSV exports a BOM; previously every
+    # encoding attempt raised UnicodeDecodeError and the load failed.
+    csv = tmp_path / "futu_utf16.csv"
+    body = "Date,Symbol,Side,Quantity,Price\n2024-01-02,AAPL,Buy,10,100\n"
+    csv.write_bytes(body.encode("utf-16"))
+    df = load_dataframe(csv)
+    assert list(df.columns) == ["Date", "Symbol", "Side", "Quantity", "Price"]
+    assert detect_format(df) == "futu"
+    assert df.iloc[0]["Symbol"] == "AAPL"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Excel CSV UTF-16 exports start with a BOM that utf-8/gbk cannot decode, so load_dataframe raised and analyze_trade_journal never ran. Try utf-16 in the encoding fallback, with a test.