### PR TITLE
docs(readme): fix Windows install steps in all five READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,12 +657,16 @@ python -m venv .venv
 
 # Activate
 source .venv/bin/activate          # Linux / macOS
+# .venv\Scripts\activate.bat       # Windows CMD
 # .venv\Scripts\Activate.ps1       # Windows PowerShell
 
 pip install -e .
 cp agent/.env.example agent/.env   # Edit — set your LLM provider API key
 vibe-trading                       # Launch interactive TUI
 ```
+
+> [!NOTE]
+> **On Windows:** `cp` is a PowerShell alias for `Copy-Item`, so the snippets above work as-is in PowerShell. CMD has no `cp` — use `copy agent\.env.example agent\.env` instead (this applies to the Docker snippet above too). If PowerShell refuses to run `Activate.ps1`, run `Set-ExecutionPolicy -Scope Process -ExecutionPolicy RemoteSigned` first; it applies to that shell session only.
 
 <details>
 <summary><b>Start web UI (optional)</b></summary>

--- a/README_ar.md
+++ b/README_ar.md
@@ -619,12 +619,16 @@ python -m venv .venv
 
 # Activate
 source .venv/bin/activate          # Linux / macOS
+# .venv\Scripts\activate.bat       # Windows CMD
 # .venv\Scripts\Activate.ps1       # Windows PowerShell
 
 pip install -e .
 cp agent/.env.example agent/.env   # Edit — set your LLM provider API key
 vibe-trading                       # Launch interactive TUI
 ```
+
+> [!NOTE]
+> **على Windows:** الأمر `cp` هو اسم بديل لـ `Copy-Item` في PowerShell، لذا تعمل الأوامر أعلاه كما هي في PowerShell. أما في CMD فلا وجود لـ `cp`، فاستخدم بدلاً منه `copy agent\.env.example agent\.env` (وينطبق ذلك أيضاً على أمر Docker أعلاه). وإذا رفض PowerShell تشغيل `Activate.ps1`، فشغّل أولاً `Set-ExecutionPolicy -Scope Process -ExecutionPolicy RemoteSigned`؛ ويسري هذا الإعداد على جلسة الطرفية الحالية فقط.
 
 <details>
 <summary><b>تشغيل واجهة الويب (اختياري)</b></summary>

--- a/README_ja.md
+++ b/README_ja.md
@@ -619,12 +619,16 @@ python -m venv .venv
 
 # Activate
 source .venv/bin/activate          # Linux / macOS
+# .venv\Scripts\activate.bat       # Windows CMD
 # .venv\Scripts\Activate.ps1       # Windows PowerShell
 
 pip install -e .
 cp agent/.env.example agent/.env   # Edit — set your LLM provider API key
 vibe-trading                       # Launch interactive TUI
 ```
+
+> [!NOTE]
+> **Windows の場合:** `cp` は PowerShell では `Copy-Item` のエイリアスなので、上記のコマンドは PowerShell ならそのまま動きます。CMD には `cp` がないため、代わりに `copy agent\.env.example agent\.env` を使ってください（上の Docker のコマンドも同様です）。PowerShell が `Activate.ps1` の実行を拒否する場合は、先に `Set-ExecutionPolicy -Scope Process -ExecutionPolicy RemoteSigned` を実行してください。この設定は現在のシェルセッションにのみ適用されます。
 
 <details>
 <summary><b>Web UI を起動（任意）</b></summary>

--- a/README_ko.md
+++ b/README_ko.md
@@ -619,12 +619,16 @@ python -m venv .venv
 
 # Activate
 source .venv/bin/activate          # Linux / macOS
+# .venv\Scripts\activate.bat       # Windows CMD
 # .venv\Scripts\Activate.ps1       # Windows PowerShell
 
 pip install -e .
 cp agent/.env.example agent/.env   # Edit — set your LLM provider API key
 vibe-trading                       # Launch interactive TUI
 ```
+
+> [!NOTE]
+> **Windows의 경우:** `cp`는 PowerShell에서 `Copy-Item`의 별칭이므로 위 명령은 PowerShell에서 그대로 동작합니다. CMD에는 `cp`가 없으므로 대신 `copy agent\.env.example agent\.env`를 사용하세요(위의 Docker 명령도 마찬가지입니다). PowerShell이 `Activate.ps1` 실행을 거부하면 먼저 `Set-ExecutionPolicy -Scope Process -ExecutionPolicy RemoteSigned`를 실행하세요. 이 설정은 현재 셸 세션에만 적용됩니다.
 
 <details>
 <summary><b>웹 UI 시작(선택 사항)</b></summary>

--- a/README_zh.md
+++ b/README_zh.md
@@ -646,12 +646,16 @@ python -m venv .venv
 
 # Activate
 source .venv/bin/activate          # Linux / macOS
+# .venv\Scripts\activate.bat       # Windows CMD
 # .venv\Scripts\Activate.ps1       # Windows PowerShell
 
 pip install -e .
 cp agent/.env.example agent/.env   # Edit — set your LLM provider API key
 vibe-trading                       # Launch interactive TUI
 ```
+
+> [!NOTE]
+> **Windows 用户：** `cp` 在 PowerShell 里是 `Copy-Item` 的别名，所以上面的命令在 PowerShell 下可直接使用；CMD 没有 `cp`，请改用 `copy agent\.env.example agent\.env`（上面 Docker 那段同理）。如果 PowerShell 拒绝执行 `Activate.ps1`，先运行 `Set-ExecutionPolicy -Scope Process -ExecutionPolicy RemoteSigned`，该设置仅对当前终端会话生效。
 
 <details>
 <summary><b>启动 Web UI（可选）</b></summary>


### PR DESCRIPTION
## What

The `Path B: Local install` snippet tells Windows users to run
`cp agent/.env.example agent/.env`. CMD has no `cp`, so that step fails.
Reported by @brady-cec in https://github.com/HKUDS/Vibe-Trading/discussions/29.

Three fixes, applied identically to `README.md`, `README_zh.md`, `README_ja.md`,
`README_ko.md`, and `README_ar.md` (the block is duplicated verbatim in all five):

1. Add the CMD activation line — only `Activate.ps1` was listed, so CMD users had
   nothing to copy.
2. Add a Windows note giving `copy agent\.env.example agent\.env` for CMD, and
   pointing out that PowerShell's `cp` alias for `Copy-Item` means the existing
   snippets already work there. The note also covers the Docker snippet above,
   which has the same `cp`.
3. Add the `Set-ExecutionPolicy -Scope Process -ExecutionPolicy RemoteSigned`
   hint, since PowerShell blocking `Activate.ps1` is the other step people get
   stuck on.

Docs only — no code changes. The note is translated in each localized README.