### PR TITLE
docs: architecture analysis handoff under docs/analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,8 +50,12 @@ data/.duckdb_tmp/
 data/parquet/
 data/backup/
 
-# Internal docs (plans, specs)
-docs/
+# Internal docs (plans, specs) — keep private by default;
+# shared architecture handoff lives under docs/analysis/
+docs/*
+!docs/README.md
+!docs/analysis/
+!docs/analysis/**
 !wiki/docs/
 !wiki/docs/**
 docs/screenshots/agent-run.png

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+# Moved
+
+분석 자료는 **`docs/analysis/`** 로 모았습니다.
+
+- AI 진입: [`docs/analysis/README.md`](./analysis/README.md)
+- 보고서: [`docs/analysis/REPORT.md`](./analysis/REPORT.md)
+- 카탈로그: [`docs/analysis/catalog/`](./analysis/catalog/)

--- a/docs/analysis/README.md
+++ b/docs/analysis/README.md
@@ -1,0 +1,79 @@
+# Vibe-Trading 분석 자료 — AI 핸드오프
+
+> **다른 AI에게 넘길 때: 이 폴더만 주면 된다.**  
+> 경로: `docs/analysis/`
+
+---
+
+## AI가 볼 본문 (읽는 순서)
+
+| 우선순위 | 파일 | 용도 |
+|----------|------|------|
+| **1 (필수)** | [`README.md`](./README.md) (지금 이 파일) | 핸드오프 계약·범위·잔여 |
+| **2 (본문)** | [`REPORT.md`](./REPORT.md) | Part 1–28 아키텍처·계약·흐름 (서술 기준) |
+| **3 (표)** | [`catalog/INDEX.md`](./catalog/INDEX.md) | 스킬/알파/스웜/채널/테스트 전수 표 입구 |
+| **4 (필요 시)** | `catalog/*.md` · `catalog/*.json` | 특정 id 조회 |
+
+채팅 로그·IDE 캔버스는 **보조**다. 코드 해석의 단일 출처는 **이 폴더**다.
+
+---
+
+## 이 폴더에 있는 것
+
+```
+docs/analysis/
+├── README.md          ← AI 진입점 (핸드오프)
+├── REPORT.md          ← 통합 분석 보고서
+└── catalog/
+    ├── INDEX.md
+    ├── SKILLS.md (+ skills_inventory.json)      # 88
+    ├── ALPHAS.md (+ alphas_inventory.json)      # 462
+    ├── SWARM_PRESETS.md (+ swarm_inventory.json)# 30
+    ├── CHANNELS.md                              # 16
+    ├── TESTS.md                                 # 315
+    └── _build_*.py                              # 재생성 스크립트
+```
+
+---
+
+## 프로젝트에서 이미 끝난 것 (요약)
+
+- 코어: AgentLoop · Session · API · backtest (`_align` / `_execute_bars` / AST / Runner)
+- 라이브: mandate · OrderGuard · connectors 12
+- 확장: swarm · channels · shadow/SDM/hypotheses · frontend · wiki/CI
+- 카탈로그 전수 메타: skills 88 · alphas 462 · presets 30 · channels 16 · tests 315
+
+상세는 `REPORT.md` Part 1–28.
+
+---
+
+## 의도적으로 안 깐 것 (온디맨드)
+
+- 개별 스킬 references 대량 md, 개별 알파 `compute()` 전 라인
+- 서드파티 IM/SDK 라이브러리 내부
+- 테스트 assertion 한 줄씩
+
+→ id를 지정하면 그때 해당 파일만 추가 딥.
+
+---
+
+## 다른 AI에게 붙일 프롬프트 예시
+
+```
+워크스페이스: Vibe-Trading
+먼저 읽고 따르기: docs/analysis/README.md → docs/analysis/REPORT.md
+표·목록: docs/analysis/catalog/
+이미 분석된 계약을 재탐색하지 말고, 위 문서를 기준으로 답하거나 지정한 잔여만 딥할 것.
+```
+
+---
+
+## 사람용 vs AI용
+
+| | 사람 | AI |
+|--|------|-----|
+| 본문 | `REPORT.md` (같은 파일) | **먼저 `README.md`**, 그다음 `REPORT.md` |
+| 목록 | `catalog/*.md` | 동일 + `*.json`으로 기계 조회 |
+| 캔버스 | IDE에서 시각화 | 무시해도 됨 |
+
+한 폴더로 묶으면 **경로 하나·컨텍스트 오염 감소·재탐색 비용 감소**에 도움이 된다.

--- a/docs/analysis/REPORT.md
+++ b/docs/analysis/REPORT.md
@@ -1,0 +1,569 @@
+# Vibe-Trading 분석 보고서
+
+> 세션 분석 통합본 (2026-07, Part 21–27 잔여 딥 포함).  
+> 범위: 아키텍처·백테스트·런타임·UI·라이브 + 이전에 애매했던 전 패키지.  
+> 깊이 범례: **딥** = 계약·흐름·모듈 단위 · **맵** = 폴더·역할 · **카탈로그** = 목록만(본문 전수 제외).
+
+관련 캔버스(IDE): `~/.cursor/projects/.../canvases/*.canvas.tsx`  
+지식 그래프: `graphify-out/GRAPH_REPORT.md`
+
+---
+
+## 0. 목차
+
+| Part | 주제 | 깊이 |
+|------|------|------|
+| 1 | 프로젝트 정체·전체 아키텍처 | 맵→딥 |
+| 2 | `agent/src` 패키지 맵 | 맵 |
+| 3 | tools · skills · memory · goal | 딥(패키지) |
+| 4 | Skills 카탈로그 (88) | 맵 |
+| 5 | 백테스트 패키지 전체 | 맵→딥 |
+| 6 | `_execute_bars` · ChinaA · Composite | 딥 |
+| 7 | loaders base + tushare | 딥 |
+| 8 | `_align` · Crypto funding/liq | 딥 |
+| 9 | SignalEngine · AST · auto fallback | 딥 |
+| 10 | BacktestConfigSchema · subprocess Runner | 딥 |
+| 11 | AgentLoop · SessionService | 딥 |
+| 12 | FastAPI `api/` | 맵→딥 |
+| 13 | live/ · trading/ | 맵→딥 |
+| 14 | swarm/ | 맵→딥 |
+| 15 | frontend/src (라우트·SSE) | 맵→딥 |
+| 16 | 나머지 engines | 맵→딥 |
+| 17 | loaders 전체 · optimizers · metrics · validation | 맵→딥 |
+| 18 | factors / Alpha Zoo | 맵 |
+| 19 | CLI · MCP | 맵→딥 |
+| 20 | 폴더 구조 | 맵 |
+| **21** | **providers · config · security · 루트 유틸** | **딥** |
+| **22** | **channels · channelsui · scheduled_research** | **딥** |
+| **23** | **shadow_account · strategy_store · hypotheses** | **딥** |
+| **24** | **trading connectors 12종** | **딥** |
+| **25** | **백테스트 잔여 (benchmark…loaders·options)** | **딥** |
+| **26** | **frontend 컴포넌트 · CLI slash · agent/skills** | **딥** |
+| **27** | **wiki · CI · Docker · packaging** | **딥** |
+| **28** | **카탈로그 전수 (skills/alphas/swarm/channels/tests)** | **카탈로그** |
+| A | 남은 초미세 잔여 · 읽는 순서 | — |
+
+---
+
+## 1. 프로젝트 정체 · 전체 아키텍처
+
+### 어떻게 분석했나
+- 레포 클론 후 `pyproject.toml` / README / 패키지 루트(`agent/`) 확인.
+- Graphify AST 그래프 생성 → god nodes·커뮤니티로 허브 파악.
+- 진입점(CLI / FastAPI `:8899` / React `:5899` / MCP / IM) → 오케스트레이션 → 실행 레이어로 분해.
+
+### 결론
+- **정체**: 자연어 금융 리서치 에이전트. ReAct 루프 + 도구(~60) + 스킬(88) + 멀티마켓 백테스트 + (옵션) 라이브.
+- **진짜 코어**: `src/agent` (특히 `loop.py`) + `src/tools` + `backtest/`. Skills는 플레이북.
+- **흐름**: Surfaces → `SessionService` → `AgentLoop` → Tools → (무거운 경로) `backtest.runner` 서브프로세스 → artifacts → SSE/UI.
+
+### 핵심 경로
+- `agent/src/agent/loop.py`
+- `agent/src/session/service.py`
+- `agent/backtest/runner.py`
+- `agent/api_server.py`
+
+---
+
+## 2. `agent/src` 패키지 맵
+
+### 어떻게 분석했나
+- `agent/src/*` 디렉터리 전수 목록화, 패키지별 역할 한 줄 매핑.
+- 이후 Part 11–19에서 개별 딥다이브로 확장.
+
+### 패키지 역할 요약
+
+| 패키지 | 역할 |
+|--------|------|
+| `agent/` | ReAct 루프 |
+| `session/` | 세션·JSONL·FTS·SSE |
+| `api/` | HTTP 라우트 |
+| `tools/` | 실행 도구 |
+| `skills/` | SKILL.md 플레이북 88 |
+| `memory/` · `goal/` · `hypotheses/` | 연구 상태 |
+| `swarm/` | 멀티에이전트 |
+| `factors/` | Alpha Zoo |
+| `live/` · `trading/` | 실거래 |
+| `channels/` | IM |
+| `providers/` · `config/` · `core/` | LLM·설정·Runner |
+| `shadow_account/` · `strategy_store/` | 섀도우·전략 저장 |
+
+---
+
+## 3. tools · skills · memory · goal (+ `agent/SKILL.md`)
+
+### 어떻게 분석했나
+- `src/tools/` 파일 목록·도구명 inventory.
+- `src/memory/`(3), `src/goal/`(5) 파일 단위 읽기.
+- `agent/SKILL.md` = MCP/ClawHub 매니페스트 vs `src/skills/*/SKILL.md` 구분.
+
+### 결론
+- **Tools**: `build_registry()`가 BaseTool 자동 발견; backtest/swarm/live/data/file 등.
+- **Memory**: `PersistentMemory` → `~/.vibe-trading/memory/` (opt-in lifecycle).
+- **Goal**: SQLite `GoalStore`; live-execution 목표 거부; 루프 continuation과 연동.
+- **SKILL.md(루트)**: 외부 MCP 클라이언트가 보는 54-tool 카탈로그. 내부 스킬 디렉터리와 다름.
+
+---
+
+## 4. Skills 카탈로그 (88)
+
+### 어떻게 분석했나
+- `src/skills/*` 디렉터리 분류(analysis / strategy / data-source / tool / asset-class / flow / crypto / research / risk).
+- `tushare` 스킬 references 규모(~232) 인지. 개별 SKILL 전문 88개 전부는 읽지 않음(**맵**).
+
+### 결론
+- 스킬 = 에이전트에게 주는 플레이북(`load_skill`).
+- 코어 로직을 대체하지 않음.
+
+---
+
+## 5. 백테스트 패키지 (`agent/backtest/`)
+
+### 어떻게 분석했나
+- `runner` → loader → `SignalEngine.generate` → `_align` → engine → metrics/run_card 파이프라인 추적.
+- engines / loaders / optimizers / validation / run_card 맵.
+
+### 파이프라인
+```
+safe_run_dir → config schema → AST sandbox(signal_engine.py)
+  → fetch_data_map (+ fallback) → generate → _align(shift-1)
+  → _execute_bars → metrics / artifacts / run_card
+```
+
+---
+
+## 6. `_execute_bars` · ChinaA · Composite
+
+### 어떻게 분석했나
+- `engines/base.py` 바 루프 순서·주석 의도 라인 단위.
+- `china_a.py` / `composite.py` 오버라이드·위임 비교.
+
+### `_execute_bars` 한 바 순서
+1. open equity로 사이즈 기준
+2. 청산/플립 먼저 (순서 독립)
+3. 신규 open 계획 → 자금 부족 시 **공통 scale** 이분탐색 → 일괄 체결
+4. `on_bar` (펀딩/스왑/청산)
+5. close equity 스냅샷
+6. EOB 강제청산 + 터미널 equity 보정
+
+### ChinaA vs Composite
+| | ChinaA | Composite |
+|--|--------|-----------|
+| 상태 | 자기 capital/positions | **공유** 장부 |
+| 규칙 | T+1·한도·100주·인지세 | 서브엔진 = 룰북만 |
+| T+1 | 자체 `can_execute` | Composite가 가로챔 |
+| 펀딩/스왑 | 없음 | Composite `on_bar` |
+
+---
+
+## 7. loaders `base` + `tushare`
+
+### 어떻게 분석했나
+- `DataLoaderProtocol`, `validate_ohlc`, retry/budget, opt-in parquet cache.
+- `tushare.py` 라우팅: ETF/`fund_daily`, 지수/`index_daily`, HK/`hk_daily`, 주식/`daily`, 분봉/`stk_mins`.
+
+### 결론
+- 모든 fetch는 최종적으로 `validate_ohlc`로 수렴 (`fetch_data_map`).
+- US/crypto는 tushare 스킵 → 다른 로더/fallback.
+
+---
+
+## 8. `_align` · CryptoEngine `on_bar`
+
+### 어떻게 분석했나
+- `_align` 133–229행: 통합 캘린더 → close 격자 → 심볼 캘린더에서 shift(1) → ffill → optimizer → `Σ|w|≤1`.
+- `crypto.py` + `_market_hooks.calc_crypto_funding_fee` / `check_crypto_liquidation`.
+
+### 수식 요약
+- **Funding**: `fee = size × mark × rate × direction` ; UTC `{0,8,16}` 또는 일 1회 fallback ; `capital -= fee`
+- **Liq**: `(margin + unrealized) ≤ maint_margin` (OKX식 tier); lev≤1이면 스킵
+
+### 인과성
+- t바 시그널 → `_align` shift → **t+1 open** 체결.
+
+---
+
+## 9. SignalEngine · AST · auto fallback
+
+### 어떻게 분석했나
+- 계약: `strategy-generate/SKILL.md`, `scaffold_signal_engine` 템플릿, runner `_validate_*`.
+- AST 2단: import-time 구조 검사 + runtime-reachable scrub (VT-001).
+- `FALLBACK_CHAINS` / `_fetch_auto` / `fetch_data_map`.
+
+### SignalEngine 계약
+```python
+class SignalEngine:  # 무인자 생성
+    def generate(self, data_map) -> dict[str, pd.Series]:  # [-1,1], 동일 index
+```
+
+### AST
+- 차단: network/subprocess/eval/os.system/쓰기 open/`getattr(os,…)`
+- 한계: 진짜 OS 샌드박스 아님; 스킬 예제의 미도달 `requests`는 허용 가능.
+
+### Fallback
+- `auto`: 시장 그룹 → `resolve_loader` → missing만 체인.
+- `local`/`qveris`: 네트워크로 조용히 안 넘어감.
+
+---
+
+## 10. BacktestConfigSchema · subprocess Runner
+
+### 어떻게 분석했나
+- `BacktestConfigSchema` pydantic 필드·validator.
+- `backtest_tool` → `src/core/runner.py` `Runner(timeout=300)`.
+
+### 스키마
+- **검사**: codes, dates, source, interval, engine, initial_cash(>0), fundamental_fields, event_feeds.
+- **`extra="allow"`**: leverage/slippage/optimizer/validation/commission* 등은 엔진이 `config.get`.
+
+### 서브프로세스
+- cmd: `python backtest/runner.py <run_dir>`, cwd=`agent/`
+- env allowlist (시세 키·proxy 유지, LLM/브로커 시크릿 차단)
+- ephemeral HOME (cache/data-bridge/qveris만 symlink)
+- Docker에서만 UID drop + RLIMIT; 항상 AST는 on
+- 타임아웃 300s; artifacts 수집
+
+---
+
+## 11. AgentLoop · SessionService
+
+### 어떻게 분석했나
+- `loop.py` `run()` iteration·도구 배치·압축 5단·goal continuation·이벤트 emit.
+- `SessionService.send_message` → Attempt → ThreadPool `AgentLoop` → EventBus.
+- Store: `session.json` + `messages.jsonl`; 검색: SQLite FTS5.
+
+### ReAct 요약
+```
+build messages (ContextBuilder + skills + memory recall)
+→ stream_chat (+ tools)
+→ tool_calls? → parallel readonly / serial write → continue
+→ text-only → (goal continuation?) → success/fail/cancel
+```
+
+### SSE 이벤트 예
+`text_delta`, `tool_call`, `tool_result`, `attempt.*`, `goal.updated`, `swarm.event`, …
+
+---
+
+## 12. FastAPI `api/`
+
+### 어떻게 분석했나
+- `api_server.py` 조립 순서·미들웨어.
+- 각 `*_routes.py` method/path/auth 표로 정리.
+
+### 조립
+`register_runs` → sessions → system → settings → uploads → channels → qveris → swarm → live → alpha → auth → scheduled
+
+### 축
+| 영역 | SessionService? |
+|------|-----------------|
+| `/sessions*` · goal · SSE | 예 |
+| `/runs*` | 디스크만 |
+| `/swarm*` | SwarmRuntime 단독 |
+| `/live*` · mandate | 예(이벤트 relay) + LiveRunner |
+| `/alpha*` | 인메모리 job |
+
+인증: `require_auth` / SSE는 `POST /auth/sse-ticket` + ticket.
+
+---
+
+## 13. live/ · trading/
+
+### 어떻게 분석했나
+- mandate 모델·commit(에이전트 쓰기 불가)·OrderGuard/SDK gate 순서.
+- LiveRunner tick: halt → mandate → reconcile → agent.
+- connectors 12종 + transport(paper/live, mcp/sdk/tws).
+
+### 실주문 게이트 (요약)
+mandate 유효 → HALT 없음 → intent → `check_mandate` → (옵션 advisory) → broker → audit/count
+
+백테스트 경로와 **완전 분리** (시뮬은 mandate 안 탐).
+
+---
+
+## 14. swarm/
+
+### 어떻게 분석했나
+- YAML preset → `SwarmRun` → `SwarmRuntime` DAG 레이어 → `run_worker`.
+- grounding: run 시작 1회 OHLCV prefetch → 전 워커 프롬프트.
+- 메인 `AgentLoop`과 **별도 루프**; 연결은 `run_swarm` 도구(+ REST).
+
+### 규모
+- 번들 preset **30**.
+
+---
+
+## 15. frontend/src
+
+### 어떻게 분석했나
+- router 페이지·Zustand `agent`·`useSSE`·`api.ts`/`apiAuth.ts` 흐름.
+- Agent 페이지: `?session=` + EventSource `replay=active` + RunCompleteCard.
+- Runs/Reports/AlphaZoo(별도 EventSource) 맵.
+
+### 결론
+- 채팅 실시간 = 세션 SSE; Runtime live status = 폴링; Alpha = 독립 스트림.
+
+---
+
+## 16. 나머지 engines
+
+### 어떻게 분석했나
+- forex / global_equity / china·global futures / futures_base / india / options_portfolio를 Base 대비 표로 비교 (이미 분석한 ChinaA·Composite·Crypto 제외).
+
+### 요지
+| 엔진 | 특징 |
+|------|------|
+| Forex | lev 100, commission 0, pip 스프레드, on_bar swap |
+| GlobalEquity | US/HK lot·fee 분기, can_execute 항상 True |
+| ChinaFutures | 승수·품목 증거금·涨跌停 |
+| GlobalFutures | 고정 ~10x, USD/계약, 지수 한도 |
+| India | T+1·서킷·세금 스택 |
+| Options | BaseEngine 밖 BS 일별 루프 |
+
+---
+
+## 17. loaders 전체 · optimizers · metrics · validation
+
+### 어떻게 분석했나
+- 등록 로더 23종 name/markets/auth/한 줄 specialty.
+- optimizer 5: equal_vol / risk_parity / mean_variance / max_div / turnover_aware.
+- `calc_metrics` 키 · `calc_bars_per_year`.
+- validation: monte_carlo / bootstrap / walk_forward / `run_validation`.
+
+---
+
+## 18. factors / Alpha Zoo
+
+### 어떻게 분석했나
+- AST `Registry` 스캔 → `__alpha_meta__` → lazy `compute(panel)`.
+- zoo: alpha101(101) + gtja191(191) + qlib158(154) + academic(12) + fundamental(4) ≈ **462**.
+- 진입: CLI / API `/alpha/*` / tools / `ZooSignalEngine`; backtest는 `fund:*` 패널 주입.
+
+---
+
+## 19. CLI · MCP
+
+### 어떻게 분석했나
+- `cli.main` 대화형(SessionStore 직접) vs `_legacy` 서브커맨드 vs `serve`→api_server.
+- `mcp_server.py` 54 `@mcp.tool` → 대부분 `build_registry().execute`; swarm만 `load_swarm_agent_config`.
+- `agent/SKILL.md` = 외부용 MCP 카탈로그.
+
+### 엔트리
+- `vibe-trading` → CLI  
+- `vibe-trading-mcp` → MCP  
+- `serve` → FastAPI  
+
+---
+
+## 20. 폴더 구조
+
+### 어떻게 분석했나
+- 레포·`agent/`·`agent/src/`·`frontend/` 트리 depth 1–2 스캔 + 역할 주석.
+
+```
+Vibe-Trading/
+├── agent/          # Python 본체
+│   ├── api_server.py · mcp_server.py · SKILL.md
+│   ├── backtest/ · cli/ · src/ · tests/
+├── frontend/       # React UI
+├── wiki/ · scripts/ · tools/ · assets/
+└── pyproject.toml
+```
+
+런타임 홈(레포 밖): `~/.vibe-trading/` (sessions, memory, cache, mandate…).
+
+---
+
+## 21. providers · config · security · 루트 유틸
+
+### 어떻게 분석했나
+- `providers/` ChatLLM·build_llm·content_filter·Codex OAuth 전 파일.
+- `config/` load_agent vs load_runtime vs load_swarm, AgentConfig vs EnvConfig.
+- `security/` scanner(경고만)·network SSRF·workspace path.
+- `preflight.py` · `market_data.py` · `ui_services.py` · `utils/media_decode.py`.
+
+### 결론
+- LLM: dotenv → EnvConfig → provider env를 `OPENAI_*`에 미러 → LangChain invoke/stream.
+- Content filter: finish_reason 감지 → 최대 10회 skip → circuit breaker.
+- **세션 MCP 주입 기본 금지** (`ALLOW_SESSION_MCP_SERVERS` opt-in).
+- Swarm 설정 파일은 `VIBE_TRADING_SWARM_AGENT_CONFIG` / `swarm-agent.json` 별도 해석.
+- Scanner는 삭제 없이 경고+토큰 defang만.
+
+---
+
+## 22. channels · channelsui · scheduled_research
+
+### 어떻게 분석했나
+- BaseChannel → MessageBus → ChannelRuntime → SessionService; Manager는 outbound.
+- 어댑터 16종(+websocket) 프로토콜 한 줄씩.
+- channelsui = WebSocket/WebUI 게이트웨이만.
+- scheduled_research: JSON store + executor tick → 새 세션 enqueue.
+
+### 결론
+```
+IM event → _handle_message → inbound queue
+  → ChannelRuntime (pairing / /new)
+  → SessionService.send_message → poll assistant
+  → outbound → ChannelManager → adapter.send
+```
+- **AgentLoop→bus 실시간 스트림은 IM에 미연결** (최종 답변 폴링).
+- 채널 auto-start / 스케줄러 **기본 OFF** (env 플래그).
+- WebSocket은 동일 bus + channelsui hydrate.
+
+---
+
+## 23. shadow_account · strategy_store · hypotheses
+
+### 어떻게 분석했나
+- Shadow: extract→codegen→backtest_tool→report→scan 전체.
+- SDM: SqliteStrategyStore · DecayEvaluator · sdm_* 도구; **record_bench를 호출하는 도구 없음** 갭 확인.
+- Hypotheses JSON + autopilot 4도구 + link_backtest.
+
+### 결론
+| 축 | 저장 | 도구 |
+|----|------|------|
+| Shadow | shadow_accounts/runs/reports | extract/run/render/scan |
+| SDM | strategy_store.db | register/status/decay_scan |
+| Hypotheses | hypotheses.json | create/update/search/link + autopilot |
+
+세 축은 `hypothesis_id`·run_dir로 **느슨 연결**.
+
+---
+
+## 24. trading connectors 12종
+
+### 어떻게 분석했나
+- `service.py` transport 분기 + 브로커별 profiles/sdk/classification.
+- tap_forward는 **Alpaca만**.
+
+### 요약 표
+
+| 브로커 | Transport | place via service |
+|--------|-----------|-------------------|
+| IBKR | local_tws / mcp RO | **불가** |
+| Robinhood | remote_mcp | **불가**(별도 MCP gate) |
+| Alpaca/Binance/OKX/Tiger/Futu/MT5 | broker_sdk | paper 직행 / live mandate |
+| Longbridge | broker_sdk | **paper만** |
+| Dhan/Shoonya | broker_sdk | **paper 로컬 시뮬만** |
+| Trading212 | broker_sdk | **항상 거부** |
+
+선택 프로필: `~/.vibe-trading/trading-connections.json`.
+
+---
+
+## 25. 백테스트 잔여 딥
+
+### 어떻게 분석했나
+- benchmark / correlation / regime / risk_xray / rebalance_notes / run_card.
+- options_portfolio 일 루프·Greeks·시그널 계약.
+- optimizer 5 목적함수·제약.
+- tushare_fundamentals + rsshub_events PIT/이벤트 계약.
+- 전 등록 로더 interval·auth 표.
+
+### 하이라이트
+- **benchmark**: market 추론 티커 → loader → (비 local) yfinance 폴백.
+- **regime**: \|ρ\| 엣지 밀도 + Schmitt 히스테리시스 (거래 시그널 아님).
+- **risk_xray**: 순수 수치(가격+가중치), I/O 없음.
+- **run_card**: schema 0.1, hashes, artifacts sha256, validation 복사.
+- **options**: `generate`→ list of open/close legs; BS+smile; greeks.csv.
+- **local/qveris**: 네트워크 폴백 금지.
+
+---
+
+## 26. frontend 컴포넌트 · CLI slash · agent/skills
+
+### 어떻게 분석했나
+- chat/charts/layout/common/settings 파일 단위 + Agent 조립도.
+- Runtime/Settings/Correlation/AlphaZoo SSE/Compare 데이터 흐름.
+- slash_router 전 명령; onboard/completer/stream.
+- `agent/skills/` = mootdx 레퍼런스 1파일 (번들은 `src/skills`).
+
+### 결론
+- Agent: Zustand + useSSE → ThinkingTimeline / MessageBubble / Swarm / Mandate / RunnerStatus.
+- AlphaZoo bench/compare: raw EventSource (Agent와 패턴 다름).
+- Compare 페이지 = 백테스트 run A/B (AlphaZoo compare와 별개).
+- CLI slash: help/model/memory/history/search/goal/swarm/skill/show/…; `/quit`→exit 2.
+- `StreamRenderer`는 구현됐으나 **main에 아직 미연결**.
+
+---
+
+## 27. wiki · CI · Docker · packaging
+
+### 어떻게 분석했나
+- wiki 구조·wrangler·D1 analytics; GitHub Actions 3종; tools/ CI gates; scripts/dev; Dockerfile/compose; package-data.
+
+### 결론
+| 표면 | 역할 |
+|------|------|
+| wiki | Cloudflare Pages `vibetrading.wiki`, 정적+Functions |
+| test.yml | grep gates + pytest + frontend build |
+| wiki.yml / deploy | wiki 검증 / wrangler pages deploy |
+| tools/ci_* | yaml.load·WorldQuant·utcnow·env-gate |
+| scripts/dev | :8899+:5899 로컬 오케스트레이션 |
+| Docker | 3-stage, vibe-sandbox, /live health |
+| package-data | skills/** + swarm/presets/*.yaml + factors zoo |
+
+---
+
+## 28. 카탈로그 전수 기록 (한 장씩)
+
+### 어떻게 분석했나
+- `docs/catalog/_build_inventories.py`: 88개 `SKILL.md` frontmatter, 462개 `__alpha_meta__` AST, 30개 swarm YAML.
+- `docs/catalog/_build_channels_tests.py`: 16 채널 어댑터 AST·프로토콜 노트, 315 `test_*.py` 도메인 맵.
+
+### 산출물
+| 파일 | 건수 |
+|------|------|
+| `docs/catalog/SKILLS.md` (+ json) | 88 |
+| `docs/catalog/ALPHAS.md` (+ json) | 462 |
+| `docs/catalog/SWARM_PRESETS.md` (+ json) | 30 |
+| `docs/catalog/CHANNELS.md` | 16 |
+| `docs/catalog/TESTS.md` | 315 |
+| `docs/catalog/INDEX.md` | 인덱스 |
+
+### 스킬 카테고리 분포 (요약)
+analysis 22 · strategy 19 · data-source 10 · tool 10 · asset-class 9 · flow 8 · crypto 7 · research 2 · risk-analysis 1 (frontmatter 기준; uncategorized 가능).
+
+### 알파 zoo 분포
+alpha101 101 · gtja191 191 · qlib158 154 · academic 12 · fundamental 4 → **462**.
+
+---
+
+## A. 남은 초미세 잔여
+
+카탈로그 **목록/메타/구조**는 전수 기록됨. 더 깊게 가려면 개별 선택만:
+
+| 잔여 | 의미 |
+|------|------|
+| 스킬 본문 전체 튜토리얼 문단 | 설명은 frontmatter에 있음; references 대량(tushare 등)은 온디맨드 |
+| 알파 `compute()` 구현 라인 | formula_latex + meta로 대체; 특정 id 감사 시 해당 py 열기 |
+| 채널 서드파티 SDK 내부 | 우리 쪽 어댑터 계약은 CHANNELS.md |
+| 테스트 assertion 전수 | TESTS.md는 파일 맵 |
+
+→ **“안 읽은 장” 목록 작업은 완료.** 이후는 관심 id 하나 지정 딥.
+
+---
+
+## B. 권장 읽는 순서 (갱신)
+
+1. Part 20 → 1 → 11–12 → 15/26  
+2. Part 5–10 → 16 → 25  
+3. Part 13 → 24  
+4. Part 21–23 · 22 · 14 · 18–19 · 27  
+5. **Part 28 + `docs/catalog/*`** (전수 표)
+
+---
+
+## C. 산출물 인덱스
+
+| 종류 | 위치 |
+|------|------|
+| **이 문서** | `docs/analysis/REPORT.md` |
+| **AI 핸드오프** | `docs/analysis/README.md` |
+| **카탈로그** | `docs/analysis/catalog/` |
+| Graphify | `graphify-out/GRAPH_REPORT.md` |
+| 캔버스 | IDE canvases (architecture … analysis-report-index) |
+
+---
+
+*작성: 대화 세션 분석 통합 + Part 21–28. 애플리케이션 코드 변경 없음 — 문서화·카탈로그만.*

--- a/docs/analysis/catalog/ALPHAS.md
+++ b/docs/analysis/catalog/ALPHAS.md
@@ -1,0 +1,490 @@
+# Alpha Zoo Catalog
+
+Total modules with meta: **462**.
+
+## academic (12)
+
+| id | theme | columns | warmup | formula |
+|----|-------|---------|-------:|---------|
+| `academic_bab` | volatility | close | 253 | \mathrm{zscore}_{x}\bigl(-\,\mathrm{ts\_cov}(r_i, r_m, 252)  |
+| `academic_carhart_mom` | momentum | close | 252 | \mathrm{zscore}_{x}\bigl((\mathrm{close}_t - \mathrm{close}_ |
+| `academic_cma` | quality | volume | 120 | \mathrm{zscore}_{x}\bigl(-\Delta_{60}\log(\mathrm{ts\_mean}( |
+| `academic_corr_rewire` | volatility | close | 142 | \mathrm{zscore}_{x}\Bigl(-\,\frac{1}{/J_i/}\sum_{j \in J_i}\ |
+| `academic_high52w` | momentum | close | 252 | \mathrm{zscore}_{x}\bigl(\mathrm{close}_t / \mathrm{ts\_max} |
+| `academic_hml` | value | close | 252 | \mathrm{zscore}_{x}\bigl(-(\mathrm{close}_t - \mathrm{close} |
+| `academic_illiq` | liquidity | close,volume | 22 | \mathrm{zscore}_{x}\bigl(\mathrm{ts\_mean}(/r_t/ / (\mathrm{ |
+| `academic_mkt_rf` | momentum | close | 21 | \mathrm{zscore}_{x}\bigl((\mathrm{close}_t - \mathrm{close}_ |
+| `academic_retskew` | volatility | close | 61 | \mathrm{zscore}_{x}\bigl(-\mathrm{skew}_{60}(r_t)\bigr) |
+| `academic_rmw` | quality | close | 60 | \mathrm{zscore}_{x}\bigl(-\mathrm{ts\_std}((\mathrm{close}_t |
+| `academic_smb` | quality | close,volume | 60 | \mathrm{zscore}_{x}\bigl(-\log(\mathrm{ts\_mean}(\mathrm{vol |
+| `academic_strev` | reversal | close | 21 | \mathrm{zscore}_{x}\bigl(-(\mathrm{close}_t - \mathrm{close} |
+
+## alpha101 (101)
+
+| id | theme | columns | warmup | formula |
+|----|-------|---------|-------:|---------|
+| `alpha101_001` | reversal,volatility | close | 25 | rank(ts_argmax(SignedPower((returns<0)?stddev(returns,20):cl |
+| `alpha101_002` | volume,reversal | open,close,volume | 10 | -1 * correlation(rank(delta(log(volume), 2)), rank(((close-o |
+| `alpha101_003` | volume,reversal | open,volume,close | 10 | -1 * correlation(rank(open), rank(volume), 10) |
+| `alpha101_004` | reversal | low,close | 9 | -1 * Ts_Rank(rank(low), 9) |
+| `alpha101_005` | reversal | open,close,vwap | 10 | rank((open - sum(vwap,10)/10)) * (-1 * abs(rank((close - vwa |
+| `alpha101_006` | volume,reversal | open,volume,close | 10 | -1 * correlation(open, volume, 10) |
+| `alpha101_007` | momentum,volume | close,volume | 67 | (adv20<volume)?((-1*ts_rank(abs(delta(close,7)),60))*sign(de |
+| `alpha101_008` | reversal | open,close | 15 | -1 * rank((sum(open,5)*sum(returns,5)) - delay(sum(open,5)*s |
+| `alpha101_009` | momentum | close | 6 | (0<ts_min(delta(close,1),5))?delta(close,1):((ts_max(delta(c |
+| `alpha101_010` | momentum | close | 5 | rank((0<ts_min(delta(close,1),4))?delta(close,1):((ts_max(de |
+| `alpha101_011` | volume,reversal | close,volume,vwap | 5 | (rank(ts_max(vwap-close,3))+rank(ts_min(vwap-close,3)))*rank |
+| `alpha101_012` | volume,reversal | close,volume | 2 | sign(delta(volume,1)) * (-1 * delta(close,1)) |
+| `alpha101_013` | volume | close,volume | 5 | -1 * rank(covariance(rank(close), rank(volume), 5)) |
+| `alpha101_014` | volume,momentum | open,close,volume | 10 | (-1*rank(delta(returns,3))) * correlation(open, volume, 10) |
+| `alpha101_015` | volume | high,volume,close | 6 | -1 * sum(rank(correlation(rank(high), rank(volume), 3)), 3) |
+| `alpha101_016` | volume | high,volume,close | 5 | -1 * rank(covariance(rank(high), rank(volume), 5)) |
+| `alpha101_017` | volume,reversal | close,volume | 25 | ((-1*rank(ts_rank(close,10)))*rank(delta(delta(close,1),1))) |
+| `alpha101_018` | volatility | open,close | 10 | -1 * rank(stddev(abs(close-open),5) + (close-open) + correla |
+| `alpha101_019` | momentum | close | 250 | (-1*sign((close-delay(close,7))+delta(close,7))) * (1+rank(1 |
+| `alpha101_020` | reversal | open,high,low,close | 2 | (((-1*rank(open-delay(high,1)))*rank(open-delay(close,1)))*r |
+| `alpha101_021` | momentum,volatility | close,volume | 20 | complex piecewise; see paper |
+| `alpha101_022` | volume,volatility | high,close,volume | 25 | -1 * (delta(correlation(high,volume,5),5) * rank(stddev(clos |
+| `alpha101_023` | momentum | high,close | 20 | ((sum(high,20)/20) < high) ? (-1*delta(high,2)) : 0 |
+| `alpha101_024` | momentum | close | 200 | complex piecewise; see paper |
+| `alpha101_025` | momentum,volume | high,close,volume,vwap | 21 | rank((((-1*returns)*adv20)*vwap)*(high-close)) |
+| `alpha101_026` | volume | high,volume,close | 13 | -1 * ts_max(correlation(ts_rank(volume,5),ts_rank(high,5),5) |
+| `alpha101_027` | volume | volume,vwap,close | 10 | (0.5<rank((sum(correlation(rank(volume),rank(vwap),6),2)/2.0 |
+| `alpha101_028` | volume | high,low,close,volume | 25 | scale((correlation(adv20,low,5) + (high+low)/2) - close) |
+| `alpha101_029` | reversal,volume | close,volume | 12 | min(product(rank(rank(scale(log(sum(ts_min(rank(rank(-1*rank |
+| `alpha101_030` | momentum,volume | close,volume | 20 | ((1-rank(sign(d1)+sign(d2)+sign(d3))) * sum(volume,5)) / sum |
+| `alpha101_031` | momentum | low,close,volume | 25 | rank(rank(rank(decay_linear(-1*rank(rank(delta(close,10))),1 |
+| `alpha101_032` | momentum | close,vwap | 235 | scale(sum(close,7)/7 - close) + 20*scale(correlation(vwap, d |
+| `alpha101_033` | reversal | open,close | 1 | rank(-1*(1-open/close)) |
+| `alpha101_034` | volatility | close | 6 | rank((1-rank(stddev(returns,2)/stddev(returns,5))) + (1-rank |
+| `alpha101_035` | volume,momentum | high,low,close,volume | 33 | ts_rank(volume,32) * (1 - ts_rank((close+high-low),16)) * (1 |
+| `alpha101_036` | momentum,volume | open,close,volume,vwap | 200 | weighted sum; see paper |
+| `alpha101_037` | momentum | open,close | 201 | rank(correlation(delay(open-close,1),close,200)) + rank(open |
+| `alpha101_038` | reversal | open,close | 10 | (-1*rank(ts_rank(close,10))) * rank(close/open) |
+| `alpha101_039` | momentum,volume | close,volume | 250 | (-1*rank(delta(close,7)*(1-rank(decay_linear(volume/adv20,9) |
+| `alpha101_040` | volatility,volume | high,volume,close | 10 | (-1*rank(stddev(high,10))) * correlation(high,volume,10) |
+| `alpha101_041` | reversal | high,low,vwap,close | 1 | (high*low)^0.5 - vwap |
+| `alpha101_042` | reversal | close,vwap | 1 | rank(vwap-close) / rank(vwap+close) |
+| `alpha101_043` | volume,momentum | close,volume | 39 | ts_rank(volume/adv20,20) * ts_rank(-1*delta(close,7),8) |
+| `alpha101_044` | volume | high,volume,close | 5 | -1 * correlation(high, rank(volume), 5) |
+| `alpha101_045` | momentum,volume | close,volume | 25 | -1 * (rank(sum(delay(close,5),20)/20)*correlation(close,volu |
+| `alpha101_046` | momentum | close | 21 | complex piecewise; see paper |
+| `alpha101_047` | volume,momentum | high,close,volume,vwap | 25 | ((rank(1/close)*volume/adv20) * (high*rank(high-close)/(sum( |
+| `alpha101_048` | momentum,volatility | close | 251 | indneutralize(...subindustry...) / sum((delta(close,1)/delay |
+| `alpha101_049` | momentum | close | 21 | (((delay(close,20)-delay(close,10))/10 - (delay(close,10)-cl |
+| `alpha101_050` | volume | volume,vwap,close | 10 | -1 * ts_max(rank(correlation(rank(volume), rank(vwap), 5)),  |
+| `alpha101_051` | momentum | close | 21 | (...< -0.05) ? 1 : -1*(close-delay(close,1)) |
+| `alpha101_052` | momentum | low,close,volume | 240 | ((-1*ts_min(low,5)+delay(ts_min(low,5),5)) * rank((sum(retur |
+| `alpha101_053` | reversal | high,low,close | 10 | -1 * delta(((close-low) - (high-close))/(close-low), 9) |
+| `alpha101_054` | reversal | open,high,low,close | 1 | -1 * ((low-close)*(open^5)) / ((low-high)*(close^5)) |
+| `alpha101_055` | volume,reversal | high,low,close,volume | 17 | -1 * correlation(rank((close-ts_min(low,12))/(ts_max(high,12 |
+| `alpha101_056` | momentum | close | 10 | 0 - 1*(rank(sum(returns,10)/sum(sum(returns,2),3)) * rank((r |
+| `alpha101_057` | reversal | close,vwap | 32 | 0 - 1 * ((close-vwap) / decay_linear(rank(ts_argmax(close,30 |
+| `alpha101_058` | volume | volume,vwap,close | 25 | -1 * Ts_Rank(decay_linear(correlation(IndNeutralize(vwap, se |
+| `alpha101_059` | volume | volume,vwap,close | 30 | -1 * Ts_Rank(decay_linear(correlation(IndNeutralize(vwap*0.7 |
+| `alpha101_060` | volume | high,low,close,volume | 10 | 0 - (2*scale(rank((((close-low)-(high-close))/(high-low))*vo |
+| `alpha101_061` | volume | volume,vwap,close | 197 | rank(vwap - ts_min(vwap,16)) < rank(correlation(vwap, adv180 |
+| `alpha101_062` | volume | open,high,low,volume,vwap,close | 35 | (rank(correlation(vwap, sum(adv20,22), 10)) < rank(((rank(op |
+| `alpha101_063` | volume,momentum | open,close,volume,vwap | 204 | (rank(decay_linear(delta(IndNeutralize(close, industry), 2), |
+| `alpha101_064` | volume | open,high,low,volume,vwap,close | 136 | (rank(correlation(sum(0.178*open+0.822*low,13), sum(adv120,1 |
+| `alpha101_065` | volume | open,volume,vwap,close | 65 | (rank(correlation(0.008*open+0.992*vwap, sum(adv60,9), 6)) < |
+| `alpha101_066` | momentum | open,high,low,vwap,close | 18 | (rank(decay_linear(delta(vwap,4), 7)) + Ts_Rank(decay_linear |
+| `alpha101_067` | volume | high,volume,vwap,close | 25 | (rank(high-ts_min(high,2))^rank(correlation(IndNeutralize(vw |
+| `alpha101_068` | volume | high,low,close,volume | 36 | (Ts_Rank(correlation(rank(high), rank(adv15), 9), 14) < rank |
+| `alpha101_069` | volume | close,volume,vwap | 32 | (rank(ts_max(delta(IndNeutralize(vwap, industry), 3), 5))^Ts |
+| `alpha101_070` | momentum,volume | close,volume,vwap | 84 | (rank(delta(vwap,1))^Ts_Rank(correlation(IndNeutralize(close |
+| `alpha101_071` | volume,reversal | open,low,close,volume,vwap | 226 | max(Ts_Rank(decay_linear(correlation(Ts_Rank(close,3), Ts_Ra |
+| `alpha101_072` | volume | high,low,volume,vwap,close | 57 | rank(decay_linear(correlation((high+low)/2, adv40, 9), 10))  |
+| `alpha101_073` | volume | open,low,vwap,close | 21 | max(rank(decay_linear(delta(vwap,5), 3)), Ts_Rank(decay_line |
+| `alpha101_074` | volume | high,close,volume,vwap | 60 | (rank(correlation(close, sum(adv30,37), 15)) < rank(correlat |
+| `alpha101_075` | volume | low,volume,vwap,close | 61 | rank(correlation(vwap, volume, 4)) < rank(correlation(rank(l |
+| `alpha101_076` | volume | low,volume,vwap,close | 141 | max(rank(decay_linear(delta(vwap,1),12)), Ts_Rank(decay_line |
+| `alpha101_077` | volume | high,low,volume,vwap,close | 47 | min(rank(decay_linear((high+low)/2 + high - (vwap+high), 20) |
+| `alpha101_078` | volume | low,volume,vwap,close | 46 | rank(correlation(sum(0.352*low+0.648*vwap, 20), sum(adv40,20 |
+| `alpha101_079` | volume,momentum | open,close,volume,vwap | 172 | rank(delta(IndNeutralize(0.607*close+0.393*open, sector), 1) |
+| `alpha101_080` | momentum,volume | open,high,volume,close | 19 | (rank(Sign(delta(IndNeutralize(0.868*open+0.132*high, subind |
+| `alpha101_081` | volume | volume,vwap,close | 70 | (rank(Log(product(rank((rank(correlation(vwap, sum(adv10,50) |
+| `alpha101_082` | volume | open,volume,close | 35 | min(rank(decay_linear(delta(open,1),15)), Ts_Rank(decay_line |
+| `alpha101_083` | volume,volatility | high,low,close,volume,vwap | 7 | (rank(delay((high-low)/(sum(close,5)/5), 2)) * rank(rank(vol |
+| `alpha101_084` | momentum | close,vwap | 35 | SignedPower(Ts_Rank(vwap-ts_max(vwap,15), 21), delta(close,5 |
+| `alpha101_085` | volume | high,low,close,volume | 39 | rank(correlation(0.877*high+0.123*close, adv30, 10))^rank(co |
+| `alpha101_086` | volume | open,close,volume,vwap | 44 | (Ts_Rank(correlation(close, sum(adv20,15), 6), 20) < rank((o |
+| `alpha101_087` | momentum | close,vwap,volume | 110 | max(rank(decay_linear(delta(0.37*close+0.63*vwap, 2), 3)), T |
+| `alpha101_088` | volume | open,high,low,close,volume | 94 | min(rank(decay_linear((rank(open)+rank(low))-(rank(high)+ran |
+| `alpha101_089` | volume,momentum | low,volume,vwap,close | 30 | Ts_Rank(decay_linear(correlation(low, adv10, 7), 6), 4) - Ts |
+| `alpha101_090` | volume | low,close,volume | 46 | (rank(close-ts_max(close,5))^Ts_Rank(correlation(IndNeutrali |
+| `alpha101_091` | volume | close,volume,vwap | 35 | (Ts_Rank(decay_linear(decay_linear(correlation(IndNeutralize |
+| `alpha101_092` | volume | open,high,low,close,volume | 49 | min(Ts_Rank(decay_linear(((high+low)/2 + close < low+open),  |
+| `alpha101_093` | volume | close,volume,vwap | 123 | Ts_Rank(decay_linear(correlation(IndNeutralize(vwap, industr |
+| `alpha101_094` | volume | volume,vwap,close | 82 | (rank(vwap-ts_min(vwap,12))^Ts_Rank(correlation(Ts_Rank(vwap |
+| `alpha101_095` | volume | open,high,low,volume,close | 63 | rank(open-ts_min(open,13)) < Ts_Rank((rank(correlation(sum(( |
+| `alpha101_096` | volume | close,volume,vwap | 103 | max(Ts_Rank(decay_linear(correlation(rank(vwap), rank(volume |
+| `alpha101_097` | volume | low,volume,vwap,close | 128 | (rank(decay_linear(delta(IndNeutralize(0.721*low+0.279*vwap, |
+| `alpha101_098` | volume | open,volume,vwap,close | 56 | rank(decay_linear(correlation(vwap, sum(adv5,26), 5), 7)) -  |
+| `alpha101_099` | volume | high,low,volume,close | 68 | (rank(correlation(sum((high+low)/2, 20), sum(adv60, 20), 9)) |
+| `alpha101_100` | volume,momentum | high,low,close,volume | 30 | 0 - 1*((1.5*scale(IN(IN(rank(((close-low)-(high-close))/(hig |
+| `alpha101_101` | reversal | open,high,low,close | 1 | (close - open) / ((high - low) + 0.001) |
+
+## fundamental (4)
+
+| id | theme | columns | warmup | formula |
+|----|-------|---------|-------:|---------|
+| `fund_asset_growth` | growth | fund:asset_growth | 1 | -\mathrm{zscore}_{x}(\Delta \mathrm{total\_assets}_{YoY}) |
+| `fund_earnings_yield` | value | close,fund:net_income,fund:shares_dilute | 1 | \mathrm{zscore}_{x}\left(\frac{\mathrm{net\_income}}{\mathrm |
+| `fund_gross_profitability` | quality | fund:gross_profitability | 1 | \mathrm{zscore}_{x}(\mathrm{gross\_profit}/\mathrm{total\_as |
+| `fund_roe` | quality | fund:roe | 1 | \mathrm{zscore}_{x}(\mathrm{ROE}) |
+
+## gtja191 (191)
+
+| id | theme | columns | warmup | formula |
+|----|-------|---------|-------:|---------|
+| `gtja191_001` | volume,reversal | volume,close,open | 7 | (-1 * CORR(RANK(DELTA(LOG(VOLUME), 1)), RANK(((CLOSE - OPEN) |
+| `gtja191_002` | reversal,microstructure | close,high,low | 2 | (-1 * DELTA(((CLOSE - LOW) - (HIGH - CLOSE)) / (HIGH - LOW), |
+| `gtja191_003` | momentum | close,high,low | 7 | SUM((CLOSE=DELAY(CLOSE,1)?0:CLOSE-(CLOSE>DELAY(CLOSE,1)?MIN( |
+| `gtja191_004` | momentum,volume | close,volume | 20 | ((((SUM(CLOSE,8)/8)+STD(CLOSE,8))<(SUM(CLOSE,2)/2))?(-1):((S |
+| `gtja191_005` | volume | volume,high | 13 | (-1 * TSMAX(CORR(TSRANK(VOLUME,5), TSRANK(HIGH,5), 5), 3)) |
+| `gtja191_006` | reversal | open,high | 5 | (RANK(SIGN(DELTA((OPEN*0.85+HIGH*0.15), 4))) * -1) |
+| `gtja191_007` | volume,microstructure | close,volume,amount | 4 | ((RANK(MAX((VWAP-CLOSE),3)) + RANK(MIN((VWAP-CLOSE),3))) * R |
+| `gtja191_008` | reversal | high,low,volume,amount | 5 | RANK(DELTA(((HIGH+LOW)/2)*0.2 + VWAP*0.8, 4)) * -1 |
+| `gtja191_009` | volume,microstructure | high,low,volume | 8 | SMA(((HIGH+LOW)/2-(DELAY(HIGH,1)+DELAY(LOW,1))/2)*(HIGH-LOW) |
+| `gtja191_010` | volatility,reversal | close | 21 | RANK(MAX(((RET<0)?STD(RET,20):CLOSE)^2,5)) |
+| `gtja191_011` | volume,microstructure | close,high,low,volume | 7 | SUM(((CLOSE-LOW)-(HIGH-CLOSE))/(HIGH-LOW)*VOLUME,6) |
+| `gtja191_012` | reversal,microstructure | open,close,volume,amount | 11 | (RANK((OPEN - (SUM(VWAP,10)/10))) * (-1 * RANK(ABS((CLOSE -  |
+| `gtja191_013` | microstructure | high,low,volume,amount | 1 | (((HIGH*LOW)^0.5) - VWAP) |
+| `gtja191_014` | momentum | close | 6 | CLOSE - DELAY(CLOSE,5) |
+| `gtja191_015` | reversal | open,close | 2 | (OPEN/DELAY(CLOSE,1) - 1) |
+| `gtja191_016` | volume,microstructure | volume,amount | 11 | (-1 * TSMAX(RANK(CORR(RANK(VOLUME), RANK(VWAP), 5)), 5)) |
+| `gtja191_017` | reversal | close,volume,amount | 16 | (RANK(VWAP - MAX(VWAP,15))^DELTA(CLOSE,5)) |
+| `gtja191_018` | momentum | close | 6 | CLOSE/DELAY(CLOSE,5) |
+| `gtja191_019` | reversal | close | 6 | (CLOSE<DELAY(CLOSE,5)?(CLOSE-DELAY(CLOSE,5))/DELAY(CLOSE,5): |
+| `gtja191_020` | momentum | close | 7 | ((CLOSE-DELAY(CLOSE,6))/DELAY(CLOSE,6))*100 |
+| `gtja191_021` | momentum | close | 12 | REGBETA(MEAN(CLOSE,6), SEQUENCE(6)) |
+| `gtja191_022` | reversal | close | 10 | SMA(((CLOSE-MEAN(CLOSE,6))/MEAN(CLOSE,6) - DELAY((CLOSE-MEAN |
+| `gtja191_023` | volatility | close | 22 | SMA((CLOSE>DELAY(CLOSE,1)?STD(CLOSE,20):0),20,1)/(SMA((CLOSE |
+| `gtja191_024` | momentum | close | 6 | SMA(CLOSE-DELAY(CLOSE,5),5,1) |
+| `gtja191_025` | momentum,volume | close,volume | 61 | ((-1*RANK((DELTA(CLOSE,7)*(1-RANK(DECAYLINEAR((VOLUME/MEAN(V |
+| `gtja191_026` | momentum,microstructure | close,volume,amount | 35 | ((((SUM(CLOSE,7)/7)-CLOSE))+((CORR(VWAP,DELAY(CLOSE,5),230)) |
+| `gtja191_027` | momentum | close | 18 | WMA((CLOSE-DELAY(CLOSE,3))/DELAY(CLOSE,3)*100 + (CLOSE-DELAY |
+| `gtja191_028` | momentum | close,high,low | 12 | 3*SMA((CLOSE-TSMIN(LOW,9))/(TSMAX(HIGH,9)-TSMIN(LOW,9))*100, |
+| `gtja191_029` | momentum,volume | close,volume | 7 | (CLOSE-DELAY(CLOSE,6))/DELAY(CLOSE,6)*VOLUME |
+| `gtja191_030` | volatility | close | 21 | WMA((REGRESI(CLOSE/DELAY(CLOSE,1)-1, MKT_RET, SMB, HML, 60)) |
+| `gtja191_031` | reversal | close | 13 | (CLOSE-MEAN(CLOSE,12))/MEAN(CLOSE,12)*100 |
+| `gtja191_032` | volume | high,volume | 7 | (-1 * SUM(RANK(CORR(RANK(HIGH), RANK(VOLUME), 3)), 3)) |
+| `gtja191_033` | momentum,volume | low,close,volume | 61 | ((((-1*TSMIN(LOW,5))+DELAY(TSMIN(LOW,5),5))*RANK(((SUM(RET,2 |
+| `gtja191_034` | reversal | close | 13 | MEAN(CLOSE,12)/CLOSE |
+| `gtja191_035` | volume | open,volume | 25 | (MIN(RANK(DECAYLINEAR(DELTA(OPEN,1),15)), RANK(DECAYLINEAR(C |
+| `gtja191_036` | volume | volume,amount | 8 | RANK(SUM(CORR(RANK(VOLUME), RANK(VWAP), 6), 2)) |
+| `gtja191_037` | momentum | open,close | 16 | (-1*RANK(((SUM(OPEN,5)*SUM(RET,5))-DELAY((SUM(OPEN,5)*SUM(RE |
+| `gtja191_038` | reversal | high | 21 | (((SUM(HIGH,20)/20)<HIGH)?(-1*DELTA(HIGH,2)):0) |
+| `gtja191_039` | volume | close,open,volume,amount | 63 | ((RANK(DECAYLINEAR(DELTA(CLOSE,2),8)) - RANK(DECAYLINEAR(COR |
+| `gtja191_040` | volume | close,volume | 27 | SUM((CLOSE>DELAY(CLOSE,1)?VOLUME:0),26)/SUM((CLOSE<=DELAY(CL |
+| `gtja191_041` | microstructure | volume,amount | 9 | (RANK(MAX(DELTA(VWAP,3),5))*-1) |
+| `gtja191_042` | volume,volatility | high,volume | 11 | ((-1*RANK(STD(HIGH,10)))*CORR(HIGH,VOLUME,10)) |
+| `gtja191_043` | volume,momentum | close,volume | 7 | SUM((CLOSE>DELAY(CLOSE,1)?VOLUME:(CLOSE<DELAY(CLOSE,1)?-VOLU |
+| `gtja191_044` | volume | low,volume,amount | 27 | (TSRANK(DECAYLINEAR(CORR(LOW,MEAN(VOLUME,10),7),6),4)+TSRANK |
+| `gtja191_045` | volume | close,open,volume,amount | 44 | (RANK(DELTA((((CLOSE*0.6)+(OPEN*0.4))),1)) * RANK(CORR(VWAP, |
+| `gtja191_046` | reversal | close | 25 | (MEAN(CLOSE,3)+MEAN(CLOSE,6)+MEAN(CLOSE,12)+MEAN(CLOSE,24))/ |
+| `gtja191_047` | reversal | close,high,low | 10 | SMA((TSMAX(HIGH,6)-CLOSE)/(TSMAX(HIGH,6)-TSMIN(LOW,6))*100,9 |
+| `gtja191_048` | volume,momentum | close,volume | 21 | -1*((RANK((SIGN((CLOSE-DELAY(CLOSE,1)))+SIGN((DELAY(CLOSE,1) |
+| `gtja191_049` | reversal | high,low | 13 | SUM(((HIGH+LOW)>=(DELAY(HIGH,1)+DELAY(LOW,1))?0:MAX(ABS(HIGH |
+| `gtja191_050` | reversal | high,low | 13 | SUM(up_move,12)/(SUM(up_move,12)+SUM(dn_move,12)) - SUM(dn_m |
+| `gtja191_051` | reversal | high,low | 13 | SUM(up_move,12)/(SUM(up_move,12)+SUM(dn_move,12)) |
+| `gtja191_052` | microstructure | high,low,close | 27 | SUM(MAX(0,HIGH-DELAY((HIGH+LOW+CLOSE)/3,1)),26) / SUM(MAX(0, |
+| `gtja191_053` | momentum | close | 13 | COUNT(CLOSE>DELAY(CLOSE,1),12)/12*100 |
+| `gtja191_054` | volatility,microstructure | close,open | 11 | ((-1*RANK((STD(ABS(CLOSE-OPEN),10)+(CLOSE-OPEN))+CORR(CLOSE, |
+| `gtja191_055` | microstructure | close,high,low,open | 22 | SUM(16*(CLOSE-DELAY(CLOSE,1)+(CLOSE-OPEN)/2+DELAY(CLOSE,1)-D |
+| `gtja191_056` | volume | open,high,low,volume | 60 | (RANK(OPEN-TSMIN(OPEN,12)) < RANK((RANK(CORR(SUM(((HIGH+LOW) |
+| `gtja191_057` | momentum | close,high,low | 10 | SMA((CLOSE-TSMIN(LOW,9))/(TSMAX(HIGH,9)-TSMIN(LOW,9))*100,3, |
+| `gtja191_058` | momentum | close | 21 | COUNT(CLOSE>DELAY(CLOSE,1),20)/20*100 |
+| `gtja191_059` | momentum | close,high,low | 22 | SUM((CLOSE=DELAY(CLOSE,1)?0:CLOSE-(CLOSE>DELAY(CLOSE,1)?MIN( |
+| `gtja191_060` | volume,microstructure | close,high,low,volume | 21 | SUM(((CLOSE-LOW)-(HIGH-CLOSE))/(HIGH-LOW)*VOLUME, 20) |
+| `gtja191_061` | volume | volume,amount,low | 53 | (MAX(RANK(DECAYLINEAR(DELTA(VWAP,1),12)), RANK(DECAYLINEAR(R |
+| `gtja191_062` | volume | high,volume | 6 | ((-1*CORR(HIGH,RANK(VOLUME),5))) |
+| `gtja191_063` | momentum | close | 7 | SMA(MAX(CLOSE-DELAY(CLOSE,1),0),6,1)/SMA(ABS(CLOSE-DELAY(CLO |
+| `gtja191_064` | volume | close,volume,amount | 30 | (MAX(RANK(DECAYLINEAR(CORR(RANK(VWAP),RANK(VOLUME),4),4)),RA |
+| `gtja191_065` | reversal | close | 7 | MEAN(CLOSE,6)/CLOSE |
+| `gtja191_066` | reversal | close | 7 | (CLOSE-MEAN(CLOSE,6))/MEAN(CLOSE,6)*100 |
+| `gtja191_067` | momentum | close | 25 | SMA(MAX(CLOSE-DELAY(CLOSE,1),0),24,1)/SMA(ABS(CLOSE-DELAY(CL |
+| `gtja191_068` | volume | high,low,volume | 16 | SMA(((HIGH+LOW)/2-(DELAY(HIGH,1)+DELAY(LOW,1))/2)*(HIGH-LOW) |
+| `gtja191_069` | microstructure | open,high,low | 22 | (SUM(DTM,20)>SUM(DBM,20)?(SUM(DTM,20)-SUM(DBM,20))/SUM(DTM,2 |
+| `gtja191_070` | volatility,volume | amount | 7 | STD(AMOUNT,6) |
+| `gtja191_071` | reversal | close | 25 | (CLOSE-MEAN(CLOSE,24))/MEAN(CLOSE,24)*100 |
+| `gtja191_072` | reversal | close,high,low | 16 | SMA((TSMAX(HIGH,6)-CLOSE)/(TSMAX(HIGH,6)-TSMIN(LOW,6))*100,1 |
+| `gtja191_073` | volume | close,volume,amount | 35 | ((TSRANK(DECAYLINEAR(DECAYLINEAR(CORR((CLOSE),VOLUME,10),16) |
+| `gtja191_074` | volume | low,volume,amount | 30 | (RANK(CORR(SUM(((LOW*0.35)+(VWAP*0.65)),20),SUM(MEAN(VOLUME, |
+| `gtja191_075` | sentiment,momentum | close,open | 30 | COUNT((CLOSE>OPEN & BENCHMARKINDEXCLOSE<DELAY(BENCHMARKINDEX |
+| `gtja191_076` | volatility,volume | close,volume | 22 | STD(ABS((CLOSE/DELAY(CLOSE,1)-1))/VOLUME,20)/MEAN(ABS((CLOSE |
+| `gtja191_077` | volume | high,low,volume,amount | 37 | MIN(RANK(DECAYLINEAR(((HIGH+LOW)/2+HIGH-(VWAP+HIGH)),20)),RA |
+| `gtja191_078` | reversal | high,low,close | 23 | ((HIGH+LOW+CLOSE)/3-MA((HIGH+LOW+CLOSE)/3,12))/(0.015*MEAN(A |
+| `gtja191_079` | momentum | close | 13 | SMA(MAX(CLOSE-DELAY(CLOSE,1),0),12,1)/SMA(ABS(CLOSE-DELAY(CL |
+| `gtja191_080` | volume | volume | 6 | (VOLUME-DELAY(VOLUME,5))/DELAY(VOLUME,5)*100 |
+| `gtja191_081` | volume | volume | 22 | SMA(VOLUME,21,2) |
+| `gtja191_082` | reversal | close,high,low | 21 | SMA((TSMAX(HIGH,6)-CLOSE)/(TSMAX(HIGH,6)-TSMIN(LOW,6))*100,2 |
+| `gtja191_083` | volume | high,volume | 6 | (-1*RANK(COVIANCE(RANK(HIGH),RANK(VOLUME),5))) |
+| `gtja191_084` | volume,momentum | close,volume | 21 | SUM(CLOSE>DELAY(CLOSE,1)?VOLUME:(CLOSE<DELAY(CLOSE,1)?-VOLUM |
+| `gtja191_085` | volume,momentum | close,volume | 39 | (TSRANK((VOLUME/MEAN(VOLUME,20)),20)*TSRANK((-1*DELTA(CLOSE, |
+| `gtja191_086` | momentum | close | 22 | ((0.25 < (((DELAY(CLOSE,20)-DELAY(CLOSE,10))/10) - ((DELAY(C |
+| `gtja191_087` | microstructure | close,open,high,low,volume,amount | 22 | ((RANK(DECAYLINEAR(DELTA(VWAP,4),7))+TSRANK(DECAYLINEAR((((L |
+| `gtja191_088` | momentum | close | 21 | (CLOSE-DELAY(CLOSE,20))/DELAY(CLOSE,20)*100 |
+| `gtja191_089` | momentum | close | 28 | 2*(SMA(CLOSE,13,2)-SMA(CLOSE,27,2)-SMA(SMA(CLOSE,13,2)-SMA(C |
+| `gtja191_090` | volume | volume,amount | 6 | ((-1*RANK(CORR(RANK(VWAP),RANK(VOLUME),5)))) |
+| `gtja191_091` | volume,reversal | close,low,volume | 35 | ((-1*RANK((CLOSE-MAX(CLOSE,5))))*RANK(CORR(MEAN(VOLUME,40),L |
+| `gtja191_092` | volume | close,volume,amount | 60 | (MAX(RANK(DECAYLINEAR(DELTA(((CLOSE*0.35)+(VWAP*0.65)),2),3) |
+| `gtja191_093` | microstructure | open,low | 22 | SUM((OPEN>=DELAY(OPEN,1)?0:MAX(OPEN-LOW,OPEN-DELAY(OPEN,1))) |
+| `gtja191_094` | volume,momentum | close,volume | 31 | SUM(CLOSE>DELAY(CLOSE,1)?VOLUME:(CLOSE<DELAY(CLOSE,1)?-VOLUM |
+| `gtja191_095` | volatility,volume | amount | 21 | STD(AMOUNT,20) |
+| `gtja191_096` | momentum | close,high,low | 12 | SMA(SMA((CLOSE-TSMIN(LOW,9))/(TSMAX(HIGH,9)-TSMIN(LOW,9))*10 |
+| `gtja191_097` | volatility,volume | volume | 11 | STD(VOLUME,10) |
+| `gtja191_098` | reversal | close | 60 | ((((DELTA((SUM(CLOSE,100)/100),100)/DELAY(CLOSE,100))<0.05)  |
+| `gtja191_099` | volume | close,volume | 6 | (-1*RANK(COVIANCE(RANK(CLOSE),RANK(VOLUME),5))) |
+| `gtja191_100` | volatility,volume | volume | 21 | STD(VOLUME,20) |
+| `gtja191_101` | volume,momentum | open,high,low,close,volume,amount | 80 | ((rank(ts\_corr(close, sum(ts\_mean(volume,30),37), 15)) < r |
+| `gtja191_102` | volume | close,volume | 7 | sma(max(volume-delay(volume,1),0),6,1)/sma(abs(volume-delay( |
+| `gtja191_103` | reversal | close,low | 20 | ((20-lowday(low,20))/20)*100 |
+| `gtja191_104` | volume,volatility | open,high,low,close,volume | 25 | -1*delta(corr(high,volume,5),5)*rank(std(close,20)) |
+| `gtja191_105` | volume | open,volume,close | 10 | -1*corr(rank(open),rank(volume),10) |
+| `gtja191_106` | momentum | close | 21 | close-delay(close,20) |
+| `gtja191_107` | reversal | open,high,low,close | 2 | -1*rank(open-delay(high,1))*rank(open-delay(close,1))*rank(o |
+| `gtja191_108` | reversal,volume | open,high,low,close,volume,amount | 125 | (rank(high-min(high,2))^rank(corr(vwap,mean(volume,120),6))) |
+| `gtja191_109` | volatility | close,high,low | 20 | sma(high-low,10,2)/sma(sma(high-low,10,2),10,2) |
+| `gtja191_110` | momentum | close,high,low | 21 | sum(max(0,high-delay(close,1)),20)/sum(max(0,delay(close,1)- |
+| `gtja191_111` | volume,microstructure | open,high,low,close,volume | 12 | sma(v*((c-l)-(h-c))/(h-l),11,2)-sma(v*((c-l)-(h-c))/(h-l),4, |
+| `gtja191_112` | momentum | close | 13 | (sum_up(12)-sum_down(12))/(sum_up(12)+sum_down(12))*100 |
+| `gtja191_113` | volume | close,volume | 27 | -1*(rank(mean(delay(c,5),20))*corr(c,v,2))*rank(corr(sum(c,5 |
+| `gtja191_114` | volume,volatility | open,high,low,close,volume,amount | 7 | see body |
+| `gtja191_115` | volume | open,high,low,close,volume | 40 | rank(corr(0.9h+0.1c,mean(v,30),10))^rank(corr(tsrank((h+l)/2 |
+| `gtja191_116` | momentum | close | 20 | regbeta(close,sequence(20),20) |
+| `gtja191_117` | volume,momentum | close,high,low,volume | 33 | tsrank(v,32)*(1-tsrank(c+h-l,16))*(1-tsrank(ret,32)) |
+| `gtja191_118` | reversal | open,high,low,close | 20 | sum(h-o,20)/sum(o-l,20)*100 |
+| `gtja191_119` | volume | open,high,low,close,volume,amount | 60 | see body |
+| `gtja191_120` | reversal | open,high,low,close,volume,amount | 1 | rank(vwap-close)/rank(vwap+close) |
+| `gtja191_121` | volume | open,high,low,close,volume,amount | 80 | see body |
+| `gtja191_122` | momentum | close | 40 | see body |
+| `gtja191_123` | volume | open,high,low,close,volume | 90 | see body |
+| `gtja191_124` | reversal | open,high,low,close,volume,amount | 32 | (close-vwap)/decay_linear(rank(tsmax(close,30)),2) |
+| `gtja191_125` | volume | open,high,low,close,volume,amount | 120 | see body |
+| `gtja191_126` | reversal | close,high,low | 1 | (c+h+l)/3 |
+| `gtja191_127` | volatility | close | 24 | sqrt(mean((100*(c-tsmax(c,12))/tsmax(c,12))^2,12)) |
+| `gtja191_128` | momentum | open,high,low,close,volume | 16 | see body |
+| `gtja191_129` | momentum | close | 13 | sum(abs(c-delay(c,1)) if dc<0 else 0,12) |
+| `gtja191_130` | volume | open,high,low,close,volume,amount | 60 | see body |
+| `gtja191_131` | volume | open,high,low,close,volume,amount | 84 | rank(delta(vwap,1))^tsrank(corr(close,mean(v,50),18),18) |
+| `gtja191_132` | liquidity | close,amount | 20 | mean(amount,20) |
+| `gtja191_133` | momentum | close,high,low | 20 | ((20-highday(high,20))/20)*100-((20-lowday(low,20))/20)*100 |
+| `gtja191_134` | momentum,volume | close,volume | 13 | (close-delay(close,12))/delay(close,12)*volume |
+| `gtja191_135` | momentum | close | 22 | sma(delay(c/delay(c,20),1),20,1) |
+| `gtja191_136` | momentum,volume | open,close,volume | 11 | -1*rank(delta(ret,3))*corr(open,volume,10) |
+| `gtja191_137` | volatility | open,high,low,close | 2 | see body |
+| `gtja191_138` | volume | open,high,low,close,volume,amount | 119 | see body |
+| `gtja191_139` | volume | open,volume,close | 10 | -1*corr(open,volume,10) |
+| `gtja191_140` | volume | open,high,low,close,volume | 100 | see body |
+| `gtja191_141` | volume | high,volume,close | 24 | rank(corr(rank(high),rank(mean(v,15)),9))*-1 |
+| `gtja191_142` | volume,reversal | close,volume | 26 | see body |
+| `gtja191_143` | momentum | close | 2 | cumprod(1 + (c/delay(c,1)-1) if c>delay(c,1) else 0) |
+| `gtja191_144` | liquidity | close,amount | 21 | see body |
+| `gtja191_145` | volume | close,volume | 26 | (mean(v,9)-mean(v,26))/mean(v,12)*100 |
+| `gtja191_146` | momentum | close | 81 | see body |
+| `gtja191_147` | momentum | close | 24 | regbeta(mean(close,12),sequence(12)) |
+| `gtja191_148` | volume | open,high,low,close,volume | 75 | see body |
+| `gtja191_149` | momentum | close | 253 | see body |
+| `gtja191_150` | volume | close,high,low,volume | 1 | (close+high+low)/3*volume |
+| `gtja191_151` | momentum | close | 21 | sma(close-delay(close,20),20,1) |
+| `gtja191_152` | momentum | close | 50 | see body |
+| `gtja191_153` | momentum | close | 24 | (mean(c,3)+mean(c,6)+mean(c,12)+mean(c,24))/4 |
+| `gtja191_154` | volume | open,high,low,close,volume,amount | 198 | see body |
+| `gtja191_155` | volume | close,volume | 40 | sma(v,13,2)-sma(v,27,2)-sma(sma(v,13,2)-sma(v,27,2),10,2) |
+| `gtja191_156` | volume | open,high,low,close,volume,amount | 10 | see body |
+| `gtja191_157` | volume | close | 12 | see body |
+| `gtja191_158` | volatility | close,high,low | 16 | ((h-sma(c,15,2))-(l-sma(c,15,2)))/c |
+| `gtja191_159` | momentum | open,high,low,close,volume | 25 | see body |
+| `gtja191_160` | volatility | close | 22 | sma((c<=delay(c,1)?std(c,20):0),20,1) |
+| `gtja191_161` | volatility | close,high,low | 13 | mean(true_range,12) |
+| `gtja191_162` | momentum | close | 24 | see body |
+| `gtja191_163` | volume | open,high,low,close,volume,amount | 21 | rank(((-1*ret)*mean(v,20))*vwap*(high-close)) |
+| `gtja191_164` | momentum | close,high,low | 20 | see body |
+| `gtja191_165` | volatility | close | 142 | see body |
+| `gtja191_166` | volatility | close | 40 | see body |
+| `gtja191_167` | momentum | close | 13 | sum(max(0,c-delay(c,1)),12) |
+| `gtja191_168` | volume | close,volume | 20 | -1*volume/mean(volume,20) |
+| `gtja191_169` | momentum | close | 50 | see body |
+| `gtja191_170` | volume | open,high,low,close,volume,amount | 21 | see body |
+| `gtja191_171` | microstructure | open,high,low,close | 1 | -1*((l-c)*(o^5))/((c-h)*(c^5)) |
+| `gtja191_172` | momentum | close,high,low | 20 | see body |
+| `gtja191_173` | momentum | close | 40 | 3*sma(c,13,2)-2*sma(sma(c,13,2),13,2)+sma(sma(sma(log(c),13, |
+| `gtja191_174` | volatility | close | 22 | sma((c>delay(c,1)?std(c,20):0),20,1) |
+| `gtja191_175` | volatility | close,high,low | 7 | mean(true_range,6) |
+| `gtja191_176` | volume | open,high,low,close,volume | 18 | see body |
+| `gtja191_177` | momentum | close,high | 20 | ((20-highday(h,20))/20)*100 |
+| `gtja191_178` | momentum,volume | close,volume | 2 | (c-delay(c,1))/delay(c,1)*v |
+| `gtja191_179` | volume | open,high,low,close,volume,amount | 62 | rank(corr(vwap,v,4))*rank(corr(rank(low),rank(mean(v,50)),12 |
+| `gtja191_180` | volume,reversal | close,volume | 67 | see body |
+| `gtja191_181` | volatility | close | 40 | see body |
+| `gtja191_182` | momentum | open,high,low,close,volume | 21 | see body |
+| `gtja191_183` | volatility | close | 70 | see body |
+| `gtja191_184` | reversal | open,close | 202 | see body |
+| `gtja191_185` | reversal | open,close | 1 | rank(-1*(1-open/close)^2) |
+| `gtja191_186` | momentum | close,high,low | 27 | see body (alpha172 averaged with its 6-day lag) |
+| `gtja191_187` | reversal | open,high | 21 | see body |
+| `gtja191_188` | volatility | close,high,low | 13 | (h-l-sma(h-l,11,2))/sma(h-l,11,2)*100 |
+| `gtja191_189` | volatility | close | 12 | mean(abs(c-mean(c,6)),6) |
+| `gtja191_190` | momentum | close | 39 | see body |
+| `gtja191_191` | volume | open,high,low,close,volume | 25 | see body |
+
+## qlib158 (154)
+
+| id | theme | columns | warmup | formula |
+|----|-------|---------|-------:|---------|
+| `qlib158_beta10` | momentum | close | 10 | (\\mathrm{close}_t - \\mathrm{close}_{{t-10}}) / (10\\,\\mat |
+| `qlib158_beta20` | momentum | close | 20 | (\\mathrm{close}_t - \\mathrm{close}_{{t-20}}) / (20\\,\\mat |
+| `qlib158_beta30` | momentum | close | 30 | (\\mathrm{close}_t - \\mathrm{close}_{{t-30}}) / (30\\,\\mat |
+| `qlib158_beta5` | momentum | close | 5 | (\\mathrm{close}_t - \\mathrm{close}_{{t-5}}) / (5\\,\\mathr |
+| `qlib158_beta60` | momentum | close | 60 | (\\mathrm{close}_t - \\mathrm{close}_{{t-60}}) / (60\\,\\mat |
+| `qlib158_cntd10` | reversal | close | 10 | \\mathrm{CNTP}_10 - \\mathrm{CNTN}_10 |
+| `qlib158_cntd20` | reversal | close | 20 | \\mathrm{CNTP}_20 - \\mathrm{CNTN}_20 |
+| `qlib158_cntd30` | reversal | close | 30 | \\mathrm{CNTP}_30 - \\mathrm{CNTN}_30 |
+| `qlib158_cntd5` | reversal | close | 5 | \\mathrm{CNTP}_5 - \\mathrm{CNTN}_5 |
+| `qlib158_cntd60` | reversal | close | 60 | \\mathrm{CNTP}_60 - \\mathrm{CNTN}_60 |
+| `qlib158_cntn10` | reversal | close | 10 | \\mathrm{rolling\\_mean}(\\mathrm{1}[\\mathrm{close}<\\mathr |
+| `qlib158_cntn20` | reversal | close | 20 | \\mathrm{rolling\\_mean}(\\mathrm{1}[\\mathrm{close}<\\mathr |
+| `qlib158_cntn30` | reversal | close | 30 | \\mathrm{rolling\\_mean}(\\mathrm{1}[\\mathrm{close}<\\mathr |
+| `qlib158_cntn5` | reversal | close | 5 | \\mathrm{rolling\\_mean}(\\mathrm{1}[\\mathrm{close}<\\mathr |
+| `qlib158_cntn60` | reversal | close | 60 | \\mathrm{rolling\\_mean}(\\mathrm{1}[\\mathrm{close}<\\mathr |
+| `qlib158_cntp10` | reversal | close | 10 | \\mathrm{rolling\\_mean}(\\mathrm{1}[\\mathrm{close}>\\mathr |
+| `qlib158_cntp20` | reversal | close | 20 | \\mathrm{rolling\\_mean}(\\mathrm{1}[\\mathrm{close}>\\mathr |
+| `qlib158_cntp30` | reversal | close | 30 | \\mathrm{rolling\\_mean}(\\mathrm{1}[\\mathrm{close}>\\mathr |
+| `qlib158_cntp5` | reversal | close | 5 | \\mathrm{rolling\\_mean}(\\mathrm{1}[\\mathrm{close}>\\mathr |
+| `qlib158_cntp60` | reversal | close | 60 | \\mathrm{rolling\\_mean}(\\mathrm{1}[\\mathrm{close}>\\mathr |
+| `qlib158_cord10` | volume,microstructure | close,volume | 10 | \\mathrm{ts\\_corr}(\\mathrm{close}/\\mathrm{close}_{{-1}},  |
+| `qlib158_cord20` | volume,microstructure | close,volume | 20 | \\mathrm{ts\\_corr}(\\mathrm{close}/\\mathrm{close}_{{-1}},  |
+| `qlib158_cord30` | volume,microstructure | close,volume | 30 | \\mathrm{ts\\_corr}(\\mathrm{close}/\\mathrm{close}_{{-1}},  |
+| `qlib158_cord5` | volume,microstructure | close,volume | 5 | \\mathrm{ts\\_corr}(\\mathrm{close}/\\mathrm{close}_{{-1}},  |
+| `qlib158_cord60` | volume,microstructure | close,volume | 60 | \\mathrm{ts\\_corr}(\\mathrm{close}/\\mathrm{close}_{{-1}},  |
+| `qlib158_corr10` | volume,microstructure | close,volume | 10 | \\mathrm{ts\\_corr}(\\mathrm{close}, \\log(\\mathrm{volume}+ |
+| `qlib158_corr20` | volume,microstructure | close,volume | 20 | \\mathrm{ts\\_corr}(\\mathrm{close}, \\log(\\mathrm{volume}+ |
+| `qlib158_corr30` | volume,microstructure | close,volume | 30 | \\mathrm{ts\\_corr}(\\mathrm{close}, \\log(\\mathrm{volume}+ |
+| `qlib158_corr5` | volume,microstructure | close,volume | 5 | \\mathrm{ts\\_corr}(\\mathrm{close}, \\log(\\mathrm{volume}+ |
+| `qlib158_corr60` | volume,microstructure | close,volume | 60 | \\mathrm{ts\\_corr}(\\mathrm{close}, \\log(\\mathrm{volume}+ |
+| `qlib158_imax10` | momentum | high | 10 | \\mathrm{ts\\_argmax}(\\mathrm{high}, 10) / 10 |
+| `qlib158_imax20` | momentum | high | 20 | \\mathrm{ts\\_argmax}(\\mathrm{high}, 20) / 20 |
+| `qlib158_imax30` | momentum | high | 30 | \\mathrm{ts\\_argmax}(\\mathrm{high}, 30) / 30 |
+| `qlib158_imax5` | momentum | high | 5 | \\mathrm{ts\\_argmax}(\\mathrm{high}, 5) / 5 |
+| `qlib158_imax60` | momentum | high | 60 | \\mathrm{ts\\_argmax}(\\mathrm{high}, 60) / 60 |
+| `qlib158_imin10` | momentum | low | 10 | \\mathrm{ts\\_argmin}(\\mathrm{low}, 10) / 10 |
+| `qlib158_imin20` | momentum | low | 20 | \\mathrm{ts\\_argmin}(\\mathrm{low}, 20) / 20 |
+| `qlib158_imin30` | momentum | low | 30 | \\mathrm{ts\\_argmin}(\\mathrm{low}, 30) / 30 |
+| `qlib158_imin5` | momentum | low | 5 | \\mathrm{ts\\_argmin}(\\mathrm{low}, 5) / 5 |
+| `qlib158_imin60` | momentum | low | 60 | \\mathrm{ts\\_argmin}(\\mathrm{low}, 60) / 60 |
+| `qlib158_imxd10` | momentum | high,low | 10 | (\\mathrm{ts\\_argmax}(\\mathrm{high}, 10) - \\mathrm{ts\\_a |
+| `qlib158_imxd20` | momentum | high,low | 20 | (\\mathrm{ts\\_argmax}(\\mathrm{high}, 20) - \\mathrm{ts\\_a |
+| `qlib158_imxd30` | momentum | high,low | 30 | (\\mathrm{ts\\_argmax}(\\mathrm{high}, 30) - \\mathrm{ts\\_a |
+| `qlib158_imxd5` | momentum | high,low | 5 | (\\mathrm{ts\\_argmax}(\\mathrm{high}, 5) - \\mathrm{ts\\_ar |
+| `qlib158_imxd60` | momentum | high,low | 60 | (\\mathrm{ts\\_argmax}(\\mathrm{high}, 60) - \\mathrm{ts\\_a |
+| `qlib158_klen` | microstructure | open,high,low | 1 | (\\mathrm{high} - \\mathrm{low}) / \\mathrm{open} |
+| `qlib158_klow` | microstructure | open,low,close | 1 | (\\min(\\mathrm{open}, \\mathrm{close}) - \\mathrm{low}) / \ |
+| `qlib158_klow2` | microstructure | open,high,low,close | 1 | (\\min(\\mathrm{open}, \\mathrm{close}) - \\mathrm{low}) / ( |
+| `qlib158_kmid` | microstructure | open,close | 1 | (\\mathrm{close} - \\mathrm{open}) / \\mathrm{open} |
+| `qlib158_kmid2` | microstructure | open,high,low,close | 1 | (\\mathrm{close} - \\mathrm{open}) / (\\mathrm{high} - \\mat |
+| `qlib158_ksft` | microstructure | open,high,low,close | 1 | (2\\,\\mathrm{close} - \\mathrm{high} - \\mathrm{low}) / \\m |
+| `qlib158_ksft2` | microstructure | open,high,low,close | 1 | (2\\,\\mathrm{close} - \\mathrm{high} - \\mathrm{low}) / (\\ |
+| `qlib158_kup` | microstructure | open,high,close | 1 | (\\mathrm{high} - \\max(\\mathrm{open}, \\mathrm{close})) /  |
+| `qlib158_kup2` | microstructure | open,high,low,close | 1 | (\\mathrm{high} - \\max(\\mathrm{open}, \\mathrm{close})) /  |
+| `qlib158_ma10` | momentum | close | 10 | \\mathrm{ts\\_mean}(\\mathrm{close}, 10) / \\mathrm{close} |
+| `qlib158_ma20` | momentum | close | 20 | \\mathrm{ts\\_mean}(\\mathrm{close}, 20) / \\mathrm{close} |
+| `qlib158_ma30` | momentum | close | 30 | \\mathrm{ts\\_mean}(\\mathrm{close}, 30) / \\mathrm{close} |
+| `qlib158_ma5` | momentum | close | 5 | \\mathrm{ts\\_mean}(\\mathrm{close}, 5) / \\mathrm{close} |
+| `qlib158_ma60` | momentum | close | 60 | \\mathrm{ts\\_mean}(\\mathrm{close}, 60) / \\mathrm{close} |
+| `qlib158_max10` | momentum | high,close | 10 | \\mathrm{ts\\_max}(\\mathrm{high}, 10) / \\mathrm{close} |
+| `qlib158_max20` | momentum | high,close | 20 | \\mathrm{ts\\_max}(\\mathrm{high}, 20) / \\mathrm{close} |
+| `qlib158_max30` | momentum | high,close | 30 | \\mathrm{ts\\_max}(\\mathrm{high}, 30) / \\mathrm{close} |
+| `qlib158_max5` | momentum | high,close | 5 | \\mathrm{ts\\_max}(\\mathrm{high}, 5) / \\mathrm{close} |
+| `qlib158_max60` | momentum | high,close | 60 | \\mathrm{ts\\_max}(\\mathrm{high}, 60) / \\mathrm{close} |
+| `qlib158_min10` | momentum | low,close | 10 | \\mathrm{ts\\_min}(\\mathrm{low}, 10) / \\mathrm{close} |
+| `qlib158_min20` | momentum | low,close | 20 | \\mathrm{ts\\_min}(\\mathrm{low}, 20) / \\mathrm{close} |
+| `qlib158_min30` | momentum | low,close | 30 | \\mathrm{ts\\_min}(\\mathrm{low}, 30) / \\mathrm{close} |
+| `qlib158_min5` | momentum | low,close | 5 | \\mathrm{ts\\_min}(\\mathrm{low}, 5) / \\mathrm{close} |
+| `qlib158_min60` | momentum | low,close | 60 | \\mathrm{ts\\_min}(\\mathrm{low}, 60) / \\mathrm{close} |
+| `qlib158_qtld10` | momentum | close | 10 | \\mathrm{quantile}_{{0.2}}(\\mathrm{close}, 10) / \\mathrm{c |
+| `qlib158_qtld20` | momentum | close | 20 | \\mathrm{quantile}_{{0.2}}(\\mathrm{close}, 20) / \\mathrm{c |
+| `qlib158_qtld30` | momentum | close | 30 | \\mathrm{quantile}_{{0.2}}(\\mathrm{close}, 30) / \\mathrm{c |
+| `qlib158_qtld5` | momentum | close | 5 | \\mathrm{quantile}_{{0.2}}(\\mathrm{close}, 5) / \\mathrm{cl |
+| `qlib158_qtld60` | momentum | close | 60 | \\mathrm{quantile}_{{0.2}}(\\mathrm{close}, 60) / \\mathrm{c |
+| `qlib158_qtlu10` | momentum | close | 10 | \\mathrm{quantile}_{{0.8}}(\\mathrm{close}, 10) / \\mathrm{c |
+| `qlib158_qtlu20` | momentum | close | 20 | \\mathrm{quantile}_{{0.8}}(\\mathrm{close}, 20) / \\mathrm{c |
+| `qlib158_qtlu30` | momentum | close | 30 | \\mathrm{quantile}_{{0.8}}(\\mathrm{close}, 30) / \\mathrm{c |
+| `qlib158_qtlu5` | momentum | close | 5 | \\mathrm{quantile}_{{0.8}}(\\mathrm{close}, 5) / \\mathrm{cl |
+| `qlib158_qtlu60` | momentum | close | 60 | \\mathrm{quantile}_{{0.8}}(\\mathrm{close}, 60) / \\mathrm{c |
+| `qlib158_rank10` | momentum | close | 10 | \\mathrm{ts\\_rank}(\\mathrm{close}, 10) |
+| `qlib158_rank20` | momentum | close | 20 | \\mathrm{ts\\_rank}(\\mathrm{close}, 20) |
+| `qlib158_rank30` | momentum | close | 30 | \\mathrm{ts\\_rank}(\\mathrm{close}, 30) |
+| `qlib158_rank5` | momentum | close | 5 | \\mathrm{ts\\_rank}(\\mathrm{close}, 5) |
+| `qlib158_rank60` | momentum | close | 60 | \\mathrm{ts\\_rank}(\\mathrm{close}, 60) |
+| `qlib158_resi10` | momentum | close | 10 | (\\mathrm{close} - \\mathrm{ts\\_mean}(\\mathrm{close}, 10)) |
+| `qlib158_resi20` | momentum | close | 20 | (\\mathrm{close} - \\mathrm{ts\\_mean}(\\mathrm{close}, 20)) |
+| `qlib158_resi30` | momentum | close | 30 | (\\mathrm{close} - \\mathrm{ts\\_mean}(\\mathrm{close}, 30)) |
+| `qlib158_resi5` | momentum | close | 5 | (\\mathrm{close} - \\mathrm{ts\\_mean}(\\mathrm{close}, 5))  |
+| `qlib158_resi60` | momentum | close | 60 | (\\mathrm{close} - \\mathrm{ts\\_mean}(\\mathrm{close}, 60)) |
+| `qlib158_roc10` | momentum | close | 10 | \\mathrm{close}_t / \\mathrm{close}_{{t-10}} - 1 |
+| `qlib158_roc20` | momentum | close | 20 | \\mathrm{close}_t / \\mathrm{close}_{{t-20}} - 1 |
+| `qlib158_roc30` | momentum | close | 30 | \\mathrm{close}_t / \\mathrm{close}_{{t-30}} - 1 |
+| `qlib158_roc5` | momentum | close | 5 | \\mathrm{close}_t / \\mathrm{close}_{{t-5}} - 1 |
+| `qlib158_roc60` | momentum | close | 60 | \\mathrm{close}_t / \\mathrm{close}_{{t-60}} - 1 |
+| `qlib158_rsqr10` | momentum | close | 10 | \\mathrm{ts\\_corr}(\\mathrm{close}, t, 10)^2 |
+| `qlib158_rsqr20` | momentum | close | 20 | \\mathrm{ts\\_corr}(\\mathrm{close}, t, 20)^2 |
+| `qlib158_rsqr30` | momentum | close | 30 | \\mathrm{ts\\_corr}(\\mathrm{close}, t, 30)^2 |
+| `qlib158_rsqr5` | momentum | close | 5 | \\mathrm{ts\\_corr}(\\mathrm{close}, t, 5)^2 |
+| `qlib158_rsqr60` | momentum | close | 60 | \\mathrm{ts\\_corr}(\\mathrm{close}, t, 60)^2 |
+| `qlib158_rsv10` | momentum | high,low,close | 10 | (\\mathrm{close} - \\mathrm{ts\\_min}(\\mathrm{low}, 10)) /  |
+| `qlib158_rsv20` | momentum | high,low,close | 20 | (\\mathrm{close} - \\mathrm{ts\\_min}(\\mathrm{low}, 20)) /  |
+| `qlib158_rsv30` | momentum | high,low,close | 30 | (\\mathrm{close} - \\mathrm{ts\\_min}(\\mathrm{low}, 30)) /  |
+| `qlib158_rsv5` | momentum | high,low,close | 5 | (\\mathrm{close} - \\mathrm{ts\\_min}(\\mathrm{low}, 5)) / ( |
+| `qlib158_rsv60` | momentum | high,low,close | 60 | (\\mathrm{close} - \\mathrm{ts\\_min}(\\mathrm{low}, 60)) /  |
+| `qlib158_std10` | momentum | close | 10 | \\mathrm{ts\\_std}(\\mathrm{close}, 10) / \\mathrm{close} |
+| `qlib158_std20` | momentum | close | 20 | \\mathrm{ts\\_std}(\\mathrm{close}, 20) / \\mathrm{close} |
+| `qlib158_std30` | momentum | close | 30 | \\mathrm{ts\\_std}(\\mathrm{close}, 30) / \\mathrm{close} |
+| `qlib158_std5` | momentum | close | 5 | \\mathrm{ts\\_std}(\\mathrm{close}, 5) / \\mathrm{close} |
+| `qlib158_std60` | momentum | close | 60 | \\mathrm{ts\\_std}(\\mathrm{close}, 60) / \\mathrm{close} |
+| `qlib158_sumd10` | reversal | close | 10 | \\mathrm{SUMP}_w - \\mathrm{SUMN}_w |
+| `qlib158_sumd20` | reversal | close | 20 | \\mathrm{SUMP}_w - \\mathrm{SUMN}_w |
+| `qlib158_sumd30` | reversal | close | 30 | \\mathrm{SUMP}_w - \\mathrm{SUMN}_w |
+| `qlib158_sumd5` | reversal | close | 5 | \\mathrm{SUMP}_w - \\mathrm{SUMN}_w |
+| `qlib158_sumd60` | reversal | close | 60 | \\mathrm{SUMP}_w - \\mathrm{SUMN}_w |
+| `qlib158_sumn10` | reversal | close | 10 | \\sum \\max(-\\Delta\\mathrm{close}, 0) / \\sum /\\Delta\\ma |
+| `qlib158_sumn20` | reversal | close | 20 | \\sum \\max(-\\Delta\\mathrm{close}, 0) / \\sum /\\Delta\\ma |
+| `qlib158_sumn30` | reversal | close | 30 | \\sum \\max(-\\Delta\\mathrm{close}, 0) / \\sum /\\Delta\\ma |
+| `qlib158_sumn5` | reversal | close | 5 | \\sum \\max(-\\Delta\\mathrm{close}, 0) / \\sum /\\Delta\\ma |
+| `qlib158_sumn60` | reversal | close | 60 | \\sum \\max(-\\Delta\\mathrm{close}, 0) / \\sum /\\Delta\\ma |
+| `qlib158_sump10` | reversal | close | 10 | \\sum \\max(\\Delta\\mathrm{close}, 0) / \\sum /\\Delta\\mat |
+| `qlib158_sump20` | reversal | close | 20 | \\sum \\max(\\Delta\\mathrm{close}, 0) / \\sum /\\Delta\\mat |
+| `qlib158_sump30` | reversal | close | 30 | \\sum \\max(\\Delta\\mathrm{close}, 0) / \\sum /\\Delta\\mat |
+| `qlib158_sump5` | reversal | close | 5 | \\sum \\max(\\Delta\\mathrm{close}, 0) / \\sum /\\Delta\\mat |
+| `qlib158_sump60` | reversal | close | 60 | \\sum \\max(\\Delta\\mathrm{close}, 0) / \\sum /\\Delta\\mat |
+| `qlib158_vma10` | volume,volatility | volume | 10 | \\mathrm{ts\\_mean}(\\mathrm{volume}, 10) / \\mathrm{volume} |
+| `qlib158_vma20` | volume,volatility | volume | 20 | \\mathrm{ts\\_mean}(\\mathrm{volume}, 20) / \\mathrm{volume} |
+| `qlib158_vma30` | volume,volatility | volume | 30 | \\mathrm{ts\\_mean}(\\mathrm{volume}, 30) / \\mathrm{volume} |
+| `qlib158_vma5` | volume,volatility | volume | 5 | \\mathrm{ts\\_mean}(\\mathrm{volume}, 5) / \\mathrm{volume} |
+| `qlib158_vma60` | volume,volatility | volume | 60 | \\mathrm{ts\\_mean}(\\mathrm{volume}, 60) / \\mathrm{volume} |
+| `qlib158_vstd10` | volume,volatility | volume | 10 | \\mathrm{ts\\_std}(\\mathrm{volume}, 10) / \\mathrm{volume} |
+| `qlib158_vstd20` | volume,volatility | volume | 20 | \\mathrm{ts\\_std}(\\mathrm{volume}, 20) / \\mathrm{volume} |
+| `qlib158_vstd30` | volume,volatility | volume | 30 | \\mathrm{ts\\_std}(\\mathrm{volume}, 30) / \\mathrm{volume} |
+| `qlib158_vstd5` | volume,volatility | volume | 5 | \\mathrm{ts\\_std}(\\mathrm{volume}, 5) / \\mathrm{volume} |
+| `qlib158_vstd60` | volume,volatility | volume | 60 | \\mathrm{ts\\_std}(\\mathrm{volume}, 60) / \\mathrm{volume} |
+| `qlib158_vsumd10` | volume,volatility | volume | 10 | \\mathrm{VSUMP}_w - \\mathrm{VSUMN}_w |
+| `qlib158_vsumd20` | volume,volatility | volume | 20 | \\mathrm{VSUMP}_w - \\mathrm{VSUMN}_w |
+| `qlib158_vsumd30` | volume,volatility | volume | 30 | \\mathrm{VSUMP}_w - \\mathrm{VSUMN}_w |
+| `qlib158_vsumd5` | volume,volatility | volume | 5 | \\mathrm{VSUMP}_w - \\mathrm{VSUMN}_w |
+| `qlib158_vsumd60` | volume,volatility | volume | 60 | \\mathrm{VSUMP}_w - \\mathrm{VSUMN}_w |
+| `qlib158_vsumn10` | volume,volatility | volume | 10 | \\sum \\max(-\\Delta v, 0) / \\sum /\\Delta v/ |
+| `qlib158_vsumn20` | volume,volatility | volume | 20 | \\sum \\max(-\\Delta v, 0) / \\sum /\\Delta v/ |
+| `qlib158_vsumn30` | volume,volatility | volume | 30 | \\sum \\max(-\\Delta v, 0) / \\sum /\\Delta v/ |
+| `qlib158_vsumn5` | volume,volatility | volume | 5 | \\sum \\max(-\\Delta v, 0) / \\sum /\\Delta v/ |
+| `qlib158_vsumn60` | volume,volatility | volume | 60 | \\sum \\max(-\\Delta v, 0) / \\sum /\\Delta v/ |
+| `qlib158_vsump10` | volume,volatility | volume | 10 | \\sum \\max(\\Delta v, 0) / \\sum /\\Delta v/ |
+| `qlib158_vsump20` | volume,volatility | volume | 20 | \\sum \\max(\\Delta v, 0) / \\sum /\\Delta v/ |
+| `qlib158_vsump30` | volume,volatility | volume | 30 | \\sum \\max(\\Delta v, 0) / \\sum /\\Delta v/ |
+| `qlib158_vsump5` | volume,volatility | volume | 5 | \\sum \\max(\\Delta v, 0) / \\sum /\\Delta v/ |
+| `qlib158_vsump60` | volume,volatility | volume | 60 | \\sum \\max(\\Delta v, 0) / \\sum /\\Delta v/ |
+| `qlib158_wvma10` | volume,volatility | close,volume | 10 | \\mathrm{ts\\_std}(\\mathrm{ret}\\cdot v, 10) / \\mathrm{ts\ |
+| `qlib158_wvma20` | volume,volatility | close,volume | 20 | \\mathrm{ts\\_std}(\\mathrm{ret}\\cdot v, 20) / \\mathrm{ts\ |
+| `qlib158_wvma30` | volume,volatility | close,volume | 30 | \\mathrm{ts\\_std}(\\mathrm{ret}\\cdot v, 30) / \\mathrm{ts\ |
+| `qlib158_wvma5` | volume,volatility | close,volume | 5 | \\mathrm{ts\\_std}(\\mathrm{ret}\\cdot v, 5) / \\mathrm{ts\\ |
+| `qlib158_wvma60` | volume,volatility | close,volume | 60 | \\mathrm{ts\\_std}(\\mathrm{ret}\\cdot v, 60) / \\mathrm{ts\ |

--- a/docs/analysis/catalog/CHANNELS.md
+++ b/docs/analysis/catalog/CHANNELS.md
@@ -1,0 +1,122 @@
+# Channels Adapter Catalog
+
+Core: `base.py` → `bus/` → `runtime.py` (inbound→SessionService) + `manager.py` (outbound).
+
+Adapters analyzed: **16**.
+
+| name | display | file | lines | _handle override | libs (hint) | doc |
+|------|---------|------|------:|:----------------:|-------------|-----|
+| `dingtalk` | DingTalk | `dingtalk.py` | 774 |  | `httpx`, `pydantic`, `zipfile` | DingTalk/DingDing channel implementation using Stream Mode. |
+| `discord` | Discord | `discord.py` | 819 |  | `__future__`, `importlib`, `pydantic` | Discord channel implementation using discord.py. |
+| `email` | Email | `email.py` | 915 |  | `email`, `fnmatch`, `imaplib`, `pydantic`, `smtplib` | Email channel implementation using IMAP polling + SMTP replies. |
+| `feishu` | Feishu | `feishu.py` | 2360 |  | `__future__`, `importlib`, `pydantic`, `rich` | Feishu/Lark channel implementation using lark-oapi SDK with WebSocket long connection. |
+| `matrix` | Matrix | `matrix.py` | 1033 |  | `pydantic` | Matrix (Element) channel — inbound sync + outbound message/media delivery. |
+| `mochat` | Mochat | `mochat.py` | 944 |  | `__future__`, `httpx`, `pydantic` | Mochat channel implementation using Socket.IO with HTTP polling fallback. |
+| `msteams` | Microsoft Teams | `msteams.py` | 823 |  | `__future__`, `httpx`, `importlib`, `pydantic` | Microsoft Teams channel MVP using a tiny built-in HTTP webhook server. |
+| `napcat` | Napcat (QQ) | `napcat.py` | 581 |  | `__future__`, `aiohttp`, `pydantic`, `random`, `websockets` | Napcat (OneBot v11) channel for QQ, over WebSocket. |
+| `qq` | QQ | `qq.py` | 715 |  | `__future__`, `aiohttp`, `pydantic` | QQ channel implementation using botpy SDK. |
+| `signal` | Signal | `signal.py` | 1421 | Y | `__future__`, `httpx`, `pydantic`, `unicodedata` | Signal channel implementation using signal-cli daemon JSON-RPC interface. |
+| `slack` | Slack | `slack.py` | 741 |  | `httpx`, `pydantic`, `slack_sdk`, `slackify_markdown` | Slack channel implementation using Socket Mode. |
+| `telegram` | Telegram | `telegram.py` | 1691 |  | `__future__`, `pydantic`, `telegram`, `unicodedata` | Telegram channel implementation using python-telegram-bot. |
+| `websocket` | WebSocket | `websocket.py` | 1204 |  | `__future__`, `pydantic`, `websockets` | WebSocket server channel: vibe-trading acts as a WebSocket server and serves connected clients. |
+| `wecom` | WeCom | `wecom.py` | 555 |  | `importlib`, `pydantic` | WeCom (Enterprise WeChat) channel implementation using wecom_aibot_sdk. |
+| `weixin` | WeChat | `weixin.py` | 1587 |  | `__future__`, `httpx`, `pydantic`, `random` | Personal WeChat (微信) channel using HTTP long-poll API. |
+| `whatsapp` | WhatsApp | `whatsapp.py` | 683 |  | `__future__`, `pydantic`, `secrets` | WhatsApp channel implementation using neonize. |
+
+## Per-adapter notes (from code structure)
+
+### `dingtalk`
+
+- class: `DingTalkChannel` (774 lines)
+- start/send: yes / yes
+- note: dingtalk_stream Stream Mode.
+
+### `discord`
+
+- class: `DiscordChannel` (819 lines)
+- start/send: yes / yes
+- note: discord.py gateway; thread session_key.
+
+### `email`
+
+- class: `EmailChannel` (915 lines)
+- start/send: yes / yes
+- note: IMAP poll + SMTP reply.
+
+### `feishu`
+
+- class: `FeishuChannel` (2360 lines)
+- start/send: yes / yes
+- note: lark_oapi WebSocket.
+
+### `matrix`
+
+- class: `MatrixChannel` (1033 lines)
+- start/send: yes / yes
+- note: matrix-nio sync; workspace restrict kwargs.
+
+### `mochat`
+
+- class: `MochatChannel` (944 lines)
+- start/send: yes / yes
+- note: Socket.IO + HTTP polling fallback.
+
+### `msteams`
+
+- class: `MSTeamsChannel` (823 lines)
+- start/send: yes / yes
+- note: Bot Framework webhook HTTP (DM MVP).
+
+### `napcat`
+
+- class: `NapcatChannel` (581 lines)
+- start/send: yes / yes
+- note: OneBot v11 WebSocket.
+
+### `qq`
+
+- class: `QQChannel` (715 lines)
+- start/send: yes / yes
+- note: botpy official QQ bot.
+
+### `signal`
+
+- class: `SignalChannel` (1421 lines)
+- start/send: yes / yes
+- note: signal-cli REST/JSON-RPC; **overrides _handle_message** (direct publish).
+
+### `slack`
+
+- class: `SlackChannel` (741 lines)
+- start/send: yes / yes
+- note: Socket Mode; emoji react progress.
+
+### `telegram`
+
+- class: `TelegramChannel` (1691 lines)
+- start/send: yes / yes
+- note: python-telegram-bot long polling; media download; pairing via BaseChannel.
+
+### `websocket`
+
+- class: `WebSocketChannel` (1204 lines)
+- start/send: yes / yes
+- note: Local WS/Unix + channelsui gateway for WebUI.
+
+### `wecom`
+
+- class: `WecomChannel` (555 lines)
+- start/send: yes / yes
+- note: enterprise WeCom aibot SDK.
+
+### `weixin`
+
+- class: `WeixinChannel` (1587 lines)
+- start/send: yes / yes
+- note: personal WeChat HTTP long-poll (ilink).
+
+### `whatsapp`
+
+- class: `WhatsAppChannel` (683 lines)
+- start/send: yes / yes
+- note: neonize WhatsApp Web; rich media.

--- a/docs/analysis/catalog/INDEX.md
+++ b/docs/analysis/catalog/INDEX.md
@@ -1,0 +1,38 @@
+# Catalog Index — 한 장씩 읽기 결과
+
+이 폴더는 이전에 “카탈로그 잔여”로 남겨 둔 항목을 **전수 추출·기록**한 결과입니다.
+
+| 문서 | 건수 | 내용 |
+|------|------|------|
+| [SKILLS.md](./SKILLS.md) | **88** | 모든 `SKILL.md` frontmatter (category, description, files, example_engine) |
+| [ALPHAS.md](./ALPHAS.md) | **462** | zoo별 `__alpha_meta__` (id, theme, columns, warmup, formula_latex) |
+| [SWARM_PRESETS.md](./SWARM_PRESETS.md) | **30** | agents/tasks/depends_on/variables |
+| [CHANNELS.md](./CHANNELS.md) | **16** | IM 어댑터 class/lines/override/프로토콜 노트 |
+| [TESTS.md](./TESTS.md) | **315** | `test_*.py` 도메인 prefix 맵 |
+
+## JSON (기계용)
+
+- `skills_inventory.json`
+- `alphas_inventory.json`
+- `swarm_inventory.json`
+
+## 재생성
+
+```bash
+python docs/analysis/catalog/_build_inventories.py
+python docs/analysis/catalog/_build_channels_tests.py
+```
+
+## 읽는 방법
+
+1. 사람이 훑을 때 → 각 `*.md` 표  
+2. 필터/검색할 때 → 대응 `*.json`  
+3. 전체 아키텍처 맥락 → `docs/analysis/REPORT.md` Part 28  
+4. AI 핸드오프 진입 → `docs/analysis/README.md` 
+
+## 한계 (정직하게)
+
+- 스킬: frontmatter + 파일 수. **본문 전체 문단**은 md 길이가 커서 요약만(설명 필드에 핵심).
+- 알파: AST로 `__alpha_meta__` literal. `compute()` 구현 라인 전부는 표에 formula_latex로 대체.
+- 채널: 구조·프로토콜·라인 수. SDK 라이브러리 내부까지 추적하지는 않음.
+- 테스트: 파일명 기반 도메인 맵. 케이스별 assertion 전수는 별도.

--- a/docs/analysis/catalog/SKILLS.md
+++ b/docs/analysis/catalog/SKILLS.md
@@ -1,0 +1,138 @@
+# Skills Catalog (88)
+
+Total: **88** skills under `agent/src/skills/`.
+
+## By category
+
+### analysis (22)
+
+| id | description | files | example_engine |
+|----|-------------|------:|:--------------:|
+| `behavioral-finance` | Behavioral finance applications: theories of overreaction and underreaction, behavioral explanations for momentum and reversal, investor sentiment cycles, cognitive-bias checklists, and debiasing quantitative strategies. | 1 |  |
+| `commodity-analysis` | Commodity analysis (oil supply-demand balance / gold pricing / copper as an economic predictor / inventory cycles / futures premium-discount structure / seasonality), generating directional commodity signals. | 1 |  |
+| `correlation-analysis` | Correlation and cointegration analysis — co-movement discovery, deep return-correlation analysis, sector clustering, realized correlation, Engle-Granger / Johansen cointegration, half-life, Kalman dynamic hedge ratio, cross-market linkage analysis, and pair-trading signal generation | 1 |  |
+| `correlation-regime` | Correlation-regime detection and crisis attribution — edge-density regime states with hysteresis, causal (no look-ahead) smoothing, regime-aware exposure context, first-mover crisis attribution with honest NAME / MACRO / AMBIGUOUS / ABSTAIN verdicts, and a correlation-rewiring leaderboard that catches slow bleed-outs | 1 |  |
+| `credit-analysis` | 固收与信用分析：信用债评级、利差分析、违约风险评估、城投债研究、可转债定价与策略。 | 1 |  |
+| `deep-company-series` | Write a publication-grade 8-part deep-dive series on a single company (~120k words total): cognitive reset / moat / profit engine / hidden assets / era variable (e.g. AI) / financials Buffett-style / management / valuation+redlines. The core IP is NOT writing but REVISING — a strict fact-check checklist catches pseudo-precision (probability-weighted expectations, third-party MAU discrepancies, lin | 1 |  |
+| `dividend-analysis` | Dividend stock analysis for income, dividend-growth, and shareholder-return strategies, including yield quality, payout sustainability, ex-dividend mechanics, and yield-trap checks. | 1 |  |
+| `earnings-forecast` | 盈利预测与一致预期分析（自上而下/自下而上预测法/SUE/PEAD/分析师预期修正），捕捉业绩超预期交易机会。 | 1 |  |
+| `earnings-revision` | Earnings estimate revisions, guidance analysis, and post-earnings drift (PEAD) — track analyst consensus changes, earnings surprise patterns, and management guidance shifts for US/HK equities. | 1 |  |
+| `factor-research` | Factor research framework with IC/IR analysis, quantile backtesting, and factor combination. Suitable for cross-sectional factor evaluation across multiple instruments. | 1 |  |
+| `global-macro` | Global macro analysis framework (central bank policy transmission / FX forecasting / geopolitical risk / capital flows), used to build macro factor signals that drive cross-asset allocation. | 1 |  |
+| `macro-analysis` | Macroeconomic cycle positioning and central-bank policy interpretation, including GDP/CPI/PMI/rates/FX analysis, with output in the form of major-asset allocation tilts. | 1 |  |
+| `management-deep-dive` | Deep management assessment — the 'buying a stock is buying a person' layer. For a company or a named executive, evaluate integrity (promise-vs-delivery tracking, crisis behavior, stakeholder treatment), ability (strategic foresight, execution, capital-allocation record) and governance (equity structure, compensation, related-party deals). Outputs a weighted score across integrity / ability / capit | 1 |  |
+| `market-microstructure` | Market microstructure: bid-ask spread analysis, order-flow toxicity metrics (VPIN / Kyle lambda), liquidity measures (Amihud / Roll), price-impact models, limit-order-book analysis, and China A-share call auction / block trade mechanics. | 1 |  |
+| `performance-attribution` | Performance attribution analysis — Brinson sector/stock-selection attribution, factor alpha/beta decomposition, market-timing evaluation, and benchmark comparison framework. | 1 |  |
+| `private-company-research` | Deep research framework for pre-IPO / private companies (Ant Group, SpaceX, Stripe, ByteDance...). Six analyst lenses — business model, financial forensics, competitive landscape, risk & governance, tech & IP, alternative-data signals — run in parallel via run_swarm, then cross-validated for signal consistency before any verdict. Built around the core challenge of private-company work: information | 1 |  |
+| `quant-statistics` | Quantitative statistical methods: ADF unit-root / cointegration tests, GARCH volatility modeling, regression diagnostics (heteroskedasticity / autocorrelation), Bootstrap, and hypothesis testing. | 1 |  |
+| `research-discipline` | A short self-bias checklist to run at the START of any investment research task (stock screen / sector study / company deep-dive). Four biases that systematically warp AI research — leader-bias (only big caps), English-bias (miss JP/KR/TW players), narrative-bias (chase concept labels), confirmation-bias (only bullish evidence) — plus recency-bias. Load this first, then research with the correctio | 1 |  |
+| `risk-analysis` | Risk measurement and stress testing — VaR/CVaR/max drawdown calculation, Monte Carlo simulation, extreme-value tail-risk analysis, and historical scenario stress testing. | 1 |  |
+| `sentiment-analysis` | 市场情绪分析——恐贪指数/Put-Call Ratio/融资融券/北向资金信号解读、社交媒体舆情量化框架 | 1 |  |
+| `shadow-account` | Shadow Account — 从用户交割单提炼盈利模式（3-5 条人话规则）→ 跨 A股/港股/美股/crypto 多市场回测 → 差值归因 → 8-section PDF 报告。叙事：你的影子，没有情绪噪音。 | 1 |  |
+| `valuation-model` | Valuation methodology — absolute valuation with DCF / DDM / SOTP, relative valuation with PE-Band / PB-ROE / EV-EBITDA, sensitivity analysis, and valuation-trap detection. | 1 |  |
+
+### asset-class (9)
+
+| id | description | files | example_engine |
+|----|-------------|------:|:--------------:|
+| `asset-allocation` | Asset allocation theory and optimizer usage — MPT / Black-Litterman / risk budgeting / all-weather strategy, including guides for 5 optimizers and rebalancing rules. | 1 |  |
+| `convertible-bond` | A股可转债分析——转股/纯债/期权三维估值、下修/强赎/回售博弈、双低策略与转债轮动选债框架 | 1 |  |
+| `etf-analysis` | ETF分析：产品筛选、费率对比、跟踪误差、流动性评估、策略应用与中国市场ETF量化配置框架。 | 1 |  |
+| `fund-analysis` | 基金分析与筛选：晨星评级/夏普比率/信息比率、Sharpe风格箱分析、风格漂移检测、基金经理评价、FOF组合构建、ETF选择 | 1 |  |
+| `hedging-strategy` | Hedging strategy design (beta hedge / option protection / tail risk / cross-asset hedging), including hedge-ratio calculation and cost evaluation. | 1 |  |
+| `options-advanced` | Advanced options strategies: volatility-surface modeling (SABR / Local Vol), dynamic Greeks rebalancing, calendar spreads, volatility arbitrage and skew trading, and option market-making basics. | 1 |  |
+| `options-payoff` | Option P&L analysis methodology: payoff diagrams, breakeven calculation, multi-leg strategy visualization, and Greeks-based scenario analysis. | 1 |  |
+| `options-strategy` | Options strategy framework supporting Black-Scholes pricing, Greeks analysis, and multi-leg backtesting. Suitable for cryptocurrency and equity options. | 1 |  |
+| `sector-rotation` | 行业轮动分析——申万行业景气度评分、行业动量排名、产业链传导、估值/盈利/资金流多维比较框架 | 1 |  |
+
+### crypto (7)
+
+| id | description | files | example_engine |
+|----|-------------|------:|:--------------:|
+| `crypto-derivatives` | Crypto-derivatives strategies — perpetual funding-rate arbitrage, futures term-structure contango/backwardation trading, and option volatility-smile / Greeks analysis. | 1 |  |
+| `defi-yield` | DeFi yield analysis and optimization — lending rates, LP yields, staking returns, yield farming strategies, risk-adjusted yield comparison, and protocol-level sustainability assessment. | 1 |  |
+| `liquidation-heatmap` | Liquidation level analysis and heatmap interpretation — identify leveraged position concentration, liquidation cascades, stop-hunt zones, and use liquidation data as support/resistance signals. | 1 |  |
+| `onchain-analysis` | On-chain data analysis — active addresses / whale tracking / TVL / DEX liquidity, interpretation and signal generation using on-chain valuation metrics such as MVRV / NVT / SOPR. | 1 |  |
+| `perp-funding-basis` | Perpetual futures funding rate analysis and cash-carry basis trading — funding rate regimes, annualized basis signals, carry trade construction, and funding rate arbitrage between exchanges. | 1 |  |
+| `stablecoin-flow` | Stablecoin supply and flow analysis — USDT/USDC mint-burn signals, exchange stablecoin reserves, on-chain stablecoin velocity, and capital rotation indicators for crypto market timing. | 1 |  |
+| `token-unlock-treasury` | Token unlock schedule analysis and project treasury tracking — vesting cliffs, linear unlocks, team/investor/ecosystem token releases, treasury diversification, and sell pressure forecasting. | 1 |  |
+
+### data-source (10)
+
+| id | description | files | example_engine |
+|----|-------------|------:|:--------------:|
+| `akshare` | AKShare financial data aggregator (18k+ stars). Free, no API key. Covers A-shares, US, HK, futures, macro, forex. Primary fallback for tushare and yfinance. | 1 |  |
+| `ccxt` | CCXT unified crypto exchange library (100+ exchanges). Free public market data. Fallback when OKX is unavailable. | 1 |  |
+| `data-routing` | The single ROUTER for every data need. Load this skill BEFORE any backtest, data-fetch, or research task to pick the best available source/tool, honour auth (env) requirements, and avoid ban-risk providers. | 1 |  |
+| `eastmoney` | 东方财富（Eastmoney）免费免鉴权数据接口，覆盖资金流向、龙虎榜、融资融券、大宗交易、股东户数、限售解禁、行业概念板块、券商研报、财经新闻、A股/港股三大报表+主要指标、全市场选股与代码搜索；美股财报由 get_financial_statements 转 SEC EDGAR。东财请求经共享 IP 限速层节流（东财按源 IP 限流并临时封禁突发请求），通过 Vibe-Trading 工具直接调用，无需 token。 | 17 |  |
+| `mootdx` | Mootdx A-share market data via TCP-direct 通达信 servers. Free, no API key, no IP rate limits. Use as the stable A-share OHLCV fallback when akshare's East Money scrape is throttled. | 1 |  |
+| `okx-market` | OKX cryptocurrency market data interface. Uses the OKX V5 REST API to retrieve spot, derivatives, index, and other crypto market data, including real-time prices, candlesticks, funding rates, open interest, and more. No authentication required, free to use. | 16 |  |
+| `qveris` | Paid capability marketplace for global multi-asset data; use it when free Vibe-Trading sources lack coverage, depth, or provider quality, and keep free sources as the default for routine OHLCV. | 3 |  |
+| `sec-edgar` | U.S. SEC EDGAR fetch interface — resolve a ticker to its CIK, list recent filings (10-K / 10-Q / 8-K and friends) with primary-document URLs, and pull XBRL companyfacts financial series. Free, no API key; rate-limited by IP so every request is throttled and carries a contact User-Agent. United States only. | 6 |  |
+| `tushare` | tushare是一个财经数据接口包，拥有丰富的数据内容，如股票、基金、期货、数字货币等行情数据，公司财务、基金经理等基本面数据。该模块通过标准化API方式统一了数据资产的对外服务方式，以帮助有需要的技术用户更实时、简洁、轻量的使用相关数据。 | 232 |  |
+| `yfinance` | yfinance global market data interface — retrieve OHLCV, financials, insider transactions, and institutional holdings for US stocks, HK stocks, ETFs, and indices via Yahoo Finance. Free, no API key required. | 7 |  |
+
+### flow (8)
+
+| id | description | files | example_engine |
+|----|-------------|------:|:--------------:|
+| `adr-hshare` | ADR/H-share/A-share cross-listing premium analysis — track pricing gaps between US-listed ADRs, HK-listed H-shares, and A-shares for arbitrage signals, dual-listing valuation, and delisting risk assessment. | 1 |  |
+| `corporate-events` | 公司事件驱动分析：并购套利价差计算、大股东增减持信号、股权激励解读、定增配股影响评估、A股ST/退市预警 | 1 |  |
+| `edgar-sec-filings` | SEC EDGAR filing analysis — 10-K, 10-Q, 8-K, proxy statements, insider Form 4. Extract key financials, risk factors, management discussion, and generate investment signals from US public company filings. | 1 |  |
+| `financial-statement` | 财报三表深度解读——三表勾稽关系、盈利质量(应计vs现金流)分析、杜邦分解、10+财务造假红旗指标 | 1 |  |
+| `fundamental-filter` | Fundamental factor screening — filter stocks by PE/PB/ROE, financial statement fields, and other metrics for value or growth selection. Supports A-shares (via tushare extra_fields or fundamental_fields) and HK/US stocks (via yfinance Ticker info). | 2 | Y |
+| `hk-connect-flow` | Stock Connect (Shanghai/Shenzhen-Hong Kong) fund flow analysis — Northbound (foreign into A-shares), Southbound (mainland into HK), sector allocation tracking, and cross-border arbitrage signals. | 1 |  |
+| `research-goal` | Goal-driven finance research workflow: attach a research-only objective, track criteria, and add evidence while avoiding live trading execution. | 1 |  |
+| `us-etf-flow` | US ETF fund flow analysis, sector rotation breadth, and style factor flows — track institutional capital movement via ETF creation/redemption, sector breadth signals, and thematic momentum. | 1 |  |
+
+### research (2)
+
+| id | description | files | example_engine |
+|----|-------------|------:|:--------------:|
+| `alpha-zoo` | Browse and bench the bundled alpha zoos — prebuilt cross-sectional factor libraries (Kakushadze 101, GTJA 191, Qlib 158, Fama-French / Carhart). Use when the user asks "which alphas exist", wants metadata on a named alpha, or wants to run IC/IR on a whole zoo over a universe. | 1 |  |
+| `strategy-dev-manager` | Strategy Development Manager: convert academic papers and research reports into validated factors and strategies with automated backtesting, persistent storage, and decay monitoring. | 9 |  |
+
+### risk-analysis (1)
+
+| id | description | files | example_engine |
+|----|-------------|------:|:--------------:|
+| `ashare-pre-st-filter` | A 股 ST/*ST 风险预测框架 — 基于最新中报/三季报或业绩预告/快报，预测下一财年是否会因营收、利润、净资产、分红不达标而被风险警示，并将新浪监管处罚记录作为独立证据面纳入风险等级。仅适用于 A 股，不预测财务造假。 | 2 |  |
+
+### strategy (19)
+
+| id | description | files | example_engine |
+|----|-------------|------:|:--------------:|
+| `bottleneck-hunter` | Supply-chain bottleneck arbitrage. Given a super-trend (AI infra, energy transition, defense, semiconductor reshoring, space economy), decompose its physical supply chain down to Layer 2/3 choke points (optics, lasers, InP/SOI substrates, IC substrates, probe cards, specialty fiberglass...) and surface under-the-radar listed companies sitting on each bottleneck. Scores each link on 6 scarcity crit | 1 |  |
+| `candlestick` | Candlestick pattern recognition engine, pure pandas vectorized implementation of 15 classic candlestick patterns (5 single-candle + 5 double-candle + 4 triple-candle + 1 trend confirmation), generating a composite signal from bullish/bearish pattern scores. | 2 | Y |
+| `chanlun` | 基于缠论（缠中说禅）的形态识别引擎，使用czsc库自动检测K线分型、笔、中枢，并生成一买/一卖/二买/二卖/三买/三卖等买卖点信号。支持多周期分析和形态分类（3/5/7/9/11笔形态）。 | 8 | Y |
+| `cross-market-strategy` | Write signal_engine.py for portfolios spanning multiple markets (A-shares + crypto, equity + forex, etc.) | 2 | Y |
+| `elliott-wave` | Elliott Wave Theory signal engine. Detects swing points through Zigzag, matches 5-wave impulse and 3-wave corrective structures, validates them with Fibonacci wave relationships, and generates trend-top / correction-complete signals. Pure in-house pandas implementation. | 4 | Y |
+| `event-driven` | Event-driven strategy based on sentiment-scored signals from news, announcements, and macro events. The LLM acts as the NLP engine, and event data follows a CSV schema. | 2 | Y |
+| `execution-model` | Trade execution modeling (backtest only) — slippage formulas (linear / square-root impact), VWAP/TWAP execution logic, market-impact cost estimation, and execution-assumption configuration. | 1 |  |
+| `harmonic` | Harmonic Patterns signal engine. Identifies XABCD five-point structures such as Gartley/Bat/Butterfly/Crab based on Fibonacci geometry, and generates trading signals in the PRZ (Potential Reversal Zone). | 4 | Y |
+| `ichimoku` | Ichimoku Kinko Hyo five-line system signal engine. A standalone Japanese technical-analysis school that generates trading signals from Tenkan/Kijun crossovers, cloud position, and Chikou confirmation. Pure pandas implementation. | 4 | Y |
+| `minute-analysis` | Minute-level data analysis and backtesting. Retrieves minute candlesticks through OKX/Tushare/yfinance and can be used both for analysis and as input to the backtest engine. | 2 | Y |
+| `ml-strategy` | Machine-learning predictive strategy based on sklearn walk-forward training, feature engineering, and signal generation. Suitable for any OHLCV data. | 1 |  |
+| `multi-factor` | Multi-factor cross-sectional stock ranking. Combines factor standardization, equal-weight or IC-weighted scoring, and TopN portfolio construction. Suitable for multi-instrument portfolio strategies. | 3 | Y |
+| `pair-trading` | Pair trading strategy. Trades mean reversion using the spread/ratio Z-score of two correlated instruments. Requires at least two instruments. | 2 | Y |
+| `seasonal` | Seasonal/calendar-effect strategy. Generates trading signals from time-based patterns such as month-of-year effects and day-of-week effects. Suitable for any OHLCV data. | 2 | Y |
+| `smc` | Smart Money Concepts (ICT) signal engine. Uses the smartmoneyconcepts library to implement institutional-trading-school analysis of BOS, ChoCH, FVG, and order blocks (OB). | 4 | Y |
+| `strategy-generate` | Create, modify, and optimize quantitative trading strategies, then backtest and evaluate them. | 2 |  |
+| `technical-basic` | Core technical indicator collection (trend EMA/ADX + mean-reversion BB/RSI + volume-price OBV/volume ratio), generates a composite signal via three-dimensional voting. Pure pandas implementation for any OHLCV data. | 2 | Y |
+| `thesis-tracker` | Buy-side discipline system. For each holding, maintain a written investment thesis — core thesis in 5 sentences, falsifiable assumptions, red lines, valuation anchors — and re-check it each quarter against new earnings/events. Scores thesis health 1-10 from assumption breakage and red-line triggers, and recommends hold / add / trim / exit. Use it right after buying a stock (to write the thesis) an | 1 |  |
+| `volatility` | Volatility strategy. Trades mean reversion based on percentile ranking of historical volatility (HV). Suitable for any OHLCV data. | 2 | Y |
+
+### tool (10)
+
+| id | description | files | example_engine |
+|----|-------------|------:|:--------------:|
+| `backtest-diagnose` | Diagnose failed or underperforming backtests, locate the root cause, and fix the issue | 1 |  |
+| `doc-reader` | Read any common document/data file — PDF, Word (.docx), Excel (.xlsx/.xls), PowerPoint (.pptx), images (OCR), CSV/TSV, plain text, JSON/YAML/TOML, HTML/XML, and most source-code files. Use the `read_document` tool. | 1 |  |
+| `geopolitical-risk` | Geopolitical risk analysis: quantify crisis signals, identify precursors, and build event-driven strategies for war, sanctions, and supply disruption scenarios. | 1 |  |
+| `pine-script` | Export backtest strategies to indicator/strategy code for major trading platforms — TradingView, 通达信, 同花顺, 东方财富, MT5. | 1 |  |
+| `regulatory-knowledge` | 金融监管知识库：A股涨跌停/ST退市新规/融券、港股T+0/做空机制、美股PDT/熔断、加密监管政策、跨境税务基础 | 1 |  |
+| `report-generate` | Professional financial research report generation — standard structure (summary / views / main body / risks / recommendation), Markdown formatting standards, rating system, and terminology guide. | 1 |  |
+| `social-media-intelligence` | Social media intelligence: financial signal extraction from Twitter/X, Telegram, Discord, and Reddit for sentiment-driven trading strategies. | 1 |  |
+| `trade-journal` | Analyze a user's trade journal (CSV/Excel broker export). Parses 同花顺/东方财富/富途/generic formats, produces a trading profile and 4 behavior diagnostics (disposition effect, overtrading, chasing, anchoring). Use the `analyze_trade_journal` tool. | 1 |  |
+| `vnpy-export` | Export a Vibe-Trading backtest strategy to a runnable vnpy CtaTemplate Python class — supports A-share equities, futures, and crypto via BarGenerator + ArrayManager. | 2 |  |
+| `web-reader` | Read web pages, articles, and document links by converting URLs into Markdown text. Use the `read_url` tool directly, without bash. Sends the full URL to the third-party Jina Reader (r.jina.ai). | 1 |  |

--- a/docs/analysis/catalog/SWARM_PRESETS.md
+++ b/docs/analysis/catalog/SWARM_PRESETS.md
@@ -1,0 +1,313 @@
+# Swarm Presets Catalog (30)
+
+Total: **30**.
+
+## `commodity_research_team` — Commodity Research Team
+
+Parallel deep-dive on supply and demand, synthesized by a cycle strategist into an investment thesis — DAG workflow
+
+- agents (3): `supply_analyst`, `demand_analyst`, `cycle_strategist`
+- tasks (3): `task-supply-research`, `task-demand-research`, `task-cycle-strategy`
+- depends_on:
+  - `task-cycle-strategy` ← ['task-supply-research', 'task-demand-research']
+- variables: [{'name': 'commodity', 'description': 'Commodity type, e.g.: crude oil / gold / copper / iron ore / natural gas / soybeans / aluminum / rebar', 'required': True}, {'name': 'horizon', 'description': 'Investment horizon, e.g.: 1 month / 3 months / 6 months / 1 year', 'required': True}]
+
+## `convertible_bond_team` — Convertible Bond Research Team
+
+Parallel three-dimensional analysis — bond floor, equity optionality, and embedded option value — synthesized into a convertible bond investment strategy
+
+- agents (4): `bond_analyst`, `equity_analyst`, `option_analyst`, `cb_strategist`
+- tasks (4): `task-bond`, `task-equity`, `task-option`, `task-strategy`
+- depends_on:
+  - `task-strategy` ← ['task-bond', 'task-equity', 'task-option']
+- variables: [{'name': 'market', 'description': 'Target market (default: A-share convertible bonds)', 'required': True}, {'name': 'goal', 'description': 'Research focus (e.g.: uncover undervalued convertibles, position for conversion price reset candidates)', 'required': True}, {'name': 'strategy_type', 'description': "Strategy type (low-price / dual-low / high-convexity / rotation; leave blank for strategist's discretion)", 'required': False}]
+
+## `credit_research_team` — Fixed Income Credit Research Team
+
+Credit quality + interest rate environment + sector credit three-dimensional parallel analysis → fixed income strategist synthesizes a complete bond investment strategy
+
+- agents (4): `credit_analyst`, `rate_analyst`, `sector_credit_analyst`, `fixed_income_strategist`
+- tasks (4): `task-credit`, `task-rate`, `task-sector-credit`, `task-strategy`
+- depends_on:
+  - `task-strategy` ← ['task-credit', 'task-rate', 'task-sector-credit']
+- variables: [{'name': 'target', 'description': 'Research subject or sector (e.g.: a specific LGFV platform, the property sector, steel bonds, AA-rated credit bond portfolio)', 'required': True}, {'name': 'market', 'description': 'Bond market (default: China bond market; options: credit bonds / LGFV bonds / rate bonds / convertible bonds)', 'required': False}]
+
+## `crypto_research_lab` — Crypto Asset Research Lab
+
+On-chain data + DeFi protocol + market sentiment three-dimensional parallel analysis → Alpha synthesizer converges investment recommendations
+
+- agents (4): `onchain_analyst`, `defi_analyst`, `crypto_sentiment_analyst`, `alpha_synthesizer`
+- tasks (4): `task-onchain`, `task-defi`, `task-sentiment`, `task-alpha`
+- depends_on:
+  - `task-alpha` ← ['task-onchain', 'task-defi', 'task-sentiment']
+- variables: [{'name': 'target', 'description': 'Target asset (e.g.: BTC / ETH / SOL; default BTC/ETH/SOL)', 'required': True}, {'name': 'timeframe', 'description': 'Analysis time horizon (short-term 1–4 weeks / medium-term 1–3 months / long-term 3–12 months)', 'required': True}]
+
+## `crypto_trading_desk` — Crypto Trading & Risk Desk
+
+Execution-oriented crypto desk: funding/basis analyst + liquidation/microstructure analyst + on-chain/flow analyst + risk manager. Goes beyond research into position sizing, execution timing, and risk gating.
+
+- agents (4): `funding_basis_analyst`, `liquidation_analyst`, `flow_analyst`, `desk_risk_manager`
+- tasks (4): `task-funding`, `task-liquidation`, `task-flow`, `task-risk-decision`
+- depends_on:
+  - `task-risk-decision` ← ['task-funding', 'task-liquidation', 'task-flow']
+- variables: [{'name': 'target', 'description': 'Target asset (e.g., BTC-USDT, ETH-USDT, SOL-USDT)', 'required': True}, {'name': 'timeframe', 'description': 'Trading horizon (intraday / swing 1-2 weeks / position 1-3 months)', 'required': True}]
+
+## `derivatives_strategy_desk` — Derivatives Strategy Desk
+
+Volatility analysis → strategy design → Greeks risk management: sequential options trading desk workflow
+
+- agents (3): `vol_analyst`, `strategy_designer`, `greeks_manager`
+- tasks (3): `task-vol`, `task-strategy`, `task-greeks`
+- depends_on:
+  - `task-strategy` ← ['task-vol']
+  - `task-greeks` ← ['task-strategy']
+- variables: [{'name': 'target', 'description': 'Underlying (e.g.: BTC, CSI 300 ETF, AAPL)', 'required': True}, {'name': 'view', 'description': 'Market view (bullish / bearish / neutral / long volatility / short volatility)', 'required': True}]
+
+## `earnings_research_desk` — Earnings Research Desk
+
+Earnings-focused research team: fundamental analyst + earnings revision tracker + options/event analyst + earnings strategist. Deep-dives into company financials, consensus revisions, earnings event trades, and post-earnings drift.
+
+- agents (4): `fundamental_analyst`, `revision_tracker`, `event_options_analyst`, `earnings_strategist`
+- tasks (4): `task-fundamental`, `task-revision`, `task-options-event`, `task-earnings-strategy`
+- depends_on:
+  - `task-earnings-strategy` ← ['task-fundamental', 'task-revision', 'task-options-event']
+- variables: [{'name': 'target', 'description': 'Target stock (e.g., AAPL.US, NVDA.US, 700.HK, 600519.SH)', 'required': True}]
+
+## `equity_research_team` — Equity Research Team
+
+Macro → sector → stock three-tier deep research → research editor consolidates into a complete report
+
+- agents (4): `macro_analyst`, `sector_analyst`, `stock_picker`, `aggregator`
+- tasks (4): `task-macro`, `task-sector`, `task-stock`, `task-aggregate`
+- depends_on:
+  - `task-sector` ← ['task-macro']
+  - `task-stock` ← ['task-sector']
+  - `task-aggregate` ← ['task-stock']
+- variables: [{'name': 'market', 'description': 'Target market (e.g.: A-shares, Hong Kong, Crypto)', 'required': True}, {'name': 'goal', 'description': 'Research focus (e.g.: Q2 2026 outlook, opportunities in the new energy sector)', 'required': True}]
+
+## `etf_allocation_desk` — ETF Allocation Desk
+
+ETF screening + macro allocation + risk budgeting three-dimensional parallel analysis → portfolio optimizer constructs the final ETF portfolio and backtests
+
+- agents (4): `etf_screener`, `macro_allocator`, `risk_budgeter`, `portfolio_optimizer`
+- tasks (4): `task-etf-screen`, `task-macro-alloc`, `task-risk-budget`, `task-optimize`
+- depends_on:
+  - `task-optimize` ← ['task-etf-screen', 'task-macro-alloc', 'task-risk-budget']
+- variables: [{'name': 'risk_profile', 'description': 'Risk profile (conservative / balanced / aggressive)', 'required': True}, {'name': 'market', 'description': 'Target market (default: A-shares; options: global multi-asset, HK/US equities, A-shares + HK)', 'required': False}]
+
+## `event_driven_task_force` — Event-Driven Task Force
+
+Event scanning → deep impact analysis → strategy construction: sequential deep-dive chain replicating an event-driven hedge fund special investigation unit workflow
+
+- agents (3): `event_scanner`, `impact_analyst`, `strategy_builder`
+- tasks (3): `task-event-scan`, `task-impact-analysis`, `task-strategy-build`
+- depends_on:
+  - `task-impact-analysis` ← ['task-event-scan']
+  - `task-strategy-build` ← ['task-impact-analysis']
+- variables: [{'name': 'market', 'description': 'Target market, e.g.: A-shares / Hong Kong / US equities / Chinese ADRs', 'required': True}, {'name': 'event_type', 'description': "Event type filter, e.g.: M&A / insider trading / earnings / policy / litigation / management change; enter 'all types' for no filter", 'required': False}]
+
+## `factor_research_committee` — Factor Research Committee
+
+Factor mining + factor validation running in parallel → factor combination construction → backtest review: quant fund internal research review workflow
+
+- agents (4): `factor_miner`, `factor_validator`, `factor_combiner`, `backtest_reviewer`
+- tasks (4): `task-mine`, `task-validate`, `task-combine`, `task-review`
+- depends_on:
+  - `task-combine` ← ['task-mine', 'task-validate']
+  - `task-review` ← ['task-combine']
+- variables: [{'name': 'market', 'description': 'Target market (e.g.: A-shares, Hong Kong, US equities)', 'required': True}, {'name': 'factor_type', 'description': 'Factor type (value / momentum / quality / growth / alternative)', 'required': True}]
+
+## `fund_selection_panel` — Fund Selection Panel
+
+Multi-dimensional quantitative screening → Brinson performance attribution and style analysis → FOF portfolio weight optimization, sequential professional review chain
+
+- agents (3): `fund_screener`, `attribution_analyst`, `fof_optimizer`
+- tasks (3): `task-fund-screen`, `task-performance-attribution`, `task-fof-optimize`
+- depends_on:
+  - `task-performance-attribution` ← ['task-fund-screen']
+  - `task-fof-optimize` ← ['task-performance-attribution']
+- variables: [{'name': 'fund_type', 'description': 'Fund type, e.g.: equity / bond / balanced / index-enhanced / quant hedge / QDII', 'required': True}, {'name': 'goal', 'description': 'Investment objective, e.g.: build a steady FOF portfolio with annualized return >10% and max drawdown <15%', 'required': True}]
+
+## `fundamental_research_team` — Fundamental Deep Research Team
+
+Financial / valuation / quality three-dimensional parallel analysis → research editor consolidates into a buy-side deep research report
+
+- agents (4): `financial_analyst`, `valuation_analyst`, `quality_analyst`, `report_editor`
+- tasks (4): `task-financial`, `task-valuation`, `task-quality`, `task-report`
+- depends_on:
+  - `task-report` ← ['task-financial', 'task-valuation', 'task-quality']
+- variables: [{'name': 'target', 'description': 'Research subject (stock code or name, e.g.: 600519 Kweichow Moutai)', 'required': True}, {'name': 'market', 'description': 'Market (e.g.: A-shares, Hong Kong, US equities)', 'required': True}]
+
+## `geopolitical_war_room` — Geopolitical Risk War Room
+
+Geopolitical analysis, energy shock, and supply-chain impact run in parallel, then feed into the Chief Strategist for synthesis, producing emergency asset-allocation playbooks for geopolitical crises.
+
+- agents (4): `geopolitical_analyst`, `energy_analyst`, `supply_chain_analyst`, `chief_strategist`
+- tasks (4): `task-geopolitical`, `task-energy`, `task-supply-chain`, `task-strategy`
+- depends_on:
+  - `task-strategy` ← ['task-geopolitical', 'task-energy', 'task-supply-chain']
+- variables: [{'name': 'crisis', 'description': 'Crisis narrative (e.g., Taiwan Strait escalation, Hormuz blockade, full Red Sea Houthi disruption)', 'required': True}, {'name': 'market', 'description': 'Focus market (e.g., A-shares, Hong Kong, global multi-asset)', 'required': True}]
+
+## `global_allocation_committee` — Global Allocation Committee
+
+Parallel A-shares + crypto + HK/US analysts; allocator synthesizes cross-market allocation with data-driven weighting, scenario analysis, and rebalancing rules.
+
+- agents (4): `a_share_analyst`, `crypto_analyst`, `us_hk_analyst`, `allocator`
+- tasks (4): `task-ashare`, `task-crypto`, `task-ushk`, `task-allocate`
+- depends_on:
+  - `task-allocate` ← ['task-ashare', 'task-crypto', 'task-ushk']
+- variables: [{'name': 'goal', 'description': 'Investment objective (e.g., Q2 2026 multi-asset allocation)', 'required': True}, {'name': 'risk_tolerance', 'description': 'Risk tolerance (conservative / moderate / aggressive)', 'required': False}]
+
+## `global_equities_desk` — Global Equities Research Desk
+
+Cross-market equity research: A-share analyst + HK/US analyst + crypto analyst + global strategist. Covers fundamental screening, earnings analysis, ETF flows, and cross-listing arbitrage for multi-market stock selection.
+
+- agents (4): `a_share_researcher`, `us_hk_researcher`, `crypto_researcher`, `global_strategist`
+- tasks (4): `task-ashare`, `task-ushk`, `task-crypto`, `task-strategy`
+- depends_on:
+  - `task-strategy` ← ['task-ashare', 'task-ushk', 'task-crypto']
+- variables: [{'name': 'goal', 'description': 'Investment objective (e.g., Q2 2026 global equity allocation, tech sector deep-dive)', 'required': True}, {'name': 'risk_tolerance', 'description': 'Risk tolerance level (conservative / moderate / aggressive)', 'required': False}]
+
+## `investment_committee` — Investment Committee
+
+Long–short debate → risk review → PM final call: buy-side fund investment committee workflow.
+
+- agents (4): `bull_advocate`, `bear_advocate`, `risk_officer`, `portfolio_manager`
+- tasks (4): `task-bull`, `task-bear`, `task-risk`, `task-decision`
+- depends_on:
+  - `task-risk` ← ['task-bull', 'task-bear']
+  - `task-decision` ← ['task-risk']
+- variables: [{'name': 'target', 'description': 'Security (e.g., 600519.SH Kweichow Moutai, BTC-USDT, AAPL)', 'required': True}, {'name': 'market', 'description': 'Market (e.g., A-shares, Hong Kong, US, crypto)', 'required': True}]
+
+## `macro_rates_fx_desk` — Macro / Rates / FX Desk
+
+Cross-asset macro desk: global rates analyst + FX strategist + commodity/inflation analyst + macro portfolio manager. Covers central bank policy, yield curve dynamics, currency positioning, and macro-driven asset allocation.
+
+- agents (4): `rates_analyst`, `fx_strategist`, `commodity_inflation_analyst`, `macro_pm`
+- tasks (4): `task-rates`, `task-fx`, `task-commodity-inflation`, `task-macro-allocation`
+- depends_on:
+  - `task-macro-allocation` ← ['task-rates', 'task-fx', 'task-commodity-inflation']
+- variables: [{'name': 'goal', 'description': 'Macro investment objective (e.g., Q2 2026 cross-asset positioning, rate cycle trade)', 'required': True}, {'name': 'timeframe', 'description': 'Investment horizon (tactical 1-3 months / strategic 6-12 months)', 'required': True}]
+
+## `macro_strategy_forum` — Macro Strategy Forum
+
+Global + domestic + policy perspectives run in parallel; chief strategist delivers integrated cross-asset allocation guidance.
+
+- agents (4): `global_economist`, `domestic_economist`, `policy_analyst`, `chief_strategist`
+- tasks (4): `task-global`, `task-domestic`, `task-policy`, `task-strategy`
+- depends_on:
+  - `task-strategy` ← ['task-global', 'task-domestic', 'task-policy']
+- variables: [{'name': 'market', 'description': 'Focus market (e.g., A-shares, Hong Kong, global multi-asset, crypto)', 'required': True}, {'name': 'horizon', 'description': 'Horizon (e.g., monthly, quarterly, annual)', 'required': True}]
+
+## `ml_quant_lab` — Machine Learning Quant Lab
+
+Feature engineering and model design in parallel; flows into the backtest engineer for strict out-of-sample validation.
+
+- agents (3): `feature_engineer`, `data_scientist`, `backtest_engineer`
+- tasks (3): `task-features`, `task-model`, `task-backtest`
+- depends_on:
+  - `task-backtest` ← ['task-features', 'task-model']
+- variables: [{'name': 'market', 'description': 'Target market (e.g., A-shares, Hong Kong/US equities)', 'required': True}, {'name': 'target_variable', 'description': 'Prediction target (return / direction / volatility)', 'required': True}, {'name': 'goal', 'description': 'Research focus (e.g., build a monthly stock-selection model, forecast daily volatility)', 'required': True}]
+
+## `pairs_research_lab` — Pairs Trading Research Lab
+
+Correlation scan and cointegration testing in parallel → converge into the pair strategist for strategy design → final microstructure review for execution feasibility.
+
+- agents (4): `correlation_scanner`, `cointegration_tester`, `pair_strategist`, `microstructure_reviewer`
+- tasks (4): `task-correlation-scan`, `task-cointegration-test`, `task-pair-strategy`, `task-microstructure-review`
+- depends_on:
+  - `task-pair-strategy` ← ['task-correlation-scan', 'task-cointegration-test']
+  - `task-microstructure-review` ← ['task-pair-strategy']
+- variables: [{'name': 'market', 'description': 'Target market (e.g. A-shares, Hong Kong, US, crypto)', 'required': True}, {'name': 'sector', 'description': 'Sector filter (e.g. banks, consumer, semis); empty = full market', 'required': False}]
+
+## `portfolio_review_board` — Portfolio Review Board
+
+Performance attribution, risk review, and execution quality in parallel; CIO synthesizes into rebalance decisions.
+
+- agents (4): `attribution_analyst`, `risk_inspector`, `execution_analyst`, `chief_investment_officer`
+- tasks (4): `task-attribution`, `task-risk`, `task-execution`, `task-cio-decision`
+- depends_on:
+  - `task-cio-decision` ← ['task-attribution', 'task-risk', 'task-execution']
+- variables: [{'name': 'portfolio', 'description': 'Portfolio name or description (e.g., value-growth blend, CSI 300 enhanced)', 'required': True}, {'name': 'review_period', 'description': 'Review cadence (monthly / quarterly)', 'required': True}, {'name': 'goal', 'description': 'Focus of this review (e.g., assess Q1 performance, diagnose recent NAV drawdown)', 'required': True}]
+
+## `quant_strategy_desk` — Quant Strategy Desk
+
+Stock screening + factor research in parallel → strategy backtest → risk audit.
+
+- agents (4): `screener`, `factor_miner`, `backtester`, `risk_auditor`
+- tasks (4): `task-screen`, `task-factor`, `task-backtest`, `task-risk`
+- depends_on:
+  - `task-backtest` ← ['task-screen', 'task-factor']
+  - `task-risk` ← ['task-backtest']
+- variables: [{'name': 'market', 'description': 'Target market', 'required': True}, {'name': 'goal', 'description': 'Strategy objective (e.g., momentum + value dual factor)', 'required': True}]
+
+## `risk_committee` — Risk Committee
+
+Drawdown, tail risk, and market regime reviews run in parallel; head of risk signs off.
+
+- agents (4): `drawdown_analyst`, `tail_risk_analyst`, `regime_detector`, `aggregator`
+- tasks (4): `task-drawdown`, `task-tail`, `task-regime`, `task-aggregate`
+- depends_on:
+  - `task-aggregate` ← ['task-drawdown', 'task-tail', 'task-regime']
+- variables: [{'name': 'goal', 'description': 'Audit target (e.g., BTC position risk, CSI 300 strategy risk)', 'required': True}]
+
+## `sector_rotation_team` — Sector Rotation Research Team
+
+Economic cycle + prosperity + capital flows in parallel → rotation strategist builds and backtests a sector rotation strategy.
+
+- agents (4): `cycle_analyst`, `prosperity_analyst`, `flow_analyst`, `rotation_strategist`
+- tasks (4): `task-cycle`, `task-prosperity`, `task-flow`, `task-strategy`
+- depends_on:
+  - `task-strategy` ← ['task-cycle', 'task-prosperity', 'task-flow']
+- variables: [{'name': 'market', 'description': 'Target market (default A-shares; can specify HK/US)', 'required': True}, {'name': 'goal', 'description': 'Focus theme (e.g. new energy, tech growth, high dividend, exporters)', 'required': True}]
+
+## `sentiment_intelligence_team` — Market Sentiment Intelligence Unit
+
+News intel / social sentiment / capital flows in parallel → sentiment signal synthesizer outputs composite score and reversal signals.
+
+- agents (4): `news_analyst`, `social_analyst`, `flow_analyst`, `signal_synthesizer`
+- tasks (4): `task-news-intel`, `task-social-sentiment`, `task-flow-analysis`, `task-signal-synthesis`
+- depends_on:
+  - `task-signal-synthesis` ← ['task-news-intel', 'task-social-sentiment', 'task-flow-analysis']
+- variables: [{'name': 'market', 'description': 'Target market, e.g. A-shares / HK / US / crypto / CSI 300', 'required': True}, {'name': 'timeframe', 'description': 'Horizon: daily or weekly', 'required': True}]
+
+## `social_alpha_team` — Social-Media Alternative Data Team
+
+Twitter, Telegram, and Reddit analyzed in parallel → Alpha synthesizer extracts tradable social sentiment factors.
+
+- agents (4): `twitter_analyst`, `telegram_analyst`, `reddit_analyst`, `alpha_synthesizer`
+- tasks (4): `task-twitter`, `task-telegram`, `task-reddit`, `task-alpha-synthesis`
+- depends_on:
+  - `task-alpha-synthesis` ← ['task-twitter', 'task-telegram', 'task-reddit']
+- variables: [{'name': 'target', 'description': 'Focus name or market (e.g. BTC, Tesla, A-share tech, Nasdaq)', 'required': True}, {'name': 'timeframe', 'description': 'Horizon (real-time / daily / weekly)', 'required': True}]
+
+## `statistical_arbitrage_desk` — Statistical Arbitrage Desk
+
+Pair scanning and microstructure analysis in parallel → converge into the arbitrage strategist to build the strategy → final risk-control review.
+
+- agents (4): `pair_scanner`, `microstructure_analyst`, `arb_strategist`, `risk_monitor`
+- tasks (4): `task-pair-scan`, `task-microstructure`, `task-strategy`, `task-risk-review`
+- depends_on:
+  - `task-strategy` ← ['task-pair-scan', 'task-microstructure']
+  - `task-risk-review` ← ['task-strategy']
+- variables: [{'name': 'market', 'description': 'Target market (e.g. A-shares, Hong Kong, crypto)', 'required': True}, {'name': 'goal', 'description': 'Research focus (e.g. CSI 300 pair book, crypto arb ideas)', 'required': True}, {'name': 'sector', 'description': 'Sector filter (e.g. banks, consumer); empty = full market', 'required': False}]
+
+## `technical_analysis_panel` — Technical Analysis Panel
+
+Classic TA + Ichimoku + harmonic patterns + Elliott Wave + SMC run in parallel → signal aggregator scores consensus and resonance.
+
+- agents (6): `classic_ta_analyst`, `ichimoku_analyst`, `harmonic_analyst`, `wave_analyst`, `smc_analyst`, `signal_aggregator`
+- tasks (6): `task-classic-ta`, `task-ichimoku`, `task-harmonic`, `task-wave`, `task-smc`, `task-aggregate`
+- depends_on:
+  - `task-aggregate` ← ['task-classic-ta', 'task-ichimoku', 'task-harmonic', 'task-wave', 'task-smc']
+- variables: [{'name': 'target', 'description': 'Symbol (e.g. 600519.SH Kweichow Moutai, BTC-USDT, AAPL)', 'required': True}, {'name': 'timeframe', 'description': 'Interval (e.g. daily, weekly, monthly, 4H)', 'required': True}]
+
+## `value_investing_committee` — Value Investing Committee (Buffett / Munger / Duan / Li Lu)
+
+Four adversarial master perspectives — Buffett (moat & price), Munger (inversion & risk), Duan Yongping (good business & trustworthy management), Li Lu (10-year certainty & civilizational trend, incl. demographic/consumption macro) — run in parallel on one company, then a chair synthesizes consensus and contradictions into a verdict. Inspired by the ai-berkshire master-视角 framework. Use for deep v
+
+- agents (5): `buffett`, `munger`, `duan_yongping`, `li_lu`, `chair`
+- tasks (5): `task-buffett`, `task-munger`, `task-duan`, `task-li`, `task-chair`
+- depends_on:
+  - `task-chair` ← ['task-buffett', 'task-munger', 'task-duan', 'task-li']
+- variables: [{'name': 'company', 'description': 'Target company name or ticker (e.g.: Tencent, NVDA, Moutai)', 'required': True}, {'name': 'market', 'description': 'Market (e.g.: A-shares, Hong Kong, US)', 'required': True}]

--- a/docs/analysis/catalog/TESTS.md
+++ b/docs/analysis/catalog/TESTS.md
@@ -1,0 +1,191 @@
+# Agent Tests Suite Map
+
+Top-level `test_*.py` files: **315**.
+
+Subdirs: `factors/`, `fixtures/`, `memory/`.
+
+## By domain prefix
+
+| prefix | count | examples |
+|--------|------:|----------|
+| `swarm` | 22 | `test_swarm_dag_gating.py`, `test_swarm_error_surfacing.py`, `test_swarm_grounding.py`, …(+19) |
+| `cli` | 16 | `test_cli_channels.py`, `test_cli_connector_renderers.py`, `test_cli_continue.py`, …(+13) |
+| `agent` | 11 | `test_agent_config.py`, `test_agent_goal_context.py`, `test_agent_guide_paths.py`, …(+8) |
+| `mcp` | 11 | `test_mcp_client_adapter.py`, `test_mcp_factor_analysis_contract.py`, `test_mcp_host_origin_guard.py`, …(+8) |
+| `runtime` | 7 | `test_runtime_flatten.py`, `test_runtime_jobstore.py`, `test_runtime_liveness.py`, …(+4) |
+| `alpha` | 6 | `test_alpha_bench_cache.py`, `test_alpha_bench_forward_returns.py`, `test_alpha_bench_strict_cli.py`, …(+3) |
+| `session` | 6 | `test_session_events.py`, `test_session_search.py`, `test_session_service_mcp.py`, …(+3) |
+| `options` | 5 | `test_options_bs_nonpositive_strike.py`, `test_options_chain_tool.py`, `test_options_partial_close.py`, …(+2) |
+| `ccxt` | 4 | `test_ccxt_interval_map.py`, `test_ccxt_loader_bounded.py`, `test_ccxt_loader_proxy.py`, …(+1) |
+| `doc` | 4 | `test_doc_reader.py`, `test_doc_reader_inverted_pages.py`, `test_doc_reader_security.py`, …(+1) |
+| `india` | 4 | `test_india_backtest_smoke.py`, `test_india_broker_loader.py`, `test_india_equity_engine.py`, …(+1) |
+| `longbridge` | 4 | `test_longbridge_credentials.py`, `test_longbridge_loader.py`, `test_longbridge_period_hour_case.py`, …(+1) |
+| `mandate` | 4 | `test_mandate_commit_security.py`, `test_mandate_enforcement.py`, `test_mandate_forex.py`, …(+1) |
+| `market` | 4 | `test_market_data.py`, `test_market_data_tool.py`, `test_market_detection.py`, …(+1) |
+| `channel` | 3 | `test_channel_media_roots.py`, `test_channels_api.py`, `test_channels_runtime.py` |
+| `eastmoney` | 3 | `test_eastmoney_client.py`, `test_eastmoney_float_dates.py`, `test_eastmoney_loader.py` |
+| `get` | 3 | `test_get_fundamentals_tool.py`, `test_get_market_data_size.py`, `test_get_market_data_unresolved.py` |
+| `goal` | 3 | `test_goal_api.py`, `test_goal_store.py`, `test_goal_tools.py` |
+| `mt5` | 3 | `test_mt5_connector.py`, `test_mt5_interval_lowercase.py`, `test_mt5_loader.py` |
+| `qveris` | 3 | `test_qveris_loader.py`, `test_qveris_routes.py`, `test_qveris_tool.py` |
+| `run` | 3 | `test_run_card.py`, `test_run_card_content_filter.py`, `test_run_card_strict_json.py` |
+| `scheduled` | 3 | `test_scheduled_research_executor.py`, `test_scheduled_research_store.py`, `test_scheduled_routes.py` |
+| `shadow` | 3 | `test_shadow_account.py`, `test_shadow_codegen_security.py`, `test_shadow_scanner.py` |
+| `tushare` | 3 | `test_tushare_fallbacks.py`, `test_tushare_fundamentals_provider.py`, `test_tushare_loader.py` |
+| `web` | 3 | `test_web_reader_privacy.py`, `test_web_reader_security.py`, `test_web_search_tool.py` |
+| `akshare` | 2 | `test_akshare_interval_reject.py`, `test_akshare_loader.py` |
+| `alpaca` | 2 | `test_alpaca_tap_routing.py`, `test_alpaca_timeframe_map.py` |
+| `api` | 2 | `test_api_infrastructure.py`, `test_api_live_runtime.py` |
+| `autopilot` | 2 | `test_autopilot_phase3.py`, `test_autopilot_tool.py` |
+| `china` | 2 | `test_china_a_engine.py`, `test_china_futures_engine.py` |
+| `content` | 2 | `test_content_filter_e2e.py`, `test_content_filter_gemini_detection.py` |
+| `engine` | 2 | `test_engine_metrics_json.py`, `test_engine_robustness.py` |
+| `factor` | 2 | `test_factor_gate_fund_prefix.py`, `test_factor_operators.py` |
+| `financial` | 2 | `test_financial_rigor_tool.py`, `test_financial_statements_tool.py` |
+| `fundamental` | 2 | `test_fundamental_filter_example.py`, `test_fundamental_schema.py` |
+| `futu` | 2 | `test_futu_excel_serial_dates.py`, `test_futu_loader.py` |
+| `global` | 2 | `test_global_equity_engine.py`, `test_global_futures_engine.py` |
+| `ibkr` | 2 | `test_ibkr_local.py`, `test_ibkr_mcp_seed.py` |
+| `llm` | 2 | `test_llm.py`, `test_llm_provider_defaults.py` |
+| `local` | 2 | `test_local_loader.py`, `test_local_source_routing.py` |
+| `memory` | 2 | `test_memory_gc.py`, `test_memory_lifecycle.py` |
+| `ocr` | 2 | `test_ocr_engine.py`, `test_ocr_integration.py` |
+| `okx` | 2 | `test_okx_bar_map.py`, `test_okx_loader_bounded.py` |
+| `redaction` | 2 | `test_redaction.py`, `test_redaction_shared.py` |
+| `registry` | 2 | `test_registry.py`, `test_registry_mcp_integration.py` |
+| `remember` | 2 | `test_remember_tool.py`, `test_remember_tool_security.py` |
+| `risk` | 2 | `test_risk_parity.py`, `test_risk_xray.py` |
+| `rsshub` | 2 | `test_rsshub_events_lookahead.py`, `test_rsshub_events_provider.py` |
+| `sdk` | 2 | `test_sdk_connectors.py`, `test_sdk_order_gate.py` |
+| `sec` | 2 | `test_sec_edgar_client.py`, `test_sec_filings_tool.py` |
+| `security` | 2 | `test_security_auth_api.py`, `test_security_scanner.py` |
+| `skill` | 2 | `test_skill_reference_links.py`, `test_skill_writer_tools.py` |
+| `stock` | 2 | `test_stock_news_tool.py`, `test_stock_profile_tool.py` |
+| `tool` | 2 | `test_tool_registry_security.py`, `test_tool_timeout.py` |
+| `trading` | 2 | `test_trading212_connector.py`, `test_trading_connections.py` |
+| `upload` | 2 | `test_upload_api.py`, `test_upload_security.py` |
+| `validation` | 2 | `test_validation.py`, `test_validation_cli.py` |
+| `yahoo` | 2 | `test_yahoo_client.py`, `test_yahoo_loader.py` |
+| `yfinance` | 2 | `test_yfinance_crypto.py`, `test_yfinance_interval_map.py` |
+| `advisory` | 1 | `test_advisory.py` |
+| `audit` | 1 | `test_audit_redact.py` |
+| `auth` | 1 | `test_auth_precedence.py` |
+| `background` | 1 | `test_background_tools.py` |
+| `backtest` | 1 | `test_backtest_runner_security.py` |
+| `baostock` | 1 | `test_baostock_loader.py` |
+| `base` | 1 | `test_base_engine.py` |
+| `bench` | 1 | `test_bench_parallel.py` |
+| `binance` | 1 | `test_binance_fallback.py` |
+| `block` | 1 | `test_block_trades_tool.py` |
+| `chat` | 1 | `test_chat_llm_streaming.py` |
+| `classification` | 1 | `test_classification.py` |
+| `composite` | 1 | `test_composite_engine_fallback.py` |
+| `consent` | 1 | `test_consent_commit.py` |
+| `context` | 1 | `test_context_attribution_layers.py` |
+| `correlation` | 1 | `test_correlation.py` |
+| `crypto` | 1 | `test_crypto_engine.py` |
+| `daily` | 1 | `test_daily_count.py` |
+| `data` | 1 | `test_data_routing_sources_subset.py` |
+| `default` | 1 | `test_default_deny_unknown_robinhood_tool.py` |
+| `distribution` | 1 | `test_distribution_skill_manifest.py` |
+| `dividend` | 1 | `test_dividend_analysis_skill.py` |
+| `dotenv` | 1 | `test_dotenv_observability.py` |
+| `dragon` | 1 | `test_dragon_tiger_tool.py` |
+| `enforcement` | 1 | `test_enforcement_l6.py` |
+| `env` | 1 | `test_env_schema.py` |
+| `equity` | 1 | `test_equity_regression.py` |
+| `error` | 1 | `test_error_path_redaction.py` |
+| `execution` | 1 | `test_execution_causality.py` |
+| `feishu` | 1 | `test_feishu_parse_md_table_edge_columns.py` |
+| `fetch` | 1 | `test_fetch_sina_penalties.py` |
+| `file` | 1 | `test_file_tool_sandbox_security.py` |
+| `finnhub` | 1 | `test_finnhub_loader.py` |
+| `fmp` | 1 | `test_fmp_loader.py` |
+| `forex` | 1 | `test_forex_engine.py` |
+| `fred` | 1 | `test_fred_macro_tool.py` |
+| `fund` | 1 | `test_fund_flow_tool.py` |
+| `fundamentals` | 1 | `test_fundamentals_pit.py` |
+| `halt` | 1 | `test_halt.py` |
+| `hypothesis` | 1 | `test_hypothesis_registry.py` |
+| `image` | 1 | `test_image_vision_tool.py` |
+| `indicator` | 1 | `test_indicator_period_nonpositive.py` |
+| `iwencai` | 1 | `test_iwencai_tool.py` |
+| `journal` | 1 | `test_journal_inverted_date_filter.py` |
+| `killswitch` | 1 | `test_killswitch_blocks_orders.py` |
+| `kimi` | 1 | `test_kimi_reasoning_content.py` |
+| `load` | 1 | `test_load_equity_aliases.py` |
+| `loader` | 1 | `test_loader_retry_helpers.py` |
+| `lockup` | 1 | `test_lockup_expiry_tool.py` |
+| `loop` | 1 | `test_loop_helpers.py` |
+| `margin` | 1 | `test_margin_trading_tool.py` |
+| `metrics` | 1 | `test_metrics.py` |
+| `models` | 1 | `test_models.py` |
+| `mootdx` | 1 | `test_mootdx_loader.py` |
+| `no` | 1 | `test_no_set_mandate_tool.py` |
+| `northbound` | 1 | `test_northbound_tool.py` |
+| `oauth` | 1 | `test_oauth_token_cache.py` |
+| `ohlc` | 1 | `test_ohlc_validation.py` |
+| `openai` | 1 | `test_openai_codex.py` |
+| `optimizer` | 1 | `test_optimizer_causality.py` |
+| `packaging` | 1 | `test_packaging_dependencies.py` |
+| `parse` | 1 | `test_parse_period_inverted.py` |
+| `path` | 1 | `test_path_safety.py` |
+| `pattern` | 1 | `test_pattern_tool.py` |
+| `persistent` | 1 | `test_persistent_memory.py` |
+| `preflight` | 1 | `test_preflight.py` |
+| `progress` | 1 | `test_progress.py` |
+| `provider` | 1 | `test_provider_diagnostics.py` |
+| `readonly` | 1 | `test_readonly_default.py` |
+| `realized` | 1 | `test_realized_turnover.py` |
+| `reasoning` | 1 | `test_reasoning_delta_throttle.py` |
+| `rebalance` | 1 | `test_rebalance_notes.py` |
+| `regime` | 1 | `test_regime.py` |
+| `report` | 1 | `test_report_audit_tool.py` |
+| `research` | 1 | `test_research_reports_tool.py` |
+| `runner` | 1 | `test_runner_env.py` |
+| `sector` | 1 | `test_sector_tool.py` |
+| `serve` | 1 | `test_serve_bind.py` |
+| `settings` | 1 | `test_settings_api.py` |
+| `shareholder` | 1 | `test_shareholder_count_tool.py` |
+| `shoonya` | 1 | `test_shoonya_interval_map.py` |
+| `signal` | 1 | `test_signal_alignment_perf.py` |
+| `sina` | 1 | `test_sina_loader.py` |
+| `skills` | 1 | `test_skills.py` |
+| `spa` | 1 | `test_spa_deep_link.py` |
+| `special` | 1 | `test_special_token_neutralization.py` |
+| `split` | 1 | `test_split_message_nonpositive.py` |
+| `sse` | 1 | `test_sse_ticket_and_headers.py` |
+| `state` | 1 | `test_state_fsync.py` |
+| `stooq` | 1 | `test_stooq_loader.py` |
+| `strategy` | 1 | `test_strategy_store.py` |
+| `symbol` | 1 | `test_symbol_search_tool.py` |
+| `system` | 1 | `test_system_routes.py` |
+| `tap` | 1 | `test_tap_forward.py` |
+| `telegram` | 1 | `test_telegram_split_fence_hang.py` |
+| `tencent` | 1 | `test_tencent_loader.py` |
+| `terminal` | 1 | `test_terminal_close_accounting.py` |
+| `ths` | 1 | `test_ths_excel_serial_dates.py` |
+| `tiger` | 1 | `test_tiger_period_hour_case.py` |
+| `tiingo` | 1 | `test_tiingo_loader.py` |
+| `trace` | 1 | `test_trace_writer.py` |
+| `trade` | 1 | `test_trade_journal.py` |
+| `turnover` | 1 | `test_turnover_aware_optimizer.py` |
+| `ui` | 1 | `test_ui_services.py` |
+| `url` | 1 | `test_url_target_security.py` |
+| `vnpy` | 1 | `test_vnpy_export.py` |
+
+## Notable areas (coverage intent)
+
+- **swarm_***: DAG, grounding, registry, trust model, worker, presets packaging
+- **loader / tushare / yahoo / okx / futu**: data fetch contracts
+- **runner / backtest / validation**: execution pipeline
+- **live / mandate / sdk / trading**: order gate & connectors
+- **session / goal / sse / api**: HTTP + EventBus
+- **mcp / security / web**: tool surface & SSRF
+- **shadow / factor / alpha**: research artifacts
+
+## Subpackages
+
+- `factors/` — 14 test modules
+- `fixtures/` — 0 test modules
+- `memory/` — 2 test modules

--- a/docs/analysis/catalog/_build_channels_tests.py
+++ b/docs/analysis/catalog/_build_channels_tests.py
@@ -1,0 +1,271 @@
+"""Build CHANNELS.md and TESTS.md catalogs."""
+from __future__ import annotations
+
+import ast
+import re
+from collections import defaultdict
+from pathlib import Path
+
+ROOT = Path(r"c:\Users\user\Desktop\github\Vibe-Trading")
+OUT = ROOT / "docs" / "analysis" / "catalog"
+CHANNELS = ROOT / "agent" / "src" / "channels"
+TESTS = ROOT / "agent" / "tests"
+
+
+def channel_info(path: Path) -> dict | None:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return None
+    name = display = None
+    bases = []
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name.endswith("Channel"):
+            for b in node.bases:
+                if isinstance(b, ast.Name):
+                    bases.append(b.id)
+            for item in node.body:
+                if isinstance(item, ast.Assign):
+                    for t in item.targets:
+                        if isinstance(t, ast.Name) and t.id in {"name", "display_name"}:
+                            if isinstance(item.value, ast.Constant):
+                                if t.id == "name":
+                                    name = item.value.value
+                                else:
+                                    display = item.value.value
+            break
+    # docstring first line
+    doc = ast.get_docstring(tree) or ""
+    first = (doc.strip().splitlines() or [""])[0][:200]
+    # deps hints
+    deps = sorted(
+        {
+            m.group(1)
+            for m in re.finditer(r"^(?:import|from)\s+([a-zA-Z0-9_]+)", text, re.M)
+            if m.group(1)
+            not in {
+                "asyncio",
+                "base64",
+                "json",
+                "logging",
+                "os",
+                "re",
+                "sys",
+                "time",
+                "typing",
+                "pathlib",
+                "dataclasses",
+                "collections",
+                "functools",
+                "hashlib",
+                "hmac",
+                "io",
+                "tempfile",
+                "uuid",
+                "datetime",
+                "enum",
+                "contextlib",
+                "inspect",
+                "traceback",
+                "urllib",
+                "http",
+                "ssl",
+                "struct",
+                "html",
+                "mimetypes",
+                "shutil",
+                "subprocess",
+                "threading",
+                "queue",
+                "copy",
+                "math",
+                "warnings",
+                "abc",
+                "src",
+            }
+        }
+    )
+    has_start = "async def start(" in text
+    has_send = "async def send(" in text
+    overrides_handle = "def _handle_message" in text or "async def _handle_message" in text
+    return {
+        "file": path.name,
+        "class": next(
+            (
+                n.name
+                for n in tree.body
+                if isinstance(n, ast.ClassDef) and n.name.endswith("Channel")
+            ),
+            "",
+        ),
+        "name": name or path.stem,
+        "display_name": display or "",
+        "bases": bases,
+        "doc": first,
+        "lines": text.count("\n") + 1,
+        "has_start": has_start,
+        "has_send": has_send,
+        "overrides_handle": overrides_handle,
+        "third_party_hints": [d for d in deps if d not in {"src", "channels"}][:12],
+    }
+
+
+def write_channels() -> None:
+    adapters = []
+    skip = {
+        "base.py",
+        "registry.py",
+        "manager.py",
+        "runtime.py",
+        "config.py",
+        "utils.py",
+        "__init__.py",
+    }
+    for path in sorted(CHANNELS.glob("*.py")):
+        if path.name in skip:
+            continue
+        info = channel_info(path)
+        if info and info["class"]:
+            adapters.append(info)
+
+    lines = [
+        "# Channels Adapter Catalog",
+        "",
+        "Core: `base.py` → `bus/` → `runtime.py` (inbound→SessionService) + `manager.py` (outbound).",
+        "",
+        f"Adapters analyzed: **{len(adapters)}**.",
+        "",
+        "| name | display | file | lines | _handle override | libs (hint) | doc |",
+        "|------|---------|------|------:|:----------------:|-------------|-----|",
+    ]
+    for a in adapters:
+        libs = ", ".join(f"`{x}`" for x in a["third_party_hints"][:5])
+        doc = a["doc"].replace("|", "/")
+        lines.append(
+            f"| `{a['name']}` | {a['display_name']} | `{a['file']}` | {a['lines']} | "
+            f"{'Y' if a['overrides_handle'] else ''} | {libs} | {doc} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Per-adapter notes (from code structure)",
+            "",
+        ]
+    )
+    notes = {
+        "telegram": "python-telegram-bot long polling; media download; pairing via BaseChannel.",
+        "discord": "discord.py gateway; thread session_key.",
+        "slack": "Socket Mode; emoji react progress.",
+        "dingtalk": "dingtalk_stream Stream Mode.",
+        "feishu": "lark_oapi WebSocket.",
+        "whatsapp": "neonize WhatsApp Web; rich media.",
+        "matrix": "matrix-nio sync; workspace restrict kwargs.",
+        "email": "IMAP poll + SMTP reply.",
+        "signal": "signal-cli REST/JSON-RPC; **overrides _handle_message** (direct publish).",
+        "weixin": "personal WeChat HTTP long-poll (ilink).",
+        "wecom": "enterprise WeCom aibot SDK.",
+        "msteams": "Bot Framework webhook HTTP (DM MVP).",
+        "qq": "botpy official QQ bot.",
+        "napcat": "OneBot v11 WebSocket.",
+        "mochat": "Socket.IO + HTTP polling fallback.",
+        "websocket": "Local WS/Unix + channelsui gateway for WebUI.",
+    }
+    for a in adapters:
+        note = notes.get(a["name"], "Standard BaseChannel ingress.")
+        lines.append(f"### `{a['name']}`")
+        lines.append("")
+        lines.append(f"- class: `{a['class']}` ({a['lines']} lines)")
+        lines.append(f"- start/send: {'yes' if a['has_start'] else 'no'} / {'yes' if a['has_send'] else 'no'}")
+        lines.append(f"- note: {note}")
+        lines.append("")
+
+    (OUT / "CHANNELS.md").write_text("\n".join(lines), encoding="utf-8")
+    print(f"channels: {len(adapters)}")
+
+
+def write_tests() -> None:
+    files = sorted(TESTS.glob("test_*.py"))
+    groups: dict[str, list[str]] = defaultdict(list)
+    for f in files:
+        stem = f.stem[len("test_") :]
+        # group by first token or known prefixes
+        prefix = stem.split("_")[0]
+        # longer domain prefixes
+        for p in (
+            "swarm",
+            "tushare",
+            "alpha",
+            "cli",
+            "sdk",
+            "runner",
+            "loader",
+            "goal",
+            "session",
+            "channel",
+            "live",
+            "mandate",
+            "shadow",
+            "mcp",
+            "backtest",
+            "factor",
+            "yahoo",
+            "okx",
+            "futu",
+            "trading",
+            "security",
+            "web",
+            "sse",
+            "api",
+        ):
+            if stem.startswith(p):
+                prefix = p
+                break
+        groups[prefix].append(f.name)
+
+    lines = [
+        "# Agent Tests Suite Map",
+        "",
+        f"Top-level `test_*.py` files: **{len(files)}**.",
+        "",
+        "Subdirs: `factors/`, `fixtures/`, `memory/`.",
+        "",
+        "## By domain prefix",
+        "",
+        "| prefix | count | examples |",
+        "|--------|------:|----------|",
+    ]
+    for prefix, names in sorted(groups.items(), key=lambda x: (-len(x[1]), x[0])):
+        ex = ", ".join(f"`{n}`" for n in names[:3])
+        if len(names) > 3:
+            ex += f", …(+{len(names)-3})"
+        lines.append(f"| `{prefix}` | {len(names)} | {ex} |")
+
+    lines.extend(
+        [
+            "",
+            "## Notable areas (coverage intent)",
+            "",
+            "- **swarm_***: DAG, grounding, registry, trust model, worker, presets packaging",
+            "- **loader / tushare / yahoo / okx / futu**: data fetch contracts",
+            "- **runner / backtest / validation**: execution pipeline",
+            "- **live / mandate / sdk / trading**: order gate & connectors",
+            "- **session / goal / sse / api**: HTTP + EventBus",
+            "- **mcp / security / web**: tool surface & SSRF",
+            "- **shadow / factor / alpha**: research artifacts",
+            "",
+            "## Subpackages",
+            "",
+        ]
+    )
+    for sub in sorted(p.name for p in TESTS.iterdir() if p.is_dir() and not p.name.startswith(".")):
+        n = sum(1 for _ in (TESTS / sub).rglob("test_*.py"))
+        lines.append(f"- `{sub}/` — {n} test modules")
+
+    (OUT / "TESTS.md").write_text("\n".join(lines), encoding="utf-8")
+    print(f"tests: {len(files)}")
+
+
+if __name__ == "__main__":
+    write_channels()
+    write_tests()

--- a/docs/analysis/catalog/_build_inventories.py
+++ b/docs/analysis/catalog/_build_inventories.py
@@ -1,0 +1,267 @@
+"""Extract catalog inventories for skills, alphas, swarm presets."""
+from __future__ import annotations
+
+import ast
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(r"c:\Users\user\Desktop\github\Vibe-Trading")
+OUT = ROOT / "docs" / "analysis" / "catalog"
+OUT.mkdir(parents=True, exist_ok=True)
+
+
+def parse_frontmatter(text: str) -> dict[str, str]:
+    fm: dict[str, str] = {}
+    if not text.startswith("---"):
+        return fm
+    end = text.find("---", 3)
+    if end < 0:
+        return fm
+    for line in text[3:end].splitlines():
+        if ":" not in line:
+            continue
+        k, v = line.split(":", 1)
+        fm[k.strip()] = v.strip().strip("\"'")
+    return fm
+
+
+def inventory_skills() -> list[dict]:
+    skills_root = ROOT / "agent" / "src" / "skills"
+    rows: list[dict] = []
+    for d in sorted(skills_root.iterdir()):
+        if not d.is_dir() or d.name.startswith("."):
+            continue
+        skill = d / "SKILL.md"
+        if not skill.exists():
+            rows.append({"id": d.name, "error": "no SKILL.md"})
+            continue
+        text = skill.read_text(encoding="utf-8", errors="replace")
+        fm = parse_frontmatter(text)
+        n_files = sum(1 for p in d.rglob("*") if p.is_file())
+        rows.append(
+            {
+                "id": d.name,
+                "name": fm.get("name", d.name),
+                "category": fm.get("category", "") or "uncategorized",
+                "description": (fm.get("description") or "")[:400],
+                "files": n_files,
+                "has_example_engine": (d / "example_signal_engine.py").exists(),
+                "body_chars": len(text),
+            }
+        )
+    return rows
+
+
+def load_alpha_meta(path: Path) -> dict | None:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+    except SyntaxError:
+        return None
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for t in node.targets:
+                if isinstance(t, ast.Name) and t.id == "__alpha_meta__":
+                    try:
+                        return ast.literal_eval(node.value)
+                    except Exception:
+                        return {"id": path.stem, "error": "non-literal meta"}
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            if node.target.id == "__alpha_meta__" and node.value is not None:
+                try:
+                    return ast.literal_eval(node.value)
+                except Exception:
+                    return {"id": path.stem, "error": "non-literal meta"}
+    return None
+
+
+def inventory_alphas() -> list[dict]:
+    zoo = ROOT / "agent" / "src" / "factors" / "zoo"
+    rows: list[dict] = []
+    for zoo_dir in sorted(zoo.iterdir()):
+        if not zoo_dir.is_dir() or zoo_dir.name.startswith(("_", ".")):
+            continue
+        for py in sorted(zoo_dir.glob("*.py")):
+            if py.name.startswith("_"):
+                continue
+            meta = load_alpha_meta(py) or {}
+            rows.append(
+                {
+                    "zoo": zoo_dir.name,
+                    "file": py.name,
+                    "id": meta.get("id") or f"{zoo_dir.name}_{py.stem}",
+                    "theme": meta.get("theme")
+                    if isinstance(meta.get("theme"), str)
+                    else (
+                        ",".join(str(x) for x in meta.get("theme"))
+                        if isinstance(meta.get("theme"), (list, tuple))
+                        else str(meta.get("theme") or "")
+                    ),
+                    "formula_latex": str(meta.get("formula_latex") or "")[:200],
+                    "columns_required": meta.get("columns_required") or [],
+                    "extras_required": meta.get("extras_required") or [],
+                    "requires_sector": bool(meta.get("requires_sector")),
+                    "universe": meta.get("universe", ""),
+                    "frequency": meta.get("frequency", ""),
+                    "decay_horizon": meta.get("decay_horizon"),
+                    "min_warmup_bars": meta.get("min_warmup_bars"),
+                    "error": meta.get("error"),
+                }
+            )
+    return rows
+
+
+def inventory_swarm() -> list[dict]:
+    presets = ROOT / "agent" / "src" / "swarm" / "presets"
+    rows: list[dict] = []
+    try:
+        import yaml  # type: ignore
+    except ImportError:
+        yaml = None
+
+    for path in sorted(presets.glob("*.yaml")):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        data: dict = {}
+        if yaml is not None:
+            data = yaml.safe_load(text) or {}
+        else:
+            # minimal fallback
+            for key in ("name", "title", "description"):
+                m = re.search(rf"^{key}:\s*[\"']?(.*?)[\"']?\s*$", text, re.M)
+                if m:
+                    data[key] = m.group(1)
+            data["agents"] = re.findall(r"^\s*-\s*id:\s*(\S+)", text, re.M)
+            data["tasks"] = re.findall(r"^\s*-\s*id:\s*(\S+)", text, re.M)
+
+        agents = data.get("agents") or []
+        tasks = data.get("tasks") or []
+        agent_ids = [
+            a.get("id") if isinstance(a, dict) else str(a) for a in agents
+        ]
+        task_ids = [t.get("id") if isinstance(t, dict) else str(t) for t in tasks]
+        deps = []
+        for t in tasks:
+            if isinstance(t, dict) and t.get("depends_on"):
+                deps.append({"task": t.get("id"), "depends_on": t.get("depends_on")})
+        rows.append(
+            {
+                "file": path.name,
+                "name": data.get("name") or path.stem,
+                "title": data.get("title") or "",
+                "description": (data.get("description") or "")[:400],
+                "n_agents": len(agents),
+                "n_tasks": len(tasks),
+                "agent_ids": agent_ids,
+                "task_ids": task_ids,
+                "dependencies": deps,
+                "variables": list((data.get("variables") or {}).keys())
+                if isinstance(data.get("variables"), dict)
+                else data.get("variables") or [],
+            }
+        )
+    return rows
+
+
+def write_md_skills(rows: list[dict]) -> None:
+    by_cat: dict[str, list] = {}
+    for r in rows:
+        by_cat.setdefault(r.get("category") or "uncategorized", []).append(r)
+    lines = [
+        "# Skills Catalog (88)",
+        "",
+        f"Total: **{len(rows)}** skills under `agent/src/skills/`.",
+        "",
+        "## By category",
+        "",
+    ]
+    for cat in sorted(by_cat):
+        lines.append(f"### {cat} ({len(by_cat[cat])})")
+        lines.append("")
+        lines.append("| id | description | files | example_engine |")
+        lines.append("|----|-------------|------:|:--------------:|")
+        for r in by_cat[cat]:
+            desc = (r.get("description") or "").replace("|", "/")
+            lines.append(
+                f"| `{r['id']}` | {desc} | {r.get('files', 0)} | "
+                f"{'Y' if r.get('has_example_engine') else ''} |"
+            )
+        lines.append("")
+    (OUT / "SKILLS.md").write_text("\n".join(lines), encoding="utf-8")
+
+
+def write_md_alphas(rows: list[dict]) -> None:
+    by_zoo: dict[str, list] = {}
+    for r in rows:
+        by_zoo.setdefault(r["zoo"], []).append(r)
+    lines = [
+        "# Alpha Zoo Catalog",
+        "",
+        f"Total modules with meta: **{len(rows)}**.",
+        "",
+    ]
+    for zoo in sorted(by_zoo):
+        items = by_zoo[zoo]
+        lines.append(f"## {zoo} ({len(items)})")
+        lines.append("")
+        lines.append("| id | theme | columns | warmup | formula |")
+        lines.append("|----|-------|---------|-------:|---------|")
+        for r in items:
+            cols = ",".join(r.get("columns_required") or [])[:40]
+            formula = (r.get("formula_latex") or "").replace("|", "/")[:60]
+            theme = (r.get("theme") or "").replace("|", "/")[:30]
+            lines.append(
+                f"| `{r['id']}` | {theme} | {cols} | {r.get('min_warmup_bars') or ''} | {formula} |"
+            )
+        lines.append("")
+    (OUT / "ALPHAS.md").write_text("\n".join(lines), encoding="utf-8")
+
+
+def write_md_swarm(rows: list[dict]) -> None:
+    lines = [
+        "# Swarm Presets Catalog (30)",
+        "",
+        f"Total: **{len(rows)}**.",
+        "",
+    ]
+    for r in rows:
+        lines.append(f"## `{r['name']}` — {r.get('title') or r['file']}")
+        lines.append("")
+        lines.append(r.get("description") or "(no description)")
+        lines.append("")
+        lines.append(f"- agents ({r['n_agents']}): {', '.join(f'`{a}`' for a in r['agent_ids'])}")
+        lines.append(f"- tasks ({r['n_tasks']}): {', '.join(f'`{t}`' for t in r['task_ids'])}")
+        if r.get("dependencies"):
+            lines.append("- depends_on:")
+            for d in r["dependencies"]:
+                lines.append(f"  - `{d['task']}` ← {d['depends_on']}")
+        if r.get("variables"):
+            lines.append(f"- variables: {r['variables']}")
+        lines.append("")
+    (OUT / "SWARM_PRESETS.md").write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> None:
+    skills = inventory_skills()
+    (OUT / "skills_inventory.json").write_text(
+        json.dumps(skills, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    write_md_skills(skills)
+    print(f"skills: {len(skills)}")
+
+    alphas = inventory_alphas()
+    (OUT / "alphas_inventory.json").write_text(
+        json.dumps(alphas, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    write_md_alphas(alphas)
+    print(f"alphas: {len(alphas)}")
+
+    swarm = inventory_swarm()
+    (OUT / "swarm_inventory.json").write_text(
+        json.dumps(swarm, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    write_md_swarm(swarm)
+    print(f"swarm: {len(swarm)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/analysis/catalog/alphas_inventory.json
+++ b/docs/analysis/catalog/alphas_inventory.json
@@ -1,0 +1,10881 @@
+[
+  {
+    "zoo": "academic",
+    "file": "bab.py",
+    "id": "academic_bab",
+    "theme": "volatility",
+    "formula_latex": "\\mathrm{zscore}_{x}\\bigl(-\\,\\mathrm{ts\\_cov}(r_i, r_m, 252) / \\mathrm{ts\\_std}(r_m, 252)^2\\bigr)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 252,
+    "min_warmup_bars": 253,
+    "error": null
+  },
+  {
+    "zoo": "academic",
+    "file": "carhart_mom.py",
+    "id": "academic_carhart_mom",
+    "theme": "momentum",
+    "formula_latex": "\\mathrm{zscore}_{x}\\bigl((\\mathrm{close}_t - \\mathrm{close}_{t-252})/\\mathrm{close}_{t-252} - (\\mathrm{close}_t - \\mathrm{close}_{t-21})/\\mathrm{close}_{t-21}\\bigr)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 252,
+    "error": null
+  },
+  {
+    "zoo": "academic",
+    "file": "cma.py",
+    "id": "academic_cma",
+    "theme": "quality",
+    "formula_latex": "\\mathrm{zscore}_{x}\\bigl(-\\Delta_{60}\\log(\\mathrm{ts\\_mean}(\\mathrm{volume},\\,60) + 1)\\bigr)",
+    "columns_required": [
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 120,
+    "error": null
+  },
+  {
+    "zoo": "academic",
+    "file": "corr_rewire.py",
+    "id": "academic_corr_rewire",
+    "theme": "volatility",
+    "formula_latex": "\\mathrm{zscore}_{x}\\Bigl(-\\,\\frac{1}{|J_i|}\\sum_{j \\in J_i}\\bigl|\\rho_{ij}^{\\mathrm{event}} - \\rho_{ij}^{\\mathrm{calm}}\\bigr|\\Bigr),\\quad \\rho^{\\mathrm{event}} = \\mathrm{corr}(r_{t-19..t}),\\ \\rho^{\\ma",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "crypto"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 142,
+    "error": null
+  },
+  {
+    "zoo": "academic",
+    "file": "high52w.py",
+    "id": "academic_high52w",
+    "theme": "momentum",
+    "formula_latex": "\\mathrm{zscore}_{x}\\bigl(\\mathrm{close}_t / \\mathrm{ts\\_max}(\\mathrm{close},\\,252)\\bigr)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 252,
+    "error": null
+  },
+  {
+    "zoo": "academic",
+    "file": "hml.py",
+    "id": "academic_hml",
+    "theme": "value",
+    "formula_latex": "\\mathrm{zscore}_{x}\\bigl(-(\\mathrm{close}_t - \\mathrm{close}_{t-252}) / \\mathrm{close}_{t-252}\\bigr)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 252,
+    "error": null
+  },
+  {
+    "zoo": "academic",
+    "file": "illiq.py",
+    "id": "academic_illiq",
+    "theme": "liquidity",
+    "formula_latex": "\\mathrm{zscore}_{x}\\bigl(\\mathrm{ts\\_mean}(|r_t| / (\\mathrm{close}_t \\cdot \\mathrm{volume}_t),\\,21)\\bigr)",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 21,
+    "min_warmup_bars": 22,
+    "error": null
+  },
+  {
+    "zoo": "academic",
+    "file": "mkt_rf.py",
+    "id": "academic_mkt_rf",
+    "theme": "momentum",
+    "formula_latex": "\\mathrm{zscore}_{x}\\bigl((\\mathrm{close}_t - \\mathrm{close}_{t-21}) / \\mathrm{close}_{t-21}\\bigr)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 21,
+    "min_warmup_bars": 21,
+    "error": null
+  },
+  {
+    "zoo": "academic",
+    "file": "retskew.py",
+    "id": "academic_retskew",
+    "theme": "volatility",
+    "formula_latex": "\\mathrm{zscore}_{x}\\bigl(-\\mathrm{skew}_{60}(r_t)\\bigr)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 61,
+    "error": null
+  },
+  {
+    "zoo": "academic",
+    "file": "rmw.py",
+    "id": "academic_rmw",
+    "theme": "quality",
+    "formula_latex": "\\mathrm{zscore}_{x}\\bigl(-\\mathrm{ts\\_std}((\\mathrm{close}_t - \\mathrm{close}_{t-1}) / \\mathrm{close}_{t-1},\\,60)\\bigr)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "academic",
+    "file": "smb.py",
+    "id": "academic_smb",
+    "theme": "quality",
+    "formula_latex": "\\mathrm{zscore}_{x}\\bigl(-\\log(\\mathrm{ts\\_mean}(\\mathrm{volume} \\cdot \\mathrm{close},\\,60) + 1)\\bigr)",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "academic",
+    "file": "strev.py",
+    "id": "academic_strev",
+    "theme": "reversal",
+    "formula_latex": "\\mathrm{zscore}_{x}\\bigl(-(\\mathrm{close}_t - \\mathrm{close}_{t-21}) / \\mathrm{close}_{t-21}\\bigr)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 21,
+    "min_warmup_bars": 21,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_001.py",
+    "id": "alpha101_001",
+    "theme": "reversal,volatility",
+    "formula_latex": "rank(ts_argmax(SignedPower((returns<0)?stddev(returns,20):close, 2.), 5)) - 0.5",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 25,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_002.py",
+    "id": "alpha101_002",
+    "theme": "volume,reversal",
+    "formula_latex": "-1 * correlation(rank(delta(log(volume), 2)), rank(((close-open)/open)), 6)",
+    "columns_required": [
+      "open",
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_003.py",
+    "id": "alpha101_003",
+    "theme": "volume,reversal",
+    "formula_latex": "-1 * correlation(rank(open), rank(volume), 10)",
+    "columns_required": [
+      "open",
+      "volume",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_004.py",
+    "id": "alpha101_004",
+    "theme": "reversal",
+    "formula_latex": "-1 * Ts_Rank(rank(low), 9)",
+    "columns_required": [
+      "low",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 9,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_005.py",
+    "id": "alpha101_005",
+    "theme": "reversal",
+    "formula_latex": "rank((open - sum(vwap,10)/10)) * (-1 * abs(rank((close - vwap))))",
+    "columns_required": [
+      "open",
+      "close",
+      "vwap"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_006.py",
+    "id": "alpha101_006",
+    "theme": "volume,reversal",
+    "formula_latex": "-1 * correlation(open, volume, 10)",
+    "columns_required": [
+      "open",
+      "volume",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_007.py",
+    "id": "alpha101_007",
+    "theme": "momentum,volume",
+    "formula_latex": "(adv20<volume)?((-1*ts_rank(abs(delta(close,7)),60))*sign(delta(close,7))):(-1)",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 67,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_008.py",
+    "id": "alpha101_008",
+    "theme": "reversal",
+    "formula_latex": "-1 * rank((sum(open,5)*sum(returns,5)) - delay(sum(open,5)*sum(returns,5),10))",
+    "columns_required": [
+      "open",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 15,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_009.py",
+    "id": "alpha101_009",
+    "theme": "momentum",
+    "formula_latex": "(0<ts_min(delta(close,1),5))?delta(close,1):((ts_max(delta(close,1),5)<0)?delta(close,1):(-1*delta(close,1)))",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 6,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_010.py",
+    "id": "alpha101_010",
+    "theme": "momentum",
+    "formula_latex": "rank((0<ts_min(delta(close,1),4))?delta(close,1):((ts_max(delta(close,1),4)<0)?delta(close,1):(-1*delta(close,1))))",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_011.py",
+    "id": "alpha101_011",
+    "theme": "volume,reversal",
+    "formula_latex": "(rank(ts_max(vwap-close,3))+rank(ts_min(vwap-close,3)))*rank(delta(volume,3))",
+    "columns_required": [
+      "close",
+      "volume",
+      "vwap"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_012.py",
+    "id": "alpha101_012",
+    "theme": "volume,reversal",
+    "formula_latex": "sign(delta(volume,1)) * (-1 * delta(close,1))",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 2,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_013.py",
+    "id": "alpha101_013",
+    "theme": "volume",
+    "formula_latex": "-1 * rank(covariance(rank(close), rank(volume), 5))",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_014.py",
+    "id": "alpha101_014",
+    "theme": "volume,momentum",
+    "formula_latex": "(-1*rank(delta(returns,3))) * correlation(open, volume, 10)",
+    "columns_required": [
+      "open",
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_015.py",
+    "id": "alpha101_015",
+    "theme": "volume",
+    "formula_latex": "-1 * sum(rank(correlation(rank(high), rank(volume), 3)), 3)",
+    "columns_required": [
+      "high",
+      "volume",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 6,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_016.py",
+    "id": "alpha101_016",
+    "theme": "volume",
+    "formula_latex": "-1 * rank(covariance(rank(high), rank(volume), 5))",
+    "columns_required": [
+      "high",
+      "volume",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_017.py",
+    "id": "alpha101_017",
+    "theme": "volume,reversal",
+    "formula_latex": "((-1*rank(ts_rank(close,10)))*rank(delta(delta(close,1),1)))*rank(ts_rank(volume/adv20,5))",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 25,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_018.py",
+    "id": "alpha101_018",
+    "theme": "volatility",
+    "formula_latex": "-1 * rank(stddev(abs(close-open),5) + (close-open) + correlation(close,open,10))",
+    "columns_required": [
+      "open",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_019.py",
+    "id": "alpha101_019",
+    "theme": "momentum",
+    "formula_latex": "(-1*sign((close-delay(close,7))+delta(close,7))) * (1+rank(1+sum(returns,250)))",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 250,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_020.py",
+    "id": "alpha101_020",
+    "theme": "reversal",
+    "formula_latex": "(((-1*rank(open-delay(high,1)))*rank(open-delay(close,1)))*rank(open-delay(low,1)))",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 2,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_021.py",
+    "id": "alpha101_021",
+    "theme": "momentum,volatility",
+    "formula_latex": "complex piecewise; see paper",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_022.py",
+    "id": "alpha101_022",
+    "theme": "volume,volatility",
+    "formula_latex": "-1 * (delta(correlation(high,volume,5),5) * rank(stddev(close,20)))",
+    "columns_required": [
+      "high",
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 25,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_023.py",
+    "id": "alpha101_023",
+    "theme": "momentum",
+    "formula_latex": "((sum(high,20)/20) < high) ? (-1*delta(high,2)) : 0",
+    "columns_required": [
+      "high",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_024.py",
+    "id": "alpha101_024",
+    "theme": "momentum",
+    "formula_latex": "complex piecewise; see paper",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 200,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_025.py",
+    "id": "alpha101_025",
+    "theme": "momentum,volume",
+    "formula_latex": "rank((((-1*returns)*adv20)*vwap)*(high-close))",
+    "columns_required": [
+      "high",
+      "close",
+      "volume",
+      "vwap"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 21,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_026.py",
+    "id": "alpha101_026",
+    "theme": "volume",
+    "formula_latex": "-1 * ts_max(correlation(ts_rank(volume,5),ts_rank(high,5),5),3)",
+    "columns_required": [
+      "high",
+      "volume",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 13,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_027.py",
+    "id": "alpha101_027",
+    "theme": "volume",
+    "formula_latex": "(0.5<rank((sum(correlation(rank(volume),rank(vwap),6),2)/2.0)))?(-1):1",
+    "columns_required": [
+      "volume",
+      "vwap",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_028.py",
+    "id": "alpha101_028",
+    "theme": "volume",
+    "formula_latex": "scale((correlation(adv20,low,5) + (high+low)/2) - close)",
+    "columns_required": [
+      "high",
+      "low",
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 25,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_029.py",
+    "id": "alpha101_029",
+    "theme": "reversal,volume",
+    "formula_latex": "min(product(rank(rank(scale(log(sum(ts_min(rank(rank(-1*rank(delta(close-1,5)))),2),1))))),1),5) + ts_rank(delay(-1*returns,6),5)",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 12,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_030.py",
+    "id": "alpha101_030",
+    "theme": "momentum,volume",
+    "formula_latex": "((1-rank(sign(d1)+sign(d2)+sign(d3))) * sum(volume,5)) / sum(volume,20)",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_031.py",
+    "id": "alpha101_031",
+    "theme": "momentum",
+    "formula_latex": "rank(rank(rank(decay_linear(-1*rank(rank(delta(close,10))),10)))) + rank(-1*delta(close,3)) + sign(scale(correlation(adv20,low,12)))",
+    "columns_required": [
+      "low",
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 25,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_032.py",
+    "id": "alpha101_032",
+    "theme": "momentum",
+    "formula_latex": "scale(sum(close,7)/7 - close) + 20*scale(correlation(vwap, delay(close,5), 230))",
+    "columns_required": [
+      "close",
+      "vwap"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 235,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_033.py",
+    "id": "alpha101_033",
+    "theme": "reversal",
+    "formula_latex": "rank(-1*(1-open/close))",
+    "columns_required": [
+      "open",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 1,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_034.py",
+    "id": "alpha101_034",
+    "theme": "volatility",
+    "formula_latex": "rank((1-rank(stddev(returns,2)/stddev(returns,5))) + (1-rank(delta(close,1))))",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 6,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_035.py",
+    "id": "alpha101_035",
+    "theme": "volume,momentum",
+    "formula_latex": "ts_rank(volume,32) * (1 - ts_rank((close+high-low),16)) * (1 - ts_rank(returns,32))",
+    "columns_required": [
+      "high",
+      "low",
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 33,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_036.py",
+    "id": "alpha101_036",
+    "theme": "momentum,volume",
+    "formula_latex": "weighted sum; see paper",
+    "columns_required": [
+      "open",
+      "close",
+      "volume",
+      "vwap"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 200,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_037.py",
+    "id": "alpha101_037",
+    "theme": "momentum",
+    "formula_latex": "rank(correlation(delay(open-close,1),close,200)) + rank(open-close)",
+    "columns_required": [
+      "open",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 201,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_038.py",
+    "id": "alpha101_038",
+    "theme": "reversal",
+    "formula_latex": "(-1*rank(ts_rank(close,10))) * rank(close/open)",
+    "columns_required": [
+      "open",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_039.py",
+    "id": "alpha101_039",
+    "theme": "momentum,volume",
+    "formula_latex": "(-1*rank(delta(close,7)*(1-rank(decay_linear(volume/adv20,9))))) * (1+rank(sum(returns,250)))",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 250,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_040.py",
+    "id": "alpha101_040",
+    "theme": "volatility,volume",
+    "formula_latex": "(-1*rank(stddev(high,10))) * correlation(high,volume,10)",
+    "columns_required": [
+      "high",
+      "volume",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_041.py",
+    "id": "alpha101_041",
+    "theme": "reversal",
+    "formula_latex": "(high*low)^0.5 - vwap",
+    "columns_required": [
+      "high",
+      "low",
+      "vwap",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 1,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_042.py",
+    "id": "alpha101_042",
+    "theme": "reversal",
+    "formula_latex": "rank(vwap-close) / rank(vwap+close)",
+    "columns_required": [
+      "close",
+      "vwap"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 1,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_043.py",
+    "id": "alpha101_043",
+    "theme": "volume,momentum",
+    "formula_latex": "ts_rank(volume/adv20,20) * ts_rank(-1*delta(close,7),8)",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 39,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_044.py",
+    "id": "alpha101_044",
+    "theme": "volume",
+    "formula_latex": "-1 * correlation(high, rank(volume), 5)",
+    "columns_required": [
+      "high",
+      "volume",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_045.py",
+    "id": "alpha101_045",
+    "theme": "momentum,volume",
+    "formula_latex": "-1 * (rank(sum(delay(close,5),20)/20)*correlation(close,volume,2)*rank(correlation(sum(close,5),sum(close,20),2)))",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 25,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_046.py",
+    "id": "alpha101_046",
+    "theme": "momentum",
+    "formula_latex": "complex piecewise; see paper",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 21,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_047.py",
+    "id": "alpha101_047",
+    "theme": "volume,momentum",
+    "formula_latex": "((rank(1/close)*volume/adv20) * (high*rank(high-close)/(sum(high,5)/5))) - rank(vwap-delay(vwap,5))",
+    "columns_required": [
+      "high",
+      "close",
+      "volume",
+      "vwap"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 25,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_048.py",
+    "id": "alpha101_048",
+    "theme": "momentum,volatility",
+    "formula_latex": "indneutralize(...subindustry...) / sum((delta(close,1)/delay(close,1))^2, 250)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": true,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 251,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_049.py",
+    "id": "alpha101_049",
+    "theme": "momentum",
+    "formula_latex": "(((delay(close,20)-delay(close,10))/10 - (delay(close,10)-close)/10) < -0.1) ? 1 : -1*(close-delay(close,1))",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 21,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_050.py",
+    "id": "alpha101_050",
+    "theme": "volume",
+    "formula_latex": "-1 * ts_max(rank(correlation(rank(volume), rank(vwap), 5)), 5)",
+    "columns_required": [
+      "volume",
+      "vwap",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_051.py",
+    "id": "alpha101_051",
+    "theme": "momentum",
+    "formula_latex": "(...< -0.05) ? 1 : -1*(close-delay(close,1))",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 21,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_052.py",
+    "id": "alpha101_052",
+    "theme": "momentum",
+    "formula_latex": "((-1*ts_min(low,5)+delay(ts_min(low,5),5)) * rank((sum(returns,240)-sum(returns,20))/220)) * ts_rank(volume,5)",
+    "columns_required": [
+      "low",
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 240,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_053.py",
+    "id": "alpha101_053",
+    "theme": "reversal",
+    "formula_latex": "-1 * delta(((close-low) - (high-close))/(close-low), 9)",
+    "columns_required": [
+      "high",
+      "low",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_054.py",
+    "id": "alpha101_054",
+    "theme": "reversal",
+    "formula_latex": "-1 * ((low-close)*(open^5)) / ((low-high)*(close^5))",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 1,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_055.py",
+    "id": "alpha101_055",
+    "theme": "volume,reversal",
+    "formula_latex": "-1 * correlation(rank((close-ts_min(low,12))/(ts_max(high,12)-ts_min(low,12))), rank(volume), 6)",
+    "columns_required": [
+      "high",
+      "low",
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 17,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_056.py",
+    "id": "alpha101_056",
+    "theme": "momentum",
+    "formula_latex": "0 - 1*(rank(sum(returns,10)/sum(sum(returns,2),3)) * rank((returns * cap)))  [cap unavailable -> 1]",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": true,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_057.py",
+    "id": "alpha101_057",
+    "theme": "reversal",
+    "formula_latex": "0 - 1 * ((close-vwap) / decay_linear(rank(ts_argmax(close,30)), 2))",
+    "columns_required": [
+      "close",
+      "vwap"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 32,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_058.py",
+    "id": "alpha101_058",
+    "theme": "volume",
+    "formula_latex": "-1 * Ts_Rank(decay_linear(correlation(IndNeutralize(vwap, sector), volume, 4), 8), 6)",
+    "columns_required": [
+      "volume",
+      "vwap",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": true,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 25,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_059.py",
+    "id": "alpha101_059",
+    "theme": "volume",
+    "formula_latex": "-1 * Ts_Rank(decay_linear(correlation(IndNeutralize(vwap*0.728+vwap*0.272, industry), volume, 4), 16), 8)",
+    "columns_required": [
+      "volume",
+      "vwap",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": true,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_060.py",
+    "id": "alpha101_060",
+    "theme": "volume",
+    "formula_latex": "0 - (2*scale(rank((((close-low)-(high-close))/(high-low))*volume)) - scale(rank(ts_argmax(close,10))))",
+    "columns_required": [
+      "high",
+      "low",
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_061.py",
+    "id": "alpha101_061",
+    "theme": "volume",
+    "formula_latex": "rank(vwap - ts_min(vwap,16)) < rank(correlation(vwap, adv180, 18))",
+    "columns_required": [
+      "volume",
+      "vwap",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 197,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_062.py",
+    "id": "alpha101_062",
+    "theme": "volume",
+    "formula_latex": "(rank(correlation(vwap, sum(adv20,22), 10)) < rank(((rank(open)+rank(open)) < (rank((high+low)/2)+rank(high))))) * -1",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "volume",
+      "vwap",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 35,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_063.py",
+    "id": "alpha101_063",
+    "theme": "volume,momentum",
+    "formula_latex": "(rank(decay_linear(delta(IndNeutralize(close, industry), 2), 8)) - rank(decay_linear(correlation(0.318*vwap+0.682*open, sum(adv180,37), 14), 12))) * -1",
+    "columns_required": [
+      "open",
+      "close",
+      "volume",
+      "vwap"
+    ],
+    "extras_required": [],
+    "requires_sector": true,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 204,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_064.py",
+    "id": "alpha101_064",
+    "theme": "volume",
+    "formula_latex": "(rank(correlation(sum(0.178*open+0.822*low,13), sum(adv120,13), 17)) < rank(delta(0.178*((high+low)/2)+0.822*vwap, 4))) * -1",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "volume",
+      "vwap",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 136,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_065.py",
+    "id": "alpha101_065",
+    "theme": "volume",
+    "formula_latex": "(rank(correlation(0.008*open+0.992*vwap, sum(adv60,9), 6)) < rank(open-ts_min(open,14))) * -1",
+    "columns_required": [
+      "open",
+      "volume",
+      "vwap",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 65,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_066.py",
+    "id": "alpha101_066",
+    "theme": "momentum",
+    "formula_latex": "(rank(decay_linear(delta(vwap,4), 7)) + Ts_Rank(decay_linear(((0.966*low+0.034*low - vwap)/(open-(high+low)/2)), 11), 7)) * -1",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "vwap",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 18,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_067.py",
+    "id": "alpha101_067",
+    "theme": "volume",
+    "formula_latex": "(rank(high-ts_min(high,2))^rank(correlation(IndNeutralize(vwap,sector), IndNeutralize(adv20,subindustry), 6))) * -1",
+    "columns_required": [
+      "high",
+      "volume",
+      "vwap",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": true,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 25,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_068.py",
+    "id": "alpha101_068",
+    "theme": "volume",
+    "formula_latex": "(Ts_Rank(correlation(rank(high), rank(adv15), 9), 14) < rank(delta(0.518*close+0.482*low, 1))) * -1",
+    "columns_required": [
+      "high",
+      "low",
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 36,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_069.py",
+    "id": "alpha101_069",
+    "theme": "volume",
+    "formula_latex": "(rank(ts_max(delta(IndNeutralize(vwap, industry), 3), 5))^Ts_Rank(correlation(0.49*close+0.51*vwap, adv20, 5), 9)) * -1",
+    "columns_required": [
+      "close",
+      "volume",
+      "vwap"
+    ],
+    "extras_required": [],
+    "requires_sector": true,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 32,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_070.py",
+    "id": "alpha101_070",
+    "theme": "momentum,volume",
+    "formula_latex": "(rank(delta(vwap,1))^Ts_Rank(correlation(IndNeutralize(close,industry), adv50, 18), 18)) * -1",
+    "columns_required": [
+      "close",
+      "volume",
+      "vwap"
+    ],
+    "extras_required": [],
+    "requires_sector": true,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 84,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_071.py",
+    "id": "alpha101_071",
+    "theme": "volume,reversal",
+    "formula_latex": "max(Ts_Rank(decay_linear(correlation(Ts_Rank(close,3), Ts_Rank(adv180,12), 18), 4), 16), Ts_Rank(decay_linear((rank((low+open)-(2*vwap))^2, 16), 4))",
+    "columns_required": [
+      "open",
+      "low",
+      "close",
+      "volume",
+      "vwap"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 226,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_072.py",
+    "id": "alpha101_072",
+    "theme": "volume",
+    "formula_latex": "rank(decay_linear(correlation((high+low)/2, adv40, 9), 10)) / rank(decay_linear(correlation(Ts_Rank(vwap,4), Ts_Rank(volume,19), 7), 3))",
+    "columns_required": [
+      "high",
+      "low",
+      "volume",
+      "vwap",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 57,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_073.py",
+    "id": "alpha101_073",
+    "theme": "volume",
+    "formula_latex": "max(rank(decay_linear(delta(vwap,5), 3)), Ts_Rank(decay_linear(-1*(delta(0.147*open+0.853*low,2)/(0.147*open+0.853*low)), 3), 17)) * -1",
+    "columns_required": [
+      "open",
+      "low",
+      "vwap",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 21,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_074.py",
+    "id": "alpha101_074",
+    "theme": "volume",
+    "formula_latex": "(rank(correlation(close, sum(adv30,37), 15)) < rank(correlation(rank(0.026*high+0.974*vwap), rank(volume), 11))) * -1",
+    "columns_required": [
+      "high",
+      "close",
+      "volume",
+      "vwap"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_075.py",
+    "id": "alpha101_075",
+    "theme": "volume",
+    "formula_latex": "rank(correlation(vwap, volume, 4)) < rank(correlation(rank(low), rank(adv50), 12))",
+    "columns_required": [
+      "low",
+      "volume",
+      "vwap",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 61,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_076.py",
+    "id": "alpha101_076",
+    "theme": "volume",
+    "formula_latex": "max(rank(decay_linear(delta(vwap,1),12)), Ts_Rank(decay_linear(Ts_Rank(correlation(IndNeutralize(low, sector), adv81, 8), 20), 17), 19)) * -1",
+    "columns_required": [
+      "low",
+      "volume",
+      "vwap",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": true,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 141,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_077.py",
+    "id": "alpha101_077",
+    "theme": "volume",
+    "formula_latex": "min(rank(decay_linear((high+low)/2 + high - (vwap+high), 20)), rank(decay_linear(correlation((high+low)/2, adv40, 3), 6)))",
+    "columns_required": [
+      "high",
+      "low",
+      "volume",
+      "vwap",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 47,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_078.py",
+    "id": "alpha101_078",
+    "theme": "volume",
+    "formula_latex": "rank(correlation(sum(0.352*low+0.648*vwap, 20), sum(adv40,20), 7))^rank(correlation(rank(vwap), rank(volume), 6))",
+    "columns_required": [
+      "low",
+      "volume",
+      "vwap",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 46,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_079.py",
+    "id": "alpha101_079",
+    "theme": "volume,momentum",
+    "formula_latex": "rank(delta(IndNeutralize(0.607*close+0.393*open, sector), 1)) < rank(correlation(Ts_Rank(vwap,4), Ts_Rank(adv150,9), 15))",
+    "columns_required": [
+      "open",
+      "close",
+      "volume",
+      "vwap"
+    ],
+    "extras_required": [],
+    "requires_sector": true,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 172,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_080.py",
+    "id": "alpha101_080",
+    "theme": "momentum,volume",
+    "formula_latex": "(rank(Sign(delta(IndNeutralize(0.868*open+0.132*high, subindustry),4)))^Ts_Rank(correlation(high,adv10,5),6)) * -1",
+    "columns_required": [
+      "open",
+      "high",
+      "volume",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": true,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 19,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_081.py",
+    "id": "alpha101_081",
+    "theme": "volume",
+    "formula_latex": "(rank(Log(product(rank((rank(correlation(vwap, sum(adv10,50), 8))^4)), 15))) < rank(correlation(rank(vwap), rank(volume), 5))) * -1",
+    "columns_required": [
+      "volume",
+      "vwap",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 70,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_082.py",
+    "id": "alpha101_082",
+    "theme": "volume",
+    "formula_latex": "min(rank(decay_linear(delta(open,1),15)), Ts_Rank(decay_linear(correlation(IndNeutralize(volume, sector), 0.634*open+0.366*open, 17), 7), 13)) * -1",
+    "columns_required": [
+      "open",
+      "volume",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": true,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 35,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_083.py",
+    "id": "alpha101_083",
+    "theme": "volume,volatility",
+    "formula_latex": "(rank(delay((high-low)/(sum(close,5)/5), 2)) * rank(rank(volume))) / (((high-low)/(sum(close,5)/5)) / (vwap-close))",
+    "columns_required": [
+      "high",
+      "low",
+      "close",
+      "volume",
+      "vwap"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 7,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_084.py",
+    "id": "alpha101_084",
+    "theme": "momentum",
+    "formula_latex": "SignedPower(Ts_Rank(vwap-ts_max(vwap,15), 21), delta(close,5))",
+    "columns_required": [
+      "close",
+      "vwap"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 35,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_085.py",
+    "id": "alpha101_085",
+    "theme": "volume",
+    "formula_latex": "rank(correlation(0.877*high+0.123*close, adv30, 10))^rank(correlation(Ts_Rank((high+low)/2,4), Ts_Rank(volume,10), 7))",
+    "columns_required": [
+      "high",
+      "low",
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 39,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_086.py",
+    "id": "alpha101_086",
+    "theme": "volume",
+    "formula_latex": "(Ts_Rank(correlation(close, sum(adv20,15), 6), 20) < rank((open+close) - (vwap+open))) * -1",
+    "columns_required": [
+      "open",
+      "close",
+      "volume",
+      "vwap"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 44,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_087.py",
+    "id": "alpha101_087",
+    "theme": "momentum",
+    "formula_latex": "max(rank(decay_linear(delta(0.37*close+0.63*vwap, 2), 3)), Ts_Rank(decay_linear(abs(correlation(IndNeutralize(adv81, industry), close, 13)), 5), 14)) * -1",
+    "columns_required": [
+      "close",
+      "vwap",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": true,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 110,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_088.py",
+    "id": "alpha101_088",
+    "theme": "volume",
+    "formula_latex": "min(rank(decay_linear((rank(open)+rank(low))-(rank(high)+rank(close)),8)), Ts_Rank(decay_linear(correlation(Ts_Rank(close,8),Ts_Rank(adv60,20),8),7),3))",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 94,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_089.py",
+    "id": "alpha101_089",
+    "theme": "volume,momentum",
+    "formula_latex": "Ts_Rank(decay_linear(correlation(low, adv10, 7), 6), 4) - Ts_Rank(decay_linear(delta(IndNeutralize(vwap, industry),3),10),15)",
+    "columns_required": [
+      "low",
+      "volume",
+      "vwap",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": true,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_090.py",
+    "id": "alpha101_090",
+    "theme": "volume",
+    "formula_latex": "(rank(close-ts_max(close,5))^Ts_Rank(correlation(IndNeutralize(adv40, subindustry), low, 5), 3)) * -1",
+    "columns_required": [
+      "low",
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": true,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 46,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_091.py",
+    "id": "alpha101_091",
+    "theme": "volume",
+    "formula_latex": "(Ts_Rank(decay_linear(decay_linear(correlation(IndNeutralize(close, industry), volume, 10), 16), 4), 5) - rank(decay_linear(correlation(vwap, adv30, 4), 3))) * -1",
+    "columns_required": [
+      "close",
+      "volume",
+      "vwap"
+    ],
+    "extras_required": [],
+    "requires_sector": true,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 35,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_092.py",
+    "id": "alpha101_092",
+    "theme": "volume",
+    "formula_latex": "min(Ts_Rank(decay_linear(((high+low)/2 + close < low+open), 15), 19), Ts_Rank(decay_linear(correlation(rank(low), rank(adv30), 8), 7), 7))",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 49,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_093.py",
+    "id": "alpha101_093",
+    "theme": "volume",
+    "formula_latex": "Ts_Rank(decay_linear(correlation(IndNeutralize(vwap, industry), adv81, 17), 20), 8) / rank(decay_linear(delta(0.524*close+0.476*vwap, 3), 16))",
+    "columns_required": [
+      "close",
+      "volume",
+      "vwap"
+    ],
+    "extras_required": [],
+    "requires_sector": true,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 123,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_094.py",
+    "id": "alpha101_094",
+    "theme": "volume",
+    "formula_latex": "(rank(vwap-ts_min(vwap,12))^Ts_Rank(correlation(Ts_Rank(vwap,20), Ts_Rank(adv60,4), 18), 3)) * -1",
+    "columns_required": [
+      "volume",
+      "vwap",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 82,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_095.py",
+    "id": "alpha101_095",
+    "theme": "volume",
+    "formula_latex": "rank(open-ts_min(open,13)) < Ts_Rank((rank(correlation(sum((high+low)/2,19), sum(adv40,19),13))^5), 12)",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "volume",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 63,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_096.py",
+    "id": "alpha101_096",
+    "theme": "volume",
+    "formula_latex": "max(Ts_Rank(decay_linear(correlation(rank(vwap), rank(volume), 4), 4), 8), Ts_Rank(decay_linear(Ts_ArgMax(correlation(Ts_Rank(close,7), Ts_Rank(adv60,4), 4), 13), 14), 13)) * -1",
+    "columns_required": [
+      "close",
+      "volume",
+      "vwap"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 103,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_097.py",
+    "id": "alpha101_097",
+    "theme": "volume",
+    "formula_latex": "(rank(decay_linear(delta(IndNeutralize(0.721*low+0.279*vwap, industry),3),20)) - Ts_Rank(decay_linear(Ts_Rank(correlation(Ts_Rank(low,8), Ts_Rank(adv60,17), 5), 19), 16),16)) * -1",
+    "columns_required": [
+      "low",
+      "volume",
+      "vwap",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": true,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 128,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_098.py",
+    "id": "alpha101_098",
+    "theme": "volume",
+    "formula_latex": "rank(decay_linear(correlation(vwap, sum(adv5,26), 5), 7)) - rank(decay_linear(Ts_Rank(Ts_ArgMin(correlation(rank(open), rank(adv15), 21), 9), 7), 8))",
+    "columns_required": [
+      "open",
+      "volume",
+      "vwap",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 56,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_099.py",
+    "id": "alpha101_099",
+    "theme": "volume",
+    "formula_latex": "(rank(correlation(sum((high+low)/2, 20), sum(adv60, 20), 9)) < rank(correlation(low, volume, 6))) * -1",
+    "columns_required": [
+      "high",
+      "low",
+      "volume",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 68,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_100.py",
+    "id": "alpha101_100",
+    "theme": "volume,momentum",
+    "formula_latex": "0 - 1*((1.5*scale(IN(IN(rank(((close-low)-(high-close))/(high-low)*volume), subind), subind)) - scale(IN(correlation(close, rank(adv20), 5) - rank(ts_argmin(close,30)), subind))) * (volume/adv20))",
+    "columns_required": [
+      "high",
+      "low",
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": true,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "alpha101",
+    "file": "alpha_101.py",
+    "id": "alpha101_101",
+    "theme": "reversal",
+    "formula_latex": "(close - open) / ((high - low) + 0.001)",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_in"
+    ],
+    "frequency": [
+      "1D"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 1,
+    "error": null
+  },
+  {
+    "zoo": "fundamental",
+    "file": "asset_growth.py",
+    "id": "fund_asset_growth",
+    "theme": "growth",
+    "formula_latex": "-\\mathrm{zscore}_{x}(\\Delta \\mathrm{total\\_assets}_{YoY})",
+    "columns_required": [
+      "fund:asset_growth"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 252,
+    "min_warmup_bars": 1,
+    "error": null
+  },
+  {
+    "zoo": "fundamental",
+    "file": "earnings_yield.py",
+    "id": "fund_earnings_yield",
+    "theme": "value",
+    "formula_latex": "\\mathrm{zscore}_{x}\\left(\\frac{\\mathrm{net\\_income}}{\\mathrm{close}\\times\\mathrm{shares\\_diluted}}\\right)",
+    "columns_required": [
+      "close",
+      "fund:net_income",
+      "fund:shares_diluted"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 252,
+    "min_warmup_bars": 1,
+    "error": null
+  },
+  {
+    "zoo": "fundamental",
+    "file": "gross_profitability.py",
+    "id": "fund_gross_profitability",
+    "theme": "quality",
+    "formula_latex": "\\mathrm{zscore}_{x}(\\mathrm{gross\\_profit}/\\mathrm{total\\_assets})",
+    "columns_required": [
+      "fund:gross_profitability"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 252,
+    "min_warmup_bars": 1,
+    "error": null
+  },
+  {
+    "zoo": "fundamental",
+    "file": "roe.py",
+    "id": "fund_roe",
+    "theme": "quality",
+    "formula_latex": "\\mathrm{zscore}_{x}(\\mathrm{ROE})",
+    "columns_required": [
+      "fund:roe"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 252,
+    "min_warmup_bars": 1,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_001.py",
+    "id": "gtja191_001",
+    "theme": "volume,reversal",
+    "formula_latex": "(-1 * CORR(RANK(DELTA(LOG(VOLUME), 1)), RANK(((CLOSE - OPEN) / OPEN)), 6))",
+    "columns_required": [
+      "volume",
+      "close",
+      "open"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 6,
+    "min_warmup_bars": 7,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_002.py",
+    "id": "gtja191_002",
+    "theme": "reversal,microstructure",
+    "formula_latex": "(-1 * DELTA(((CLOSE - LOW) - (HIGH - CLOSE)) / (HIGH - LOW), 1))",
+    "columns_required": [
+      "close",
+      "high",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 1,
+    "min_warmup_bars": 2,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_003.py",
+    "id": "gtja191_003",
+    "theme": "momentum",
+    "formula_latex": "SUM((CLOSE=DELAY(CLOSE,1)?0:CLOSE-(CLOSE>DELAY(CLOSE,1)?MIN(LOW,DELAY(CLOSE,1)):MAX(HIGH,DELAY(CLOSE,1)))),6)",
+    "columns_required": [
+      "close",
+      "high",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 6,
+    "min_warmup_bars": 7,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_004.py",
+    "id": "gtja191_004",
+    "theme": "momentum,volume",
+    "formula_latex": "((((SUM(CLOSE,8)/8)+STD(CLOSE,8))<(SUM(CLOSE,2)/2))?(-1):((SUM(CLOSE,2)/2<(SUM(CLOSE,8)/8-STD(CLOSE,8)))?1:((1<(VOLUME/MEAN(VOLUME,20)))?1:(-1))))",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 8,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_005.py",
+    "id": "gtja191_005",
+    "theme": "volume",
+    "formula_latex": "(-1 * TSMAX(CORR(TSRANK(VOLUME,5), TSRANK(HIGH,5), 5), 3))",
+    "columns_required": [
+      "volume",
+      "high"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 13,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_006.py",
+    "id": "gtja191_006",
+    "theme": "reversal",
+    "formula_latex": "(RANK(SIGN(DELTA((OPEN*0.85+HIGH*0.15), 4))) * -1)",
+    "columns_required": [
+      "open",
+      "high"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 4,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_007.py",
+    "id": "gtja191_007",
+    "theme": "volume,microstructure",
+    "formula_latex": "((RANK(MAX((VWAP-CLOSE),3)) + RANK(MIN((VWAP-CLOSE),3))) * RANK(DELTA(VOLUME,3)))",
+    "columns_required": [
+      "close",
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 3,
+    "min_warmup_bars": 4,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_008.py",
+    "id": "gtja191_008",
+    "theme": "reversal",
+    "formula_latex": "RANK(DELTA(((HIGH+LOW)/2)*0.2 + VWAP*0.8, 4)) * -1",
+    "columns_required": [
+      "high",
+      "low",
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 4,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_009.py",
+    "id": "gtja191_009",
+    "theme": "volume,microstructure",
+    "formula_latex": "SMA(((HIGH+LOW)/2-(DELAY(HIGH,1)+DELAY(LOW,1))/2)*(HIGH-LOW)/VOLUME,7,2)",
+    "columns_required": [
+      "high",
+      "low",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 7,
+    "min_warmup_bars": 8,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_010.py",
+    "id": "gtja191_010",
+    "theme": "volatility,reversal",
+    "formula_latex": "RANK(MAX(((RET<0)?STD(RET,20):CLOSE)^2,5))",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 21,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_011.py",
+    "id": "gtja191_011",
+    "theme": "volume,microstructure",
+    "formula_latex": "SUM(((CLOSE-LOW)-(HIGH-CLOSE))/(HIGH-LOW)*VOLUME,6)",
+    "columns_required": [
+      "close",
+      "high",
+      "low",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 6,
+    "min_warmup_bars": 7,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_012.py",
+    "id": "gtja191_012",
+    "theme": "reversal,microstructure",
+    "formula_latex": "(RANK((OPEN - (SUM(VWAP,10)/10))) * (-1 * RANK(ABS((CLOSE - VWAP)))))",
+    "columns_required": [
+      "open",
+      "close",
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 11,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_013.py",
+    "id": "gtja191_013",
+    "theme": "microstructure",
+    "formula_latex": "(((HIGH*LOW)^0.5) - VWAP)",
+    "columns_required": [
+      "high",
+      "low",
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 1,
+    "min_warmup_bars": 1,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_014.py",
+    "id": "gtja191_014",
+    "theme": "momentum",
+    "formula_latex": "CLOSE - DELAY(CLOSE,5)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 6,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_015.py",
+    "id": "gtja191_015",
+    "theme": "reversal",
+    "formula_latex": "(OPEN/DELAY(CLOSE,1) - 1)",
+    "columns_required": [
+      "open",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 1,
+    "min_warmup_bars": 2,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_016.py",
+    "id": "gtja191_016",
+    "theme": "volume,microstructure",
+    "formula_latex": "(-1 * TSMAX(RANK(CORR(RANK(VOLUME), RANK(VWAP), 5)), 5))",
+    "columns_required": [
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 11,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_017.py",
+    "id": "gtja191_017",
+    "theme": "reversal",
+    "formula_latex": "(RANK(VWAP - MAX(VWAP,15))^DELTA(CLOSE,5))",
+    "columns_required": [
+      "close",
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 15,
+    "min_warmup_bars": 16,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_018.py",
+    "id": "gtja191_018",
+    "theme": "momentum",
+    "formula_latex": "CLOSE/DELAY(CLOSE,5)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 6,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_019.py",
+    "id": "gtja191_019",
+    "theme": "reversal",
+    "formula_latex": "(CLOSE<DELAY(CLOSE,5)?(CLOSE-DELAY(CLOSE,5))/DELAY(CLOSE,5):(CLOSE=DELAY(CLOSE,5)?0:(CLOSE-DELAY(CLOSE,5))/CLOSE))",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 6,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_020.py",
+    "id": "gtja191_020",
+    "theme": "momentum",
+    "formula_latex": "((CLOSE-DELAY(CLOSE,6))/DELAY(CLOSE,6))*100",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 6,
+    "min_warmup_bars": 7,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_021.py",
+    "id": "gtja191_021",
+    "theme": "momentum",
+    "formula_latex": "REGBETA(MEAN(CLOSE,6), SEQUENCE(6))",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 6,
+    "min_warmup_bars": 12,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_022.py",
+    "id": "gtja191_022",
+    "theme": "reversal",
+    "formula_latex": "SMA(((CLOSE-MEAN(CLOSE,6))/MEAN(CLOSE,6) - DELAY((CLOSE-MEAN(CLOSE,6))/MEAN(CLOSE,6),3)),12,1)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 12,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_023.py",
+    "id": "gtja191_023",
+    "theme": "volatility",
+    "formula_latex": "SMA((CLOSE>DELAY(CLOSE,1)?STD(CLOSE,20):0),20,1)/(SMA((CLOSE>DELAY(CLOSE,1)?STD(CLOSE,20):0),20,1) + SMA((CLOSE<=DELAY(CLOSE,1)?STD(CLOSE,20):0),20,1)) * 100",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 22,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_024.py",
+    "id": "gtja191_024",
+    "theme": "momentum",
+    "formula_latex": "SMA(CLOSE-DELAY(CLOSE,5),5,1)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 6,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_025.py",
+    "id": "gtja191_025",
+    "theme": "momentum,volume",
+    "formula_latex": "((-1*RANK((DELTA(CLOSE,7)*(1-RANK(DECAYLINEAR((VOLUME/MEAN(VOLUME,20)),9))))))*(1+RANK(SUM(RET,250))))",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 9,
+    "min_warmup_bars": 61,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_026.py",
+    "id": "gtja191_026",
+    "theme": "momentum,microstructure",
+    "formula_latex": "((((SUM(CLOSE,7)/7)-CLOSE))+((CORR(VWAP,DELAY(CLOSE,5),230))))",
+    "columns_required": [
+      "close",
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 7,
+    "min_warmup_bars": 35,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_027.py",
+    "id": "gtja191_027",
+    "theme": "momentum",
+    "formula_latex": "WMA((CLOSE-DELAY(CLOSE,3))/DELAY(CLOSE,3)*100 + (CLOSE-DELAY(CLOSE,6))/DELAY(CLOSE,6)*100, 12)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 12,
+    "min_warmup_bars": 18,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_028.py",
+    "id": "gtja191_028",
+    "theme": "momentum",
+    "formula_latex": "3*SMA((CLOSE-TSMIN(LOW,9))/(TSMAX(HIGH,9)-TSMIN(LOW,9))*100,3,1)-2*SMA(SMA((CLOSE-TSMIN(LOW,9))/(TSMAX(HIGH,9)-TSMIN(LOW,9))*100,3,1),3,1)",
+    "columns_required": [
+      "close",
+      "high",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 9,
+    "min_warmup_bars": 12,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_029.py",
+    "id": "gtja191_029",
+    "theme": "momentum,volume",
+    "formula_latex": "(CLOSE-DELAY(CLOSE,6))/DELAY(CLOSE,6)*VOLUME",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 6,
+    "min_warmup_bars": 7,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_030.py",
+    "id": "gtja191_030",
+    "theme": "volatility",
+    "formula_latex": "WMA((REGRESI(CLOSE/DELAY(CLOSE,1)-1, MKT_RET, SMB, HML, 60))^2, 20)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 21,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_031.py",
+    "id": "gtja191_031",
+    "theme": "reversal",
+    "formula_latex": "(CLOSE-MEAN(CLOSE,12))/MEAN(CLOSE,12)*100",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 12,
+    "min_warmup_bars": 13,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_032.py",
+    "id": "gtja191_032",
+    "theme": "volume",
+    "formula_latex": "(-1 * SUM(RANK(CORR(RANK(HIGH), RANK(VOLUME), 3)), 3))",
+    "columns_required": [
+      "high",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 3,
+    "min_warmup_bars": 7,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_033.py",
+    "id": "gtja191_033",
+    "theme": "momentum,volume",
+    "formula_latex": "((((-1*TSMIN(LOW,5))+DELAY(TSMIN(LOW,5),5))*RANK(((SUM(RET,240)-SUM(RET,20))/220)))*TSRANK(VOLUME,5))",
+    "columns_required": [
+      "low",
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 61,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_034.py",
+    "id": "gtja191_034",
+    "theme": "reversal",
+    "formula_latex": "MEAN(CLOSE,12)/CLOSE",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 12,
+    "min_warmup_bars": 13,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_035.py",
+    "id": "gtja191_035",
+    "theme": "volume",
+    "formula_latex": "(MIN(RANK(DECAYLINEAR(DELTA(OPEN,1),15)), RANK(DECAYLINEAR(CORR(VOLUME,((OPEN*0.65)+(OPEN*0.35)),17),7))) * -1)",
+    "columns_required": [
+      "open",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 15,
+    "min_warmup_bars": 25,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_036.py",
+    "id": "gtja191_036",
+    "theme": "volume",
+    "formula_latex": "RANK(SUM(CORR(RANK(VOLUME), RANK(VWAP), 6), 2))",
+    "columns_required": [
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 6,
+    "min_warmup_bars": 8,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_037.py",
+    "id": "gtja191_037",
+    "theme": "momentum",
+    "formula_latex": "(-1*RANK(((SUM(OPEN,5)*SUM(RET,5))-DELAY((SUM(OPEN,5)*SUM(RET,5)),10))))",
+    "columns_required": [
+      "open",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 16,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_038.py",
+    "id": "gtja191_038",
+    "theme": "reversal",
+    "formula_latex": "(((SUM(HIGH,20)/20)<HIGH)?(-1*DELTA(HIGH,2)):0)",
+    "columns_required": [
+      "high"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 21,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_039.py",
+    "id": "gtja191_039",
+    "theme": "volume",
+    "formula_latex": "((RANK(DECAYLINEAR(DELTA(CLOSE,2),8)) - RANK(DECAYLINEAR(CORR(((VWAP*0.3)+(OPEN*0.7)),SUM(MEAN(VOLUME,180),37),14),12)))*-1)",
+    "columns_required": [
+      "close",
+      "open",
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 14,
+    "min_warmup_bars": 63,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_040.py",
+    "id": "gtja191_040",
+    "theme": "volume",
+    "formula_latex": "SUM((CLOSE>DELAY(CLOSE,1)?VOLUME:0),26)/SUM((CLOSE<=DELAY(CLOSE,1)?VOLUME:0),26)*100",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 26,
+    "min_warmup_bars": 27,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_041.py",
+    "id": "gtja191_041",
+    "theme": "microstructure",
+    "formula_latex": "(RANK(MAX(DELTA(VWAP,3),5))*-1)",
+    "columns_required": [
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 9,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_042.py",
+    "id": "gtja191_042",
+    "theme": "volume,volatility",
+    "formula_latex": "((-1*RANK(STD(HIGH,10)))*CORR(HIGH,VOLUME,10))",
+    "columns_required": [
+      "high",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 11,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_043.py",
+    "id": "gtja191_043",
+    "theme": "volume,momentum",
+    "formula_latex": "SUM((CLOSE>DELAY(CLOSE,1)?VOLUME:(CLOSE<DELAY(CLOSE,1)?-VOLUME:0)),6)",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 6,
+    "min_warmup_bars": 7,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_044.py",
+    "id": "gtja191_044",
+    "theme": "volume",
+    "formula_latex": "(TSRANK(DECAYLINEAR(CORR(LOW,MEAN(VOLUME,10),7),6),4)+TSRANK(DECAYLINEAR(DELTA(VWAP,3),10),15))",
+    "columns_required": [
+      "low",
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 27,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_045.py",
+    "id": "gtja191_045",
+    "theme": "volume",
+    "formula_latex": "(RANK(DELTA((((CLOSE*0.6)+(OPEN*0.4))),1)) * RANK(CORR(VWAP,MEAN(VOLUME,150),15)))",
+    "columns_required": [
+      "close",
+      "open",
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 15,
+    "min_warmup_bars": 44,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_046.py",
+    "id": "gtja191_046",
+    "theme": "reversal",
+    "formula_latex": "(MEAN(CLOSE,3)+MEAN(CLOSE,6)+MEAN(CLOSE,12)+MEAN(CLOSE,24))/(4*CLOSE)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 24,
+    "min_warmup_bars": 25,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_047.py",
+    "id": "gtja191_047",
+    "theme": "reversal",
+    "formula_latex": "SMA((TSMAX(HIGH,6)-CLOSE)/(TSMAX(HIGH,6)-TSMIN(LOW,6))*100,9,1)",
+    "columns_required": [
+      "close",
+      "high",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 9,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_048.py",
+    "id": "gtja191_048",
+    "theme": "volume,momentum",
+    "formula_latex": "-1*((RANK((SIGN((CLOSE-DELAY(CLOSE,1)))+SIGN((DELAY(CLOSE,1)-DELAY(CLOSE,2)))+SIGN((DELAY(CLOSE,2)-DELAY(CLOSE,3))))))*SUM(VOLUME,5))/SUM(VOLUME,20)",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 21,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_049.py",
+    "id": "gtja191_049",
+    "theme": "reversal",
+    "formula_latex": "SUM(((HIGH+LOW)>=(DELAY(HIGH,1)+DELAY(LOW,1))?0:MAX(ABS(HIGH-DELAY(HIGH,1)),ABS(LOW-DELAY(LOW,1)))),12)/(SUM(...,12)+SUM(...,12))",
+    "columns_required": [
+      "high",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 12,
+    "min_warmup_bars": 13,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_050.py",
+    "id": "gtja191_050",
+    "theme": "reversal",
+    "formula_latex": "SUM(up_move,12)/(SUM(up_move,12)+SUM(dn_move,12)) - SUM(dn_move,12)/(SUM(up_move,12)+SUM(dn_move,12))",
+    "columns_required": [
+      "high",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 12,
+    "min_warmup_bars": 13,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_051.py",
+    "id": "gtja191_051",
+    "theme": "reversal",
+    "formula_latex": "SUM(up_move,12)/(SUM(up_move,12)+SUM(dn_move,12))",
+    "columns_required": [
+      "high",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 12,
+    "min_warmup_bars": 13,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_052.py",
+    "id": "gtja191_052",
+    "theme": "microstructure",
+    "formula_latex": "SUM(MAX(0,HIGH-DELAY((HIGH+LOW+CLOSE)/3,1)),26) / SUM(MAX(0,DELAY((HIGH+LOW+CLOSE)/3,1)-LOW),26) * 100",
+    "columns_required": [
+      "high",
+      "low",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 26,
+    "min_warmup_bars": 27,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_053.py",
+    "id": "gtja191_053",
+    "theme": "momentum",
+    "formula_latex": "COUNT(CLOSE>DELAY(CLOSE,1),12)/12*100",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 12,
+    "min_warmup_bars": 13,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_054.py",
+    "id": "gtja191_054",
+    "theme": "volatility,microstructure",
+    "formula_latex": "((-1*RANK((STD(ABS(CLOSE-OPEN),10)+(CLOSE-OPEN))+CORR(CLOSE,OPEN,10))))",
+    "columns_required": [
+      "close",
+      "open"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 11,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_055.py",
+    "id": "gtja191_055",
+    "theme": "microstructure",
+    "formula_latex": "SUM(16*(CLOSE-DELAY(CLOSE,1)+(CLOSE-OPEN)/2+DELAY(CLOSE,1)-DELAY(OPEN,1))/((ABS(HIGH-DELAY(CLOSE,1))>ABS(LOW-DELAY(CLOSE,1)) && ABS(HIGH-DELAY(CLOSE,1))>ABS(HIGH-DELAY(LOW,1))?ABS(HIGH-DELAY(CLOSE,1))",
+    "columns_required": [
+      "close",
+      "high",
+      "low",
+      "open"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 22,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_056.py",
+    "id": "gtja191_056",
+    "theme": "volume",
+    "formula_latex": "(RANK(OPEN-TSMIN(OPEN,12)) < RANK((RANK(CORR(SUM(((HIGH+LOW)/2),19),SUM(MEAN(VOLUME,40),19),13))^5)))",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 19,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_057.py",
+    "id": "gtja191_057",
+    "theme": "momentum",
+    "formula_latex": "SMA((CLOSE-TSMIN(LOW,9))/(TSMAX(HIGH,9)-TSMIN(LOW,9))*100,3,1)",
+    "columns_required": [
+      "close",
+      "high",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 9,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_058.py",
+    "id": "gtja191_058",
+    "theme": "momentum",
+    "formula_latex": "COUNT(CLOSE>DELAY(CLOSE,1),20)/20*100",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 21,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_059.py",
+    "id": "gtja191_059",
+    "theme": "momentum",
+    "formula_latex": "SUM((CLOSE=DELAY(CLOSE,1)?0:CLOSE-(CLOSE>DELAY(CLOSE,1)?MIN(LOW,DELAY(CLOSE,1)):MAX(HIGH,DELAY(CLOSE,1)))),20)",
+    "columns_required": [
+      "close",
+      "high",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 22,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_060.py",
+    "id": "gtja191_060",
+    "theme": "volume,microstructure",
+    "formula_latex": "SUM(((CLOSE-LOW)-(HIGH-CLOSE))/(HIGH-LOW)*VOLUME, 20)",
+    "columns_required": [
+      "close",
+      "high",
+      "low",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 21,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_061.py",
+    "id": "gtja191_061",
+    "theme": "volume",
+    "formula_latex": "(MAX(RANK(DECAYLINEAR(DELTA(VWAP,1),12)), RANK(DECAYLINEAR(RANK(CORR(LOW,MEAN(VOLUME,80),8)),17))) * -1)",
+    "columns_required": [
+      "volume",
+      "amount",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 17,
+    "min_warmup_bars": 53,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_062.py",
+    "id": "gtja191_062",
+    "theme": "volume",
+    "formula_latex": "((-1*CORR(HIGH,RANK(VOLUME),5)))",
+    "columns_required": [
+      "high",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 6,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_063.py",
+    "id": "gtja191_063",
+    "theme": "momentum",
+    "formula_latex": "SMA(MAX(CLOSE-DELAY(CLOSE,1),0),6,1)/SMA(ABS(CLOSE-DELAY(CLOSE,1)),6,1)*100",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 6,
+    "min_warmup_bars": 7,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_064.py",
+    "id": "gtja191_064",
+    "theme": "volume",
+    "formula_latex": "(MAX(RANK(DECAYLINEAR(CORR(RANK(VWAP),RANK(VOLUME),4),4)),RANK(DECAYLINEAR(MAX(CORR(RANK(CLOSE),RANK(MEAN(VOLUME,60)),4),13),14)))*-1)",
+    "columns_required": [
+      "close",
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 14,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_065.py",
+    "id": "gtja191_065",
+    "theme": "reversal",
+    "formula_latex": "MEAN(CLOSE,6)/CLOSE",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 6,
+    "min_warmup_bars": 7,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_066.py",
+    "id": "gtja191_066",
+    "theme": "reversal",
+    "formula_latex": "(CLOSE-MEAN(CLOSE,6))/MEAN(CLOSE,6)*100",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 6,
+    "min_warmup_bars": 7,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_067.py",
+    "id": "gtja191_067",
+    "theme": "momentum",
+    "formula_latex": "SMA(MAX(CLOSE-DELAY(CLOSE,1),0),24,1)/SMA(ABS(CLOSE-DELAY(CLOSE,1)),24,1)*100",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 24,
+    "min_warmup_bars": 25,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_068.py",
+    "id": "gtja191_068",
+    "theme": "volume",
+    "formula_latex": "SMA(((HIGH+LOW)/2-(DELAY(HIGH,1)+DELAY(LOW,1))/2)*(HIGH-LOW)/VOLUME,15,2)",
+    "columns_required": [
+      "high",
+      "low",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 15,
+    "min_warmup_bars": 16,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_069.py",
+    "id": "gtja191_069",
+    "theme": "microstructure",
+    "formula_latex": "(SUM(DTM,20)>SUM(DBM,20)?(SUM(DTM,20)-SUM(DBM,20))/SUM(DTM,20):(SUM(DTM,20)=SUM(DBM,20)?0:(SUM(DTM,20)-SUM(DBM,20))/SUM(DBM,20)))",
+    "columns_required": [
+      "open",
+      "high",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 22,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_070.py",
+    "id": "gtja191_070",
+    "theme": "volatility,volume",
+    "formula_latex": "STD(AMOUNT,6)",
+    "columns_required": [
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 6,
+    "min_warmup_bars": 7,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_071.py",
+    "id": "gtja191_071",
+    "theme": "reversal",
+    "formula_latex": "(CLOSE-MEAN(CLOSE,24))/MEAN(CLOSE,24)*100",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 24,
+    "min_warmup_bars": 25,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_072.py",
+    "id": "gtja191_072",
+    "theme": "reversal",
+    "formula_latex": "SMA((TSMAX(HIGH,6)-CLOSE)/(TSMAX(HIGH,6)-TSMIN(LOW,6))*100,15,1)",
+    "columns_required": [
+      "close",
+      "high",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 15,
+    "min_warmup_bars": 16,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_073.py",
+    "id": "gtja191_073",
+    "theme": "volume",
+    "formula_latex": "((TSRANK(DECAYLINEAR(DECAYLINEAR(CORR((CLOSE),VOLUME,10),16),4),5) - RANK(DECAYLINEAR(CORR(VWAP,MEAN(VOLUME,30),4),3))) * -1)",
+    "columns_required": [
+      "close",
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 16,
+    "min_warmup_bars": 35,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_074.py",
+    "id": "gtja191_074",
+    "theme": "volume",
+    "formula_latex": "(RANK(CORR(SUM(((LOW*0.35)+(VWAP*0.65)),20),SUM(MEAN(VOLUME,40),20),7)) + RANK(CORR(RANK(VWAP),RANK(VOLUME),6)))",
+    "columns_required": [
+      "low",
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_075.py",
+    "id": "gtja191_075",
+    "theme": "sentiment,momentum",
+    "formula_latex": "COUNT((CLOSE>OPEN & BENCHMARKINDEXCLOSE<DELAY(BENCHMARKINDEXCLOSE,1)),50)/COUNT(BENCHMARKINDEXCLOSE<DELAY(BENCHMARKINDEXCLOSE,1),50)",
+    "columns_required": [
+      "close",
+      "open"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 50,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_076.py",
+    "id": "gtja191_076",
+    "theme": "volatility,volume",
+    "formula_latex": "STD(ABS((CLOSE/DELAY(CLOSE,1)-1))/VOLUME,20)/MEAN(ABS((CLOSE/DELAY(CLOSE,1)-1))/VOLUME,20)",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 22,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_077.py",
+    "id": "gtja191_077",
+    "theme": "volume",
+    "formula_latex": "MIN(RANK(DECAYLINEAR(((HIGH+LOW)/2+HIGH-(VWAP+HIGH)),20)),RANK(DECAYLINEAR(CORR(((HIGH+LOW)/2),MEAN(VOLUME,40),3),6)))",
+    "columns_required": [
+      "high",
+      "low",
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 37,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_078.py",
+    "id": "gtja191_078",
+    "theme": "reversal",
+    "formula_latex": "((HIGH+LOW+CLOSE)/3-MA((HIGH+LOW+CLOSE)/3,12))/(0.015*MEAN(ABS(CLOSE-MA((HIGH+LOW+CLOSE)/3,12)),12))",
+    "columns_required": [
+      "high",
+      "low",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 12,
+    "min_warmup_bars": 23,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_079.py",
+    "id": "gtja191_079",
+    "theme": "momentum",
+    "formula_latex": "SMA(MAX(CLOSE-DELAY(CLOSE,1),0),12,1)/SMA(ABS(CLOSE-DELAY(CLOSE,1)),12,1)*100",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 12,
+    "min_warmup_bars": 13,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_080.py",
+    "id": "gtja191_080",
+    "theme": "volume",
+    "formula_latex": "(VOLUME-DELAY(VOLUME,5))/DELAY(VOLUME,5)*100",
+    "columns_required": [
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 6,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_081.py",
+    "id": "gtja191_081",
+    "theme": "volume",
+    "formula_latex": "SMA(VOLUME,21,2)",
+    "columns_required": [
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 21,
+    "min_warmup_bars": 22,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_082.py",
+    "id": "gtja191_082",
+    "theme": "reversal",
+    "formula_latex": "SMA((TSMAX(HIGH,6)-CLOSE)/(TSMAX(HIGH,6)-TSMIN(LOW,6))*100,20,1)",
+    "columns_required": [
+      "close",
+      "high",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 21,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_083.py",
+    "id": "gtja191_083",
+    "theme": "volume",
+    "formula_latex": "(-1*RANK(COVIANCE(RANK(HIGH),RANK(VOLUME),5)))",
+    "columns_required": [
+      "high",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 6,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_084.py",
+    "id": "gtja191_084",
+    "theme": "volume,momentum",
+    "formula_latex": "SUM(CLOSE>DELAY(CLOSE,1)?VOLUME:(CLOSE<DELAY(CLOSE,1)?-VOLUME:0),20)",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 21,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_085.py",
+    "id": "gtja191_085",
+    "theme": "volume,momentum",
+    "formula_latex": "(TSRANK((VOLUME/MEAN(VOLUME,20)),20)*TSRANK((-1*DELTA(CLOSE,7)),8))",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 39,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_086.py",
+    "id": "gtja191_086",
+    "theme": "momentum",
+    "formula_latex": "((0.25 < (((DELAY(CLOSE,20)-DELAY(CLOSE,10))/10) - ((DELAY(CLOSE,10)-CLOSE)/10))) ? -1 : (((((DELAY(CLOSE,20)-DELAY(CLOSE,10))/10) - ((DELAY(CLOSE,10)-CLOSE)/10)) < 0) ? 1 : (-1*(CLOSE-DELAY(CLOSE,1))",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 22,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_087.py",
+    "id": "gtja191_087",
+    "theme": "microstructure",
+    "formula_latex": "((RANK(DECAYLINEAR(DELTA(VWAP,4),7))+TSRANK(DECAYLINEAR((((LOW*0.9)+(LOW*0.1))-VWAP)/(OPEN-((HIGH+LOW)/2)),11),7))*-1)",
+    "columns_required": [
+      "close",
+      "open",
+      "high",
+      "low",
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 11,
+    "min_warmup_bars": 22,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_088.py",
+    "id": "gtja191_088",
+    "theme": "momentum",
+    "formula_latex": "(CLOSE-DELAY(CLOSE,20))/DELAY(CLOSE,20)*100",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 21,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_089.py",
+    "id": "gtja191_089",
+    "theme": "momentum",
+    "formula_latex": "2*(SMA(CLOSE,13,2)-SMA(CLOSE,27,2)-SMA(SMA(CLOSE,13,2)-SMA(CLOSE,27,2),10,2))",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 27,
+    "min_warmup_bars": 28,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_090.py",
+    "id": "gtja191_090",
+    "theme": "volume",
+    "formula_latex": "((-1*RANK(CORR(RANK(VWAP),RANK(VOLUME),5))))",
+    "columns_required": [
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 6,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_091.py",
+    "id": "gtja191_091",
+    "theme": "volume,reversal",
+    "formula_latex": "((-1*RANK((CLOSE-MAX(CLOSE,5))))*RANK(CORR(MEAN(VOLUME,40),LOW,5)))",
+    "columns_required": [
+      "close",
+      "low",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 35,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_092.py",
+    "id": "gtja191_092",
+    "theme": "volume",
+    "formula_latex": "(MAX(RANK(DECAYLINEAR(DELTA(((CLOSE*0.35)+(VWAP*0.65)),2),3)),TSRANK(DECAYLINEAR(ABS(CORR(MEAN(VOLUME,180),CLOSE,13)),5),15))*-1)",
+    "columns_required": [
+      "close",
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 15,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_093.py",
+    "id": "gtja191_093",
+    "theme": "microstructure",
+    "formula_latex": "SUM((OPEN>=DELAY(OPEN,1)?0:MAX(OPEN-LOW,OPEN-DELAY(OPEN,1))),20)",
+    "columns_required": [
+      "open",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 22,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_094.py",
+    "id": "gtja191_094",
+    "theme": "volume,momentum",
+    "formula_latex": "SUM(CLOSE>DELAY(CLOSE,1)?VOLUME:(CLOSE<DELAY(CLOSE,1)?-VOLUME:0),30)",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 31,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_095.py",
+    "id": "gtja191_095",
+    "theme": "volatility,volume",
+    "formula_latex": "STD(AMOUNT,20)",
+    "columns_required": [
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 21,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_096.py",
+    "id": "gtja191_096",
+    "theme": "momentum",
+    "formula_latex": "SMA(SMA((CLOSE-TSMIN(LOW,9))/(TSMAX(HIGH,9)-TSMIN(LOW,9))*100,3,1),3,1)",
+    "columns_required": [
+      "close",
+      "high",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 9,
+    "min_warmup_bars": 12,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_097.py",
+    "id": "gtja191_097",
+    "theme": "volatility,volume",
+    "formula_latex": "STD(VOLUME,10)",
+    "columns_required": [
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 11,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_098.py",
+    "id": "gtja191_098",
+    "theme": "reversal",
+    "formula_latex": "((((DELTA((SUM(CLOSE,100)/100),100)/DELAY(CLOSE,100))<0.05) || ((DELTA((SUM(CLOSE,100)/100),100)/DELAY(CLOSE,100))==0.05)) ? (-1*(CLOSE-TSMIN(CLOSE,100))) : (-1*DELTA(CLOSE,3)))",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_099.py",
+    "id": "gtja191_099",
+    "theme": "volume",
+    "formula_latex": "(-1*RANK(COVIANCE(RANK(CLOSE),RANK(VOLUME),5)))",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 6,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_100.py",
+    "id": "gtja191_100",
+    "theme": "volatility,volume",
+    "formula_latex": "STD(VOLUME,20)",
+    "columns_required": [
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 21,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_101.py",
+    "id": "gtja191_101",
+    "theme": "volume,momentum",
+    "formula_latex": "((rank(ts\\_corr(close, sum(ts\\_mean(volume,30),37), 15)) < rank(ts\\_corr(rank(high), rank(ts\\_mean(volume,10)), 11))) * -1)",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close",
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 15,
+    "min_warmup_bars": 80,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_102.py",
+    "id": "gtja191_102",
+    "theme": "volume",
+    "formula_latex": "sma(max(volume-delay(volume,1),0),6,1)/sma(abs(volume-delay(volume,1)),6,1)*100",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 6,
+    "min_warmup_bars": 7,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_103.py",
+    "id": "gtja191_103",
+    "theme": "reversal",
+    "formula_latex": "((20-lowday(low,20))/20)*100",
+    "columns_required": [
+      "close",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_104.py",
+    "id": "gtja191_104",
+    "theme": "volume,volatility",
+    "formula_latex": "-1*delta(corr(high,volume,5),5)*rank(std(close,20))",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 25,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_105.py",
+    "id": "gtja191_105",
+    "theme": "volume",
+    "formula_latex": "-1*corr(rank(open),rank(volume),10)",
+    "columns_required": [
+      "open",
+      "volume",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_106.py",
+    "id": "gtja191_106",
+    "theme": "momentum",
+    "formula_latex": "close-delay(close,20)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 21,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_107.py",
+    "id": "gtja191_107",
+    "theme": "reversal",
+    "formula_latex": "-1*rank(open-delay(high,1))*rank(open-delay(close,1))*rank(open-delay(low,1))",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 1,
+    "min_warmup_bars": 2,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_108.py",
+    "id": "gtja191_108",
+    "theme": "reversal,volume",
+    "formula_latex": "(rank(high-min(high,2))^rank(corr(vwap,mean(volume,120),6)))*-1",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close",
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 6,
+    "min_warmup_bars": 125,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_109.py",
+    "id": "gtja191_109",
+    "theme": "volatility",
+    "formula_latex": "sma(high-low,10,2)/sma(sma(high-low,10,2),10,2)",
+    "columns_required": [
+      "close",
+      "high",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_110.py",
+    "id": "gtja191_110",
+    "theme": "momentum",
+    "formula_latex": "sum(max(0,high-delay(close,1)),20)/sum(max(0,delay(close,1)-low),20)*100",
+    "columns_required": [
+      "close",
+      "high",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 21,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_111.py",
+    "id": "gtja191_111",
+    "theme": "volume,microstructure",
+    "formula_latex": "sma(v*((c-l)-(h-c))/(h-l),11,2)-sma(v*((c-l)-(h-c))/(h-l),4,2)",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 11,
+    "min_warmup_bars": 12,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_112.py",
+    "id": "gtja191_112",
+    "theme": "momentum",
+    "formula_latex": "(sum_up(12)-sum_down(12))/(sum_up(12)+sum_down(12))*100",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 12,
+    "min_warmup_bars": 13,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_113.py",
+    "id": "gtja191_113",
+    "theme": "volume",
+    "formula_latex": "-1*(rank(mean(delay(c,5),20))*corr(c,v,2))*rank(corr(sum(c,5),sum(c,20),2))",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 27,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_114.py",
+    "id": "gtja191_114",
+    "theme": "volume,volatility",
+    "formula_latex": "see body",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close",
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 7,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_115.py",
+    "id": "gtja191_115",
+    "theme": "volume",
+    "formula_latex": "rank(corr(0.9h+0.1c,mean(v,30),10))^rank(corr(tsrank((h+l)/2,4),tsrank(v,10),7))",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 40,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_116.py",
+    "id": "gtja191_116",
+    "theme": "momentum",
+    "formula_latex": "regbeta(close,sequence(20),20)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_117.py",
+    "id": "gtja191_117",
+    "theme": "volume,momentum",
+    "formula_latex": "tsrank(v,32)*(1-tsrank(c+h-l,16))*(1-tsrank(ret,32))",
+    "columns_required": [
+      "close",
+      "high",
+      "low",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 32,
+    "min_warmup_bars": 33,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_118.py",
+    "id": "gtja191_118",
+    "theme": "reversal",
+    "formula_latex": "sum(h-o,20)/sum(o-l,20)*100",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_119.py",
+    "id": "gtja191_119",
+    "theme": "volume",
+    "formula_latex": "see body",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close",
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 26,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_120.py",
+    "id": "gtja191_120",
+    "theme": "reversal",
+    "formula_latex": "rank(vwap-close)/rank(vwap+close)",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close",
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 1,
+    "min_warmup_bars": 1,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_121.py",
+    "id": "gtja191_121",
+    "theme": "volume",
+    "formula_latex": "see body",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close",
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 80,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_122.py",
+    "id": "gtja191_122",
+    "theme": "momentum",
+    "formula_latex": "see body",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 13,
+    "min_warmup_bars": 40,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_123.py",
+    "id": "gtja191_123",
+    "theme": "volume",
+    "formula_latex": "see body",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 90,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_124.py",
+    "id": "gtja191_124",
+    "theme": "reversal",
+    "formula_latex": "(close-vwap)/decay_linear(rank(tsmax(close,30)),2)",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close",
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 32,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_125.py",
+    "id": "gtja191_125",
+    "theme": "volume",
+    "formula_latex": "see body",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close",
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 120,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_126.py",
+    "id": "gtja191_126",
+    "theme": "reversal",
+    "formula_latex": "(c+h+l)/3",
+    "columns_required": [
+      "close",
+      "high",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 1,
+    "min_warmup_bars": 1,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_127.py",
+    "id": "gtja191_127",
+    "theme": "volatility",
+    "formula_latex": "sqrt(mean((100*(c-tsmax(c,12))/tsmax(c,12))^2,12))",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 12,
+    "min_warmup_bars": 24,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_128.py",
+    "id": "gtja191_128",
+    "theme": "momentum",
+    "formula_latex": "see body",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 14,
+    "min_warmup_bars": 16,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_129.py",
+    "id": "gtja191_129",
+    "theme": "momentum",
+    "formula_latex": "sum(abs(c-delay(c,1)) if dc<0 else 0,12)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 12,
+    "min_warmup_bars": 13,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_130.py",
+    "id": "gtja191_130",
+    "theme": "volume",
+    "formula_latex": "see body",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close",
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 40,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_131.py",
+    "id": "gtja191_131",
+    "theme": "volume",
+    "formula_latex": "rank(delta(vwap,1))^tsrank(corr(close,mean(v,50),18),18)",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close",
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 50,
+    "min_warmup_bars": 84,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_132.py",
+    "id": "gtja191_132",
+    "theme": "liquidity",
+    "formula_latex": "mean(amount,20)",
+    "columns_required": [
+      "close",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_133.py",
+    "id": "gtja191_133",
+    "theme": "momentum",
+    "formula_latex": "((20-highday(high,20))/20)*100-((20-lowday(low,20))/20)*100",
+    "columns_required": [
+      "close",
+      "high",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_134.py",
+    "id": "gtja191_134",
+    "theme": "momentum,volume",
+    "formula_latex": "(close-delay(close,12))/delay(close,12)*volume",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 12,
+    "min_warmup_bars": 13,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_135.py",
+    "id": "gtja191_135",
+    "theme": "momentum",
+    "formula_latex": "sma(delay(c/delay(c,20),1),20,1)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 22,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_136.py",
+    "id": "gtja191_136",
+    "theme": "momentum,volume",
+    "formula_latex": "-1*rank(delta(ret,3))*corr(open,volume,10)",
+    "columns_required": [
+      "open",
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 11,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_137.py",
+    "id": "gtja191_137",
+    "theme": "volatility",
+    "formula_latex": "see body",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 1,
+    "min_warmup_bars": 2,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_138.py",
+    "id": "gtja191_138",
+    "theme": "volume",
+    "formula_latex": "see body",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close",
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 119,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_139.py",
+    "id": "gtja191_139",
+    "theme": "volume",
+    "formula_latex": "-1*corr(open,volume,10)",
+    "columns_required": [
+      "open",
+      "volume",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_140.py",
+    "id": "gtja191_140",
+    "theme": "volume",
+    "formula_latex": "see body",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 100,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_141.py",
+    "id": "gtja191_141",
+    "theme": "volume",
+    "formula_latex": "rank(corr(rank(high),rank(mean(v,15)),9))*-1",
+    "columns_required": [
+      "high",
+      "volume",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 15,
+    "min_warmup_bars": 24,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_142.py",
+    "id": "gtja191_142",
+    "theme": "volume,reversal",
+    "formula_latex": "see body",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 26,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_143.py",
+    "id": "gtja191_143",
+    "theme": "momentum",
+    "formula_latex": "cumprod(1 + (c/delay(c,1)-1) if c>delay(c,1) else 0)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 1,
+    "min_warmup_bars": 2,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_144.py",
+    "id": "gtja191_144",
+    "theme": "liquidity",
+    "formula_latex": "see body",
+    "columns_required": [
+      "close",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 21,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_145.py",
+    "id": "gtja191_145",
+    "theme": "volume",
+    "formula_latex": "(mean(v,9)-mean(v,26))/mean(v,12)*100",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 26,
+    "min_warmup_bars": 26,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_146.py",
+    "id": "gtja191_146",
+    "theme": "momentum",
+    "formula_latex": "see body",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 81,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_147.py",
+    "id": "gtja191_147",
+    "theme": "momentum",
+    "formula_latex": "regbeta(mean(close,12),sequence(12))",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 12,
+    "min_warmup_bars": 24,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_148.py",
+    "id": "gtja191_148",
+    "theme": "volume",
+    "formula_latex": "see body",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 75,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_149.py",
+    "id": "gtja191_149",
+    "theme": "momentum",
+    "formula_latex": "see body",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 253,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_150.py",
+    "id": "gtja191_150",
+    "theme": "volume",
+    "formula_latex": "(close+high+low)/3*volume",
+    "columns_required": [
+      "close",
+      "high",
+      "low",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 1,
+    "min_warmup_bars": 1,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_151.py",
+    "id": "gtja191_151",
+    "theme": "momentum",
+    "formula_latex": "sma(close-delay(close,20),20,1)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 21,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_152.py",
+    "id": "gtja191_152",
+    "theme": "momentum",
+    "formula_latex": "see body",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 26,
+    "min_warmup_bars": 50,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_153.py",
+    "id": "gtja191_153",
+    "theme": "momentum",
+    "formula_latex": "(mean(c,3)+mean(c,6)+mean(c,12)+mean(c,24))/4",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 24,
+    "min_warmup_bars": 24,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_154.py",
+    "id": "gtja191_154",
+    "theme": "volume",
+    "formula_latex": "see body",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close",
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 198,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_155.py",
+    "id": "gtja191_155",
+    "theme": "volume",
+    "formula_latex": "sma(v,13,2)-sma(v,27,2)-sma(sma(v,13,2)-sma(v,27,2),10,2)",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 27,
+    "min_warmup_bars": 40,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_156.py",
+    "id": "gtja191_156",
+    "theme": "volume",
+    "formula_latex": "see body",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close",
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_157.py",
+    "id": "gtja191_157",
+    "theme": "volume",
+    "formula_latex": "see body",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 12,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_158.py",
+    "id": "gtja191_158",
+    "theme": "volatility",
+    "formula_latex": "((h-sma(c,15,2))-(l-sma(c,15,2)))/c",
+    "columns_required": [
+      "close",
+      "high",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 15,
+    "min_warmup_bars": 16,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_159.py",
+    "id": "gtja191_159",
+    "theme": "momentum",
+    "formula_latex": "see body",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 24,
+    "min_warmup_bars": 25,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_160.py",
+    "id": "gtja191_160",
+    "theme": "volatility",
+    "formula_latex": "sma((c<=delay(c,1)?std(c,20):0),20,1)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 22,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_161.py",
+    "id": "gtja191_161",
+    "theme": "volatility",
+    "formula_latex": "mean(true_range,12)",
+    "columns_required": [
+      "close",
+      "high",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 12,
+    "min_warmup_bars": 13,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_162.py",
+    "id": "gtja191_162",
+    "theme": "momentum",
+    "formula_latex": "see body",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 12,
+    "min_warmup_bars": 24,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_163.py",
+    "id": "gtja191_163",
+    "theme": "volume",
+    "formula_latex": "rank(((-1*ret)*mean(v,20))*vwap*(high-close))",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close",
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 21,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_164.py",
+    "id": "gtja191_164",
+    "theme": "momentum",
+    "formula_latex": "see body",
+    "columns_required": [
+      "close",
+      "high",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 13,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_165.py",
+    "id": "gtja191_165",
+    "theme": "volatility",
+    "formula_latex": "see body",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 48,
+    "min_warmup_bars": 142,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_166.py",
+    "id": "gtja191_166",
+    "theme": "volatility",
+    "formula_latex": "see body",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 40,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_167.py",
+    "id": "gtja191_167",
+    "theme": "momentum",
+    "formula_latex": "sum(max(0,c-delay(c,1)),12)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 12,
+    "min_warmup_bars": 13,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_168.py",
+    "id": "gtja191_168",
+    "theme": "volume",
+    "formula_latex": "-1*volume/mean(volume,20)",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_169.py",
+    "id": "gtja191_169",
+    "theme": "momentum",
+    "formula_latex": "see body",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 26,
+    "min_warmup_bars": 50,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_170.py",
+    "id": "gtja191_170",
+    "theme": "volume",
+    "formula_latex": "see body",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close",
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 21,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_171.py",
+    "id": "gtja191_171",
+    "theme": "microstructure",
+    "formula_latex": "-1*((l-c)*(o^5))/((c-h)*(c^5))",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 1,
+    "min_warmup_bars": 1,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_172.py",
+    "id": "gtja191_172",
+    "theme": "momentum",
+    "formula_latex": "see body",
+    "columns_required": [
+      "close",
+      "high",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 14,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_173.py",
+    "id": "gtja191_173",
+    "theme": "momentum",
+    "formula_latex": "3*sma(c,13,2)-2*sma(sma(c,13,2),13,2)+sma(sma(sma(log(c),13,2),13,2),13,2)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 13,
+    "min_warmup_bars": 40,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_174.py",
+    "id": "gtja191_174",
+    "theme": "volatility",
+    "formula_latex": "sma((c>delay(c,1)?std(c,20):0),20,1)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 22,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_175.py",
+    "id": "gtja191_175",
+    "theme": "volatility",
+    "formula_latex": "mean(true_range,6)",
+    "columns_required": [
+      "close",
+      "high",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 6,
+    "min_warmup_bars": 7,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_176.py",
+    "id": "gtja191_176",
+    "theme": "volume",
+    "formula_latex": "see body",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 12,
+    "min_warmup_bars": 18,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_177.py",
+    "id": "gtja191_177",
+    "theme": "momentum",
+    "formula_latex": "((20-highday(h,20))/20)*100",
+    "columns_required": [
+      "close",
+      "high"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_178.py",
+    "id": "gtja191_178",
+    "theme": "momentum,volume",
+    "formula_latex": "(c-delay(c,1))/delay(c,1)*v",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 1,
+    "min_warmup_bars": 2,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_179.py",
+    "id": "gtja191_179",
+    "theme": "volume",
+    "formula_latex": "rank(corr(vwap,v,4))*rank(corr(rank(low),rank(mean(v,50)),12))",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close",
+      "volume",
+      "amount"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 50,
+    "min_warmup_bars": 62,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_180.py",
+    "id": "gtja191_180",
+    "theme": "volume,reversal",
+    "formula_latex": "see body",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 67,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_181.py",
+    "id": "gtja191_181",
+    "theme": "volatility",
+    "formula_latex": "see body",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 40,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_182.py",
+    "id": "gtja191_182",
+    "theme": "momentum",
+    "formula_latex": "see body",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 21,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_183.py",
+    "id": "gtja191_183",
+    "theme": "volatility",
+    "formula_latex": "see body",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 24,
+    "min_warmup_bars": 70,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_184.py",
+    "id": "gtja191_184",
+    "theme": "reversal",
+    "formula_latex": "see body",
+    "columns_required": [
+      "open",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 202,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_185.py",
+    "id": "gtja191_185",
+    "theme": "reversal",
+    "formula_latex": "rank(-1*(1-open/close)^2)",
+    "columns_required": [
+      "open",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 1,
+    "min_warmup_bars": 1,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_186.py",
+    "id": "gtja191_186",
+    "theme": "momentum",
+    "formula_latex": "see body (alpha172 averaged with its 6-day lag)",
+    "columns_required": [
+      "close",
+      "high",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 14,
+    "min_warmup_bars": 27,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_187.py",
+    "id": "gtja191_187",
+    "theme": "reversal",
+    "formula_latex": "see body",
+    "columns_required": [
+      "open",
+      "high"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 21,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_188.py",
+    "id": "gtja191_188",
+    "theme": "volatility",
+    "formula_latex": "(h-l-sma(h-l,11,2))/sma(h-l,11,2)*100",
+    "columns_required": [
+      "close",
+      "high",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 11,
+    "min_warmup_bars": 13,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_189.py",
+    "id": "gtja191_189",
+    "theme": "volatility",
+    "formula_latex": "mean(abs(c-mean(c,6)),6)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 6,
+    "min_warmup_bars": 12,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_190.py",
+    "id": "gtja191_190",
+    "theme": "momentum",
+    "formula_latex": "see body",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 39,
+    "error": null
+  },
+  {
+    "zoo": "gtja191",
+    "file": "alpha_191.py",
+    "id": "gtja191_191",
+    "theme": "volume",
+    "formula_latex": "see body",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_cn"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 25,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "beta10.py",
+    "id": "qlib158_beta10",
+    "theme": "momentum",
+    "formula_latex": "(\\\\mathrm{close}_t - \\\\mathrm{close}_{{t-10}}) / (10\\\\,\\\\mathrm{close})",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "beta20.py",
+    "id": "qlib158_beta20",
+    "theme": "momentum",
+    "formula_latex": "(\\\\mathrm{close}_t - \\\\mathrm{close}_{{t-20}}) / (20\\\\,\\\\mathrm{close})",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "beta30.py",
+    "id": "qlib158_beta30",
+    "theme": "momentum",
+    "formula_latex": "(\\\\mathrm{close}_t - \\\\mathrm{close}_{{t-30}}) / (30\\\\,\\\\mathrm{close})",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "beta5.py",
+    "id": "qlib158_beta5",
+    "theme": "momentum",
+    "formula_latex": "(\\\\mathrm{close}_t - \\\\mathrm{close}_{{t-5}}) / (5\\\\,\\\\mathrm{close})",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "beta60.py",
+    "id": "qlib158_beta60",
+    "theme": "momentum",
+    "formula_latex": "(\\\\mathrm{close}_t - \\\\mathrm{close}_{{t-60}}) / (60\\\\,\\\\mathrm{close})",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "cntd10.py",
+    "id": "qlib158_cntd10",
+    "theme": "reversal",
+    "formula_latex": "\\\\mathrm{CNTP}_10 - \\\\mathrm{CNTN}_10",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "cntd20.py",
+    "id": "qlib158_cntd20",
+    "theme": "reversal",
+    "formula_latex": "\\\\mathrm{CNTP}_20 - \\\\mathrm{CNTN}_20",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "cntd30.py",
+    "id": "qlib158_cntd30",
+    "theme": "reversal",
+    "formula_latex": "\\\\mathrm{CNTP}_30 - \\\\mathrm{CNTN}_30",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "cntd5.py",
+    "id": "qlib158_cntd5",
+    "theme": "reversal",
+    "formula_latex": "\\\\mathrm{CNTP}_5 - \\\\mathrm{CNTN}_5",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "cntd60.py",
+    "id": "qlib158_cntd60",
+    "theme": "reversal",
+    "formula_latex": "\\\\mathrm{CNTP}_60 - \\\\mathrm{CNTN}_60",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "cntn10.py",
+    "id": "qlib158_cntn10",
+    "theme": "reversal",
+    "formula_latex": "\\\\mathrm{rolling\\\\_mean}(\\\\mathrm{1}[\\\\mathrm{close}<\\\\mathrm{close}_{{-1}}], 10)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "cntn20.py",
+    "id": "qlib158_cntn20",
+    "theme": "reversal",
+    "formula_latex": "\\\\mathrm{rolling\\\\_mean}(\\\\mathrm{1}[\\\\mathrm{close}<\\\\mathrm{close}_{{-1}}], 20)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "cntn30.py",
+    "id": "qlib158_cntn30",
+    "theme": "reversal",
+    "formula_latex": "\\\\mathrm{rolling\\\\_mean}(\\\\mathrm{1}[\\\\mathrm{close}<\\\\mathrm{close}_{{-1}}], 30)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "cntn5.py",
+    "id": "qlib158_cntn5",
+    "theme": "reversal",
+    "formula_latex": "\\\\mathrm{rolling\\\\_mean}(\\\\mathrm{1}[\\\\mathrm{close}<\\\\mathrm{close}_{{-1}}], 5)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "cntn60.py",
+    "id": "qlib158_cntn60",
+    "theme": "reversal",
+    "formula_latex": "\\\\mathrm{rolling\\\\_mean}(\\\\mathrm{1}[\\\\mathrm{close}<\\\\mathrm{close}_{{-1}}], 60)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "cntp10.py",
+    "id": "qlib158_cntp10",
+    "theme": "reversal",
+    "formula_latex": "\\\\mathrm{rolling\\\\_mean}(\\\\mathrm{1}[\\\\mathrm{close}>\\\\mathrm{close}_{{-1}}], 10)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "cntp20.py",
+    "id": "qlib158_cntp20",
+    "theme": "reversal",
+    "formula_latex": "\\\\mathrm{rolling\\\\_mean}(\\\\mathrm{1}[\\\\mathrm{close}>\\\\mathrm{close}_{{-1}}], 20)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "cntp30.py",
+    "id": "qlib158_cntp30",
+    "theme": "reversal",
+    "formula_latex": "\\\\mathrm{rolling\\\\_mean}(\\\\mathrm{1}[\\\\mathrm{close}>\\\\mathrm{close}_{{-1}}], 30)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "cntp5.py",
+    "id": "qlib158_cntp5",
+    "theme": "reversal",
+    "formula_latex": "\\\\mathrm{rolling\\\\_mean}(\\\\mathrm{1}[\\\\mathrm{close}>\\\\mathrm{close}_{{-1}}], 5)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "cntp60.py",
+    "id": "qlib158_cntp60",
+    "theme": "reversal",
+    "formula_latex": "\\\\mathrm{rolling\\\\_mean}(\\\\mathrm{1}[\\\\mathrm{close}>\\\\mathrm{close}_{{-1}}], 60)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "cord10.py",
+    "id": "qlib158_cord10",
+    "theme": "volume,microstructure",
+    "formula_latex": "\\\\mathrm{ts\\\\_corr}(\\\\mathrm{close}/\\\\mathrm{close}_{{-1}}, \\\\log((\\\\mathrm{volume}+1)/(\\\\mathrm{volume}_{{-1}}+1)), 10)",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "cord20.py",
+    "id": "qlib158_cord20",
+    "theme": "volume,microstructure",
+    "formula_latex": "\\\\mathrm{ts\\\\_corr}(\\\\mathrm{close}/\\\\mathrm{close}_{{-1}}, \\\\log((\\\\mathrm{volume}+1)/(\\\\mathrm{volume}_{{-1}}+1)), 20)",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "cord30.py",
+    "id": "qlib158_cord30",
+    "theme": "volume,microstructure",
+    "formula_latex": "\\\\mathrm{ts\\\\_corr}(\\\\mathrm{close}/\\\\mathrm{close}_{{-1}}, \\\\log((\\\\mathrm{volume}+1)/(\\\\mathrm{volume}_{{-1}}+1)), 30)",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "cord5.py",
+    "id": "qlib158_cord5",
+    "theme": "volume,microstructure",
+    "formula_latex": "\\\\mathrm{ts\\\\_corr}(\\\\mathrm{close}/\\\\mathrm{close}_{{-1}}, \\\\log((\\\\mathrm{volume}+1)/(\\\\mathrm{volume}_{{-1}}+1)), 5)",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "cord60.py",
+    "id": "qlib158_cord60",
+    "theme": "volume,microstructure",
+    "formula_latex": "\\\\mathrm{ts\\\\_corr}(\\\\mathrm{close}/\\\\mathrm{close}_{{-1}}, \\\\log((\\\\mathrm{volume}+1)/(\\\\mathrm{volume}_{{-1}}+1)), 60)",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "corr10.py",
+    "id": "qlib158_corr10",
+    "theme": "volume,microstructure",
+    "formula_latex": "\\\\mathrm{ts\\\\_corr}(\\\\mathrm{close}, \\\\log(\\\\mathrm{volume}+1), 10)",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "corr20.py",
+    "id": "qlib158_corr20",
+    "theme": "volume,microstructure",
+    "formula_latex": "\\\\mathrm{ts\\\\_corr}(\\\\mathrm{close}, \\\\log(\\\\mathrm{volume}+1), 20)",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "corr30.py",
+    "id": "qlib158_corr30",
+    "theme": "volume,microstructure",
+    "formula_latex": "\\\\mathrm{ts\\\\_corr}(\\\\mathrm{close}, \\\\log(\\\\mathrm{volume}+1), 30)",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "corr5.py",
+    "id": "qlib158_corr5",
+    "theme": "volume,microstructure",
+    "formula_latex": "\\\\mathrm{ts\\\\_corr}(\\\\mathrm{close}, \\\\log(\\\\mathrm{volume}+1), 5)",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "corr60.py",
+    "id": "qlib158_corr60",
+    "theme": "volume,microstructure",
+    "formula_latex": "\\\\mathrm{ts\\\\_corr}(\\\\mathrm{close}, \\\\log(\\\\mathrm{volume}+1), 60)",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "imax10.py",
+    "id": "qlib158_imax10",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_argmax}(\\\\mathrm{high}, 10) / 10",
+    "columns_required": [
+      "high"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "imax20.py",
+    "id": "qlib158_imax20",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_argmax}(\\\\mathrm{high}, 20) / 20",
+    "columns_required": [
+      "high"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "imax30.py",
+    "id": "qlib158_imax30",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_argmax}(\\\\mathrm{high}, 30) / 30",
+    "columns_required": [
+      "high"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "imax5.py",
+    "id": "qlib158_imax5",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_argmax}(\\\\mathrm{high}, 5) / 5",
+    "columns_required": [
+      "high"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "imax60.py",
+    "id": "qlib158_imax60",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_argmax}(\\\\mathrm{high}, 60) / 60",
+    "columns_required": [
+      "high"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "imin10.py",
+    "id": "qlib158_imin10",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_argmin}(\\\\mathrm{low}, 10) / 10",
+    "columns_required": [
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "imin20.py",
+    "id": "qlib158_imin20",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_argmin}(\\\\mathrm{low}, 20) / 20",
+    "columns_required": [
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "imin30.py",
+    "id": "qlib158_imin30",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_argmin}(\\\\mathrm{low}, 30) / 30",
+    "columns_required": [
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "imin5.py",
+    "id": "qlib158_imin5",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_argmin}(\\\\mathrm{low}, 5) / 5",
+    "columns_required": [
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "imin60.py",
+    "id": "qlib158_imin60",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_argmin}(\\\\mathrm{low}, 60) / 60",
+    "columns_required": [
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "imxd10.py",
+    "id": "qlib158_imxd10",
+    "theme": "momentum",
+    "formula_latex": "(\\\\mathrm{ts\\\\_argmax}(\\\\mathrm{high}, 10) - \\\\mathrm{ts\\\\_argmin}(\\\\mathrm{low}, 10)) / 10",
+    "columns_required": [
+      "high",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "imxd20.py",
+    "id": "qlib158_imxd20",
+    "theme": "momentum",
+    "formula_latex": "(\\\\mathrm{ts\\\\_argmax}(\\\\mathrm{high}, 20) - \\\\mathrm{ts\\\\_argmin}(\\\\mathrm{low}, 20)) / 20",
+    "columns_required": [
+      "high",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "imxd30.py",
+    "id": "qlib158_imxd30",
+    "theme": "momentum",
+    "formula_latex": "(\\\\mathrm{ts\\\\_argmax}(\\\\mathrm{high}, 30) - \\\\mathrm{ts\\\\_argmin}(\\\\mathrm{low}, 30)) / 30",
+    "columns_required": [
+      "high",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "imxd5.py",
+    "id": "qlib158_imxd5",
+    "theme": "momentum",
+    "formula_latex": "(\\\\mathrm{ts\\\\_argmax}(\\\\mathrm{high}, 5) - \\\\mathrm{ts\\\\_argmin}(\\\\mathrm{low}, 5)) / 5",
+    "columns_required": [
+      "high",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "imxd60.py",
+    "id": "qlib158_imxd60",
+    "theme": "momentum",
+    "formula_latex": "(\\\\mathrm{ts\\\\_argmax}(\\\\mathrm{high}, 60) - \\\\mathrm{ts\\\\_argmin}(\\\\mathrm{low}, 60)) / 60",
+    "columns_required": [
+      "high",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "klen.py",
+    "id": "qlib158_klen",
+    "theme": "microstructure",
+    "formula_latex": "(\\\\mathrm{high} - \\\\mathrm{low}) / \\\\mathrm{open}",
+    "columns_required": [
+      "open",
+      "high",
+      "low"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 1,
+    "min_warmup_bars": 1,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "klow.py",
+    "id": "qlib158_klow",
+    "theme": "microstructure",
+    "formula_latex": "(\\\\min(\\\\mathrm{open}, \\\\mathrm{close}) - \\\\mathrm{low}) / \\\\mathrm{open}",
+    "columns_required": [
+      "open",
+      "low",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 1,
+    "min_warmup_bars": 1,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "klow2.py",
+    "id": "qlib158_klow2",
+    "theme": "microstructure",
+    "formula_latex": "(\\\\min(\\\\mathrm{open}, \\\\mathrm{close}) - \\\\mathrm{low}) / (\\\\mathrm{high} - \\\\mathrm{low})",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 1,
+    "min_warmup_bars": 1,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "kmid.py",
+    "id": "qlib158_kmid",
+    "theme": "microstructure",
+    "formula_latex": "(\\\\mathrm{close} - \\\\mathrm{open}) / \\\\mathrm{open}",
+    "columns_required": [
+      "open",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 1,
+    "min_warmup_bars": 1,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "kmid2.py",
+    "id": "qlib158_kmid2",
+    "theme": "microstructure",
+    "formula_latex": "(\\\\mathrm{close} - \\\\mathrm{open}) / (\\\\mathrm{high} - \\\\mathrm{low})",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 1,
+    "min_warmup_bars": 1,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "ksft.py",
+    "id": "qlib158_ksft",
+    "theme": "microstructure",
+    "formula_latex": "(2\\\\,\\\\mathrm{close} - \\\\mathrm{high} - \\\\mathrm{low}) / \\\\mathrm{open}",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 1,
+    "min_warmup_bars": 1,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "ksft2.py",
+    "id": "qlib158_ksft2",
+    "theme": "microstructure",
+    "formula_latex": "(2\\\\,\\\\mathrm{close} - \\\\mathrm{high} - \\\\mathrm{low}) / (\\\\mathrm{high} - \\\\mathrm{low})",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 1,
+    "min_warmup_bars": 1,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "kup.py",
+    "id": "qlib158_kup",
+    "theme": "microstructure",
+    "formula_latex": "(\\\\mathrm{high} - \\\\max(\\\\mathrm{open}, \\\\mathrm{close})) / \\\\mathrm{open}",
+    "columns_required": [
+      "open",
+      "high",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 1,
+    "min_warmup_bars": 1,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "kup2.py",
+    "id": "qlib158_kup2",
+    "theme": "microstructure",
+    "formula_latex": "(\\\\mathrm{high} - \\\\max(\\\\mathrm{open}, \\\\mathrm{close})) / (\\\\mathrm{high} - \\\\mathrm{low})",
+    "columns_required": [
+      "open",
+      "high",
+      "low",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 1,
+    "min_warmup_bars": 1,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "ma10.py",
+    "id": "qlib158_ma10",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_mean}(\\\\mathrm{close}, 10) / \\\\mathrm{close}",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "ma20.py",
+    "id": "qlib158_ma20",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_mean}(\\\\mathrm{close}, 20) / \\\\mathrm{close}",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "ma30.py",
+    "id": "qlib158_ma30",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_mean}(\\\\mathrm{close}, 30) / \\\\mathrm{close}",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "ma5.py",
+    "id": "qlib158_ma5",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_mean}(\\\\mathrm{close}, 5) / \\\\mathrm{close}",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "ma60.py",
+    "id": "qlib158_ma60",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_mean}(\\\\mathrm{close}, 60) / \\\\mathrm{close}",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "max10.py",
+    "id": "qlib158_max10",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_max}(\\\\mathrm{high}, 10) / \\\\mathrm{close}",
+    "columns_required": [
+      "high",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "max20.py",
+    "id": "qlib158_max20",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_max}(\\\\mathrm{high}, 20) / \\\\mathrm{close}",
+    "columns_required": [
+      "high",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "max30.py",
+    "id": "qlib158_max30",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_max}(\\\\mathrm{high}, 30) / \\\\mathrm{close}",
+    "columns_required": [
+      "high",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "max5.py",
+    "id": "qlib158_max5",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_max}(\\\\mathrm{high}, 5) / \\\\mathrm{close}",
+    "columns_required": [
+      "high",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "max60.py",
+    "id": "qlib158_max60",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_max}(\\\\mathrm{high}, 60) / \\\\mathrm{close}",
+    "columns_required": [
+      "high",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "min10.py",
+    "id": "qlib158_min10",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_min}(\\\\mathrm{low}, 10) / \\\\mathrm{close}",
+    "columns_required": [
+      "low",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "min20.py",
+    "id": "qlib158_min20",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_min}(\\\\mathrm{low}, 20) / \\\\mathrm{close}",
+    "columns_required": [
+      "low",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "min30.py",
+    "id": "qlib158_min30",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_min}(\\\\mathrm{low}, 30) / \\\\mathrm{close}",
+    "columns_required": [
+      "low",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "min5.py",
+    "id": "qlib158_min5",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_min}(\\\\mathrm{low}, 5) / \\\\mathrm{close}",
+    "columns_required": [
+      "low",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "min60.py",
+    "id": "qlib158_min60",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_min}(\\\\mathrm{low}, 60) / \\\\mathrm{close}",
+    "columns_required": [
+      "low",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "qtld10.py",
+    "id": "qlib158_qtld10",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{quantile}_{{0.2}}(\\\\mathrm{close}, 10) / \\\\mathrm{close}",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "qtld20.py",
+    "id": "qlib158_qtld20",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{quantile}_{{0.2}}(\\\\mathrm{close}, 20) / \\\\mathrm{close}",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "qtld30.py",
+    "id": "qlib158_qtld30",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{quantile}_{{0.2}}(\\\\mathrm{close}, 30) / \\\\mathrm{close}",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "qtld5.py",
+    "id": "qlib158_qtld5",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{quantile}_{{0.2}}(\\\\mathrm{close}, 5) / \\\\mathrm{close}",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "qtld60.py",
+    "id": "qlib158_qtld60",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{quantile}_{{0.2}}(\\\\mathrm{close}, 60) / \\\\mathrm{close}",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "qtlu10.py",
+    "id": "qlib158_qtlu10",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{quantile}_{{0.8}}(\\\\mathrm{close}, 10) / \\\\mathrm{close}",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "qtlu20.py",
+    "id": "qlib158_qtlu20",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{quantile}_{{0.8}}(\\\\mathrm{close}, 20) / \\\\mathrm{close}",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "qtlu30.py",
+    "id": "qlib158_qtlu30",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{quantile}_{{0.8}}(\\\\mathrm{close}, 30) / \\\\mathrm{close}",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "qtlu5.py",
+    "id": "qlib158_qtlu5",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{quantile}_{{0.8}}(\\\\mathrm{close}, 5) / \\\\mathrm{close}",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "qtlu60.py",
+    "id": "qlib158_qtlu60",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{quantile}_{{0.8}}(\\\\mathrm{close}, 60) / \\\\mathrm{close}",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "rank10.py",
+    "id": "qlib158_rank10",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_rank}(\\\\mathrm{close}, 10)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "rank20.py",
+    "id": "qlib158_rank20",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_rank}(\\\\mathrm{close}, 20)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "rank30.py",
+    "id": "qlib158_rank30",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_rank}(\\\\mathrm{close}, 30)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "rank5.py",
+    "id": "qlib158_rank5",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_rank}(\\\\mathrm{close}, 5)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "rank60.py",
+    "id": "qlib158_rank60",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_rank}(\\\\mathrm{close}, 60)",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "resi10.py",
+    "id": "qlib158_resi10",
+    "theme": "momentum",
+    "formula_latex": "(\\\\mathrm{close} - \\\\mathrm{ts\\\\_mean}(\\\\mathrm{close}, 10)) / \\\\mathrm{close}",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "resi20.py",
+    "id": "qlib158_resi20",
+    "theme": "momentum",
+    "formula_latex": "(\\\\mathrm{close} - \\\\mathrm{ts\\\\_mean}(\\\\mathrm{close}, 20)) / \\\\mathrm{close}",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "resi30.py",
+    "id": "qlib158_resi30",
+    "theme": "momentum",
+    "formula_latex": "(\\\\mathrm{close} - \\\\mathrm{ts\\\\_mean}(\\\\mathrm{close}, 30)) / \\\\mathrm{close}",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "resi5.py",
+    "id": "qlib158_resi5",
+    "theme": "momentum",
+    "formula_latex": "(\\\\mathrm{close} - \\\\mathrm{ts\\\\_mean}(\\\\mathrm{close}, 5)) / \\\\mathrm{close}",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "resi60.py",
+    "id": "qlib158_resi60",
+    "theme": "momentum",
+    "formula_latex": "(\\\\mathrm{close} - \\\\mathrm{ts\\\\_mean}(\\\\mathrm{close}, 60)) / \\\\mathrm{close}",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "roc10.py",
+    "id": "qlib158_roc10",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{close}_t / \\\\mathrm{close}_{{t-10}} - 1",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "roc20.py",
+    "id": "qlib158_roc20",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{close}_t / \\\\mathrm{close}_{{t-20}} - 1",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "roc30.py",
+    "id": "qlib158_roc30",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{close}_t / \\\\mathrm{close}_{{t-30}} - 1",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "roc5.py",
+    "id": "qlib158_roc5",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{close}_t / \\\\mathrm{close}_{{t-5}} - 1",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "roc60.py",
+    "id": "qlib158_roc60",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{close}_t / \\\\mathrm{close}_{{t-60}} - 1",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "rsqr10.py",
+    "id": "qlib158_rsqr10",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_corr}(\\\\mathrm{close}, t, 10)^2",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "rsqr20.py",
+    "id": "qlib158_rsqr20",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_corr}(\\\\mathrm{close}, t, 20)^2",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "rsqr30.py",
+    "id": "qlib158_rsqr30",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_corr}(\\\\mathrm{close}, t, 30)^2",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "rsqr5.py",
+    "id": "qlib158_rsqr5",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_corr}(\\\\mathrm{close}, t, 5)^2",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "rsqr60.py",
+    "id": "qlib158_rsqr60",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_corr}(\\\\mathrm{close}, t, 60)^2",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "rsv10.py",
+    "id": "qlib158_rsv10",
+    "theme": "momentum",
+    "formula_latex": "(\\\\mathrm{close} - \\\\mathrm{ts\\\\_min}(\\\\mathrm{low}, 10)) / (\\\\mathrm{ts\\\\_max}(\\\\mathrm{high}, 10) - \\\\mathrm{ts\\\\_min}(\\\\mathrm{low}, 10))",
+    "columns_required": [
+      "high",
+      "low",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "rsv20.py",
+    "id": "qlib158_rsv20",
+    "theme": "momentum",
+    "formula_latex": "(\\\\mathrm{close} - \\\\mathrm{ts\\\\_min}(\\\\mathrm{low}, 20)) / (\\\\mathrm{ts\\\\_max}(\\\\mathrm{high}, 20) - \\\\mathrm{ts\\\\_min}(\\\\mathrm{low}, 20))",
+    "columns_required": [
+      "high",
+      "low",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "rsv30.py",
+    "id": "qlib158_rsv30",
+    "theme": "momentum",
+    "formula_latex": "(\\\\mathrm{close} - \\\\mathrm{ts\\\\_min}(\\\\mathrm{low}, 30)) / (\\\\mathrm{ts\\\\_max}(\\\\mathrm{high}, 30) - \\\\mathrm{ts\\\\_min}(\\\\mathrm{low}, 30))",
+    "columns_required": [
+      "high",
+      "low",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "rsv5.py",
+    "id": "qlib158_rsv5",
+    "theme": "momentum",
+    "formula_latex": "(\\\\mathrm{close} - \\\\mathrm{ts\\\\_min}(\\\\mathrm{low}, 5)) / (\\\\mathrm{ts\\\\_max}(\\\\mathrm{high}, 5) - \\\\mathrm{ts\\\\_min}(\\\\mathrm{low}, 5))",
+    "columns_required": [
+      "high",
+      "low",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "rsv60.py",
+    "id": "qlib158_rsv60",
+    "theme": "momentum",
+    "formula_latex": "(\\\\mathrm{close} - \\\\mathrm{ts\\\\_min}(\\\\mathrm{low}, 60)) / (\\\\mathrm{ts\\\\_max}(\\\\mathrm{high}, 60) - \\\\mathrm{ts\\\\_min}(\\\\mathrm{low}, 60))",
+    "columns_required": [
+      "high",
+      "low",
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "std10.py",
+    "id": "qlib158_std10",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_std}(\\\\mathrm{close}, 10) / \\\\mathrm{close}",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "std20.py",
+    "id": "qlib158_std20",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_std}(\\\\mathrm{close}, 20) / \\\\mathrm{close}",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "std30.py",
+    "id": "qlib158_std30",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_std}(\\\\mathrm{close}, 30) / \\\\mathrm{close}",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "std5.py",
+    "id": "qlib158_std5",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_std}(\\\\mathrm{close}, 5) / \\\\mathrm{close}",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "std60.py",
+    "id": "qlib158_std60",
+    "theme": "momentum",
+    "formula_latex": "\\\\mathrm{ts\\\\_std}(\\\\mathrm{close}, 60) / \\\\mathrm{close}",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "sumd10.py",
+    "id": "qlib158_sumd10",
+    "theme": "reversal",
+    "formula_latex": "\\\\mathrm{SUMP}_w - \\\\mathrm{SUMN}_w",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "sumd20.py",
+    "id": "qlib158_sumd20",
+    "theme": "reversal",
+    "formula_latex": "\\\\mathrm{SUMP}_w - \\\\mathrm{SUMN}_w",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "sumd30.py",
+    "id": "qlib158_sumd30",
+    "theme": "reversal",
+    "formula_latex": "\\\\mathrm{SUMP}_w - \\\\mathrm{SUMN}_w",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "sumd5.py",
+    "id": "qlib158_sumd5",
+    "theme": "reversal",
+    "formula_latex": "\\\\mathrm{SUMP}_w - \\\\mathrm{SUMN}_w",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "sumd60.py",
+    "id": "qlib158_sumd60",
+    "theme": "reversal",
+    "formula_latex": "\\\\mathrm{SUMP}_w - \\\\mathrm{SUMN}_w",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "sumn10.py",
+    "id": "qlib158_sumn10",
+    "theme": "reversal",
+    "formula_latex": "\\\\sum \\\\max(-\\\\Delta\\\\mathrm{close}, 0) / \\\\sum |\\\\Delta\\\\mathrm{close}|",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "sumn20.py",
+    "id": "qlib158_sumn20",
+    "theme": "reversal",
+    "formula_latex": "\\\\sum \\\\max(-\\\\Delta\\\\mathrm{close}, 0) / \\\\sum |\\\\Delta\\\\mathrm{close}|",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "sumn30.py",
+    "id": "qlib158_sumn30",
+    "theme": "reversal",
+    "formula_latex": "\\\\sum \\\\max(-\\\\Delta\\\\mathrm{close}, 0) / \\\\sum |\\\\Delta\\\\mathrm{close}|",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "sumn5.py",
+    "id": "qlib158_sumn5",
+    "theme": "reversal",
+    "formula_latex": "\\\\sum \\\\max(-\\\\Delta\\\\mathrm{close}, 0) / \\\\sum |\\\\Delta\\\\mathrm{close}|",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "sumn60.py",
+    "id": "qlib158_sumn60",
+    "theme": "reversal",
+    "formula_latex": "\\\\sum \\\\max(-\\\\Delta\\\\mathrm{close}, 0) / \\\\sum |\\\\Delta\\\\mathrm{close}|",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "sump10.py",
+    "id": "qlib158_sump10",
+    "theme": "reversal",
+    "formula_latex": "\\\\sum \\\\max(\\\\Delta\\\\mathrm{close}, 0) / \\\\sum |\\\\Delta\\\\mathrm{close}|",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "sump20.py",
+    "id": "qlib158_sump20",
+    "theme": "reversal",
+    "formula_latex": "\\\\sum \\\\max(\\\\Delta\\\\mathrm{close}, 0) / \\\\sum |\\\\Delta\\\\mathrm{close}|",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "sump30.py",
+    "id": "qlib158_sump30",
+    "theme": "reversal",
+    "formula_latex": "\\\\sum \\\\max(\\\\Delta\\\\mathrm{close}, 0) / \\\\sum |\\\\Delta\\\\mathrm{close}|",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "sump5.py",
+    "id": "qlib158_sump5",
+    "theme": "reversal",
+    "formula_latex": "\\\\sum \\\\max(\\\\Delta\\\\mathrm{close}, 0) / \\\\sum |\\\\Delta\\\\mathrm{close}|",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "sump60.py",
+    "id": "qlib158_sump60",
+    "theme": "reversal",
+    "formula_latex": "\\\\sum \\\\max(\\\\Delta\\\\mathrm{close}, 0) / \\\\sum |\\\\Delta\\\\mathrm{close}|",
+    "columns_required": [
+      "close"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "vma10.py",
+    "id": "qlib158_vma10",
+    "theme": "volume,volatility",
+    "formula_latex": "\\\\mathrm{ts\\\\_mean}(\\\\mathrm{volume}, 10) / \\\\mathrm{volume}",
+    "columns_required": [
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "vma20.py",
+    "id": "qlib158_vma20",
+    "theme": "volume,volatility",
+    "formula_latex": "\\\\mathrm{ts\\\\_mean}(\\\\mathrm{volume}, 20) / \\\\mathrm{volume}",
+    "columns_required": [
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "vma30.py",
+    "id": "qlib158_vma30",
+    "theme": "volume,volatility",
+    "formula_latex": "\\\\mathrm{ts\\\\_mean}(\\\\mathrm{volume}, 30) / \\\\mathrm{volume}",
+    "columns_required": [
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "vma5.py",
+    "id": "qlib158_vma5",
+    "theme": "volume,volatility",
+    "formula_latex": "\\\\mathrm{ts\\\\_mean}(\\\\mathrm{volume}, 5) / \\\\mathrm{volume}",
+    "columns_required": [
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "vma60.py",
+    "id": "qlib158_vma60",
+    "theme": "volume,volatility",
+    "formula_latex": "\\\\mathrm{ts\\\\_mean}(\\\\mathrm{volume}, 60) / \\\\mathrm{volume}",
+    "columns_required": [
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "vstd10.py",
+    "id": "qlib158_vstd10",
+    "theme": "volume,volatility",
+    "formula_latex": "\\\\mathrm{ts\\\\_std}(\\\\mathrm{volume}, 10) / \\\\mathrm{volume}",
+    "columns_required": [
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "vstd20.py",
+    "id": "qlib158_vstd20",
+    "theme": "volume,volatility",
+    "formula_latex": "\\\\mathrm{ts\\\\_std}(\\\\mathrm{volume}, 20) / \\\\mathrm{volume}",
+    "columns_required": [
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "vstd30.py",
+    "id": "qlib158_vstd30",
+    "theme": "volume,volatility",
+    "formula_latex": "\\\\mathrm{ts\\\\_std}(\\\\mathrm{volume}, 30) / \\\\mathrm{volume}",
+    "columns_required": [
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "vstd5.py",
+    "id": "qlib158_vstd5",
+    "theme": "volume,volatility",
+    "formula_latex": "\\\\mathrm{ts\\\\_std}(\\\\mathrm{volume}, 5) / \\\\mathrm{volume}",
+    "columns_required": [
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "vstd60.py",
+    "id": "qlib158_vstd60",
+    "theme": "volume,volatility",
+    "formula_latex": "\\\\mathrm{ts\\\\_std}(\\\\mathrm{volume}, 60) / \\\\mathrm{volume}",
+    "columns_required": [
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "vsumd10.py",
+    "id": "qlib158_vsumd10",
+    "theme": "volume,volatility",
+    "formula_latex": "\\\\mathrm{VSUMP}_w - \\\\mathrm{VSUMN}_w",
+    "columns_required": [
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "vsumd20.py",
+    "id": "qlib158_vsumd20",
+    "theme": "volume,volatility",
+    "formula_latex": "\\\\mathrm{VSUMP}_w - \\\\mathrm{VSUMN}_w",
+    "columns_required": [
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "vsumd30.py",
+    "id": "qlib158_vsumd30",
+    "theme": "volume,volatility",
+    "formula_latex": "\\\\mathrm{VSUMP}_w - \\\\mathrm{VSUMN}_w",
+    "columns_required": [
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "vsumd5.py",
+    "id": "qlib158_vsumd5",
+    "theme": "volume,volatility",
+    "formula_latex": "\\\\mathrm{VSUMP}_w - \\\\mathrm{VSUMN}_w",
+    "columns_required": [
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "vsumd60.py",
+    "id": "qlib158_vsumd60",
+    "theme": "volume,volatility",
+    "formula_latex": "\\\\mathrm{VSUMP}_w - \\\\mathrm{VSUMN}_w",
+    "columns_required": [
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "vsumn10.py",
+    "id": "qlib158_vsumn10",
+    "theme": "volume,volatility",
+    "formula_latex": "\\\\sum \\\\max(-\\\\Delta v, 0) / \\\\sum |\\\\Delta v|",
+    "columns_required": [
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "vsumn20.py",
+    "id": "qlib158_vsumn20",
+    "theme": "volume,volatility",
+    "formula_latex": "\\\\sum \\\\max(-\\\\Delta v, 0) / \\\\sum |\\\\Delta v|",
+    "columns_required": [
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "vsumn30.py",
+    "id": "qlib158_vsumn30",
+    "theme": "volume,volatility",
+    "formula_latex": "\\\\sum \\\\max(-\\\\Delta v, 0) / \\\\sum |\\\\Delta v|",
+    "columns_required": [
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "vsumn5.py",
+    "id": "qlib158_vsumn5",
+    "theme": "volume,volatility",
+    "formula_latex": "\\\\sum \\\\max(-\\\\Delta v, 0) / \\\\sum |\\\\Delta v|",
+    "columns_required": [
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "vsumn60.py",
+    "id": "qlib158_vsumn60",
+    "theme": "volume,volatility",
+    "formula_latex": "\\\\sum \\\\max(-\\\\Delta v, 0) / \\\\sum |\\\\Delta v|",
+    "columns_required": [
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "vsump10.py",
+    "id": "qlib158_vsump10",
+    "theme": "volume,volatility",
+    "formula_latex": "\\\\sum \\\\max(\\\\Delta v, 0) / \\\\sum |\\\\Delta v|",
+    "columns_required": [
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "vsump20.py",
+    "id": "qlib158_vsump20",
+    "theme": "volume,volatility",
+    "formula_latex": "\\\\sum \\\\max(\\\\Delta v, 0) / \\\\sum |\\\\Delta v|",
+    "columns_required": [
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "vsump30.py",
+    "id": "qlib158_vsump30",
+    "theme": "volume,volatility",
+    "formula_latex": "\\\\sum \\\\max(\\\\Delta v, 0) / \\\\sum |\\\\Delta v|",
+    "columns_required": [
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "vsump5.py",
+    "id": "qlib158_vsump5",
+    "theme": "volume,volatility",
+    "formula_latex": "\\\\sum \\\\max(\\\\Delta v, 0) / \\\\sum |\\\\Delta v|",
+    "columns_required": [
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "vsump60.py",
+    "id": "qlib158_vsump60",
+    "theme": "volume,volatility",
+    "formula_latex": "\\\\sum \\\\max(\\\\Delta v, 0) / \\\\sum |\\\\Delta v|",
+    "columns_required": [
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 60,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "wvma10.py",
+    "id": "qlib158_wvma10",
+    "theme": "volume,volatility",
+    "formula_latex": "\\\\mathrm{ts\\\\_std}(\\\\mathrm{ret}\\\\cdot v, 10) / \\\\mathrm{ts\\\\_mean}(|\\\\mathrm{ret}|\\\\cdot v, 10)",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 10,
+    "min_warmup_bars": 10,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "wvma20.py",
+    "id": "qlib158_wvma20",
+    "theme": "volume,volatility",
+    "formula_latex": "\\\\mathrm{ts\\\\_std}(\\\\mathrm{ret}\\\\cdot v, 20) / \\\\mathrm{ts\\\\_mean}(|\\\\mathrm{ret}|\\\\cdot v, 20)",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 20,
+    "min_warmup_bars": 20,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "wvma30.py",
+    "id": "qlib158_wvma30",
+    "theme": "volume,volatility",
+    "formula_latex": "\\\\mathrm{ts\\\\_std}(\\\\mathrm{ret}\\\\cdot v, 30) / \\\\mathrm{ts\\\\_mean}(|\\\\mathrm{ret}|\\\\cdot v, 30)",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 30,
+    "min_warmup_bars": 30,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "wvma5.py",
+    "id": "qlib158_wvma5",
+    "theme": "volume,volatility",
+    "formula_latex": "\\\\mathrm{ts\\\\_std}(\\\\mathrm{ret}\\\\cdot v, 5) / \\\\mathrm{ts\\\\_mean}(|\\\\mathrm{ret}|\\\\cdot v, 5)",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 5,
+    "min_warmup_bars": 5,
+    "error": null
+  },
+  {
+    "zoo": "qlib158",
+    "file": "wvma60.py",
+    "id": "qlib158_wvma60",
+    "theme": "volume,volatility",
+    "formula_latex": "\\\\mathrm{ts\\\\_std}(\\\\mathrm{ret}\\\\cdot v, 60) / \\\\mathrm{ts\\\\_mean}(|\\\\mathrm{ret}|\\\\cdot v, 60)",
+    "columns_required": [
+      "close",
+      "volume"
+    ],
+    "extras_required": [],
+    "requires_sector": false,
+    "universe": [
+      "equity_us",
+      "equity_cn",
+      "equity_hk",
+      "equity_in"
+    ],
+    "frequency": [
+      "1d"
+    ],
+    "decay_horizon": 60,
+    "min_warmup_bars": 60,
+    "error": null
+  }
+]

--- a/docs/analysis/catalog/skills_inventory.json
+++ b/docs/analysis/catalog/skills_inventory.json
@@ -1,0 +1,794 @@
+[
+  {
+    "id": "adr-hshare",
+    "name": "adr-hshare",
+    "category": "flow",
+    "description": "ADR/H-share/A-share cross-listing premium analysis — track pricing gaps between US-listed ADRs, HK-listed H-shares, and A-shares for arbitrage signals, dual-listing valuation, and delisting risk assessment.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 9951
+  },
+  {
+    "id": "akshare",
+    "name": "akshare",
+    "category": "data-source",
+    "description": "AKShare financial data aggregator (18k+ stars). Free, no API key. Covers A-shares, US, HK, futures, macro, forex. Primary fallback for tushare and yfinance.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 3105
+  },
+  {
+    "id": "alpha-zoo",
+    "name": "alpha-zoo",
+    "category": "research",
+    "description": "Browse and bench the bundled alpha zoos — prebuilt cross-sectional factor libraries (Kakushadze 101, GTJA 191, Qlib 158, Fama-French / Carhart). Use when the user asks \"which alphas exist\", wants metadata on a named alpha, or wants to run IC/IR on a whole zoo over a universe.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 3799
+  },
+  {
+    "id": "ashare-pre-st-filter",
+    "name": "ashare-pre-st-filter",
+    "category": "risk-analysis",
+    "description": "A 股 ST/*ST 风险预测框架 — 基于最新中报/三季报或业绩预告/快报，预测下一财年是否会因营收、利润、净资产、分红不达标而被风险警示，并将新浪监管处罚记录作为独立证据面纳入风险等级。仅适用于 A 股，不预测财务造假。",
+    "files": 2,
+    "has_example_engine": false,
+    "body_chars": 19677
+  },
+  {
+    "id": "asset-allocation",
+    "name": "asset-allocation",
+    "category": "asset-class",
+    "description": "Asset allocation theory and optimizer usage — MPT / Black-Litterman / risk budgeting / all-weather strategy, including guides for 5 optimizers and rebalancing rules.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 11704
+  },
+  {
+    "id": "backtest-diagnose",
+    "name": "backtest-diagnose",
+    "category": "tool",
+    "description": "Diagnose failed or underperforming backtests, locate the root cause, and fix the issue",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 4264
+  },
+  {
+    "id": "behavioral-finance",
+    "name": "behavioral-finance",
+    "category": "analysis",
+    "description": "Behavioral finance applications: theories of overreaction and underreaction, behavioral explanations for momentum and reversal, investor sentiment cycles, cognitive-bias checklists, and debiasing quantitative strategies.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 10618
+  },
+  {
+    "id": "bottleneck-hunter",
+    "name": "bottleneck-hunter",
+    "category": "strategy",
+    "description": "Supply-chain bottleneck arbitrage. Given a super-trend (AI infra, energy transition, defense, semiconductor reshoring, space economy), decompose its physical supply chain down to Layer 2/3 choke points (optics, lasers, InP/SOI substrates, IC substrates, probe cards, specialty fiberglass...) and surface under-the-radar listed companies sitting on each bottleneck. Scores each link on 6 scarcity crit",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 10756
+  },
+  {
+    "id": "candlestick",
+    "name": "candlestick",
+    "category": "strategy",
+    "description": "Candlestick pattern recognition engine, pure pandas vectorized implementation of 15 classic candlestick patterns (5 single-candle + 5 double-candle + 4 triple-candle + 1 trend confirmation), generating a composite signal from bullish/bearish pattern scores.",
+    "files": 2,
+    "has_example_engine": true,
+    "body_chars": 1870
+  },
+  {
+    "id": "ccxt",
+    "name": "ccxt",
+    "category": "data-source",
+    "description": "CCXT unified crypto exchange library (100+ exchanges). Free public market data. Fallback when OKX is unavailable.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 2174
+  },
+  {
+    "id": "chanlun",
+    "name": "chanlun",
+    "category": "strategy",
+    "description": "基于缠论（缠中说禅）的形态识别引擎，使用czsc库自动检测K线分型、笔、中枢，并生成一买/一卖/二买/二卖/三买/三卖等买卖点信号。支持多周期分析和形态分类（3/5/7/9/11笔形态）。",
+    "files": 8,
+    "has_example_engine": true,
+    "body_chars": 2581
+  },
+  {
+    "id": "commodity-analysis",
+    "name": "commodity-analysis",
+    "category": "analysis",
+    "description": "Commodity analysis (oil supply-demand balance / gold pricing / copper as an economic predictor / inventory cycles / futures premium-discount structure / seasonality), generating directional commodity signals.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 9047
+  },
+  {
+    "id": "convertible-bond",
+    "name": "convertible-bond",
+    "category": "asset-class",
+    "description": "A股可转债分析——转股/纯债/期权三维估值、下修/强赎/回售博弈、双低策略与转债轮动选债框架",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 4440
+  },
+  {
+    "id": "corporate-events",
+    "name": "corporate-events",
+    "category": "flow",
+    "description": "公司事件驱动分析：并购套利价差计算、大股东增减持信号、股权激励解读、定增配股影响评估、A股ST/退市预警",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 4230
+  },
+  {
+    "id": "correlation-analysis",
+    "name": "correlation-analysis",
+    "category": "analysis",
+    "description": "Correlation and cointegration analysis — co-movement discovery, deep return-correlation analysis, sector clustering, realized correlation, Engle-Granger / Johansen cointegration, half-life, Kalman dynamic hedge ratio, cross-market linkage analysis, and pair-trading signal generation",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 40194
+  },
+  {
+    "id": "correlation-regime",
+    "name": "correlation-regime",
+    "category": "analysis",
+    "description": "Correlation-regime detection and crisis attribution — edge-density regime states with hysteresis, causal (no look-ahead) smoothing, regime-aware exposure context, first-mover crisis attribution with honest NAME / MACRO / AMBIGUOUS / ABSTAIN verdicts, and a correlation-rewiring leaderboard that catches slow bleed-outs",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 21768
+  },
+  {
+    "id": "credit-analysis",
+    "name": "credit-analysis",
+    "category": "analysis",
+    "description": "固收与信用分析：信用债评级、利差分析、违约风险评估、城投债研究、可转债定价与策略。",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 23248
+  },
+  {
+    "id": "cross-market-strategy",
+    "name": "cross-market-strategy",
+    "category": "strategy",
+    "description": "Write signal_engine.py for portfolios spanning multiple markets (A-shares + crypto, equity + forex, etc.)",
+    "files": 2,
+    "has_example_engine": true,
+    "body_chars": 3842
+  },
+  {
+    "id": "crypto-derivatives",
+    "name": "crypto-derivatives",
+    "category": "crypto",
+    "description": "Crypto-derivatives strategies — perpetual funding-rate arbitrage, futures term-structure contango/backwardation trading, and option volatility-smile / Greeks analysis.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 9502
+  },
+  {
+    "id": "data-routing",
+    "name": "data-routing",
+    "category": "data-source",
+    "description": "The single ROUTER for every data need. Load this skill BEFORE any backtest, data-fetch, or research task to pick the best available source/tool, honour auth (env) requirements, and avoid ban-risk providers.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 8226
+  },
+  {
+    "id": "deep-company-series",
+    "name": "deep-company-series",
+    "category": "analysis",
+    "description": "Write a publication-grade 8-part deep-dive series on a single company (~120k words total): cognitive reset / moat / profit engine / hidden assets / era variable (e.g. AI) / financials Buffett-style / management / valuation+redlines. The core IP is NOT writing but REVISING — a strict fact-check checklist catches pseudo-precision (probability-weighted expectations, third-party MAU discrepancies, lin",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 9728
+  },
+  {
+    "id": "defi-yield",
+    "name": "defi-yield",
+    "category": "crypto",
+    "description": "DeFi yield analysis and optimization — lending rates, LP yields, staking returns, yield farming strategies, risk-adjusted yield comparison, and protocol-level sustainability assessment.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 10207
+  },
+  {
+    "id": "dividend-analysis",
+    "name": "dividend-analysis",
+    "category": "analysis",
+    "description": "Dividend stock analysis for income, dividend-growth, and shareholder-return strategies, including yield quality, payout sustainability, ex-dividend mechanics, and yield-trap checks.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 8100
+  },
+  {
+    "id": "doc-reader",
+    "name": "doc-reader",
+    "category": "tool",
+    "description": "Read any common document/data file — PDF, Word (.docx), Excel (.xlsx/.xls), PowerPoint (.pptx), images (OCR), CSV/TSV, plain text, JSON/YAML/TOML, HTML/XML, and most source-code files. Use the `read_document` tool.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 6015
+  },
+  {
+    "id": "earnings-forecast",
+    "name": "earnings-forecast",
+    "category": "analysis",
+    "description": "盈利预测与一致预期分析（自上而下/自下而上预测法/SUE/PEAD/分析师预期修正），捕捉业绩超预期交易机会。",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 4026
+  },
+  {
+    "id": "earnings-revision",
+    "name": "earnings-revision",
+    "category": "analysis",
+    "description": "Earnings estimate revisions, guidance analysis, and post-earnings drift (PEAD) — track analyst consensus changes, earnings surprise patterns, and management guidance shifts for US/HK equities.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 10010
+  },
+  {
+    "id": "eastmoney",
+    "name": "eastmoney",
+    "category": "data-source",
+    "description": "东方财富（Eastmoney）免费免鉴权数据接口，覆盖资金流向、龙虎榜、融资融券、大宗交易、股东户数、限售解禁、行业概念板块、券商研报、财经新闻、A股/港股三大报表+主要指标、全市场选股与代码搜索；美股财报由 get_financial_statements 转 SEC EDGAR。东财请求经共享 IP 限速层节流（东财按源 IP 限流并临时封禁突发请求），通过 Vibe-Trading 工具直接调用，无需 token。",
+    "files": 17,
+    "has_example_engine": false,
+    "body_chars": 4107
+  },
+  {
+    "id": "edgar-sec-filings",
+    "name": "edgar-sec-filings",
+    "category": "flow",
+    "description": "SEC EDGAR filing analysis — 10-K, 10-Q, 8-K, proxy statements, insider Form 4. Extract key financials, risk factors, management discussion, and generate investment signals from US public company filings.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 12337
+  },
+  {
+    "id": "elliott-wave",
+    "name": "elliott-wave",
+    "category": "strategy",
+    "description": "Elliott Wave Theory signal engine. Detects swing points through Zigzag, matches 5-wave impulse and 3-wave corrective structures, validates them with Fibonacci wave relationships, and generates trend-top / correction-complete signals. Pure in-house pandas implementation.",
+    "files": 4,
+    "has_example_engine": true,
+    "body_chars": 1925
+  },
+  {
+    "id": "etf-analysis",
+    "name": "etf-analysis",
+    "category": "asset-class",
+    "description": "ETF分析：产品筛选、费率对比、跟踪误差、流动性评估、策略应用与中国市场ETF量化配置框架。",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 19048
+  },
+  {
+    "id": "event-driven",
+    "name": "event-driven",
+    "category": "strategy",
+    "description": "Event-driven strategy based on sentiment-scored signals from news, announcements, and macro events. The LLM acts as the NLP engine, and event data follows a CSV schema.",
+    "files": 2,
+    "has_example_engine": true,
+    "body_chars": 8500
+  },
+  {
+    "id": "execution-model",
+    "name": "execution-model",
+    "category": "strategy",
+    "description": "Trade execution modeling (backtest only) — slippage formulas (linear / square-root impact), VWAP/TWAP execution logic, market-impact cost estimation, and execution-assumption configuration.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 10879
+  },
+  {
+    "id": "factor-research",
+    "name": "factor-research",
+    "category": "analysis",
+    "description": "Factor research framework with IC/IR analysis, quantile backtesting, and factor combination. Suitable for cross-sectional factor evaluation across multiple instruments.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 7985
+  },
+  {
+    "id": "financial-statement",
+    "name": "financial-statement",
+    "category": "flow",
+    "description": "财报三表深度解读——三表勾稽关系、盈利质量(应计vs现金流)分析、杜邦分解、10+财务造假红旗指标",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 4834
+  },
+  {
+    "id": "fund-analysis",
+    "name": "fund-analysis",
+    "category": "asset-class",
+    "description": "基金分析与筛选：晨星评级/夏普比率/信息比率、Sharpe风格箱分析、风格漂移检测、基金经理评价、FOF组合构建、ETF选择",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 4935
+  },
+  {
+    "id": "fundamental-filter",
+    "name": "fundamental-filter",
+    "category": "flow",
+    "description": "Fundamental factor screening — filter stocks by PE/PB/ROE, financial statement fields, and other metrics for value or growth selection. Supports A-shares (via tushare extra_fields or fundamental_fields) and HK/US stocks (via yfinance Ticker info).",
+    "files": 2,
+    "has_example_engine": true,
+    "body_chars": 6445
+  },
+  {
+    "id": "geopolitical-risk",
+    "name": "geopolitical-risk",
+    "category": "tool",
+    "description": "Geopolitical risk analysis: quantify crisis signals, identify precursors, and build event-driven strategies for war, sanctions, and supply disruption scenarios.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 31359
+  },
+  {
+    "id": "global-macro",
+    "name": "global-macro",
+    "category": "analysis",
+    "description": "Global macro analysis framework (central bank policy transmission / FX forecasting / geopolitical risk / capital flows), used to build macro factor signals that drive cross-asset allocation.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 7747
+  },
+  {
+    "id": "harmonic",
+    "name": "harmonic",
+    "category": "strategy",
+    "description": "Harmonic Patterns signal engine. Identifies XABCD five-point structures such as Gartley/Bat/Butterfly/Crab based on Fibonacci geometry, and generates trading signals in the PRZ (Potential Reversal Zone).",
+    "files": 4,
+    "has_example_engine": true,
+    "body_chars": 1420
+  },
+  {
+    "id": "hedging-strategy",
+    "name": "hedging-strategy",
+    "category": "asset-class",
+    "description": "Hedging strategy design (beta hedge / option protection / tail risk / cross-asset hedging), including hedge-ratio calculation and cost evaluation.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 10823
+  },
+  {
+    "id": "hk-connect-flow",
+    "name": "hk-connect-flow",
+    "category": "flow",
+    "description": "Stock Connect (Shanghai/Shenzhen-Hong Kong) fund flow analysis — Northbound (foreign into A-shares), Southbound (mainland into HK), sector allocation tracking, and cross-border arbitrage signals.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 10437
+  },
+  {
+    "id": "ichimoku",
+    "name": "ichimoku",
+    "category": "strategy",
+    "description": "Ichimoku Kinko Hyo five-line system signal engine. A standalone Japanese technical-analysis school that generates trading signals from Tenkan/Kijun crossovers, cloud position, and Chikou confirmation. Pure pandas implementation.",
+    "files": 4,
+    "has_example_engine": true,
+    "body_chars": 1666
+  },
+  {
+    "id": "liquidation-heatmap",
+    "name": "liquidation-heatmap",
+    "category": "crypto",
+    "description": "Liquidation level analysis and heatmap interpretation — identify leveraged position concentration, liquidation cascades, stop-hunt zones, and use liquidation data as support/resistance signals.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 11954
+  },
+  {
+    "id": "macro-analysis",
+    "name": "macro-analysis",
+    "category": "analysis",
+    "description": "Macroeconomic cycle positioning and central-bank policy interpretation, including GDP/CPI/PMI/rates/FX analysis, with output in the form of major-asset allocation tilts.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 8334
+  },
+  {
+    "id": "management-deep-dive",
+    "name": "management-deep-dive",
+    "category": "analysis",
+    "description": "Deep management assessment — the 'buying a stock is buying a person' layer. For a company or a named executive, evaluate integrity (promise-vs-delivery tracking, crisis behavior, stakeholder treatment), ability (strategic foresight, execution, capital-allocation record) and governance (equity structure, compensation, related-party deals). Outputs a weighted score across integrity / ability / capit",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 8965
+  },
+  {
+    "id": "market-microstructure",
+    "name": "market-microstructure",
+    "category": "analysis",
+    "description": "Market microstructure: bid-ask spread analysis, order-flow toxicity metrics (VPIN / Kyle lambda), liquidity measures (Amihud / Roll), price-impact models, limit-order-book analysis, and China A-share call auction / block trade mechanics.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 11997
+  },
+  {
+    "id": "minute-analysis",
+    "name": "minute-analysis",
+    "category": "strategy",
+    "description": "Minute-level data analysis and backtesting. Retrieves minute candlesticks through OKX/Tushare/yfinance and can be used both for analysis and as input to the backtest engine.",
+    "files": 2,
+    "has_example_engine": true,
+    "body_chars": 3471
+  },
+  {
+    "id": "ml-strategy",
+    "name": "ml-strategy",
+    "category": "strategy",
+    "description": "Machine-learning predictive strategy based on sklearn walk-forward training, feature engineering, and signal generation. Suitable for any OHLCV data.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 11461
+  },
+  {
+    "id": "mootdx",
+    "name": "mootdx",
+    "category": "data-source",
+    "description": "Mootdx A-share market data via TCP-direct 通达信 servers. Free, no API key, no IP rate limits. Use as the stable A-share OHLCV fallback when akshare's East Money scrape is throttled.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 4200
+  },
+  {
+    "id": "multi-factor",
+    "name": "multi-factor",
+    "category": "strategy",
+    "description": "Multi-factor cross-sectional stock ranking. Combines factor standardization, equal-weight or IC-weighted scoring, and TopN portfolio construction. Suitable for multi-instrument portfolio strategies.",
+    "files": 3,
+    "has_example_engine": true,
+    "body_chars": 4097
+  },
+  {
+    "id": "okx-market",
+    "name": "okx-market",
+    "category": "data-source",
+    "description": "OKX cryptocurrency market data interface. Uses the OKX V5 REST API to retrieve spot, derivatives, index, and other crypto market data, including real-time prices, candlesticks, funding rates, open interest, and more. No authentication required, free to use.",
+    "files": 16,
+    "has_example_engine": false,
+    "body_chars": 4981
+  },
+  {
+    "id": "onchain-analysis",
+    "name": "onchain-analysis",
+    "category": "crypto",
+    "description": "On-chain data analysis — active addresses / whale tracking / TVL / DEX liquidity, interpretation and signal generation using on-chain valuation metrics such as MVRV / NVT / SOPR.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 9807
+  },
+  {
+    "id": "options-advanced",
+    "name": "options-advanced",
+    "category": "asset-class",
+    "description": "Advanced options strategies: volatility-surface modeling (SABR / Local Vol), dynamic Greeks rebalancing, calendar spreads, volatility arbitrage and skew trading, and option market-making basics.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 7982
+  },
+  {
+    "id": "options-payoff",
+    "name": "options-payoff",
+    "category": "asset-class",
+    "description": "Option P&L analysis methodology: payoff diagrams, breakeven calculation, multi-leg strategy visualization, and Greeks-based scenario analysis.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 28860
+  },
+  {
+    "id": "options-strategy",
+    "name": "options-strategy",
+    "category": "asset-class",
+    "description": "Options strategy framework supporting Black-Scholes pricing, Greeks analysis, and multi-leg backtesting. Suitable for cryptocurrency and equity options.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 7568
+  },
+  {
+    "id": "pair-trading",
+    "name": "pair-trading",
+    "category": "strategy",
+    "description": "Pair trading strategy. Trades mean reversion using the spread/ratio Z-score of two correlated instruments. Requires at least two instruments.",
+    "files": 2,
+    "has_example_engine": true,
+    "body_chars": 2601
+  },
+  {
+    "id": "performance-attribution",
+    "name": "performance-attribution",
+    "category": "analysis",
+    "description": "Performance attribution analysis — Brinson sector/stock-selection attribution, factor alpha/beta decomposition, market-timing evaluation, and benchmark comparison framework.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 8637
+  },
+  {
+    "id": "perp-funding-basis",
+    "name": "perp-funding-basis",
+    "category": "crypto",
+    "description": "Perpetual futures funding rate analysis and cash-carry basis trading — funding rate regimes, annualized basis signals, carry trade construction, and funding rate arbitrage between exchanges.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 10695
+  },
+  {
+    "id": "pine-script",
+    "name": "pine-script",
+    "category": "tool",
+    "description": "Export backtest strategies to indicator/strategy code for major trading platforms — TradingView, 通达信, 同花顺, 东方财富, MT5.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 14968
+  },
+  {
+    "id": "private-company-research",
+    "name": "private-company-research",
+    "category": "analysis",
+    "description": "Deep research framework for pre-IPO / private companies (Ant Group, SpaceX, Stripe, ByteDance...). Six analyst lenses — business model, financial forensics, competitive landscape, risk & governance, tech & IP, alternative-data signals — run in parallel via run_swarm, then cross-validated for signal consistency before any verdict. Built around the core challenge of private-company work: information",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 14027
+  },
+  {
+    "id": "quant-statistics",
+    "name": "quant-statistics",
+    "category": "analysis",
+    "description": "Quantitative statistical methods: ADF unit-root / cointegration tests, GARCH volatility modeling, regression diagnostics (heteroskedasticity / autocorrelation), Bootstrap, and hypothesis testing.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 14723
+  },
+  {
+    "id": "qveris",
+    "name": "qveris",
+    "category": "data-source",
+    "description": "Paid capability marketplace for global multi-asset data; use it when free Vibe-Trading sources lack coverage, depth, or provider quality, and keep free sources as the default for routine OHLCV.",
+    "files": 3,
+    "has_example_engine": false,
+    "body_chars": 4851
+  },
+  {
+    "id": "regulatory-knowledge",
+    "name": "regulatory-knowledge",
+    "category": "tool",
+    "description": "金融监管知识库：A股涨跌停/ST退市新规/融券、港股T+0/做空机制、美股PDT/熔断、加密监管政策、跨境税务基础",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 5275
+  },
+  {
+    "id": "report-generate",
+    "name": "report-generate",
+    "category": "tool",
+    "description": "Professional financial research report generation — standard structure (summary / views / main body / risks / recommendation), Markdown formatting standards, rating system, and terminology guide.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 9728
+  },
+  {
+    "id": "research-discipline",
+    "name": "research-discipline",
+    "category": "analysis",
+    "description": "A short self-bias checklist to run at the START of any investment research task (stock screen / sector study / company deep-dive). Four biases that systematically warp AI research — leader-bias (only big caps), English-bias (miss JP/KR/TW players), narrative-bias (chase concept labels), confirmation-bias (only bullish evidence) — plus recency-bias. Load this first, then research with the correctio",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 2877
+  },
+  {
+    "id": "research-goal",
+    "name": "research-goal",
+    "category": "flow",
+    "description": "Goal-driven finance research workflow: attach a research-only objective, track criteria, and add evidence while avoiding live trading execution.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 2840
+  },
+  {
+    "id": "risk-analysis",
+    "name": "risk-analysis",
+    "category": "analysis",
+    "description": "Risk measurement and stress testing — VaR/CVaR/max drawdown calculation, Monte Carlo simulation, extreme-value tail-risk analysis, and historical scenario stress testing.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 10986
+  },
+  {
+    "id": "seasonal",
+    "name": "seasonal",
+    "category": "strategy",
+    "description": "Seasonal/calendar-effect strategy. Generates trading signals from time-based patterns such as month-of-year effects and day-of-week effects. Suitable for any OHLCV data.",
+    "files": 2,
+    "has_example_engine": true,
+    "body_chars": 2289
+  },
+  {
+    "id": "sec-edgar",
+    "name": "sec-edgar",
+    "category": "data-source",
+    "description": "U.S. SEC EDGAR fetch interface — resolve a ticker to its CIK, list recent filings (10-K / 10-Q / 8-K and friends) with primary-document URLs, and pull XBRL companyfacts financial series. Free, no API key; rate-limited by IP so every request is throttled and carries a contact User-Agent. United States only.",
+    "files": 6,
+    "has_example_engine": false,
+    "body_chars": 5531
+  },
+  {
+    "id": "sector-rotation",
+    "name": "sector-rotation",
+    "category": "asset-class",
+    "description": "行业轮动分析——申万行业景气度评分、行业动量排名、产业链传导、估值/盈利/资金流多维比较框架",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 3857
+  },
+  {
+    "id": "sentiment-analysis",
+    "name": "sentiment-analysis",
+    "category": "analysis",
+    "description": "市场情绪分析——恐贪指数/Put-Call Ratio/融资融券/北向资金信号解读、社交媒体舆情量化框架",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 4460
+  },
+  {
+    "id": "shadow-account",
+    "name": "shadow-account",
+    "category": "analysis",
+    "description": "Shadow Account — 从用户交割单提炼盈利模式（3-5 条人话规则）→ 跨 A股/港股/美股/crypto 多市场回测 → 差值归因 → 8-section PDF 报告。叙事：你的影子，没有情绪噪音。",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 2265
+  },
+  {
+    "id": "smc",
+    "name": "smc",
+    "category": "strategy",
+    "description": "Smart Money Concepts (ICT) signal engine. Uses the smartmoneyconcepts library to implement institutional-trading-school analysis of BOS, ChoCH, FVG, and order blocks (OB).",
+    "files": 4,
+    "has_example_engine": true,
+    "body_chars": 1439
+  },
+  {
+    "id": "social-media-intelligence",
+    "name": "social-media-intelligence",
+    "category": "tool",
+    "description": "Social media intelligence: financial signal extraction from Twitter/X, Telegram, Discord, and Reddit for sentiment-driven trading strategies.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 40675
+  },
+  {
+    "id": "stablecoin-flow",
+    "name": "stablecoin-flow",
+    "category": "crypto",
+    "description": "Stablecoin supply and flow analysis — USDT/USDC mint-burn signals, exchange stablecoin reserves, on-chain stablecoin velocity, and capital rotation indicators for crypto market timing.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 9977
+  },
+  {
+    "id": "strategy-dev-manager",
+    "name": "strategy-dev-manager",
+    "category": "research",
+    "description": "Strategy Development Manager: convert academic papers and research reports into validated factors and strategies with automated backtesting, persistent storage, and decay monitoring.",
+    "files": 9,
+    "has_example_engine": false,
+    "body_chars": 11967
+  },
+  {
+    "id": "strategy-generate",
+    "name": "strategy-generate",
+    "category": "strategy",
+    "description": "Create, modify, and optimize quantitative trading strategies, then backtest and evaluate them.",
+    "files": 2,
+    "has_example_engine": false,
+    "body_chars": 12150
+  },
+  {
+    "id": "technical-basic",
+    "name": "technical-basic",
+    "category": "strategy",
+    "description": "Core technical indicator collection (trend EMA/ADX + mean-reversion BB/RSI + volume-price OBV/volume ratio), generates a composite signal via three-dimensional voting. Pure pandas implementation for any OHLCV data.",
+    "files": 2,
+    "has_example_engine": true,
+    "body_chars": 1968
+  },
+  {
+    "id": "thesis-tracker",
+    "name": "thesis-tracker",
+    "category": "strategy",
+    "description": "Buy-side discipline system. For each holding, maintain a written investment thesis — core thesis in 5 sentences, falsifiable assumptions, red lines, valuation anchors — and re-check it each quarter against new earnings/events. Scores thesis health 1-10 from assumption breakage and red-line triggers, and recommends hold / add / trim / exit. Use it right after buying a stock (to write the thesis) an",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 8604
+  },
+  {
+    "id": "token-unlock-treasury",
+    "name": "token-unlock-treasury",
+    "category": "crypto",
+    "description": "Token unlock schedule analysis and project treasury tracking — vesting cliffs, linear unlocks, team/investor/ecosystem token releases, treasury diversification, and sell pressure forecasting.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 11244
+  },
+  {
+    "id": "trade-journal",
+    "name": "trade-journal",
+    "category": "tool",
+    "description": "Analyze a user's trade journal (CSV/Excel broker export). Parses 同花顺/东方财富/富途/generic formats, produces a trading profile and 4 behavior diagnostics (disposition effect, overtrading, chasing, anchoring). Use the `analyze_trade_journal` tool.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 7071
+  },
+  {
+    "id": "tushare",
+    "name": "tushare",
+    "category": "data-source",
+    "description": "tushare是一个财经数据接口包，拥有丰富的数据内容，如股票、基金、期货、数字货币等行情数据，公司财务、基金经理等基本面数据。该模块通过标准化API方式统一了数据资产的对外服务方式，以帮助有需要的技术用户更实时、简洁、轻量的使用相关数据。",
+    "files": 232,
+    "has_example_engine": false,
+    "body_chars": 103037
+  },
+  {
+    "id": "us-etf-flow",
+    "name": "us-etf-flow",
+    "category": "flow",
+    "description": "US ETF fund flow analysis, sector rotation breadth, and style factor flows — track institutional capital movement via ETF creation/redemption, sector breadth signals, and thematic momentum.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 10239
+  },
+  {
+    "id": "valuation-model",
+    "name": "valuation-model",
+    "category": "analysis",
+    "description": "Valuation methodology — absolute valuation with DCF / DDM / SOTP, relative valuation with PE-Band / PB-ROE / EV-EBITDA, sensitivity analysis, and valuation-trap detection.",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 8993
+  },
+  {
+    "id": "vnpy-export",
+    "name": "vnpy-export",
+    "category": "tool",
+    "description": "Export a Vibe-Trading backtest strategy to a runnable vnpy CtaTemplate Python class — supports A-share equities, futures, and crypto via BarGenerator + ArrayManager.",
+    "files": 2,
+    "has_example_engine": false,
+    "body_chars": 11487
+  },
+  {
+    "id": "volatility",
+    "name": "volatility",
+    "category": "strategy",
+    "description": "Volatility strategy. Trades mean reversion based on percentile ranking of historical volatility (HV). Suitable for any OHLCV data.",
+    "files": 2,
+    "has_example_engine": true,
+    "body_chars": 2111
+  },
+  {
+    "id": "web-reader",
+    "name": "web-reader",
+    "category": "tool",
+    "description": "Read web pages, articles, and document links by converting URLs into Markdown text. Use the `read_url` tool directly, without bash. Sends the full URL to the third-party Jina Reader (r.jina.ai).",
+    "files": 1,
+    "has_example_engine": false,
+    "body_chars": 2212
+  },
+  {
+    "id": "yfinance",
+    "name": "yfinance",
+    "category": "data-source",
+    "description": "yfinance global market data interface — retrieve OHLCV, financials, insider transactions, and institutional holdings for US stocks, HK stocks, ETFs, and indices via Yahoo Finance. Free, no API key required.",
+    "files": 7,
+    "has_example_engine": false,
+    "body_chars": 8525
+  }
+]

--- a/docs/analysis/catalog/swarm_inventory.json
+++ b/docs/analysis/catalog/swarm_inventory.json
@@ -1,0 +1,1316 @@
+[
+  {
+    "file": "commodity_research_team.yaml",
+    "name": "commodity_research_team",
+    "title": "Commodity Research Team",
+    "description": "Parallel deep-dive on supply and demand, synthesized by a cycle strategist into an investment thesis — DAG workflow",
+    "n_agents": 3,
+    "n_tasks": 3,
+    "agent_ids": [
+      "supply_analyst",
+      "demand_analyst",
+      "cycle_strategist"
+    ],
+    "task_ids": [
+      "task-supply-research",
+      "task-demand-research",
+      "task-cycle-strategy"
+    ],
+    "dependencies": [
+      {
+        "task": "task-cycle-strategy",
+        "depends_on": [
+          "task-supply-research",
+          "task-demand-research"
+        ]
+      }
+    ],
+    "variables": [
+      {
+        "name": "commodity",
+        "description": "Commodity type, e.g.: crude oil / gold / copper / iron ore / natural gas / soybeans / aluminum / rebar",
+        "required": true
+      },
+      {
+        "name": "horizon",
+        "description": "Investment horizon, e.g.: 1 month / 3 months / 6 months / 1 year",
+        "required": true
+      }
+    ]
+  },
+  {
+    "file": "convertible_bond_team.yaml",
+    "name": "convertible_bond_team",
+    "title": "Convertible Bond Research Team",
+    "description": "Parallel three-dimensional analysis — bond floor, equity optionality, and embedded option value — synthesized into a convertible bond investment strategy",
+    "n_agents": 4,
+    "n_tasks": 4,
+    "agent_ids": [
+      "bond_analyst",
+      "equity_analyst",
+      "option_analyst",
+      "cb_strategist"
+    ],
+    "task_ids": [
+      "task-bond",
+      "task-equity",
+      "task-option",
+      "task-strategy"
+    ],
+    "dependencies": [
+      {
+        "task": "task-strategy",
+        "depends_on": [
+          "task-bond",
+          "task-equity",
+          "task-option"
+        ]
+      }
+    ],
+    "variables": [
+      {
+        "name": "market",
+        "description": "Target market (default: A-share convertible bonds)",
+        "required": true
+      },
+      {
+        "name": "goal",
+        "description": "Research focus (e.g.: uncover undervalued convertibles, position for conversion price reset candidates)",
+        "required": true
+      },
+      {
+        "name": "strategy_type",
+        "description": "Strategy type (low-price / dual-low / high-convexity / rotation; leave blank for strategist's discretion)",
+        "required": false
+      }
+    ]
+  },
+  {
+    "file": "credit_research_team.yaml",
+    "name": "credit_research_team",
+    "title": "Fixed Income Credit Research Team",
+    "description": "Credit quality + interest rate environment + sector credit three-dimensional parallel analysis → fixed income strategist synthesizes a complete bond investment strategy",
+    "n_agents": 4,
+    "n_tasks": 4,
+    "agent_ids": [
+      "credit_analyst",
+      "rate_analyst",
+      "sector_credit_analyst",
+      "fixed_income_strategist"
+    ],
+    "task_ids": [
+      "task-credit",
+      "task-rate",
+      "task-sector-credit",
+      "task-strategy"
+    ],
+    "dependencies": [
+      {
+        "task": "task-strategy",
+        "depends_on": [
+          "task-credit",
+          "task-rate",
+          "task-sector-credit"
+        ]
+      }
+    ],
+    "variables": [
+      {
+        "name": "target",
+        "description": "Research subject or sector (e.g.: a specific LGFV platform, the property sector, steel bonds, AA-rated credit bond portfolio)",
+        "required": true
+      },
+      {
+        "name": "market",
+        "description": "Bond market (default: China bond market; options: credit bonds / LGFV bonds / rate bonds / convertible bonds)",
+        "required": false
+      }
+    ]
+  },
+  {
+    "file": "crypto_research_lab.yaml",
+    "name": "crypto_research_lab",
+    "title": "Crypto Asset Research Lab",
+    "description": "On-chain data + DeFi protocol + market sentiment three-dimensional parallel analysis → Alpha synthesizer converges investment recommendations",
+    "n_agents": 4,
+    "n_tasks": 4,
+    "agent_ids": [
+      "onchain_analyst",
+      "defi_analyst",
+      "crypto_sentiment_analyst",
+      "alpha_synthesizer"
+    ],
+    "task_ids": [
+      "task-onchain",
+      "task-defi",
+      "task-sentiment",
+      "task-alpha"
+    ],
+    "dependencies": [
+      {
+        "task": "task-alpha",
+        "depends_on": [
+          "task-onchain",
+          "task-defi",
+          "task-sentiment"
+        ]
+      }
+    ],
+    "variables": [
+      {
+        "name": "target",
+        "description": "Target asset (e.g.: BTC / ETH / SOL; default BTC/ETH/SOL)",
+        "required": true
+      },
+      {
+        "name": "timeframe",
+        "description": "Analysis time horizon (short-term 1–4 weeks / medium-term 1–3 months / long-term 3–12 months)",
+        "required": true
+      }
+    ]
+  },
+  {
+    "file": "crypto_trading_desk.yaml",
+    "name": "crypto_trading_desk",
+    "title": "Crypto Trading & Risk Desk",
+    "description": "Execution-oriented crypto desk: funding/basis analyst + liquidation/microstructure analyst + on-chain/flow analyst + risk manager. Goes beyond research into position sizing, execution timing, and risk gating.",
+    "n_agents": 4,
+    "n_tasks": 4,
+    "agent_ids": [
+      "funding_basis_analyst",
+      "liquidation_analyst",
+      "flow_analyst",
+      "desk_risk_manager"
+    ],
+    "task_ids": [
+      "task-funding",
+      "task-liquidation",
+      "task-flow",
+      "task-risk-decision"
+    ],
+    "dependencies": [
+      {
+        "task": "task-risk-decision",
+        "depends_on": [
+          "task-funding",
+          "task-liquidation",
+          "task-flow"
+        ]
+      }
+    ],
+    "variables": [
+      {
+        "name": "target",
+        "description": "Target asset (e.g., BTC-USDT, ETH-USDT, SOL-USDT)",
+        "required": true
+      },
+      {
+        "name": "timeframe",
+        "description": "Trading horizon (intraday / swing 1-2 weeks / position 1-3 months)",
+        "required": true
+      }
+    ]
+  },
+  {
+    "file": "derivatives_strategy_desk.yaml",
+    "name": "derivatives_strategy_desk",
+    "title": "Derivatives Strategy Desk",
+    "description": "Volatility analysis → strategy design → Greeks risk management: sequential options trading desk workflow",
+    "n_agents": 3,
+    "n_tasks": 3,
+    "agent_ids": [
+      "vol_analyst",
+      "strategy_designer",
+      "greeks_manager"
+    ],
+    "task_ids": [
+      "task-vol",
+      "task-strategy",
+      "task-greeks"
+    ],
+    "dependencies": [
+      {
+        "task": "task-strategy",
+        "depends_on": [
+          "task-vol"
+        ]
+      },
+      {
+        "task": "task-greeks",
+        "depends_on": [
+          "task-strategy"
+        ]
+      }
+    ],
+    "variables": [
+      {
+        "name": "target",
+        "description": "Underlying (e.g.: BTC, CSI 300 ETF, AAPL)",
+        "required": true
+      },
+      {
+        "name": "view",
+        "description": "Market view (bullish / bearish / neutral / long volatility / short volatility)",
+        "required": true
+      }
+    ]
+  },
+  {
+    "file": "earnings_research_desk.yaml",
+    "name": "earnings_research_desk",
+    "title": "Earnings Research Desk",
+    "description": "Earnings-focused research team: fundamental analyst + earnings revision tracker + options/event analyst + earnings strategist. Deep-dives into company financials, consensus revisions, earnings event trades, and post-earnings drift.",
+    "n_agents": 4,
+    "n_tasks": 4,
+    "agent_ids": [
+      "fundamental_analyst",
+      "revision_tracker",
+      "event_options_analyst",
+      "earnings_strategist"
+    ],
+    "task_ids": [
+      "task-fundamental",
+      "task-revision",
+      "task-options-event",
+      "task-earnings-strategy"
+    ],
+    "dependencies": [
+      {
+        "task": "task-earnings-strategy",
+        "depends_on": [
+          "task-fundamental",
+          "task-revision",
+          "task-options-event"
+        ]
+      }
+    ],
+    "variables": [
+      {
+        "name": "target",
+        "description": "Target stock (e.g., AAPL.US, NVDA.US, 700.HK, 600519.SH)",
+        "required": true
+      }
+    ]
+  },
+  {
+    "file": "equity_research_team.yaml",
+    "name": "equity_research_team",
+    "title": "Equity Research Team",
+    "description": "Macro → sector → stock three-tier deep research → research editor consolidates into a complete report",
+    "n_agents": 4,
+    "n_tasks": 4,
+    "agent_ids": [
+      "macro_analyst",
+      "sector_analyst",
+      "stock_picker",
+      "aggregator"
+    ],
+    "task_ids": [
+      "task-macro",
+      "task-sector",
+      "task-stock",
+      "task-aggregate"
+    ],
+    "dependencies": [
+      {
+        "task": "task-sector",
+        "depends_on": [
+          "task-macro"
+        ]
+      },
+      {
+        "task": "task-stock",
+        "depends_on": [
+          "task-sector"
+        ]
+      },
+      {
+        "task": "task-aggregate",
+        "depends_on": [
+          "task-stock"
+        ]
+      }
+    ],
+    "variables": [
+      {
+        "name": "market",
+        "description": "Target market (e.g.: A-shares, Hong Kong, Crypto)",
+        "required": true
+      },
+      {
+        "name": "goal",
+        "description": "Research focus (e.g.: Q2 2026 outlook, opportunities in the new energy sector)",
+        "required": true
+      }
+    ]
+  },
+  {
+    "file": "etf_allocation_desk.yaml",
+    "name": "etf_allocation_desk",
+    "title": "ETF Allocation Desk",
+    "description": "ETF screening + macro allocation + risk budgeting three-dimensional parallel analysis → portfolio optimizer constructs the final ETF portfolio and backtests",
+    "n_agents": 4,
+    "n_tasks": 4,
+    "agent_ids": [
+      "etf_screener",
+      "macro_allocator",
+      "risk_budgeter",
+      "portfolio_optimizer"
+    ],
+    "task_ids": [
+      "task-etf-screen",
+      "task-macro-alloc",
+      "task-risk-budget",
+      "task-optimize"
+    ],
+    "dependencies": [
+      {
+        "task": "task-optimize",
+        "depends_on": [
+          "task-etf-screen",
+          "task-macro-alloc",
+          "task-risk-budget"
+        ]
+      }
+    ],
+    "variables": [
+      {
+        "name": "risk_profile",
+        "description": "Risk profile (conservative / balanced / aggressive)",
+        "required": true
+      },
+      {
+        "name": "market",
+        "description": "Target market (default: A-shares; options: global multi-asset, HK/US equities, A-shares + HK)",
+        "required": false
+      }
+    ]
+  },
+  {
+    "file": "event_driven_task_force.yaml",
+    "name": "event_driven_task_force",
+    "title": "Event-Driven Task Force",
+    "description": "Event scanning → deep impact analysis → strategy construction: sequential deep-dive chain replicating an event-driven hedge fund special investigation unit workflow",
+    "n_agents": 3,
+    "n_tasks": 3,
+    "agent_ids": [
+      "event_scanner",
+      "impact_analyst",
+      "strategy_builder"
+    ],
+    "task_ids": [
+      "task-event-scan",
+      "task-impact-analysis",
+      "task-strategy-build"
+    ],
+    "dependencies": [
+      {
+        "task": "task-impact-analysis",
+        "depends_on": [
+          "task-event-scan"
+        ]
+      },
+      {
+        "task": "task-strategy-build",
+        "depends_on": [
+          "task-impact-analysis"
+        ]
+      }
+    ],
+    "variables": [
+      {
+        "name": "market",
+        "description": "Target market, e.g.: A-shares / Hong Kong / US equities / Chinese ADRs",
+        "required": true
+      },
+      {
+        "name": "event_type",
+        "description": "Event type filter, e.g.: M&A / insider trading / earnings / policy / litigation / management change; enter 'all types' for no filter",
+        "required": false
+      }
+    ]
+  },
+  {
+    "file": "factor_research_committee.yaml",
+    "name": "factor_research_committee",
+    "title": "Factor Research Committee",
+    "description": "Factor mining + factor validation running in parallel → factor combination construction → backtest review: quant fund internal research review workflow",
+    "n_agents": 4,
+    "n_tasks": 4,
+    "agent_ids": [
+      "factor_miner",
+      "factor_validator",
+      "factor_combiner",
+      "backtest_reviewer"
+    ],
+    "task_ids": [
+      "task-mine",
+      "task-validate",
+      "task-combine",
+      "task-review"
+    ],
+    "dependencies": [
+      {
+        "task": "task-combine",
+        "depends_on": [
+          "task-mine",
+          "task-validate"
+        ]
+      },
+      {
+        "task": "task-review",
+        "depends_on": [
+          "task-combine"
+        ]
+      }
+    ],
+    "variables": [
+      {
+        "name": "market",
+        "description": "Target market (e.g.: A-shares, Hong Kong, US equities)",
+        "required": true
+      },
+      {
+        "name": "factor_type",
+        "description": "Factor type (value / momentum / quality / growth / alternative)",
+        "required": true
+      }
+    ]
+  },
+  {
+    "file": "fund_selection_panel.yaml",
+    "name": "fund_selection_panel",
+    "title": "Fund Selection Panel",
+    "description": "Multi-dimensional quantitative screening → Brinson performance attribution and style analysis → FOF portfolio weight optimization, sequential professional review chain",
+    "n_agents": 3,
+    "n_tasks": 3,
+    "agent_ids": [
+      "fund_screener",
+      "attribution_analyst",
+      "fof_optimizer"
+    ],
+    "task_ids": [
+      "task-fund-screen",
+      "task-performance-attribution",
+      "task-fof-optimize"
+    ],
+    "dependencies": [
+      {
+        "task": "task-performance-attribution",
+        "depends_on": [
+          "task-fund-screen"
+        ]
+      },
+      {
+        "task": "task-fof-optimize",
+        "depends_on": [
+          "task-performance-attribution"
+        ]
+      }
+    ],
+    "variables": [
+      {
+        "name": "fund_type",
+        "description": "Fund type, e.g.: equity / bond / balanced / index-enhanced / quant hedge / QDII",
+        "required": true
+      },
+      {
+        "name": "goal",
+        "description": "Investment objective, e.g.: build a steady FOF portfolio with annualized return >10% and max drawdown <15%",
+        "required": true
+      }
+    ]
+  },
+  {
+    "file": "fundamental_research_team.yaml",
+    "name": "fundamental_research_team",
+    "title": "Fundamental Deep Research Team",
+    "description": "Financial / valuation / quality three-dimensional parallel analysis → research editor consolidates into a buy-side deep research report",
+    "n_agents": 4,
+    "n_tasks": 4,
+    "agent_ids": [
+      "financial_analyst",
+      "valuation_analyst",
+      "quality_analyst",
+      "report_editor"
+    ],
+    "task_ids": [
+      "task-financial",
+      "task-valuation",
+      "task-quality",
+      "task-report"
+    ],
+    "dependencies": [
+      {
+        "task": "task-report",
+        "depends_on": [
+          "task-financial",
+          "task-valuation",
+          "task-quality"
+        ]
+      }
+    ],
+    "variables": [
+      {
+        "name": "target",
+        "description": "Research subject (stock code or name, e.g.: 600519 Kweichow Moutai)",
+        "required": true
+      },
+      {
+        "name": "market",
+        "description": "Market (e.g.: A-shares, Hong Kong, US equities)",
+        "required": true
+      }
+    ]
+  },
+  {
+    "file": "geopolitical_war_room.yaml",
+    "name": "geopolitical_war_room",
+    "title": "Geopolitical Risk War Room",
+    "description": "Geopolitical analysis, energy shock, and supply-chain impact run in parallel, then feed into the Chief Strategist for synthesis, producing emergency asset-allocation playbooks for geopolitical crises.",
+    "n_agents": 4,
+    "n_tasks": 4,
+    "agent_ids": [
+      "geopolitical_analyst",
+      "energy_analyst",
+      "supply_chain_analyst",
+      "chief_strategist"
+    ],
+    "task_ids": [
+      "task-geopolitical",
+      "task-energy",
+      "task-supply-chain",
+      "task-strategy"
+    ],
+    "dependencies": [
+      {
+        "task": "task-strategy",
+        "depends_on": [
+          "task-geopolitical",
+          "task-energy",
+          "task-supply-chain"
+        ]
+      }
+    ],
+    "variables": [
+      {
+        "name": "crisis",
+        "description": "Crisis narrative (e.g., Taiwan Strait escalation, Hormuz blockade, full Red Sea Houthi disruption)",
+        "required": true
+      },
+      {
+        "name": "market",
+        "description": "Focus market (e.g., A-shares, Hong Kong, global multi-asset)",
+        "required": true
+      }
+    ]
+  },
+  {
+    "file": "global_allocation_committee.yaml",
+    "name": "global_allocation_committee",
+    "title": "Global Allocation Committee",
+    "description": "Parallel A-shares + crypto + HK/US analysts; allocator synthesizes cross-market allocation with data-driven weighting, scenario analysis, and rebalancing rules.",
+    "n_agents": 4,
+    "n_tasks": 4,
+    "agent_ids": [
+      "a_share_analyst",
+      "crypto_analyst",
+      "us_hk_analyst",
+      "allocator"
+    ],
+    "task_ids": [
+      "task-ashare",
+      "task-crypto",
+      "task-ushk",
+      "task-allocate"
+    ],
+    "dependencies": [
+      {
+        "task": "task-allocate",
+        "depends_on": [
+          "task-ashare",
+          "task-crypto",
+          "task-ushk"
+        ]
+      }
+    ],
+    "variables": [
+      {
+        "name": "goal",
+        "description": "Investment objective (e.g., Q2 2026 multi-asset allocation)",
+        "required": true
+      },
+      {
+        "name": "risk_tolerance",
+        "description": "Risk tolerance (conservative / moderate / aggressive)",
+        "required": false
+      }
+    ]
+  },
+  {
+    "file": "global_equities_desk.yaml",
+    "name": "global_equities_desk",
+    "title": "Global Equities Research Desk",
+    "description": "Cross-market equity research: A-share analyst + HK/US analyst + crypto analyst + global strategist. Covers fundamental screening, earnings analysis, ETF flows, and cross-listing arbitrage for multi-market stock selection.",
+    "n_agents": 4,
+    "n_tasks": 4,
+    "agent_ids": [
+      "a_share_researcher",
+      "us_hk_researcher",
+      "crypto_researcher",
+      "global_strategist"
+    ],
+    "task_ids": [
+      "task-ashare",
+      "task-ushk",
+      "task-crypto",
+      "task-strategy"
+    ],
+    "dependencies": [
+      {
+        "task": "task-strategy",
+        "depends_on": [
+          "task-ashare",
+          "task-ushk",
+          "task-crypto"
+        ]
+      }
+    ],
+    "variables": [
+      {
+        "name": "goal",
+        "description": "Investment objective (e.g., Q2 2026 global equity allocation, tech sector deep-dive)",
+        "required": true
+      },
+      {
+        "name": "risk_tolerance",
+        "description": "Risk tolerance level (conservative / moderate / aggressive)",
+        "required": false
+      }
+    ]
+  },
+  {
+    "file": "investment_committee.yaml",
+    "name": "investment_committee",
+    "title": "Investment Committee",
+    "description": "Long–short debate → risk review → PM final call: buy-side fund investment committee workflow.",
+    "n_agents": 4,
+    "n_tasks": 4,
+    "agent_ids": [
+      "bull_advocate",
+      "bear_advocate",
+      "risk_officer",
+      "portfolio_manager"
+    ],
+    "task_ids": [
+      "task-bull",
+      "task-bear",
+      "task-risk",
+      "task-decision"
+    ],
+    "dependencies": [
+      {
+        "task": "task-risk",
+        "depends_on": [
+          "task-bull",
+          "task-bear"
+        ]
+      },
+      {
+        "task": "task-decision",
+        "depends_on": [
+          "task-risk"
+        ]
+      }
+    ],
+    "variables": [
+      {
+        "name": "target",
+        "description": "Security (e.g., 600519.SH Kweichow Moutai, BTC-USDT, AAPL)",
+        "required": true
+      },
+      {
+        "name": "market",
+        "description": "Market (e.g., A-shares, Hong Kong, US, crypto)",
+        "required": true
+      }
+    ]
+  },
+  {
+    "file": "macro_rates_fx_desk.yaml",
+    "name": "macro_rates_fx_desk",
+    "title": "Macro / Rates / FX Desk",
+    "description": "Cross-asset macro desk: global rates analyst + FX strategist + commodity/inflation analyst + macro portfolio manager. Covers central bank policy, yield curve dynamics, currency positioning, and macro-driven asset allocation.",
+    "n_agents": 4,
+    "n_tasks": 4,
+    "agent_ids": [
+      "rates_analyst",
+      "fx_strategist",
+      "commodity_inflation_analyst",
+      "macro_pm"
+    ],
+    "task_ids": [
+      "task-rates",
+      "task-fx",
+      "task-commodity-inflation",
+      "task-macro-allocation"
+    ],
+    "dependencies": [
+      {
+        "task": "task-macro-allocation",
+        "depends_on": [
+          "task-rates",
+          "task-fx",
+          "task-commodity-inflation"
+        ]
+      }
+    ],
+    "variables": [
+      {
+        "name": "goal",
+        "description": "Macro investment objective (e.g., Q2 2026 cross-asset positioning, rate cycle trade)",
+        "required": true
+      },
+      {
+        "name": "timeframe",
+        "description": "Investment horizon (tactical 1-3 months / strategic 6-12 months)",
+        "required": true
+      }
+    ]
+  },
+  {
+    "file": "macro_strategy_forum.yaml",
+    "name": "macro_strategy_forum",
+    "title": "Macro Strategy Forum",
+    "description": "Global + domestic + policy perspectives run in parallel; chief strategist delivers integrated cross-asset allocation guidance.",
+    "n_agents": 4,
+    "n_tasks": 4,
+    "agent_ids": [
+      "global_economist",
+      "domestic_economist",
+      "policy_analyst",
+      "chief_strategist"
+    ],
+    "task_ids": [
+      "task-global",
+      "task-domestic",
+      "task-policy",
+      "task-strategy"
+    ],
+    "dependencies": [
+      {
+        "task": "task-strategy",
+        "depends_on": [
+          "task-global",
+          "task-domestic",
+          "task-policy"
+        ]
+      }
+    ],
+    "variables": [
+      {
+        "name": "market",
+        "description": "Focus market (e.g., A-shares, Hong Kong, global multi-asset, crypto)",
+        "required": true
+      },
+      {
+        "name": "horizon",
+        "description": "Horizon (e.g., monthly, quarterly, annual)",
+        "required": true
+      }
+    ]
+  },
+  {
+    "file": "ml_quant_lab.yaml",
+    "name": "ml_quant_lab",
+    "title": "Machine Learning Quant Lab",
+    "description": "Feature engineering and model design in parallel; flows into the backtest engineer for strict out-of-sample validation.",
+    "n_agents": 3,
+    "n_tasks": 3,
+    "agent_ids": [
+      "feature_engineer",
+      "data_scientist",
+      "backtest_engineer"
+    ],
+    "task_ids": [
+      "task-features",
+      "task-model",
+      "task-backtest"
+    ],
+    "dependencies": [
+      {
+        "task": "task-backtest",
+        "depends_on": [
+          "task-features",
+          "task-model"
+        ]
+      }
+    ],
+    "variables": [
+      {
+        "name": "market",
+        "description": "Target market (e.g., A-shares, Hong Kong/US equities)",
+        "required": true
+      },
+      {
+        "name": "target_variable",
+        "description": "Prediction target (return / direction / volatility)",
+        "required": true
+      },
+      {
+        "name": "goal",
+        "description": "Research focus (e.g., build a monthly stock-selection model, forecast daily volatility)",
+        "required": true
+      }
+    ]
+  },
+  {
+    "file": "pairs_research_lab.yaml",
+    "name": "pairs_research_lab",
+    "title": "Pairs Trading Research Lab",
+    "description": "Correlation scan and cointegration testing in parallel → converge into the pair strategist for strategy design → final microstructure review for execution feasibility.",
+    "n_agents": 4,
+    "n_tasks": 4,
+    "agent_ids": [
+      "correlation_scanner",
+      "cointegration_tester",
+      "pair_strategist",
+      "microstructure_reviewer"
+    ],
+    "task_ids": [
+      "task-correlation-scan",
+      "task-cointegration-test",
+      "task-pair-strategy",
+      "task-microstructure-review"
+    ],
+    "dependencies": [
+      {
+        "task": "task-pair-strategy",
+        "depends_on": [
+          "task-correlation-scan",
+          "task-cointegration-test"
+        ]
+      },
+      {
+        "task": "task-microstructure-review",
+        "depends_on": [
+          "task-pair-strategy"
+        ]
+      }
+    ],
+    "variables": [
+      {
+        "name": "market",
+        "description": "Target market (e.g. A-shares, Hong Kong, US, crypto)",
+        "required": true
+      },
+      {
+        "name": "sector",
+        "description": "Sector filter (e.g. banks, consumer, semis); empty = full market",
+        "required": false
+      }
+    ]
+  },
+  {
+    "file": "portfolio_review_board.yaml",
+    "name": "portfolio_review_board",
+    "title": "Portfolio Review Board",
+    "description": "Performance attribution, risk review, and execution quality in parallel; CIO synthesizes into rebalance decisions.",
+    "n_agents": 4,
+    "n_tasks": 4,
+    "agent_ids": [
+      "attribution_analyst",
+      "risk_inspector",
+      "execution_analyst",
+      "chief_investment_officer"
+    ],
+    "task_ids": [
+      "task-attribution",
+      "task-risk",
+      "task-execution",
+      "task-cio-decision"
+    ],
+    "dependencies": [
+      {
+        "task": "task-cio-decision",
+        "depends_on": [
+          "task-attribution",
+          "task-risk",
+          "task-execution"
+        ]
+      }
+    ],
+    "variables": [
+      {
+        "name": "portfolio",
+        "description": "Portfolio name or description (e.g., value-growth blend, CSI 300 enhanced)",
+        "required": true
+      },
+      {
+        "name": "review_period",
+        "description": "Review cadence (monthly / quarterly)",
+        "required": true
+      },
+      {
+        "name": "goal",
+        "description": "Focus of this review (e.g., assess Q1 performance, diagnose recent NAV drawdown)",
+        "required": true
+      }
+    ]
+  },
+  {
+    "file": "quant_strategy_desk.yaml",
+    "name": "quant_strategy_desk",
+    "title": "Quant Strategy Desk",
+    "description": "Stock screening + factor research in parallel → strategy backtest → risk audit.",
+    "n_agents": 4,
+    "n_tasks": 4,
+    "agent_ids": [
+      "screener",
+      "factor_miner",
+      "backtester",
+      "risk_auditor"
+    ],
+    "task_ids": [
+      "task-screen",
+      "task-factor",
+      "task-backtest",
+      "task-risk"
+    ],
+    "dependencies": [
+      {
+        "task": "task-backtest",
+        "depends_on": [
+          "task-screen",
+          "task-factor"
+        ]
+      },
+      {
+        "task": "task-risk",
+        "depends_on": [
+          "task-backtest"
+        ]
+      }
+    ],
+    "variables": [
+      {
+        "name": "market",
+        "description": "Target market",
+        "required": true
+      },
+      {
+        "name": "goal",
+        "description": "Strategy objective (e.g., momentum + value dual factor)",
+        "required": true
+      }
+    ]
+  },
+  {
+    "file": "risk_committee.yaml",
+    "name": "risk_committee",
+    "title": "Risk Committee",
+    "description": "Drawdown, tail risk, and market regime reviews run in parallel; head of risk signs off.",
+    "n_agents": 4,
+    "n_tasks": 4,
+    "agent_ids": [
+      "drawdown_analyst",
+      "tail_risk_analyst",
+      "regime_detector",
+      "aggregator"
+    ],
+    "task_ids": [
+      "task-drawdown",
+      "task-tail",
+      "task-regime",
+      "task-aggregate"
+    ],
+    "dependencies": [
+      {
+        "task": "task-aggregate",
+        "depends_on": [
+          "task-drawdown",
+          "task-tail",
+          "task-regime"
+        ]
+      }
+    ],
+    "variables": [
+      {
+        "name": "goal",
+        "description": "Audit target (e.g., BTC position risk, CSI 300 strategy risk)",
+        "required": true
+      }
+    ]
+  },
+  {
+    "file": "sector_rotation_team.yaml",
+    "name": "sector_rotation_team",
+    "title": "Sector Rotation Research Team",
+    "description": "Economic cycle + prosperity + capital flows in parallel → rotation strategist builds and backtests a sector rotation strategy.",
+    "n_agents": 4,
+    "n_tasks": 4,
+    "agent_ids": [
+      "cycle_analyst",
+      "prosperity_analyst",
+      "flow_analyst",
+      "rotation_strategist"
+    ],
+    "task_ids": [
+      "task-cycle",
+      "task-prosperity",
+      "task-flow",
+      "task-strategy"
+    ],
+    "dependencies": [
+      {
+        "task": "task-strategy",
+        "depends_on": [
+          "task-cycle",
+          "task-prosperity",
+          "task-flow"
+        ]
+      }
+    ],
+    "variables": [
+      {
+        "name": "market",
+        "description": "Target market (default A-shares; can specify HK/US)",
+        "required": true
+      },
+      {
+        "name": "goal",
+        "description": "Focus theme (e.g. new energy, tech growth, high dividend, exporters)",
+        "required": true
+      }
+    ]
+  },
+  {
+    "file": "sentiment_intelligence_team.yaml",
+    "name": "sentiment_intelligence_team",
+    "title": "Market Sentiment Intelligence Unit",
+    "description": "News intel / social sentiment / capital flows in parallel → sentiment signal synthesizer outputs composite score and reversal signals.",
+    "n_agents": 4,
+    "n_tasks": 4,
+    "agent_ids": [
+      "news_analyst",
+      "social_analyst",
+      "flow_analyst",
+      "signal_synthesizer"
+    ],
+    "task_ids": [
+      "task-news-intel",
+      "task-social-sentiment",
+      "task-flow-analysis",
+      "task-signal-synthesis"
+    ],
+    "dependencies": [
+      {
+        "task": "task-signal-synthesis",
+        "depends_on": [
+          "task-news-intel",
+          "task-social-sentiment",
+          "task-flow-analysis"
+        ]
+      }
+    ],
+    "variables": [
+      {
+        "name": "market",
+        "description": "Target market, e.g. A-shares / HK / US / crypto / CSI 300",
+        "required": true
+      },
+      {
+        "name": "timeframe",
+        "description": "Horizon: daily or weekly",
+        "required": true
+      }
+    ]
+  },
+  {
+    "file": "social_alpha_team.yaml",
+    "name": "social_alpha_team",
+    "title": "Social-Media Alternative Data Team",
+    "description": "Twitter, Telegram, and Reddit analyzed in parallel → Alpha synthesizer extracts tradable social sentiment factors.",
+    "n_agents": 4,
+    "n_tasks": 4,
+    "agent_ids": [
+      "twitter_analyst",
+      "telegram_analyst",
+      "reddit_analyst",
+      "alpha_synthesizer"
+    ],
+    "task_ids": [
+      "task-twitter",
+      "task-telegram",
+      "task-reddit",
+      "task-alpha-synthesis"
+    ],
+    "dependencies": [
+      {
+        "task": "task-alpha-synthesis",
+        "depends_on": [
+          "task-twitter",
+          "task-telegram",
+          "task-reddit"
+        ]
+      }
+    ],
+    "variables": [
+      {
+        "name": "target",
+        "description": "Focus name or market (e.g. BTC, Tesla, A-share tech, Nasdaq)",
+        "required": true
+      },
+      {
+        "name": "timeframe",
+        "description": "Horizon (real-time / daily / weekly)",
+        "required": true
+      }
+    ]
+  },
+  {
+    "file": "statistical_arbitrage_desk.yaml",
+    "name": "statistical_arbitrage_desk",
+    "title": "Statistical Arbitrage Desk",
+    "description": "Pair scanning and microstructure analysis in parallel → converge into the arbitrage strategist to build the strategy → final risk-control review.",
+    "n_agents": 4,
+    "n_tasks": 4,
+    "agent_ids": [
+      "pair_scanner",
+      "microstructure_analyst",
+      "arb_strategist",
+      "risk_monitor"
+    ],
+    "task_ids": [
+      "task-pair-scan",
+      "task-microstructure",
+      "task-strategy",
+      "task-risk-review"
+    ],
+    "dependencies": [
+      {
+        "task": "task-strategy",
+        "depends_on": [
+          "task-pair-scan",
+          "task-microstructure"
+        ]
+      },
+      {
+        "task": "task-risk-review",
+        "depends_on": [
+          "task-strategy"
+        ]
+      }
+    ],
+    "variables": [
+      {
+        "name": "market",
+        "description": "Target market (e.g. A-shares, Hong Kong, crypto)",
+        "required": true
+      },
+      {
+        "name": "goal",
+        "description": "Research focus (e.g. CSI 300 pair book, crypto arb ideas)",
+        "required": true
+      },
+      {
+        "name": "sector",
+        "description": "Sector filter (e.g. banks, consumer); empty = full market",
+        "required": false
+      }
+    ]
+  },
+  {
+    "file": "technical_analysis_panel.yaml",
+    "name": "technical_analysis_panel",
+    "title": "Technical Analysis Panel",
+    "description": "Classic TA + Ichimoku + harmonic patterns + Elliott Wave + SMC run in parallel → signal aggregator scores consensus and resonance.",
+    "n_agents": 6,
+    "n_tasks": 6,
+    "agent_ids": [
+      "classic_ta_analyst",
+      "ichimoku_analyst",
+      "harmonic_analyst",
+      "wave_analyst",
+      "smc_analyst",
+      "signal_aggregator"
+    ],
+    "task_ids": [
+      "task-classic-ta",
+      "task-ichimoku",
+      "task-harmonic",
+      "task-wave",
+      "task-smc",
+      "task-aggregate"
+    ],
+    "dependencies": [
+      {
+        "task": "task-aggregate",
+        "depends_on": [
+          "task-classic-ta",
+          "task-ichimoku",
+          "task-harmonic",
+          "task-wave",
+          "task-smc"
+        ]
+      }
+    ],
+    "variables": [
+      {
+        "name": "target",
+        "description": "Symbol (e.g. 600519.SH Kweichow Moutai, BTC-USDT, AAPL)",
+        "required": true
+      },
+      {
+        "name": "timeframe",
+        "description": "Interval (e.g. daily, weekly, monthly, 4H)",
+        "required": true
+      }
+    ]
+  },
+  {
+    "file": "value_investing_committee.yaml",
+    "name": "value_investing_committee",
+    "title": "Value Investing Committee (Buffett / Munger / Duan / Li Lu)",
+    "description": "Four adversarial master perspectives — Buffett (moat & price), Munger (inversion & risk), Duan Yongping (good business & trustworthy management), Li Lu (10-year certainty & civilizational trend, incl. demographic/consumption macro) — run in parallel on one company, then a chair synthesizes consensus and contradictions into a verdict. Inspired by the ai-berkshire master-视角 framework. Use for deep v",
+    "n_agents": 5,
+    "n_tasks": 5,
+    "agent_ids": [
+      "buffett",
+      "munger",
+      "duan_yongping",
+      "li_lu",
+      "chair"
+    ],
+    "task_ids": [
+      "task-buffett",
+      "task-munger",
+      "task-duan",
+      "task-li",
+      "task-chair"
+    ],
+    "dependencies": [
+      {
+        "task": "task-chair",
+        "depends_on": [
+          "task-buffett",
+          "task-munger",
+          "task-duan",
+          "task-li"
+        ]
+      }
+    ],
+    "variables": [
+      {
+        "name": "company",
+        "description": "Target company name or ticker (e.g.: Tencent, NVDA, Moutai)",
+        "required": true
+      },
+      {
+        "name": "market",
+        "description": "Market (e.g.: A-shares, Hong Kong, US)",
+        "required": true
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- Add `docs/analysis/` as an AI/contributor handoff: narrative architecture report (Parts 1–28) plus catalogs for skills, alphas, swarm presets, channels, and tests
- Point `docs/README.md` at the analysis entry, and allow `docs/analysis/**` (plus `docs/README.md`) via a narrow `.gitignore` exception so shared docs are trackable while other internal `docs/` stay ignored

## Test plan
- [ ] Open `docs/analysis/README.md` and confirm navigation links resolve
- [ ] Spot-check catalog counts against repo (skills / alphas / swarm presets / channels / tests)
- [ ] Confirm `graphify-out/` and `.graphify_*.json` are not included in the PR
- [ ] Confirm unrelated private files under `docs/` remain untracked

Made with [Cursor](https://cursor.com)