### PR TITLE
fix(channels): preserve leading indent when splitting messages

### DIFF
--- a/agent/src/channels/signal.py
+++ b/agent/src/channels/signal.py
@@ -260,13 +260,13 @@ def _partition_styles(
         return [[] for _ in chunks]
 
     # Mirror split_message: after chunk 0, skip one separator char if present
-    # and not already part of the next chunk (so indented lines stay aligned).
+    # (split_message unconditionally drops at most one leading \n or space).
     chunk_ranges: list[tuple[int, int]] = []
     cursor = 0  # Python codepoint cursor in plain_text
     for i, chunk in enumerate(chunks):
         if i > 0 and cursor < len(plain_text):
             ch = plain_text[cursor]
-            if (ch == "\n" or ch == " ") and not chunk.startswith(ch):
+            if ch == "\n" or ch == " ":
                 cursor += 1
         utf16_start = _utf16_len(plain_text[:cursor])
         utf16_end = utf16_start + _utf16_len(chunk)

--- a/agent/src/channels/signal.py
+++ b/agent/src/channels/signal.py
@@ -248,27 +248,25 @@ def _partition_styles(
 ) -> list[list[str]]:
     """Partition Signal textStyle ranges across message chunks.
 
-    ``split_message`` slices ``plain_text`` into pieces (optionally trimming
-    whitespace at the boundaries), but the style ranges produced by
-    ``_markdown_to_signal`` are expressed in UTF-16 offsets relative to the
-    full ``plain_text``. This redistributes them per chunk with offsets
-    rebased to each chunk's start. Ranges that span a boundary are split
-    across the chunks they touch; ranges that fall entirely in trimmed
-    whitespace are dropped.
+    ``split_message`` slices ``plain_text`` into pieces and drops at most one
+    leading ``\\n`` or space at each cut (indent on the next line is kept).
+    Style ranges from ``_markdown_to_signal`` use UTF-16 offsets into the full
+    ``plain_text``; this rebases them per chunk. Ranges that land only on the
+    dropped separator are omitted.
     """
     if not chunks:
         return []
     if not text_styles:
         return [[] for _ in chunks]
 
-    # Locate each chunk's UTF-16 start in plain_text. split_message lstrips at
-    # boundaries (but not before the first chunk), so we skip whitespace
-    # between chunks to mirror that.
+    # Mirror split_message: after chunk 0, skip one separator char if present
+    # and not already part of the next chunk (so indented lines stay aligned).
     chunk_ranges: list[tuple[int, int]] = []
     cursor = 0  # Python codepoint cursor in plain_text
     for i, chunk in enumerate(chunks):
-        if i > 0:
-            while cursor < len(plain_text) and plain_text[cursor].isspace():
+        if i > 0 and cursor < len(plain_text):
+            ch = plain_text[cursor]
+            if (ch == "\n" or ch == " ") and not chunk.startswith(ch):
                 cursor += 1
         utf16_start = _utf16_len(plain_text[:cursor])
         utf16_end = utf16_start + _utf16_len(chunk)

--- a/agent/src/channels/utils.py
+++ b/agent/src/channels/utils.py
@@ -80,7 +80,12 @@ def split_message(content: str, max_len: int = 2000) -> list[str]:
         if pos <= 0:
             pos = max_len
         chunks.append(content[:pos])
-        content = content[pos:].lstrip()
+        # Drop only the separator we broke on. A blanket lstrip() also ate
+        # indentation on the next line (code blocks / nested markdown).
+        rest = content[pos:]
+        if rest.startswith("\n") or rest.startswith(" "):
+            rest = rest[1:]
+        content = rest
     return chunks
 
 

--- a/agent/tests/test_split_message_nonpositive.py
+++ b/agent/tests/test_split_message_nonpositive.py
@@ -15,3 +15,13 @@ def test_split_message_normal_path() -> None:
     chunks = split_message("aaa\nbbb\nccc", max_len=5)
     assert chunks
     assert all(len(c) <= 5 for c in chunks)
+
+
+def test_split_message_preserves_indent_after_newline_cut() -> None:
+    # Long first line forces a cut; the following indented code line must keep
+    # its leading spaces (Discord/Slack/Telegram all share this helper).
+    text = ("word " * 8) + "\n    def foo():\n        return 1\n" + ("tail " * 8)
+    chunks = split_message(text, max_len=40)
+    assert any("    def foo():" in c for c in chunks)
+    assert any("        return 1" in c for c in chunks)
+    assert all(len(c) <= 40 for c in chunks)

--- a/agent/tests/test_split_message_nonpositive.py
+++ b/agent/tests/test_split_message_nonpositive.py
@@ -25,3 +25,16 @@ def test_split_message_preserves_indent_after_newline_cut() -> None:
     assert any("    def foo():" in c for c in chunks)
     assert any("        return 1" in c for c in chunks)
     assert all(len(c) <= 40 for c in chunks)
+
+
+def test_signal_partition_styles_keeps_indent_chunk_aligned() -> None:
+    # Signal rebases UTF-16 styles onto split_message chunks; must not skip
+    # indent spaces the way the old blanket lstrip mirror did.
+    from src.channels.signal import _partition_styles, _utf16_len
+
+    text = ("word " * 8) + "\n    def foo():\n        return 1\n" + ("tail " * 8)
+    chunks = split_message(text, max_len=40)
+    idx = text.index("def")
+    styles = [f"{_utf16_len(text[:idx])}:{_utf16_len('def')}:BOLD"]
+    parts = _partition_styles(text, chunks, styles)
+    assert any("BOLD" in entry for group in parts for entry in group)

--- a/agent/tests/test_split_message_nonpositive.py
+++ b/agent/tests/test_split_message_nonpositive.py
@@ -38,3 +38,18 @@ def test_signal_partition_styles_keeps_indent_chunk_aligned() -> None:
     styles = [f"{_utf16_len(text[:idx])}:{_utf16_len('def')}:BOLD"]
     parts = _partition_styles(text, chunks, styles)
     assert any("BOLD" in entry for group in parts for entry in group)
+def test_signal_partition_styles_handles_space_separator_with_indented_next_chunk() -> None:
+    # When split_message cuts at a space separator and the next chunk is also
+    # indented with spaces, _partition_styles must still advance the cursor
+    # over the dropped separator space.
+    from src.channels.signal import _partition_styles, _utf16_len
+
+    # "12345 78" with max_len=5 cuts into "12345" and "78", dropping the space.
+    text = "12345   abc"
+    chunks = split_message(text, max_len=5)
+    # text is ["12345", "  abc"] — separator space at index 5 was dropped
+    idx = text.index("abc")
+    styles = [f"{_utf16_len(text[:idx])}:{_utf16_len('abc')}:BOLD"]
+    parts = _partition_styles(text, chunks, styles)
+    # "abc" is at offset 2 in the second chunk "  abc"
+    assert parts[1] == ["2:3:BOLD"]


### PR DESCRIPTION
After a newline cut, lstrip() removed indentation on the next chunk, so code blocks lost leading spaces across Discord/Slack/Telegram splits. Drop only the separator character, with a test.