### PR TITLE
fix(tools): decode UTF-16 BOM text before latin-1 fallback

### DIFF
--- a/agent/src/tools/doc_reader_tool.py
+++ b/agent/src/tools/doc_reader_tool.py
@@ -353,6 +353,14 @@ def _read_image(path: Path) -> str:
 def _read_text(path: Path) -> str:
     """Read a text-like file with encoding fallback."""
     data = path.read_bytes()
+    # UTF-16 with BOM (Notepad "Unicode", Excel Unicode Text) before latin-1:
+    # latin-1 never raises, so BOM+NUL bytes become mojibake without this.
+    if data.startswith((b"\xff\xfe", b"\xfe\xff")):
+        try:
+            decoded = data.decode("utf-16")
+            return _envelope(path, "text", decoded, encoding="utf-16", size=len(data))
+        except UnicodeDecodeError:
+            pass
     last_err: Exception | None = None
     for enc in _ENCODING_FALLBACK:
         try:

--- a/agent/tests/test_doc_reader.py
+++ b/agent/tests/test_doc_reader.py
@@ -63,6 +63,19 @@ def test_gbk_fallback(tmp_path: Path) -> None:
     assert "中文" in result["text"]
 
 
+def test_utf16_bom_not_latin1_mojibake(tmp_path: Path) -> None:
+    # Notepad/Excel "Unicode text" writes UTF-16 with BOM. latin-1 never
+    # raises, so without utf-16 earlier in the fallback the file was accepted
+    # as mojibake (NUL bytes between ASCII letters).
+    p = tmp_path / "unicode.txt"
+    p.write_bytes("hello 动量\n".encode("utf-16"))
+    result = _call(p)
+    assert result["status"] == "ok"
+    assert result["encoding"] == "utf-16"
+    assert result["text"] == "hello 动量\n"
+    assert "\x00" not in result["text"]
+
+
 def test_unknown_extension_treated_as_text(tmp_path: Path) -> None:
     p = tmp_path / "weird.xyzfmt"
     p.write_text("abc", encoding="utf-8")


### PR DESCRIPTION
Notepad and Excel "Unicode text" exports use a UTF-16 BOM. The reader fell through to latin-1, which never raises, so the text came back as mojibake with NUL bytes. Detect the BOM and decode as utf-16 first, with a test.