### PR TITLE
fix(metrics): annualize lowercase 1h/1d and yahoo like loaders

### DIFF
--- a/agent/backtest/metrics.py
+++ b/agent/backtest/metrics.py
@@ -31,19 +31,42 @@ _BARS_PER_DAY = {
     "1D":  {"tushare": 1,   "okx": 1,    "yfinance": 1,   "akshare": 1,   "ccxt": 1,    "mootdx": 1,   "futu": 1,   "mt5": 1},
 }
 
+# Runner/loaders also emit these aliases; map them onto the table keys above.
+_SOURCE_ALIASES = {"yahoo": "yfinance", "binance": "ccxt"}
+
+
+def _normalize_interval(interval: str) -> str:
+    """Map project interval tokens onto ``_BARS_PER_DAY`` keys.
+
+    Minute bars stay lowercase (``1m``); hour/day use the uppercase keys the
+    table already stores (``1H`` / ``4H`` / ``1D``). Loaders accept both cases
+    after the interval-map fixes; annualisation must too.
+    """
+    token = str(interval or "1D").strip()
+    lower = token.lower()
+    if lower in ("1m", "5m", "15m", "30m"):
+        return lower
+    if lower in ("1h", "4h", "1d"):
+        return lower.upper()
+    return token
+
 
 def calc_bars_per_year(interval: str = "1D", source: str = "tushare") -> int:
     """Number of bars per year for annualisation.
 
     Args:
-        interval: Bar size (1m / 5m / 15m / 30m / 1H / 4H / 1D).
-        source: Data source (tushare / yfinance / okx).
+        interval: Bar size (1m / 5m / 15m / 30m / 1H / 4H / 1D), case-insensitive
+            for hour/day tokens.
+        source: Data source (tushare / yfinance / okx). ``yahoo`` aliases to
+            ``yfinance``; ``binance`` aliases to ``ccxt``.
 
     Returns:
         Bars per year.
     """
-    trading_days = _TRADING_DAYS.get(source, 252)
-    bars_per_day = _BARS_PER_DAY.get(interval, {}).get(source, 1)
+    source_key = _SOURCE_ALIASES.get(str(source or "").strip().lower(), source)
+    interval_key = _normalize_interval(interval)
+    trading_days = _TRADING_DAYS.get(source_key, 252)
+    bars_per_day = _BARS_PER_DAY.get(interval_key, {}).get(source_key, 1)
     return trading_days * bars_per_day
 
 

--- a/agent/tests/test_metrics.py
+++ b/agent/tests/test_metrics.py
@@ -92,6 +92,20 @@ class TestBarsPerYear:
         # Falls back to 1 bar/day
         assert calc_bars_per_year("2H", "tushare") == 252
 
+    def test_lowercase_hour_matches_uppercase(self) -> None:
+        # Loaders accept 1h/4h after interval-map fixes; annualisation must too.
+        assert calc_bars_per_year("1h", "okx") == calc_bars_per_year("1H", "okx")
+        assert calc_bars_per_year("4h", "ccxt") == calc_bars_per_year("4H", "ccxt")
+        assert calc_bars_per_year("1h", "okx") == 365 * 24
+
+    def test_lowercase_day_matches_uppercase(self) -> None:
+        assert calc_bars_per_year("1d", "tushare") == calc_bars_per_year("1D", "tushare")
+
+    def test_yahoo_source_aliases_yfinance(self) -> None:
+        # Runner primary source for US equity is often "yahoo".
+        assert calc_bars_per_year("1H", "yahoo") == calc_bars_per_year("1H", "yfinance")
+        assert calc_bars_per_year("1H", "yahoo") == 252 * 7
+
 
 # ---------------------------------------------------------------------------
 # win_rate_and_stats


### PR DESCRIPTION
Loaders now accept 1h/4h/1d, but calc_bars_per_year only keyed 1H/1D, so an hourly okx run was annualised as 365 bars/year instead of 8760 and Sharpe/vol were wrong. Normalize hour/day case and alias yahoo to yfinance (runner primary source), with tests.