### PR TITLE
fix(stock-profile): handle non-iterable sections in StockProfileTool

### DIFF
--- a/agent/src/tools/stock_profile_tool.py
+++ b/agent/src/tools/stock_profile_tool.py
@@ -196,6 +196,10 @@ def _resolve_sections(sections: Optional[List[str]]) -> List[str]:
     Raises:
         ValueError: If any requested name is not a supported section.
     """
+    if sections is None:
+        return list(_ALL_SECTIONS)
+    if not isinstance(sections, (list, tuple, set)):
+        raise ValueError(f"sections must be a list of strings, got {type(sections).__name__}")
     if not sections:
         return list(_ALL_SECTIONS)
     resolved: List[str] = []

--- a/agent/tests/test_stock_profile_tool.py
+++ b/agent/tests/test_stock_profile_tool.py
@@ -168,6 +168,12 @@ class TestStockProfileErrors:
         assert payload["ok"] is False
         assert "unknown section" in payload["error"]
 
+    def test_noniterable_sections_returns_error_envelope(self):
+        out = sp.StockProfileTool().execute(ticker="AAPL.US", sections=123)
+        payload = json.loads(out)
+        assert payload["ok"] is False
+        assert "sections must be a list" in payload["error"]
+
     def test_upstream_failure_becomes_error_envelope(self):
         with patch.object(
             sp, "get_quote_summary", side_effect=RuntimeError("HTTP 429 banned")


### PR DESCRIPTION
StockProfileTool.execute raises TypeError when passed non-iterable sections arguments like integers. Validate sections is iterable before processing.