### PR TITLE
fix(anthropic): self-heal models that deprecate the temperature field

### DIFF
--- a/agent/src/providers/llm.py
+++ b/agent/src/providers/llm.py
@@ -448,13 +448,138 @@ def _build_native_deepseek(
     )
 
 
+# Anthropic model names discovered at runtime to reject the `temperature`
+# request field. Next-gen Claude models (e.g. claude-opus-5, claude-opus-4-8,
+# claude-sonnet-5) return HTTP 400 "`temperature` is deprecated for this model."
+# for ANY temperature value, while older models (claude-opus-4-5,
+# claude-sonnet-4-5, …) still honor it. Model names are not reliably
+# predictable, so membership is populated on first failure and then reused
+# process-wide to skip the redundant failed request on subsequent calls.
+_ANTHROPIC_TEMPERATURE_UNSUPPORTED: set[str] = set()
+
+# Cache of base ChatAnthropic class -> temperature-safe subclass, so the dynamic
+# subclass is built once per resolved base class (keyed to support test doubles).
+_TEMPERATURE_SAFE_ANTHROPIC_CACHE: dict[type, type] = {}
+
+
+def _is_anthropic_temperature_unsupported_error(exc: BaseException) -> bool:
+    """Return True when an Anthropic error reports `temperature` as unsupported.
+
+    Matches the model-level deprecation ("`temperature` is deprecated for this
+    model.") regardless of the SDK exception type or the temperature value sent.
+    """
+    message = str(getattr(exc, "message", "") or exc).lower()
+    if "temperature" not in message:
+        return False
+    return (
+        "deprecated" in message
+        or "not supported" in message
+        or "unsupported" in message
+        or "not allowed" in message
+    )
+
+
+def _make_temperature_safe_anthropic(base_cls: type) -> type:
+    """Build (and cache) a ChatAnthropic subclass that self-heals temperature.
+
+    Certain Claude models reject the `temperature` field entirely. This subclass
+    transparently drops `temperature` from the request and retries once when the
+    API reports it as unsupported, remembering the model in
+    ``_ANTHROPIC_TEMPERATURE_UNSUPPORTED`` so later requests omit it up front.
+    Models that accept `temperature` are unaffected — their configured value
+    (e.g. the deterministic 0.0 default) is preserved.
+
+    Built from the class resolved at call time so the optional
+    ``langchain-anthropic`` dependency stays lazily imported and test doubles
+    still work.
+    """
+    cached = _TEMPERATURE_SAFE_ANTHROPIC_CACHE.get(base_cls)
+    if cached is not None:
+        return cached
+
+    def _get_request_payload(self: Any, *args: Any, **kwargs: Any) -> dict:
+        payload = base_cls._get_request_payload(self, *args, **kwargs)
+        if isinstance(payload, dict) and self.model in _ANTHROPIC_TEMPERATURE_UNSUPPORTED:
+            payload.pop("temperature", None)
+        return payload
+
+    def _remember_and_should_retry(self: Any, exc: BaseException) -> bool:
+        if _is_anthropic_temperature_unsupported_error(exc):
+            if self.model not in _ANTHROPIC_TEMPERATURE_UNSUPPORTED:
+                logger.info(
+                    "Anthropic model %s rejects `temperature`; retrying without it "
+                    "and omitting it for subsequent calls.",
+                    self.model,
+                )
+                _ANTHROPIC_TEMPERATURE_UNSUPPORTED.add(self.model)
+                return True
+        return False
+
+    def _generate(self: Any, *args: Any, **kwargs: Any) -> Any:
+        try:
+            return base_cls._generate(self, *args, **kwargs)
+        except Exception as exc:  # noqa: BLE001 - retried or re-raised below
+            if _remember_and_should_retry(self, exc):
+                return base_cls._generate(self, *args, **kwargs)
+            raise
+
+    async def _agenerate(self: Any, *args: Any, **kwargs: Any) -> Any:
+        try:
+            return await base_cls._agenerate(self, *args, **kwargs)
+        except Exception as exc:  # noqa: BLE001 - retried or re-raised below
+            if _remember_and_should_retry(self, exc):
+                return await base_cls._agenerate(self, *args, **kwargs)
+            raise
+
+    def _stream(self: Any, *args: Any, **kwargs: Any) -> Any:
+        # The temperature-unsupported error is raised before the first chunk is
+        # produced, so retrying the whole stream cannot duplicate output.
+        try:
+            yield from base_cls._stream(self, *args, **kwargs)
+        except Exception as exc:  # noqa: BLE001 - retried or re-raised below
+            if _remember_and_should_retry(self, exc):
+                yield from base_cls._stream(self, *args, **kwargs)
+            else:
+                raise
+
+    async def _astream(self: Any, *args: Any, **kwargs: Any) -> Any:
+        try:
+            async for chunk in base_cls._astream(self, *args, **kwargs):
+                yield chunk
+        except Exception as exc:  # noqa: BLE001 - retried or re-raised below
+            if _remember_and_should_retry(self, exc):
+                async for chunk in base_cls._astream(self, *args, **kwargs):
+                    yield chunk
+            else:
+                raise
+
+    safe_cls = type(
+        "ChatAnthropicTemperatureSafe",
+        (base_cls,),
+        {
+            "_get_request_payload": _get_request_payload,
+            "_generate": _generate,
+            "_agenerate": _agenerate,
+            "_stream": _stream,
+            "_astream": _astream,
+        },
+    )
+    _TEMPERATURE_SAFE_ANTHROPIC_CACHE[base_cls] = safe_cls
+    return safe_cls
+
+
 def _build_anthropic(
     *,
     model: str,
     temperature: float,
     callbacks: Any = None,
 ) -> Any:
-    """Build the native Anthropic Messages API adapter."""
+    """Build the native Anthropic Messages API adapter.
+
+    Uses a temperature-safe subclass so models that deprecate the `temperature`
+    field (e.g. claude-opus-5 / claude-sonnet-5) work transparently while models
+    that still accept it keep the configured deterministic value.
+    """
     try:
         module = import_module("langchain_anthropic")
         chat_anthropic = getattr(module, "ChatAnthropic")
@@ -464,7 +589,8 @@ def _build_anthropic(
             'extra: pip install "vibe-trading-ai[anthropic]" (or pip install langchain-anthropic).'
         ) from exc
 
-    return chat_anthropic(
+    safe_anthropic = _make_temperature_safe_anthropic(chat_anthropic)
+    return safe_anthropic(
         model=model,
         max_tokens=get_env_config().llm.anthropic_max_tokens,
         temperature=temperature,

--- a/agent/tests/test_llm.py
+++ b/agent/tests/test_llm.py
@@ -369,6 +369,90 @@ def test_build_anthropic_uses_messages_api_proxy() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Anthropic temperature self-heal (next-gen models deprecate `temperature`)
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_anthropic_base():
+    """A minimal ChatAnthropic stand-in mimicking payload + generate wiring."""
+
+    class _FakeAnthropicBase:
+        def __init__(self, **kwargs: object) -> None:
+            self.model = kwargs.get("model")
+            self.temperature = kwargs.get("temperature")
+            self.calls: list[dict] = []
+
+        def _get_request_payload(self, *args: object, **kwargs: object) -> dict:
+            # Mirrors ChatAnthropic: temperature only present when not None.
+            payload: dict = {"model": self.model, "messages": []}
+            if self.temperature is not None:
+                payload["temperature"] = self.temperature
+            return payload
+
+        def _generate(self, *args: object, **kwargs: object):
+            payload = self._get_request_payload(*args, **kwargs)
+            self.calls.append(dict(payload))
+            if self.model == "deprecates-temp" and "temperature" in payload:
+                raise RuntimeError("`temperature` is deprecated for this model.")
+            return SimpleNamespace(payload=payload)
+
+    return _FakeAnthropicBase
+
+
+def test_anthropic_temperature_self_heal_drops_and_retries() -> None:
+    import src.providers.llm as llm_mod
+
+    llm_mod._ANTHROPIC_TEMPERATURE_UNSUPPORTED.discard("deprecates-temp")
+    base = _make_fake_anthropic_base()
+    safe_cls = llm_mod._make_temperature_safe_anthropic(base)
+    inst = safe_cls(model="deprecates-temp", temperature=0.0)
+
+    result = inst._generate([])
+
+    # First attempt carried temperature (and failed); retry dropped it.
+    assert len(inst.calls) == 2
+    assert "temperature" in inst.calls[0]
+    assert "temperature" not in inst.calls[1]
+    assert "temperature" not in result.payload
+    # Model is remembered so later calls omit temperature up front.
+    assert "deprecates-temp" in llm_mod._ANTHROPIC_TEMPERATURE_UNSUPPORTED
+
+
+def test_anthropic_temperature_preserved_for_supported_model() -> None:
+    import src.providers.llm as llm_mod
+
+    llm_mod._ANTHROPIC_TEMPERATURE_UNSUPPORTED.discard("supports-temp")
+    base = _make_fake_anthropic_base()
+    safe_cls = llm_mod._make_temperature_safe_anthropic(base)
+    inst = safe_cls(model="supports-temp", temperature=0.0)
+
+    result = inst._generate([])
+
+    # Deterministic temperature preserved; no retry, nothing remembered.
+    assert len(inst.calls) == 1
+    assert result.payload.get("temperature") == 0.0
+    assert "supports-temp" not in llm_mod._ANTHROPIC_TEMPERATURE_UNSUPPORTED
+
+
+def test_is_anthropic_temperature_unsupported_error_matching() -> None:
+    from src.providers.llm import _is_anthropic_temperature_unsupported_error
+
+    assert _is_anthropic_temperature_unsupported_error(
+        RuntimeError("`temperature` is deprecated for this model.")
+    )
+    assert _is_anthropic_temperature_unsupported_error(
+        ValueError("temperature is not supported")
+    )
+    # Unrelated errors must not trigger the temperature retry path.
+    assert not _is_anthropic_temperature_unsupported_error(
+        RuntimeError("max_tokens is required")
+    )
+    assert not _is_anthropic_temperature_unsupported_error(
+        RuntimeError("rate limit exceeded")
+    )
+
+
+# ---------------------------------------------------------------------------
 # MiniMax temperature clamping
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Problem
-------
Next-gen Claude models (e.g. claude-opus-5, claude-opus-4-8, claude-sonnet-5) reject the "temperature" request field with HTTP 400 "temperature is deprecated for this model." for ANY value, while older models (claude-opus-4-5, claude-sonnet-4-5, ...) still accept it. _build_anthropic unconditionally forwarded the global default temperature=0.0, so every run on a next-gen model failed before producing output. Model names are not predictable (opus-4-5 accepts it, opus-4-8 does not) and the rejection is value-independent, so neither a fixed model allowlist nor an "omit when 0.0" shortcut is a correct fix.

Solution
--------
Add a temperature-safe ChatAnthropic subclass (_make_temperature_safe_anthropic) that wraps all four generation entry points (_generate, _agenerate, _stream, _astream). When the API reports temperature as unsupported it drops the field and retries once, then records the model in a process-wide set so subsequent requests omit it up front (no repeated failed request). Models that accept temperature keep their configured deterministic value unchanged. The subclass is built from the lazily-imported class and cached per base class, preserving the optional langchain-anthropic dependency boundary and existing test doubles.

Correct for any temperature value, current and future model names, and the streaming path the Web UI relies on.

Tests
-----
Add regression tests in agent/tests/test_llm.py: self-heal retry drops temperature and remembers the model, temperature is preserved for supporting models, and the error matcher only triggers on temperature-unsupported errors. Full test_llm.py suite: 58 passed.

## Summary

<!-- What does this PR do? 1-3 bullet points. -->

-

## Why

<!-- What problem does it solve? Link related issues with "Closes #123". -->

## Changes

<!-- List key changes. For new skills/presets, describe what they cover. -->

-

## Test Plan

- [ ] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [ ] New tests added (if applicable)
- [ ] Tested manually (describe below)

## Checklist

- [ ] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [ ] No hardcoded values (API keys, file paths, magic numbers)
- [ ] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] Documentation updated (if user-facing change)
