### PR TITLE
fix(skills): keep CJK characters in skill directory slugs

### DIFF
--- a/agent/src/tools/skill_writer_tool.py
+++ b/agent/src/tools/skill_writer_tool.py
@@ -11,6 +11,7 @@ User-created skills are stored separately from bundled skills:
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 import shutil
@@ -22,11 +23,27 @@ from src.agent.tools import BaseTool
 
 _ALLOWED_SUBDIRS = {"references", "templates", "examples", "assets"}
 
+# Keep CJK/other scripts in slugs (same ranges as persistent memory) so
+# distinct non-ASCII skill names do not all collapse to "--".
+_NON_LATIN_SCRIPT_RANGES = (
+    "一-鿿"  # CJK Unified Ideographs
+    "㐀-䶿"  # CJK Extension A
+    "฀-๿"  # Thai
+    "ؠ-ي"  # Arabic letters
+    "א-ת"  # Hebrew letters
+    "Ѐ-ӿ"  # Cyrillic
+)
+_SKILL_SLUG_DISALLOWED_RE = re.compile(rf"[^a-z0-9\-{_NON_LATIN_SCRIPT_RANGES}]")
+
 
 def _sanitize_skill_name(name: str) -> str:
     """Sanitize skill name to a safe directory slug."""
-    return re.sub(r"[^a-z0-9-]", "-", name.lower().strip())[:60]
-
+    slug = _SKILL_SLUG_DISALLOWED_RE.sub("-", name.lower().strip())[:60]
+    if not name.strip():
+        return ""
+    if slug.strip("-") == "":
+        return hashlib.sha256(name.strip().encode("utf-8")).hexdigest()[:8]
+    return slug
 
 class SaveSkillTool(BaseTool):
     """Save a successful workflow as a reusable skill."""

--- a/agent/tests/test_skill_writer_tools.py
+++ b/agent/tests/test_skill_writer_tools.py
@@ -37,6 +37,20 @@ class TestSanitizeSkillName:
     def test_empty(self) -> None:
         assert _sanitize_skill_name("") == ""
 
+    def test_cjk_name_keeps_distinct_slug(self) -> None:
+        a = _sanitize_skill_name("动量策略")
+        b = _sanitize_skill_name("均值回归")
+        assert a == "动量策略"
+        assert b == "均值回归"
+        assert a != b
+
+    def test_punctuation_only_uses_stable_digest(self) -> None:
+        slug = _sanitize_skill_name("???")
+        assert len(slug) == 8
+        assert slug.isalnum()
+        assert slug == _sanitize_skill_name("???")
+        assert slug != _sanitize_skill_name("!!!")
+
 
 # ---------------------------------------------------------------------------
 # SaveSkillTool


### PR DESCRIPTION
Chinese skill names such as 动量策略 were scrubbed to "--", so two different names wrote the same directory and overwrote each other. Keep non-Latin script ranges in the slug (same idea as persistent memory), and hash when only punctuation remains.