### PR TITLE
fix(backtest): stop forward-filling missing closes in the correlation matrix

### DIFF
--- a/agent/backtest/correlation.py
+++ b/agent/backtest/correlation.py
@@ -142,7 +142,10 @@ def _rolling_correlation_matrix(
         # (e.g. crypto via OKX/CCXT at UTC midnight vs US equity via
         # yfinance at EDT midnight = 04:00 UTC) align correctly.
         ts.index = ts.index.normalize()
-        rets = ts.pct_change().dropna()
+        # ``fill_method=None`` is explicit because under the project's
+        # pandas>=2,<3 pin the ``pct_change`` default forward-fills missing
+        # prices, silently manufacturing 0% returns on halted sessions.
+        rets = ts.pct_change(fill_method=None).dropna()
         rets.name = code
         returns_frames.append(rets)
 

--- a/agent/tests/test_correlation.py
+++ b/agent/tests/test_correlation.py
@@ -231,6 +231,23 @@ class TestRollingCorrelationMatrix:
         assert -1 <= p_matrix[0][1] <= 1
         assert -1 <= s_matrix[0][1] <= 1
 
+    def test_does_not_forward_fill_missing_closes(self):
+        # Under pandas>=2,<3 a bare pct_change() forward-fills NaN closes,
+        # manufacturing a 0% return on the halted session and pairing it
+        # against the peer's real move. GAP tracks PEER exactly, so once the
+        # halted session is dropped instead of filled the two are perfectly
+        # correlated. Mirrors TestAlignedReturns in test_regime.py.
+        peer_closes = [100.0, 110.0, 115.5, 112.035, 121.0, 123.42]
+        gap_closes = [c / 2.0 for c in peer_closes]
+        gap_closes[2] = np.nan  # trading halt: no close printed
+        price_series = {
+            "GAP": self._make_price_df(gap_closes),
+            "PEER": self._make_price_df(peer_closes),
+        }
+        labels, matrix = _rolling_correlation_matrix(price_series, window=30, method="pearson")
+        i, j = labels.index("GAP"), labels.index("PEER")
+        assert matrix[i][j] == pytest.approx(1.0)
+
     def test_empty_dict_returns_empty(self):
         labels, matrix = _rolling_correlation_matrix({}, window=30, method="pearson")
         assert labels == []


### PR DESCRIPTION
## The bug

`agent/backtest/correlation.py:145`:

```python
rets = ts.pct_change().dropna()
```

Under the project's `pandas>=2,<3` pin, `pct_change`'s default is `fill_method='pad'`. A halted session (NaN close) is forward-filled into a **fabricated 0% return**, which then survives the inner join and gets paired against the peer's real move for that day.

## Why this is not a judgement call

The intended behaviour is already established twice in this repo:

- `agent/backtest/regime.py:113` performs the **identical** computation with `pct_change(fill_method=None)`, and its docstring says it *"Mirrors the alignment in `_rolling_correlation_matrix`"*. The sibling was written from this function and corrected there, while the original was left behind.
- `agent/backtest/risk_xray.py:144` also passes `fill_method=None`.

So this PR does not propose a new convention — it applies the one the project already chose, to the function the others were modelled on.

Passing it explicitly also silences the `FutureWarning`; the default flips again under pandas 3.

## How to test

```
pytest agent/tests/test_correlation.py -q      # 24 passed
```

One test added, `test_does_not_forward_fill_missing_closes`, mirroring `test_regime.py::TestAlignedReturns::test_does_not_forward_fill_missing_prices`. GAP tracks PEER exactly (half the price) with one halted session, so the correlation must be 1.0.

Regression proof — source reverted, test kept:

```
FAILED agent/tests/test_correlation.py::TestRollingCorrelationMatrix::test_does_not_forward_fill_missing_closes
1 failed
```

The pre-fix value was **0.7419** — two perfectly correlated assets reported as 0.74 apart because of a single halt.

Full suite after the fix: **6378 passed, 13 skipped** (baseline 6377 + this test), `--ignore=agent/tests/e2e_backtest`. Ruff clean.

`black --check` fails on both touched files, but it fails on them on a clean tree too — pre-existing. My added lines are black-clean and I did not reformat, per CONTRIBUTING's guidance about not mixing unrelated formatting into a focused PR.

## Financial risk

Effectively none. This is the read-only `/correlation` analytics path — a heatmap. It does not size positions, set risk limits, or place orders. If I am wrong, correlations for halted names shift slightly, in the direction the project already chose in two sibling modules. The cost is fewer observations (the gap day and the following day drop out), which is the deliberate trade-off `regime.py` documents.

I deliberately did **not** touch `engines/base.py:222` or `benchmark.py:92`, which have a related `pct_change().fillna(0.0)` — that is #872's territory and is claimed.

## Reviewer note

The test asserts exactly 1.0 by constructing GAP as a fixed multiple of PEER. That is intentional: it makes the fabricated zero the only possible source of decorrelation, so the assertion cannot pass for an unrelated reason.

## Separate finding, not in this PR

`agent/src/factors/base.py:275` — `decay_linear` applies weights `n, n-1, …, 1` to a chronologically-ordered window, so **weight increases with age**: the oldest bar gets `n`, the newest gets `1`. On the ramp `[1,2,3,4,5]` it returns 2.33, below the mean of 3.0, and the impulse response is exactly inverted (0.067 newest vs 0.333 oldest). The cited source says the opposite — arXiv:1601.00991 p.15: *"weighted moving average over the past d days with linearly decaying weights d, d – 1, …, 1"*.

I built a fix and then reverted it: `agent/tests/factors/test_base.py:147` hand-pins the current orientation with an explicit comment, the `gtja191_130` golden fixture breaks, and 42 alpha factors change value. That makes it a semantics RFC needing your direction, not an unsolicited PR. Happy to open it as an issue with the paper quote if useful.
