### PR TITLE
feat(backtest): execute USD-M funding and liquidation lifecycle

### DIFF
--- a/agent/backtest/engines/base.py
+++ b/agent/backtest/engines/base.py
@@ -445,6 +445,35 @@ class BaseEngine(ABC):
         Default: no-op. Override in subclass as needed.
         """
 
+    def before_rebalance_bar(
+        self,
+        timestamp: pd.Timestamp,
+        data_map: Dict[str, pd.DataFrame],
+        codes: List[str],
+    ) -> bool:
+        """Run pre-execution hooks; return True to stop after this snapshot."""
+        return False
+
+    def after_rebalance_bar(
+        self,
+        timestamp: pd.Timestamp,
+        data_map: Dict[str, pd.DataFrame],
+        codes: List[str],
+    ) -> bool:
+        """Run the legacy post-fill bar hooks; return True to stop."""
+        for code in codes:
+            if timestamp in data_map[code].index:
+                self.on_bar(code, data_map[code].loc[timestamp], timestamp)
+        return False
+
+    def execution_open(self, bar: pd.Series) -> float:
+        """Return the normal market-fill price for a bar."""
+        return float(bar.get("open", bar.get("close", 0)))
+
+    def valuation_open(self, bar: pd.Series) -> float:
+        """Return the price observable when open orders are sized."""
+        return float(bar.get("open", bar.get("close", 0)))
+
     # ── PnL / margin calculation hooks ──
     # Override in FuturesBaseEngine to inject contract multiplier.
 
@@ -711,6 +740,8 @@ class BaseEngine(ABC):
         for i, ts in enumerate(dates):
             self._bar_idx = i
 
+            stop_run = self.before_rebalance_bar(ts, data_map, codes)
+
             # a. Value the book at prices observable when orders execute.
             # Rebalances happen at the bar open, so using close_df[ts] here
             # would let the yet-unknown decision-bar close affect order size.
@@ -719,7 +750,9 @@ class BaseEngine(ABC):
             for c in codes:
                 try:
                     val = _target_arr[i, _code_to_col[c]]
-                    target_weights[c] = float(val) if not np.isnan(val) else 0.0
+                    target_weights[c] = (
+                        None if stop_run else (float(val) if not np.isnan(val) else 0.0)
+                    )
                 except Exception as exc:
                     target_weights[c] = None
                     logger.warning("Target weight failed for %s at %s: %s", c, ts, exc)
@@ -793,13 +826,9 @@ class BaseEngine(ABC):
             for order in planned:
                 self._execute_open_order(order, ts)
 
-            # d. Apply close/within-bar hooks after open execution.  Hooks use
-            # the current bar's close for funding, swaps, and liquidation, so
-            # running them first could liquidate a position that was scheduled
-            # to exit at the open (or charge a position before it was opened).
-            for c in codes:
-                if ts in data_map[c].index:
-                    self.on_bar(c, data_map[c].loc[ts], ts)
+            # d. Apply post-execution hooks after all normal market fills.
+            if not stop_run:
+                stop_run = self.after_rebalance_bar(ts, data_map, codes)
 
             # e. Record equity snapshot
             snap_equity = self._calc_equity(close_df, ts)
@@ -831,6 +860,9 @@ class BaseEngine(ABC):
                 equity=snap_equity,
                 positions=len(self.positions),
             ))
+
+            if stop_run:
+                break
 
         # f. Force close all remaining positions
         if len(dates) > 0:
@@ -889,10 +921,9 @@ class BaseEngine(ABC):
             )
             frame = data_map.get(sym)
             if frame is not None and ts in frame.index:
-                open_price = frame.loc[ts].get("open")
+                open_price = self.valuation_open(frame.loc[ts])
                 if (
-                    open_price is not None
-                    and pd.notna(open_price)
+                    pd.notna(open_price)
                     and float(open_price) > 0
                 ):
                     current_price = float(open_price)
@@ -977,7 +1008,7 @@ class BaseEngine(ABC):
             need_close = target_dir == 0 or target_dir != current_pos.direction
             if need_close:
                 if self.can_execute(symbol, 0, bar):
-                    open_price = float(bar.get("open", bar.get("close", 0)))
+                    open_price = self.execution_open(bar)
                     price = self.apply_slippage(open_price, -current_pos.direction)
                     self._close_position(symbol, price, ts, "signal")
                 else:
@@ -1004,7 +1035,7 @@ class BaseEngine(ABC):
         bar = df.loc[ts]
         if not self.can_execute(symbol, direction, bar):
             return None
-        open_price = float(bar.get("open", bar.get("close", 0)))
+        open_price = self.execution_open(bar)
         # Zero is always rejected (size = notional / price is undefined);
         # negatives are rejected unless this engine opted into non-positive
         # prices, in which case abs()-based sizing/margin below handle them.

--- a/agent/backtest/engines/base.py
+++ b/agent/backtest/engines/base.py
@@ -866,8 +866,8 @@ class BaseEngine(ABC):
 
         # f. Force close all remaining positions
         if len(dates) > 0:
-            last_ts = dates[-1]
-            _last_row = len(dates) - 1
+            _last_row = min(self._bar_idx, len(dates) - 1)
+            last_ts = dates[_last_row]
             for c in list(self.positions.keys()):
                 pos = self.positions[c]
                 mark_price = self._safe_price(

--- a/agent/backtest/engines/crypto.py
+++ b/agent/backtest/engines/crypto.py
@@ -18,9 +18,13 @@ from backtest.engines._market_hooks import (
     check_crypto_liquidation,
 )
 from backtest.perpetual_risk import (
+    AccountState,
+    CrossMarginRiskModel,
     ExecutionFrame,
     MaintenanceSchedule,
     MarketRiskFrame,
+    PositionState,
+    evaluate_isolated,
 )
 
 
@@ -45,23 +49,25 @@ class CryptoEngine(BaseEngine):
         self.perpetual_strict = bool(config.get("perpetual_strict", False))
         self.funding_mode = str(config.get("funding_mode", "fixed"))
         self.margin_mode = str(config.get("margin_mode", "isolated"))
+        self.liquidation_fee_rate = float(config.get("liquidation_fee_rate", 0.0))
         if self.perpetual_strict and self.funding_mode != "data":
             raise ValueError("perpetual_strict requires funding_mode='data'")
         if self.perpetual_strict and self.margin_mode not in {"isolated", "cross"}:
             raise ValueError("margin_mode must be 'isolated' or 'cross'")
+        if self.perpetual_strict and not 0 <= self.liquidation_fee_rate < 1:
+            raise ValueError("liquidation_fee_rate must be between zero and one")
         self.terminal_status = "active"
         self._strict_funding_applied: set[tuple[str, pd.Timestamp]] = set()
         self._isolated_margins: dict[str, float] = {}
         self._schedule_cache: dict[tuple[str, str], MaintenanceSchedule] = {}
-        self._execution_frames: dict[str, ExecutionFrame] = {}
         self._risk_frames: dict[str, MarketRiskFrame] = {}
-        self._current_mark_prices: dict[str, float] = {}
+        self._blocked_symbols: set[str] = set()
         self._funding_applied: set = set()   # (symbol, date, hour) — per-slot dedup
         self._funding_daily_done: set = set()  # (symbol, date) — daily fallback dedup
 
     def can_execute(self, symbol: str, direction: int, bar: pd.Series) -> bool:
         """Crypto: 24/7, long/short/close all allowed."""
-        return True
+        return not (self.perpetual_strict and symbol in self._blocked_symbols)
 
     def round_size(self, raw_size: float, price: float) -> float:
         """Crypto supports fractional sizes, round to 6 decimals."""
@@ -91,7 +97,10 @@ class CryptoEngine(BaseEngine):
         return float(bar["mark_open"])
 
     def _schedule(self, symbol: str, bar: pd.Series) -> MaintenanceSchedule:
-        version = str(bar["maintenance_bracket_version"])
+        version = bar["maintenance_bracket_version"]
+        if pd.isna(version):
+            raise ValueError(f"missing maintenance bracket version for {symbol}")
+        version = str(version)
         key = (symbol, version)
         if key not in self._schedule_cache:
             self._schedule_cache[key] = MaintenanceSchedule.from_loader_columns(
@@ -105,7 +114,6 @@ class CryptoEngine(BaseEngine):
         data_map: dict[str, pd.DataFrame],
         codes: list[str],
     ) -> None:
-        executions: dict[str, ExecutionFrame] = {}
         risks: dict[str, MarketRiskFrame] = {}
         for symbol in codes:
             frame = data_map.get(symbol)
@@ -114,9 +122,7 @@ class CryptoEngine(BaseEngine):
             bar = frame.loc[timestamp]
             if not isinstance(bar, pd.Series):
                 raise ValueError(f"duplicate frame timestamp for {symbol} at {timestamp}")
-            executions[symbol] = ExecutionFrame(
-                timestamp, float(bar["execution_open"])
-            )
+            ExecutionFrame(timestamp, float(bar["execution_open"]))
             rate = bar["funding_rate"]
             settlement = bar["funding_settlement_time"]
             if pd.isna(rate):
@@ -141,7 +147,6 @@ class CryptoEngine(BaseEngine):
                 schedule=self._schedule(symbol, bar),
                 source=str(self.config.get("market_risk_source", "ccxt:binanceusdm")),
             )
-        self._execution_frames = executions
         self._risk_frames = risks
 
     def _apply_data_funding(self) -> None:
@@ -154,15 +159,64 @@ class CryptoEngine(BaseEngine):
             if key in self._strict_funding_applied:
                 continue
             payment = (
-                position.direction
-                * position.size
-                * frame.mark_open
+                position.direction * position.size * frame.mark_open
                 * float(frame.funding_rate)
             )
             self.capital -= payment
             if self.margin_mode == "isolated":
                 self._isolated_margins[symbol] -= payment
             self._strict_funding_applied.add(key)
+
+    def _account_state(self) -> AccountState:
+        positions = tuple(
+            PositionState(
+                symbol=symbol,
+                quantity=position.direction * position.size,
+                entry_price=position.entry_price,
+                leverage=position.leverage,
+                accumulated_entry_fee=position.entry_commission,
+                isolated_margin=self._isolated_margins.get(symbol),
+            )
+            for symbol, position in self.positions.items()
+        )
+        locked_margin = sum(
+            self._calc_margin(
+                position.symbol, position.size, position.entry_price, position.leverage
+            )
+            for position in self.positions.values()
+        )
+        return AccountState(
+            wallet_balance=self.capital + locked_margin,
+            positions=positions,
+            margin_mode=self.margin_mode,
+            terminal_status=self.terminal_status,
+        )
+
+    def _evaluate_and_liquidate(
+        self, timestamp: pd.Timestamp, price_field: str
+    ) -> bool:
+        if not self.positions:
+            return False
+        account = self._account_state()
+        snapshot = (
+            evaluate_isolated(account, self._risk_frames, price_field)
+            if self.margin_mode == "isolated"
+            else CrossMarginRiskModel().evaluate(account, self._risk_frames, price_field)
+        )
+        if snapshot.status == "healthy":
+            return False
+        prices = {risk.symbol: risk.mark_price for risk in snapshot.per_position}
+        for symbol in snapshot.liquidation_targets:
+            position = self.positions[symbol]
+            price = prices[symbol]
+            fee = position.size * price * self.liquidation_fee_rate
+            self._close_position(symbol, price, timestamp, snapshot.status)
+            self.capital -= fee
+        if snapshot.status == "account_liquidation":
+            self.terminal_status = "account_liquidation"
+            return True
+        self._blocked_symbols.update(snapshot.liquidation_targets)
+        return False
 
     def before_rebalance_bar(
         self,
@@ -172,12 +226,10 @@ class CryptoEngine(BaseEngine):
     ) -> bool:
         if not self.perpetual_strict:
             return super().before_rebalance_bar(timestamp, data_map, codes)
+        self._blocked_symbols.clear()
         self._build_strict_frames(timestamp, data_map, codes)
-        self._current_mark_prices = {
-            symbol: frame.mark_open for symbol, frame in self._risk_frames.items()
-        }
         self._apply_data_funding()
-        return False
+        return self._evaluate_and_liquidate(timestamp, "mark_open")
 
     def after_rebalance_bar(
         self,
@@ -187,17 +239,13 @@ class CryptoEngine(BaseEngine):
     ) -> bool:
         if not self.perpetual_strict:
             return super().after_rebalance_bar(timestamp, data_map, codes)
-        self._current_mark_prices = {
-            symbol: frame.mark_close for symbol, frame in self._risk_frames.items()
-        }
-        return False
+        return self._evaluate_and_liquidate(timestamp, "adverse")
 
     def _execute_bars(self, dates, data_map, close_df, target_pos, codes) -> None:
         if self.perpetual_strict:
             try:
                 close_df = pd.DataFrame(
-                    {symbol: data_map[symbol]["mark_close"] for symbol in codes},
-                    index=dates,
+                    {symbol: data_map[symbol]["mark_close"] for symbol in codes}, index=dates
                 )
             except KeyError as exc:
                 raise ValueError(f"missing strict mark-close data: {exc}") from exc

--- a/agent/backtest/engines/crypto.py
+++ b/agent/backtest/engines/crypto.py
@@ -17,6 +17,11 @@ from backtest.engines._market_hooks import (
     calc_crypto_funding_fee,
     check_crypto_liquidation,
 )
+from backtest.perpetual_risk import (
+    ExecutionFrame,
+    MaintenanceSchedule,
+    MarketRiskFrame,
+)
 
 
 class CryptoEngine(BaseEngine):
@@ -37,6 +42,20 @@ class CryptoEngine(BaseEngine):
         self.taker_rate: float = config.get("taker_rate", 0.0005)
         self.slippage_rate: float = config.get("slippage", 0.0005)
         self.funding_rate: float = config.get("funding_rate", 0.0001)
+        self.perpetual_strict = bool(config.get("perpetual_strict", False))
+        self.funding_mode = str(config.get("funding_mode", "fixed"))
+        self.margin_mode = str(config.get("margin_mode", "isolated"))
+        if self.perpetual_strict and self.funding_mode != "data":
+            raise ValueError("perpetual_strict requires funding_mode='data'")
+        if self.perpetual_strict and self.margin_mode not in {"isolated", "cross"}:
+            raise ValueError("margin_mode must be 'isolated' or 'cross'")
+        self.terminal_status = "active"
+        self._strict_funding_applied: set[tuple[str, pd.Timestamp]] = set()
+        self._isolated_margins: dict[str, float] = {}
+        self._schedule_cache: dict[tuple[str, str], MaintenanceSchedule] = {}
+        self._execution_frames: dict[str, ExecutionFrame] = {}
+        self._risk_frames: dict[str, MarketRiskFrame] = {}
+        self._current_mark_prices: dict[str, float] = {}
         self._funding_applied: set = set()   # (symbol, date, hour) — per-slot dedup
         self._funding_daily_done: set = set()  # (symbol, date) — daily fallback dedup
 
@@ -54,12 +73,152 @@ class CryptoEngine(BaseEngine):
         ``_direction`` is unused — reserved for future funding-rate asymmetry
         between long/short legs on perp swaps.
         """
-        rate = self.taker_rate if is_open else self.maker_rate
+        rate = self.taker_rate if self.perpetual_strict or is_open else self.maker_rate
         return size * price * rate
 
     def apply_slippage(self, price: float, direction: int) -> float:
         """Slippage: unfavourable direction."""
         return price * (1 + direction * self.slippage_rate)
+
+    def execution_open(self, bar: pd.Series) -> float:
+        if not self.perpetual_strict:
+            return super().execution_open(bar)
+        return ExecutionFrame(bar.name, float(bar["execution_open"])).execution_open
+
+    def valuation_open(self, bar: pd.Series) -> float:
+        if not self.perpetual_strict:
+            return super().valuation_open(bar)
+        return float(bar["mark_open"])
+
+    def _schedule(self, symbol: str, bar: pd.Series) -> MaintenanceSchedule:
+        version = str(bar["maintenance_bracket_version"])
+        key = (symbol, version)
+        if key not in self._schedule_cache:
+            self._schedule_cache[key] = MaintenanceSchedule.from_loader_columns(
+                symbol, bar["maintenance_brackets"], version
+            )
+        return self._schedule_cache[key]
+
+    def _build_strict_frames(
+        self,
+        timestamp: pd.Timestamp,
+        data_map: dict[str, pd.DataFrame],
+        codes: list[str],
+    ) -> None:
+        executions: dict[str, ExecutionFrame] = {}
+        risks: dict[str, MarketRiskFrame] = {}
+        for symbol in codes:
+            frame = data_map.get(symbol)
+            if frame is None or timestamp not in frame.index:
+                raise ValueError(f"missing synchronized frame for {symbol} at {timestamp}")
+            bar = frame.loc[timestamp]
+            if not isinstance(bar, pd.Series):
+                raise ValueError(f"duplicate frame timestamp for {symbol} at {timestamp}")
+            executions[symbol] = ExecutionFrame(
+                timestamp, float(bar["execution_open"])
+            )
+            rate = bar["funding_rate"]
+            settlement = bar["funding_settlement_time"]
+            if pd.isna(rate):
+                raise ValueError(f"missing funding rate for {symbol} at {timestamp}")
+            if pd.isna(settlement):
+                if float(rate) != 0.0:
+                    raise ValueError(
+                        f"funding rate without settlement for {symbol} at {timestamp}"
+                    )
+                funding_rate = funding_time = None
+            else:
+                funding_rate = float(rate)
+                funding_time = pd.Timestamp(settlement)
+            risks[symbol] = MarketRiskFrame(
+                timestamp=timestamp,
+                mark_open=float(bar["mark_open"]),
+                mark_high=float(bar["mark_high"]),
+                mark_low=float(bar["mark_low"]),
+                mark_close=float(bar["mark_close"]),
+                funding_rate=funding_rate,
+                funding_settlement_time=funding_time,
+                schedule=self._schedule(symbol, bar),
+                source=str(self.config.get("market_risk_source", "ccxt:binanceusdm")),
+            )
+        self._execution_frames = executions
+        self._risk_frames = risks
+
+    def _apply_data_funding(self) -> None:
+        for symbol, position in self.positions.items():
+            frame = self._risk_frames[symbol]
+            settlement = frame.funding_settlement_time
+            if settlement is None or position.entry_time >= settlement:
+                continue
+            key = (symbol, settlement)
+            if key in self._strict_funding_applied:
+                continue
+            payment = (
+                position.direction
+                * position.size
+                * frame.mark_open
+                * float(frame.funding_rate)
+            )
+            self.capital -= payment
+            if self.margin_mode == "isolated":
+                self._isolated_margins[symbol] -= payment
+            self._strict_funding_applied.add(key)
+
+    def before_rebalance_bar(
+        self,
+        timestamp: pd.Timestamp,
+        data_map: dict[str, pd.DataFrame],
+        codes: list[str],
+    ) -> bool:
+        if not self.perpetual_strict:
+            return super().before_rebalance_bar(timestamp, data_map, codes)
+        self._build_strict_frames(timestamp, data_map, codes)
+        self._current_mark_prices = {
+            symbol: frame.mark_open for symbol, frame in self._risk_frames.items()
+        }
+        self._apply_data_funding()
+        return False
+
+    def after_rebalance_bar(
+        self,
+        timestamp: pd.Timestamp,
+        data_map: dict[str, pd.DataFrame],
+        codes: list[str],
+    ) -> bool:
+        if not self.perpetual_strict:
+            return super().after_rebalance_bar(timestamp, data_map, codes)
+        self._current_mark_prices = {
+            symbol: frame.mark_close for symbol, frame in self._risk_frames.items()
+        }
+        return False
+
+    def _execute_bars(self, dates, data_map, close_df, target_pos, codes) -> None:
+        if self.perpetual_strict:
+            try:
+                close_df = pd.DataFrame(
+                    {symbol: data_map[symbol]["mark_close"] for symbol in codes},
+                    index=dates,
+                )
+            except KeyError as exc:
+                raise ValueError(f"missing strict mark-close data: {exc}") from exc
+        super()._execute_bars(dates, data_map, close_df, target_pos, codes)
+        if self.perpetual_strict and self.terminal_status == "active":
+            self.terminal_status = "completed"
+
+    def _execute_open_order(self, order, timestamp: pd.Timestamp) -> None:
+        super()._execute_open_order(order, timestamp)
+        if self.perpetual_strict and self.margin_mode == "isolated":
+            self._isolated_margins[order.symbol] = order.margin
+
+    def _close_position(
+        self,
+        symbol: str,
+        exit_price: float,
+        exit_time: pd.Timestamp,
+        reason: str,
+    ) -> None:
+        super()._close_position(symbol, exit_price, exit_time, reason)
+        self._isolated_margins.pop(symbol, None)
 
     def on_bar(self, symbol: str, bar: pd.Series, timestamp: pd.Timestamp) -> None:
         """Crypto per-bar hooks: funding fee + liquidation check."""

--- a/agent/tests/test_base_engine.py
+++ b/agent/tests/test_base_engine.py
@@ -14,23 +14,11 @@ from backtest.engines.china_a import ChinaAEngine
 from backtest.models import Position
 
 
-class _LifecycleEngine(BaseEngine):
+class _LifecycleEngine(ChinaAEngine):
     def __init__(self, *, stop_before: bool = False):
-        super().__init__({"initial_cash": 1_000.0})
+        super().__init__({"initial_cash": 1_000_000.0})
         self.stop_before = stop_before
         self.lifecycle: list[str] = []
-
-    def can_execute(self, symbol, direction, bar):
-        return True
-
-    def round_size(self, raw_size, price):
-        return raw_size
-
-    def calc_commission(self, size, price, direction, is_open):
-        return 0.0
-
-    def apply_slippage(self, price, direction):
-        return price
 
     def before_rebalance_bar(self, timestamp, data_map, codes):
         self.lifecycle.append("pre")
@@ -46,35 +34,29 @@ class _LifecycleEngine(BaseEngine):
 
 
 def _run_lifecycle(engine: _LifecycleEngine) -> None:
-    timestamp = pd.Timestamp("2026-01-01")
-    dates = pd.DatetimeIndex([timestamp])
+    dates = pd.DatetimeIndex([pd.Timestamp("2026-01-02")])
     frame = pd.DataFrame({"open": [100.0], "close": [100.0]}, index=dates)
-    targets = pd.DataFrame({"TEST": [1.0]}, index=dates)
     engine._execute_bars(
         dates,
         {"TEST": frame},
         frame[["close"]].rename(columns={"close": "TEST"}),
-        targets,
+        pd.DataFrame({"TEST": [1.0]}, index=dates),
         ["TEST"],
     )
 
 
-def test_execute_bars_runs_pre_fill_post_lifecycle() -> None:
-    engine = _LifecycleEngine()
-
+@pytest.mark.parametrize(("stop_before", "expected"), [
+    (False, ["pre", "fill", "post"]), (True, ["pre"]),
+])
+def test_execute_bars_lifecycle_and_pre_fill_stop(
+    stop_before: bool, expected: list[str]
+) -> None:
+    engine = _LifecycleEngine(stop_before=stop_before)
     _run_lifecycle(engine)
-
-    assert engine.lifecycle == ["pre", "fill", "post"]
-
-
-def test_pre_lifecycle_can_stop_before_fill_and_still_snapshot() -> None:
-    engine = _LifecycleEngine(stop_before=True)
-
-    _run_lifecycle(engine)
-
-    assert engine.lifecycle == ["pre"]
-    assert engine.trades == []
+    assert engine.lifecycle == expected
     assert len(engine.equity_snapshots) == 1
+    if stop_before:
+        assert engine.trades == []
 
 
 # ---------------------------------------------------------------------------

--- a/agent/tests/test_base_engine.py
+++ b/agent/tests/test_base_engine.py
@@ -14,6 +14,69 @@ from backtest.engines.china_a import ChinaAEngine
 from backtest.models import Position
 
 
+class _LifecycleEngine(BaseEngine):
+    def __init__(self, *, stop_before: bool = False):
+        super().__init__({"initial_cash": 1_000.0})
+        self.stop_before = stop_before
+        self.lifecycle: list[str] = []
+
+    def can_execute(self, symbol, direction, bar):
+        return True
+
+    def round_size(self, raw_size, price):
+        return raw_size
+
+    def calc_commission(self, size, price, direction, is_open):
+        return 0.0
+
+    def apply_slippage(self, price, direction):
+        return price
+
+    def before_rebalance_bar(self, timestamp, data_map, codes):
+        self.lifecycle.append("pre")
+        return self.stop_before
+
+    def after_rebalance_bar(self, timestamp, data_map, codes):
+        self.lifecycle.append("post")
+        return False
+
+    def _execute_open_order(self, order, ts):
+        self.lifecycle.append("fill")
+        super()._execute_open_order(order, ts)
+
+
+def _run_lifecycle(engine: _LifecycleEngine) -> None:
+    timestamp = pd.Timestamp("2026-01-01")
+    dates = pd.DatetimeIndex([timestamp])
+    frame = pd.DataFrame({"open": [100.0], "close": [100.0]}, index=dates)
+    targets = pd.DataFrame({"TEST": [1.0]}, index=dates)
+    engine._execute_bars(
+        dates,
+        {"TEST": frame},
+        frame[["close"]].rename(columns={"close": "TEST"}),
+        targets,
+        ["TEST"],
+    )
+
+
+def test_execute_bars_runs_pre_fill_post_lifecycle() -> None:
+    engine = _LifecycleEngine()
+
+    _run_lifecycle(engine)
+
+    assert engine.lifecycle == ["pre", "fill", "post"]
+
+
+def test_pre_lifecycle_can_stop_before_fill_and_still_snapshot() -> None:
+    engine = _LifecycleEngine(stop_before=True)
+
+    _run_lifecycle(engine)
+
+    assert engine.lifecycle == ["pre"]
+    assert engine.trades == []
+    assert len(engine.equity_snapshots) == 1
+
+
 # ---------------------------------------------------------------------------
 # _align: signal alignment and normalization
 # ---------------------------------------------------------------------------

--- a/agent/tests/test_crypto_engine.py
+++ b/agent/tests/test_crypto_engine.py
@@ -11,8 +11,6 @@ Validates:
 
 from __future__ import annotations
 
-import json
-
 import pandas as pd
 import pytest
 
@@ -22,6 +20,11 @@ from backtest.engines._market_hooks import (
     _maintenance_rate,
 )
 from backtest.models import Position
+
+_BRACKETS = (
+    '[{"bracket_tier":1,"notional_cap":1000000.0,'
+    '"maintenance_rate":0.004,"cumulative_maintenance_amount":0.0}]'
+)
 
 
 # ---------------------------------------------------------------------------
@@ -63,34 +66,28 @@ def _strict_engine(**overrides) -> CryptoEngine:
 def _strict_frame(
     dates: pd.DatetimeIndex,
     *,
-    execution_open: list[float],
-    mark_open: list[float],
-    mark_high: list[float],
-    mark_low: list[float],
-    mark_close: list[float],
+    price: float = 100.0,
+    mark: list[float] | None = None,
+    execution_open: list[float] | None = None,
+    mark_open: list[float] | None = None,
+    mark_high: list[float] | None = None,
+    mark_low: list[float] | None = None,
+    mark_close: list[float] | None = None,
     funding_rate: list[float] | None = None,
     settlements: list[pd.Timestamp | None] | None = None,
 ) -> pd.DataFrame:
-    brackets = json.dumps(
-        [{
-            "bracket_tier": 1,
-            "notional_cap": 1_000_000.0,
-            "maintenance_rate": 0.004,
-            "cumulative_maintenance_amount": 0.0,
-        }]
-    )
+    base = [price] * len(dates)
+    marks = mark or base
     return pd.DataFrame(
         {
-            "open": [1.0] * len(dates),
-            "close": mark_close,
-            "execution_open": execution_open,
-            "mark_open": mark_open,
-            "mark_high": mark_high,
-            "mark_low": mark_low,
-            "mark_close": mark_close,
+            "execution_open": execution_open or base,
+            "mark_open": mark_open or marks,
+            "mark_high": mark_high or marks,
+            "mark_low": mark_low or marks,
+            "mark_close": mark_close or marks,
             "funding_rate": funding_rate or [0.0] * len(dates),
             "funding_settlement_time": settlements or [pd.NaT] * len(dates),
-            "maintenance_brackets": [brackets] * len(dates),
+            "maintenance_brackets": [_BRACKETS] * len(dates),
             "maintenance_bracket_version": ["fixture-v1"] * len(dates),
         },
         index=dates,
@@ -104,14 +101,10 @@ def _run_strict(
 ) -> None:
     dates = next(iter(data_map.values())).index
     codes = list(data_map)
-    close_df = pd.DataFrame(
-        {symbol: frame["close"] for symbol, frame in data_map.items()},
-        index=dates,
-    )
     engine._execute_bars(
         dates,
         data_map,
-        close_df,
+        pd.DataFrame(index=dates),
         pd.DataFrame(targets, index=dates),
         codes,
     )
@@ -467,11 +460,7 @@ class TestStrictPerpetualLifecycle:
         dates = pd.date_range("2026-01-01", periods=2, freq="8h", tz="UTC")
         frame = _strict_frame(
             dates,
-            execution_open=[60_000.0, 60_000.0],
-            mark_open=[60_000.0, 60_000.0],
-            mark_high=[60_000.0, 60_000.0],
-            mark_low=[60_000.0, 60_000.0],
-            mark_close=[60_000.0, 60_000.0],
+            price=60_000.0,
             funding_rate=[0.001, 0.001],
             settlements=list(dates),
         )
@@ -480,3 +469,79 @@ class TestStrictPerpetualLifecycle:
         _run_strict(engine, {"BTC-USDT-PERP": frame}, {"BTC-USDT-PERP": [1.0, 0.0]})
 
         assert engine.capital == pytest.approx(990.0, abs=0.001)
+
+    def test_isolated_liquidation_closes_only_breached_position(self) -> None:
+        dates = pd.date_range("2026-01-01", periods=2, freq="h", tz="UTC")
+        btc = _strict_frame(
+            dates,
+            mark_low=[90.0, 100.0],
+            mark_close=[95.0, 100.0],
+        )
+        eth = _strict_frame(dates)
+        engine = _strict_engine(
+            initial_cash=2_000.0,
+            taker_rate=0.0,
+            maker_rate=0.0,
+            liquidation_fee_rate=0.01,
+        )
+
+        _run_strict(
+            engine,
+            {"BTC-USDT-PERP": btc, "ETH-USDT-PERP": eth},
+            {"BTC-USDT-PERP": [0.5, 0.0], "ETH-USDT-PERP": [0.5, 0.5]},
+        )
+
+        reasons = {trade.symbol: trade.exit_reason for trade in engine.trades}
+        assert reasons == {
+            "BTC-USDT-PERP": "position_liquidation",
+            "ETH-USDT-PERP": "end_of_backtest",
+        }
+        assert engine.terminal_status == "completed"
+        assert engine.capital == pytest.approx(910.0)
+
+    def test_open_mark_liquidation_blocks_same_bar_reopen(self) -> None:
+        dates = pd.date_range("2026-01-01", periods=2, freq="h", tz="UTC")
+        frame = _strict_frame(
+            dates,
+            mark=[100.0, 90.0],
+        )
+        engine = _strict_engine(taker_rate=0.0, maker_rate=0.0)
+
+        _run_strict(engine, {"BTC-USDT-PERP": frame}, {"BTC-USDT-PERP": [1.0, 1.0]})
+
+        assert [trade.exit_reason for trade in engine.trades] == [
+            "position_liquidation"
+        ]
+        assert not engine.positions
+
+    def test_cross_liquidation_closes_account_and_stops_later_bars(self) -> None:
+        dates = pd.date_range("2026-01-01", periods=3, freq="h", tz="UTC")
+        frames = {
+            symbol: _strict_frame(
+                dates,
+                mark_low=[100.0, low, 100.0],
+            )
+            for symbol, low in (
+                ("BTC-USDT-PERP", 80.0),
+                ("ETH-USDT-PERP", 100.0),
+            )
+        }
+        engine = _strict_engine(
+            initial_cash=2_000.0,
+            taker_rate=0.0,
+            maker_rate=0.0,
+            margin_mode="cross",
+        )
+
+        _run_strict(
+            engine,
+            frames,
+            {symbol: [0.5] * 3 for symbol in frames},
+        )
+
+        assert {trade.exit_reason for trade in engine.trades} == {
+            "account_liquidation"
+        }
+        assert engine.terminal_status == "account_liquidation"
+        assert len(engine.equity_snapshots) == 2
+        assert engine.equity_snapshots[-1].timestamp == dates[1]

--- a/agent/tests/test_crypto_engine.py
+++ b/agent/tests/test_crypto_engine.py
@@ -11,15 +11,14 @@ Validates:
 
 from __future__ import annotations
 
+import json
+
 import pandas as pd
 import pytest
 
 from backtest.engines.crypto import CryptoEngine
 from backtest.engines._market_hooks import (
     FUNDING_HOURS as _FUNDING_HOURS,
-    _TIER_TABLE,
-    calc_crypto_funding_fee,
-    check_crypto_liquidation,
     _maintenance_rate,
 )
 from backtest.models import Position
@@ -44,6 +43,78 @@ def _make_engine(**overrides) -> CryptoEngine:
     }
     config.update(overrides)
     return CryptoEngine(config)
+
+
+def _strict_engine(**overrides) -> CryptoEngine:
+    config = {
+        "initial_cash": 1_000.0,
+        "leverage": 10.0,
+        "maker_rate": 0.0002,
+        "taker_rate": 0.0005,
+        "slippage": 0.0,
+        "perpetual_strict": True,
+        "funding_mode": "data",
+        "margin_mode": "isolated",
+    }
+    config.update(overrides)
+    return CryptoEngine(config)
+
+
+def _strict_frame(
+    dates: pd.DatetimeIndex,
+    *,
+    execution_open: list[float],
+    mark_open: list[float],
+    mark_high: list[float],
+    mark_low: list[float],
+    mark_close: list[float],
+    funding_rate: list[float] | None = None,
+    settlements: list[pd.Timestamp | None] | None = None,
+) -> pd.DataFrame:
+    brackets = json.dumps(
+        [{
+            "bracket_tier": 1,
+            "notional_cap": 1_000_000.0,
+            "maintenance_rate": 0.004,
+            "cumulative_maintenance_amount": 0.0,
+        }]
+    )
+    return pd.DataFrame(
+        {
+            "open": [1.0] * len(dates),
+            "close": mark_close,
+            "execution_open": execution_open,
+            "mark_open": mark_open,
+            "mark_high": mark_high,
+            "mark_low": mark_low,
+            "mark_close": mark_close,
+            "funding_rate": funding_rate or [0.0] * len(dates),
+            "funding_settlement_time": settlements or [pd.NaT] * len(dates),
+            "maintenance_brackets": [brackets] * len(dates),
+            "maintenance_bracket_version": ["fixture-v1"] * len(dates),
+        },
+        index=dates,
+    )
+
+
+def _run_strict(
+    engine: CryptoEngine,
+    data_map: dict[str, pd.DataFrame],
+    targets: dict[str, list[float]],
+) -> None:
+    dates = next(iter(data_map.values())).index
+    codes = list(data_map)
+    close_df = pd.DataFrame(
+        {symbol: frame["close"] for symbol, frame in data_map.items()},
+        index=dates,
+    )
+    engine._execute_bars(
+        dates,
+        data_map,
+        close_df,
+        pd.DataFrame(targets, index=dates),
+        codes,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -368,3 +439,44 @@ class TestHistoricalFundingRate:
         ts = pd.Timestamp("2025-01-01 08:00:00")
         engine.on_bar("BTC-USDT-PERP", bar, ts)
         assert engine.capital == pytest.approx(initial_capital - 6.0)
+
+
+class TestStrictPerpetualLifecycle:
+    def test_market_fills_use_execution_open_and_taker_rate(self) -> None:
+        dates = pd.date_range("2026-01-01", periods=2, freq="h", tz="UTC")
+        frame = _strict_frame(
+            dates,
+            execution_open=[60_123.0, 60_234.0],
+            mark_open=[60_000.0, 60_100.0],
+            mark_high=[60_200.0, 60_300.0],
+            mark_low=[59_900.0, 60_000.0],
+            mark_close=[60_100.0, 60_200.0],
+        )
+        engine = _strict_engine()
+
+        _run_strict(engine, {"BTC-USDT-PERP": frame}, {"BTC-USDT-PERP": [1.0, 0.0]})
+
+        trade = engine.trades[0]
+        assert trade.entry_price == 60_123.0
+        assert trade.exit_price == 60_234.0
+        assert trade.commission == pytest.approx(
+            trade.size * (trade.entry_price + trade.exit_price) * engine.taker_rate
+        )
+
+    def test_funding_applies_only_to_position_open_before_settlement(self) -> None:
+        dates = pd.date_range("2026-01-01", periods=2, freq="8h", tz="UTC")
+        frame = _strict_frame(
+            dates,
+            execution_open=[60_000.0, 60_000.0],
+            mark_open=[60_000.0, 60_000.0],
+            mark_high=[60_000.0, 60_000.0],
+            mark_low=[60_000.0, 60_000.0],
+            mark_close=[60_000.0, 60_000.0],
+            funding_rate=[0.001, 0.001],
+            settlements=list(dates),
+        )
+        engine = _strict_engine(taker_rate=0.0, maker_rate=0.0)
+
+        _run_strict(engine, {"BTC-USDT-PERP": frame}, {"BTC-USDT-PERP": [1.0, 0.0]})
+
+        assert engine.capital == pytest.approx(990.0, abs=0.001)


### PR DESCRIPTION
## Stack note

Third bounded slice of the historical USD-M work discussed in #462. It builds on the merged state and liquidation contracts from #798 and #889. This PR wires those pure decisions into the backtest lifecycle; it does not add live API or execution surfaces.

## Summary

- Add pre-fill and post-fill lifecycle seams to `BaseEngine` while preserving the existing default order.
- Add opt-in USD-M strict lifecycle handling to `CryptoEngine`, with market fills from `execution_open`, risk valuation from mark OHLC, and historical funding before target fills.
- Execute isolated breaches as `position_liquidation` and cross-account breaches as terminal `account_liquidation` events.
- Keep legacy `CryptoEngine` behavior unchanged unless `perpetual_strict=True` is selected.

## Why

#889 provides deterministic isolated and cross risk decisions but intentionally does not mutate engine positions or stop a run. Without this integration slice, the backtester cannot apply funding-before-fill ordering, close breached positions, prevent same-bar isolated reopening, or terminate a cross-liquidated account.

This advances #462 without closing it; evidence persistence and position scaling remain separate slices.

## Event order

For each synchronized bar, strict mode now:

1. validates execution, mark, funding, settlement, and maintenance-schedule inputs;
2. applies funding only to positions opened before that settlement;
3. evaluates carried positions at `mark_open`;
4. liquidates breached carried positions before normal target fills;
5. executes normal closes and opens at `execution_open`;
6. evaluates resulting positions using adverse mark prices;
7. closes only breached isolated positions, or closes the full cross account and stops;
8. records the current snapshot using `mark_close` valuation.

An isolated position liquidated before fills is blocked from reopening on the same bar.

## Accounting and fees

- The adapter derives wallet balance by adding locked entry margin back to free capital; unrealized P&L remains in the pure risk model.
- Historical funding is applied once per `(symbol, settlement)` using signed quantity and `mark_open`.
- Strict entry and exit market fills use `taker_rate`; legacy non-strict maker/taker behavior is unchanged.
- Liquidation fees use the configured `liquidation_fee_rate` and are charged separately from trading commission.
- Maintenance brackets remain versioned per symbol and fail closed above the final cap through the merged #889 contract.

## Changes

- Add default `before_rebalance_bar`, `after_rebalance_bar`, `execution_open`, and `valuation_open` seams.
- Preserve the terminal bar timestamp when a lifecycle hook stops a run early.
- Adapt engine positions into `AccountState` / `PositionState` without introducing a second accounting ledger.
- Build strict `ExecutionFrame`, `MarketRiskFrame`, and cached `MaintenanceSchedule` inputs from loader-shaped bars.
- Add deterministic coverage for execution/mark separation, funding eligibility, isolated survival semantics, same-bar reopen blocking, liquidation fee accounting, and terminal cross liquidation.

## Test plan

- [x] `pytest agent/tests/test_perpetual_risk.py agent/tests/test_ccxt_perpetual_loader.py agent/tests/test_crypto_engine.py agent/tests/test_base_engine.py -q` — 130 passed.
- [x] `ruff check agent/backtest/engines/crypto.py agent/tests/test_crypto_engine.py agent/tests/test_base_engine.py` — passed.
- [x] `ruff check --ignore E402 agent/backtest/engines/base.py` — passed; the ignored import-bootstrap E402 predates this diff.
- [x] `git diff --check upstream/main...HEAD` — passed.
- [ ] Full non-e2e suite was not run locally; CI is authoritative for repository-wide coverage.

## Safety and network risk

- Historical backtest only.
- No Binance credentials, live API calls, broker writes, OAuth, paper trading, or order placement.
- Tests are deterministic and network-free.
- No changes to connectors, API routes, protected agent/provider areas, or deployment configuration.

## Fidelity notes

This remains a conservative bar-based research model, not an identical reproduction of Binance liquidation sequencing. Adverse extrema across symbols may not occur at the same millisecond. Partial liquidation, liquidation waterfall, ADL, insurance-fund behavior, and order-book replay remain unmodeled.

## Out of scope

- Strict 100x interval enforcement and daily-bar rejection.
- Persistent lifecycle events, risk snapshots, fee totals, fidelity summaries, or JSON/JSONL artifacts (PR 2d).
- Same-direction position resizing and scale-in/scale-out accounting.
- Open orders, maker fills, hedge mode, non-USDT collateral, multi-assets mode, portfolio margin, Shadow Account reconciliation, or live execution.

## Rollback

Revert this PR. The new lifecycle is opt-in, has no data migration, and does not alter legacy `CryptoEngine` behavior by default.

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion.
- [x] No hardcoded credentials, private paths, or live exchange state.
- [x] Code follows `CONTRIBUTING.md` and every commit includes a DCO sign-off.
- [x] No user-facing documentation is required for this internal, opt-in integration slice.