### PR TITLE
fix(vnpy-export): update CtaTemplate/BacktestingEngine imports to vn.py 4.0 layout

### DIFF
--- a/agent/src/skills/vnpy-export/SKILL.md
+++ b/agent/src/skills/vnpy-export/SKILL.md
@@ -78,7 +78,7 @@ See `scripts/cta_template.py` for a complete, runnable example (MA crossover).
 The template below is the canonical skeleton — replace the `# SIGNAL LOGIC` section:
 
 ```python
-from vnpy.app.cta_strategy import (
+from vnpy_ctastrategy import (
     CtaTemplate,
     StopOrder,
     TickData,
@@ -270,7 +270,7 @@ To load in vnpy:
 To run the vnpy backtester:
 
 ```python
-from vnpy.app.cta_backtester import BacktestingEngine
+from vnpy_ctastrategy.backtesting import BacktestingEngine
 from vnpy.trader.constant import Interval
 
 engine = BacktestingEngine()

--- a/agent/src/skills/vnpy-export/scripts/cta_template.py
+++ b/agent/src/skills/vnpy-export/scripts/cta_template.py
@@ -5,14 +5,14 @@ This file is the reference implementation for the vnpy-export skill.
 Copy it to your vnpy project's strategies/ folder and adjust parameters.
 
 Requirements:
-    pip install vnpy vnpy_ctp  (or vnpy_tts for paper trading)
+    pip install vnpy vnpy_ctastrategy vnpy_ctp  (or vnpy_tts for paper trading)
 
 Usage in vnpy Trader:
     CTA Strategy App → Add Strategy → MaCrossStrategy
     Set vt_symbol, e.g. "IF2406.CFFEX" (futures) or "000001.SZSE" (A-share)
 """
 
-from vnpy.app.cta_strategy import (
+from vnpy_ctastrategy import (
     CtaTemplate,
     StopOrder,
     TickData,


### PR DESCRIPTION
## Goal

Fix the `vnpy-export` skill's generated strategy template and docs, which
still reference vn.py's pre-4.0 import path.

## Affected areas

- `agent/src/skills/vnpy-export/SKILL.md`
- `agent/src/skills/vnpy-export/scripts/cta_template.py`

## Problem

vn.py 4.0 split every app (CTA strategy, CTA backtester, ...) into its own
pip-installable package. This skill's reference template and inline docs
still import from the old pre-4.0 layout:

```python
from vnpy.app.cta_strategy import CtaTemplate, ...
from vnpy.app.cta_backtester import BacktestingEngine
```

Neither module exists in a current vn.py 4.0 install (confirmed against a
real `pip install vnpy vnpy_ctastrategy`), so any strategy file this skill
generates fails to import with `ModuleNotFoundError` the moment a user tries
to load it into their vn.py Trader.

## Fix

```python
from vnpy_ctastrategy import CtaTemplate, ...
from vnpy_ctastrategy.backtesting import BacktestingEngine
```

(Note `BacktestingEngine` lives under `vnpy_ctastrategy.backtesting`, not
`vnpy_ctabacktester` — that package only exposes the GUI-facing
`BacktesterEngine`, a different class. Easy to mix up; verified by import.)

Also added the missing `vnpy_ctastrategy` package to the install hint comment
in `cta_template.py` (it previously only mentioned `vnpy` + `vnpy_ctp`).

## Out of scope

Not touching the `CtaTemplate` method/parameter structure itself — only the
import paths. No behavior change to strategies already exported before this
fix; they'd need the same one-line import edit to run on vn.py 4.0.

## Test plan

- `pip install vnpy vnpy_ctastrategy` in a clean venv, then
  `python -c "import sys; sys.path.insert(0, 'agent/src/skills/vnpy-export/scripts'); import cta_template"`
  — fails before this change (`ModuleNotFoundError: No module named 'vnpy.app'`),
  succeeds after.
- `pytest agent/tests/test_vnpy_export.py -q` — 18 passed (this suite checks
  SKILL.md structure/sections via AST, not the literal import string, so it
  was already green either way; included for completeness).

## Risk

None — docs/skill-template only, no runtime code path, no broker/network/secret surface touched.

## Rollback

`git revert` — single isolated commit, no follow-on dependents.