### PR TITLE
fix(journal): treat BTCUSDT-style symbols as crypto markets

### DIFF
--- a/agent/src/tools/trade_journal_parsers.py
+++ b/agent/src/tools/trade_journal_parsers.py
@@ -517,6 +517,13 @@ def _infer_market_from_symbol(symbol: str) -> str:
         return "china_a"
     if "-" in s and any(quote in s for quote in ("USDT", "USDC", "BTC", "USD")):
         return "crypto"
+    # Binance-style concatenated pairs (BTCUSDT) are purely alphabetic, so the
+    # isalpha() US-equity branch below would mis-label them without this check.
+    for quote in ("USDT", "USDC", "BUSD"):
+        if len(s) > len(quote) and s.endswith(quote):
+            base = s[: -len(quote)]
+            if base.isalpha() and len(base) >= 2:
+                return "crypto"
     if s.isalpha():
         return "us"
     return "other"

--- a/agent/tests/test_trade_journal.py
+++ b/agent/tests/test_trade_journal.py
@@ -120,6 +120,9 @@ def test_normalize_side_rejects_missing_or_unknown(raw: object) -> None:
         ("AAPL", "us"),
         ("BTC-USDT", "crypto"),
         ("ETH-USD", "crypto"),
+        ("BTCUSDT", "crypto"),
+        ("ethusdc", "crypto"),
+        ("SOLBUSD", "crypto"),
         ("123456", "other"),
     ],
 )


### PR DESCRIPTION
Concatenated pairs like BTCUSDT are alphabetic, so market inference labeled them as US equities. Recognize USDT/USDC/BUSD suffixes before the equity branch, with a test.