### PR TITLE
fix(backtest): keep bar_returns bit-identical for gapped positive series

### DIFF
--- a/agent/backtest/metrics.py
+++ b/agent/backtest/metrics.py
@@ -92,6 +92,19 @@ def bar_returns(close: Any, *, label: str = "") -> Any:
     never ``inf`` or ``nan``. For an all-positive series this is identical to
     ``pct_change().fillna(0.0)``, so ordinary equity/crypto runs are unchanged.
 
+    The prior price is carried forward across gaps. ``pct_change`` did this
+    implicitly via ``fill_method='pad'`` — its default on pandas < 3, removed
+    in 3.0 — so *not* forwarding it would silently change every gapped series
+    (a halt longer than ``_align``'s ``ffill_limit``, a thinly-traded symbol)
+    and would make the bit-identity claim above false on the pinned pandas.
+    Doing it here explicitly keeps that promise and, unlike the old default,
+    gives the same answer on every supported pandas version. Note the effect
+    is to attribute the whole across-gap move to the resumed bar; that is what
+    a position held through the halt actually earned. Whether that is the right
+    convention for *statistics* (it is not, for correlation — see
+    ``correlation.py``, which drops the observation instead) is a separate
+    question from whether this function may change it as a side effect.
+
     Args:
         close: Raw price ``Series`` or per-symbol ``DataFrame``.
         label: Optional name used when warning about undefined bars.
@@ -99,10 +112,13 @@ def bar_returns(close: Any, *, label: str = "") -> Any:
     Returns:
         Returns aligned to ``close``, with the first bar ``0.0``.
     """
-    prev = close.shift(1)
-    positive_prev = prev.where(prev > 0)
+    # ffill *then* shift: the divisor is the last known price, not NaN.
+    prev = close.ffill().shift(1)
+    # ``inf > 0`` is True, so finiteness has to be asserted, not assumed.
+    usable_prev = np.isfinite(prev) & (prev > 0)
+    positive_prev = prev.where(usable_prev)
 
-    undefined = int((prev.notna() & ~(prev > 0)).to_numpy().sum())
+    undefined = int((prev.notna() & ~usable_prev).to_numpy().sum())
     if undefined:
         # Silence is the actual hazard here: a wrong return is a wrong reported
         # number, not a crash, so the run has to say it defaulted.
@@ -141,7 +157,9 @@ def buy_and_hold_return(close: Any) -> Optional[float]:
         return None
     first = float(close.iloc[0])
     last = float(close.iloc[-1])
-    if not (first > 0) or not np.isfinite(last):
+    # ``inf > 0`` is True, so an infinite entry price would otherwise yield a
+    # clean-looking -100% instead of "no honest percentage exists".
+    if not (np.isfinite(first) and first > 0) or not np.isfinite(last):
         return None
     return last / first - 1.0
 

--- a/agent/backtest/metrics.py
+++ b/agent/backtest/metrics.py
@@ -123,8 +123,8 @@ def bar_returns(close: Any, *, label: str = "") -> Any:
         # Silence is the actual hazard here: a wrong return is a wrong reported
         # number, not a crash, so the run has to say it defaulted.
         _log.warning(
-            "%s: %d bar(s) follow a non-positive price; their return is "
-            "undefined and reported as 0.0 (issue #872)",
+            "%s: %d bar(s) follow a non-positive or non-finite prior price; "
+            "their return is undefined and reported as 0.0 (issue #872)",
             label or "returns",
             undefined,
         )

--- a/agent/tests/test_nonpositive_returns.py
+++ b/agent/tests/test_nonpositive_returns.py
@@ -162,7 +162,7 @@ def test_undefined_bars_are_logged(delu: pd.Series, caplog) -> None:
         bar_returns(delu, label="DE-LU")
 
     assert "DE-LU" in caplog.text
-    assert "3 bar(s) follow a non-positive price" in caplog.text
+    assert "3 bar(s) follow a non-positive or non-finite prior price" in caplog.text
 
 
 def test_clean_series_log_nothing(caplog) -> None:

--- a/agent/tests/test_returns_gaps_and_infinities.py
+++ b/agent/tests/test_returns_gaps_and_infinities.py
@@ -1,0 +1,144 @@
+"""bar_returns must not change behaviour for gapped positive series.
+
+#872 replaced ``close.pct_change().fillna(0.0)`` with :func:`bar_returns` and
+claimed results for strictly positive series are bit-identical. That claim was
+verified only on gapless series. On the pinned pandas (``>=2.0,<3.0``)
+``pct_change`` defaults to ``fill_method='pad'``, so it forward-fills the
+divisor; ``bar_returns`` divided by the raw shifted series instead. For any
+positive series with an interior NaN -- a halt longer than ``_align``'s
+``ffill_limit``, or a thinly-traded symbol -- the two diverged, and the real
+move across the gap was silently reported as ``0.0`` with the undefined-bar
+counter deliberately not firing (it excludes NaN priors).
+
+Injecting a zero where a large move occurred understates realised volatility
+and inflates Sharpe, one-directionally: on a 20-symbol universe with two
+halted symbols, annualised vol fell 4.96% -> 4.47% and Sharpe rose 3.05 ->
+3.38. Return deltas can cancel by sign; dispersion damage cannot.
+
+These tests are written to be pandas-version-independent, so they pin the
+intended behaviour rather than whatever the installed default happens to be.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from backtest.metrics import bar_returns, buy_and_hold_return
+
+
+# ---------------------------------------------------------------------------
+# Gapped positive series
+# ---------------------------------------------------------------------------
+
+
+def test_gap_does_not_erase_the_move_across_it() -> None:
+    """The bar resuming after a gap carries the real move, not 0.0."""
+    close = pd.Series([100.0, 110.0, np.nan, np.nan, np.nan, 121.0])
+
+    ret = bar_returns(close, label="halted")
+
+    # 110 -> 121 is a real +10%, earned by anyone holding through the halt.
+    assert ret.iloc[5] == pytest.approx(0.10)
+    # Bars with no price at all are flat, not NaN.
+    assert ret.iloc[2:5].tolist() == [0.0, 0.0, 0.0]
+
+
+def test_gapped_series_match_explicit_pad_on_every_pandas() -> None:
+    """Pins the pre-#872 answer without depending on the pct_change default."""
+    close = pd.Series([100.0, 110.0, np.nan, 121.0, np.nan, np.nan, 133.1, 140.0])
+
+    padded = close.ffill()
+    expected = (padded / padded.shift(1) - 1).fillna(0.0)
+
+    assert (bar_returns(close).to_numpy() == expected.to_numpy()).all()
+
+
+def test_gap_does_not_deflate_realised_volatility() -> None:
+    """Zero-injection shrinks dispersion; that is the non-cancelling harm."""
+    close = pd.Series([100.0, 101.0, 100.5, np.nan, np.nan, np.nan, 130.0, 131.0])
+
+    ret = bar_returns(close)
+
+    zeroed = ret.copy()
+    zeroed.iloc[6] = 0.0  # what the unpatched helper produced
+    assert ret.std(ddof=1) > zeroed.std(ddof=1)
+
+
+def test_leading_nan_is_still_flat_not_forward_filled_backwards() -> None:
+    """A symbol that starts late has no prior price; ffill cannot invent one."""
+    close = pd.Series([np.nan, np.nan, 50.0, 55.0])
+
+    ret = bar_returns(close)
+
+    assert ret.iloc[:3].tolist() == [0.0, 0.0, 0.0]
+    assert ret.iloc[3] == pytest.approx(0.10)
+
+
+def test_gapped_frame_isolates_symbols() -> None:
+    frame = pd.DataFrame(
+        {"HALTED": [10.0, np.nan, np.nan, 12.0], "NORMAL": [1.0, 2.0, 4.0, 8.0]}
+    )
+
+    ret = bar_returns(frame)
+
+    assert ret["HALTED"].tolist() == [0.0, 0.0, 0.0, pytest.approx(0.2)]
+    assert ret["NORMAL"].tolist() == [0.0, 1.0, 1.0, 1.0]
+
+
+# ---------------------------------------------------------------------------
+# Non-finite prior prices
+# ---------------------------------------------------------------------------
+
+
+def test_infinite_prior_price_is_undefined_not_minus_one() -> None:
+    """``inf > 0`` is True, so finiteness must be asserted explicitly."""
+    close = pd.Series([10.0, np.inf, 42.0, 50.0])
+
+    ret = bar_returns(close)
+
+    # 42 / inf - 1 == -1.0 would read as a clean, plausible -100%.
+    assert ret.iloc[2] == 0.0
+    assert np.isfinite(ret.to_numpy()).all()
+
+
+def test_infinite_prior_price_is_logged(caplog) -> None:
+    """It must be loud, like every other undefined bar."""
+    with caplog.at_level(logging.WARNING, logger="backtest.metrics"):
+        bar_returns(pd.Series([10.0, np.inf, 42.0]), label="INF")
+
+    assert "INF" in caplog.text
+    assert "non-positive price" in caplog.text
+
+
+def test_buy_and_hold_rejects_an_infinite_entry_price() -> None:
+    """No honest percentage exists, so report nothing rather than -100%."""
+    assert buy_and_hold_return(pd.Series([np.inf, 42.0])) is None
+    assert buy_and_hold_return(pd.Series([-np.inf, 42.0])) is None
+    assert buy_and_hold_return(pd.Series([10.0, np.inf])) is None
+
+
+# ---------------------------------------------------------------------------
+# The #872 contract must survive the patch
+# ---------------------------------------------------------------------------
+
+
+def test_nonpositive_prior_is_still_undefined() -> None:
+    """The original fix is untouched: a gap must not resurrect a bad divisor."""
+    close = pd.Series([10.0, -0.02, -1.03, 42.0])
+
+    ret = bar_returns(close)
+
+    assert ret.iloc[2] == 0.0
+    assert ret.iloc[3] == 0.0
+    assert np.isfinite(ret.to_numpy()).all()
+
+
+def test_gapless_positive_series_unchanged() -> None:
+    prices = pd.Series(np.random.default_rng(7).uniform(1.0, 400.0, 200))
+    expected = (prices / prices.shift(1) - 1).fillna(0.0)
+
+    assert (bar_returns(prices).to_numpy() == expected.to_numpy()).all()

--- a/agent/tests/test_returns_gaps_and_infinities.py
+++ b/agent/tests/test_returns_gaps_and_infinities.py
@@ -111,7 +111,7 @@ def test_infinite_prior_price_is_logged(caplog) -> None:
         bar_returns(pd.Series([10.0, np.inf, 42.0]), label="INF")
 
     assert "INF" in caplog.text
-    assert "non-positive price" in caplog.text
+    assert "non-positive or non-finite prior price" in caplog.text
 
 
 def test_buy_and_hold_rejects_an_infinite_entry_price() -> None:
@@ -142,3 +142,41 @@ def test_gapless_positive_series_unchanged() -> None:
     expected = (prices / prices.shift(1) - 1).fillna(0.0)
 
     assert (bar_returns(prices).to_numpy() == expected.to_numpy()).all()
+
+
+# ---------------------------------------------------------------------------
+# The engine boundary where the gap actually leaks in
+# ---------------------------------------------------------------------------
+
+
+def test_align_keeps_move_across_halt_longer_than_ffill_limit() -> None:
+    """A suspension longer than ``_align``'s ffill limit must not erase the move.
+
+    ``_align`` forward-fills close with ``limit=5`` (single market) precisely so
+    long halts stay visible as NaN; the returns matrix it hands to the optimizer
+    and the benchmark must still credit the across-gap move to the resumed bar.
+    """
+    from backtest.engines.base import _align
+
+    dates = pd.date_range("2025-01-06", periods=10, freq="B")
+
+    def _frame(closes: pd.Series) -> pd.DataFrame:
+        return pd.DataFrame({"close": closes})
+
+    # HALTED prints days 0-1, goes dark for six sessions (> limit 5), resumes
+    # day 8 at 121: a real +10% earned by anyone holding through the halt.
+    halted = pd.Series([100.0, 110.0, 121.0, 122.0],
+                       index=dates[[0, 1, 8, 9]])
+    normal = pd.Series(np.linspace(50.0, 59.0, 10), index=dates)
+
+    data_map = {"HALTED": _frame(halted), "NORMAL": _frame(normal)}
+    signal_map = {c: pd.Series(1.0, index=df.index) for c, df in data_map.items()}
+
+    _, close, _, ret = _align(data_map, signal_map, ["HALTED", "NORMAL"])
+
+    # Precondition: the halt really does outlive the ffill limit.
+    assert np.isnan(close.loc[dates[7], "HALTED"])
+    # The resumed bar carries 110 -> 121, not a silent 0.0.
+    assert ret.loc[dates[8], "HALTED"] == pytest.approx(121.0 / 110.0 - 1.0)
+    # Bars inside the halt stay flat.
+    assert ret.loc[dates[7], "HALTED"] == 0.0


### PR DESCRIPTION
## What #872 claimed

`6635a92` replaced `close.pct_change().fillna(0.0)` with `backtest.metrics.bar_returns` in `benchmark.py` and `engines/base.py`. Its stated contract:

> `bar_returns` keeps the exact `close / prev - 1` expression `pct_change` uses, so results for strictly positive series are bit-identical and ordinary equity and crypto runs are unchanged.

That holds for the series it was tested on. `test_nonpositive_returns.py` verifies bit-identity across four lengths and a DataFrame, all drawn from `rng.uniform(1.0, 400.0, n)` — gapless and strictly positive.

## The one case where it does not hold

A strictly positive series with an **interior NaN**.

On the pinned pandas (`pandas>=2.0.0,<3.0.0`, lock `2.3.3`), the `pct_change` signature is `fill_method: 'FillnaOptions | None | lib.NoDefault' = <no_default>`, which resolves to `'pad'`, forward-filling the divisor. `bar_returns` divides by the raw shifted series. On pandas 3.0 the parameter is typed `None` and no fill happens — so the divergence exists on every version this project currently supports, and disappears only on a version it does not allow.

```
close = [100, 110, NaN, 121, NaN, NaN, 133.1, 140]     # all positive

 bar    close     prev     pct_change    bar_returns          delta
   3   121.00      nan       0.100000       0.000000      -0.100000
   6   133.10      nan       0.100000       0.000000      -0.100000

compounded:  pct_change +40.0000%   bar_returns +15.7025%
```

True buy-and-hold is `140/100 - 1` = **+40%**. `pct_change` returns exactly that; `bar_returns` discards the move across each gap. The undefined-bar counter does not fire — `prev.notna() & ~(prev > 0)` excludes NaN priors by construction, which is right for a leading bar and wrong for a resumed one.

## It reaches the engine

`_align` forward-fills `close` before calling `bar_returns`, but with a deliberate limit:

```
base.py:166   # ffill with limit to avoid masking long suspensions (e.g. 3-week halt)
base.py:167   # Cross-market needs larger limit (Chinese New Year can be 9-10 bars)
base.py:168   ffill_limit = 10 if len({_detect_market_for_align(c) for c in codes}) > 1 else 5
base.py:179   close_arr = _tmp.ffill(limit=ffill_limit).values
```

A suspension longer than the limit is *designed* to survive as NaN, and lands on `bar_returns`. Real `_align`, single market (`ffill_limit=5`), 8-bar halt, pandas 2.3.3:

```
POST 6635a92                                 PRE 46aa259
  2025-01-20   NaN      NaN    0.000000        2025-01-20   NaN      NaN    0.000000
  2025-01-21  64.7368   NaN    0.000000        2025-01-21  64.7368   NaN    0.171429
  2025-01-22  65.7895  64.7368 0.016260        2025-01-22  65.7895  64.7368 0.016260

resumed bar: 55.2632 -> 64.7368 = +17.1429% of real price movement
ret_df records: +0.0000%                     ret_df records: +17.1429%
```

Pre-commit emits `FutureWarning: The default fill_method='pad' in DataFrame.pct_change is deprecated` at `base.py:222` — the pad was live, not theoretical.

`ret_df` feeds the weight optimizer (`base.py:226`) and `bench_ret = ret_df.mean(axis=1)` (`base.py:565`), which becomes `bench_equity` (`base.py:593`) and the `benchmark_equity` column of `artifacts/equity.csv`.

## Impact

Leading with dispersion, because that is the part that does not cancel. A return delta can go either way depending on the sign of the moves erased, and across many symbols it tends to wash out. Injecting a zero where a move occurred always reduces variance, so realised vol is understated and Sharpe inflated, one-directionally, regardless of sign.

20-symbol equity universe, 250 bars, two symbols halted 12 and 8 bars.

**Benign case** — GBM paths, moves across the halts ~2.7% and ~2.9%:

| | pre `46aa259` | post `6635a92` | delta |
|---|---|---|---|
| benchmark return | +16.3761% | +16.0489% | -32.7 bp |
| realised vol (ann.) | 4.4765% | 4.4673% | -0.9 bp |
| Sharpe (ann.) | 3.4383 | 3.3817 | -0.0566 |

**Plainly: the benign case alone would not justify this change.** 33 bp and 1.6% relative on Sharpe is inside the noise most people would accept.

**News-shaped case** — same universe, gaps of -30% and +25% across the halts, which is what suspensions actually look like:

| | pre | post | delta |
|---|---|---|---|
| benchmark return | +16.0541% | +16.0489% | -0.005% (cancels) |
| **realised vol (ann.)** | 4.9619% | 4.4673% | **-0.49 pp, -10% relative** |
| **Sharpe (ann.)** | 3.0502 | 3.3817 | **+0.3315, +11% relative** |

The return delta vanishes; the risk metrics move 10-11% from two symbols in twenty. GBM over ten days only travels ~3%, but halts are selected for large moves, so the second table is the representative one.

## The fix, and why not the alternatives

Carry the prior price forward explicitly:

```python
# ffill *then* shift: the divisor is the last known price, not NaN.
prev = close.ffill().shift(1)
```

**Why not drop the observation (NaN out), matching `correlation.py`?** That is the more honest representation of an unobserved return, and I would argue for it in isolation. It fails on the consumer: `bench_equity = self.initial_capital * (1 + bench_ret).cumprod()` propagates NaN forward, so a single halt voids the entire equity curve from that bar onward. `correlation.py` can drop because it calls `.dropna()`; a cumulative product cannot.

**Why not keep 0.0 and make the counter fire on NaN priors?** That annotates the wrong number instead of fixing it. The vol and Sharpe distortion survives untouched, and the user is told their Sharpe is inflated with no way to obtain the correct one.

**Why forward-fill:** it is the only option under which the commit's own claim becomes true. A fix for non-positive prices should not change gapped-positive behaviour at all — that is an unannounced numeric change riding along with an unrelated fix.

It is also **strictly better than pre-`6635a92`**, not merely a revert. The old behaviour rested on a pandas default that is deprecated on 2.x and removed in 3.0; the same code silently produces different numbers depending on the installed version. Doing the fill explicitly makes the result version-independent. Verified identical on 2.3.3 and 3.0.1.

The #872 contract is untouched — a non-positive prior is still undefined, still `0.0`, still logged, and `test_nonpositive_returns.py` passes unmodified.

## Second, smaller item: non-finite prices

`np.inf > 0` is `True`, so `where(prev > 0)` kept an infinite prior:

```
close       : [10.0, inf, 42.0, 50.0]
bar_returns : [0.0, 0.0, -1.0, 0.1904...]
```

`42 / inf - 1` is a clean, plausible-looking **-1.0 (-100%)**, and no warning fires — `inf` is not-NaN and `inf > 0` is True, so the counter excludes it. The docstring says "defined only when the previous price is finite and strictly positive"; the finiteness half was never checked.

`buy_and_hold_return` has the same asymmetry — `np.isfinite(last)` but only `first > 0`:

| input | before | after |
|---|---|---|
| `first=+inf, last=42.0` | `-1.0` | `None` |
| `first=+inf, last=+inf` | `None` | `None` |
| `first=10.0, last=+inf` | `None` | `None` |

Both now assert finiteness on both ends.

## Relationship to #873

#873 landed on 2026-07-27, one day before `6635a92`. The two changes never saw each other, which is the whole explanation for the inconsistency below — neither is wrong on its own terms.

#873 established the principle this PR applies: do not manufacture returns that did not happen. Its comment is explicit that under the `pandas>=2,<3` pin, the `pct_change` pad default forward-fills missing prices, "silently manufacturing 0% returns on halted sessions". I agree, and this PR points that same objection at a site #873 did not touch.

`bar_returns` currently reports a real move as no move. On a series with an 8-bar halt:

```
close = [100, 110, NaN x6, 121, 122]
current (6635a92) : [0, 0.1, 0,0,0,0,0,0, 0.0,  0.0083]   manufactured zeros: 8/10
this PR           : [0, 0.1, 0,0,0,0,0,0, 0.1,  0.0083]   manufactured zeros: 7/10
```

The resumed bar carries a genuine +10% that the current code reports as 0.0%. Carrying the divisor forward produces **fewer** manufactured zeros, not more — it recovers an observation rather than inventing one.

The two sites differ in what they can tolerate. `correlation.py` builds its series from raw closes for a statistical use and can `.dropna()`. `bar_returns` feeds `cumprod`, where a single NaN voids the equity curve from that bar onward — which is also why dropping was not an option here.

**Open question, and I think it is the unresolved one.** The six zeros during the halt above are not from the divisor fill; they come from the trailing `.fillna(0.0)` in `bar_returns`, which is #872 design and untouched by this PR. The #873 principle applied consistently would say those bars should be dropped, not zeroed — they are sessions where nothing traded, and reporting 0% return deflates realised volatility exactly as #873 describes. But `cumprod` cannot take NaN, which is the same constraint that ruled out dropping here. Resolving it properly probably means separating the compounding consumer from the statistical ones rather than making one array serve both. Out of scope for this PR; worth deciding deliberately rather than by default.

@ddy4633 — tagging you since your #873 reasoning is the load-bearing argument here and you have clearly been working this seam; I would value your read on the `fillna` question.

## Tests

`agent/tests/test_returns_gaps_and_infinities.py`, 10 tests, written version-independently so they pin intent rather than whatever the installed default happens to be.

- **Pre-patch: 7 failed, 3 passed.** Post-patch: 10 passed on 3.0.1; 26 passed on pinned 2.3.3 (these plus the existing 16 from #872).
- Engine suite plus both returns files on 3.0.1: **399 passed, 1 skipped.**
- Post-rebase onto current `main`: 50 passed on 3.0.1 (including `test_correlation.py`), 26 on 2.3.3.
- Portfolio probe post-patch on 2.3.3 restores pre-commit numbers exactly: `1,163,761.40 / +16.376140% / 4.476485% / 3.438286`.
- Leading NaN still yields `0.0` — `ffill` cannot fill backwards, so late-starting symbols are unaffected. Covered.

Refs #872, #873.
