### PR TITLE
fix(cli): handle None input in slash_router match_commands

### DIFF
--- a/agent/cli/commands/slash_router.py
+++ b/agent/cli/commands/slash_router.py
@@ -71,6 +71,8 @@ def _parse_token(input_text: str) -> str:
     >>> _parse_token("not a slash")
     ''
     """
+    if not isinstance(input_text, str):
+        return ""
     text = input_text.lstrip()
     if not text.startswith("/"):
         return ""
@@ -123,9 +125,9 @@ def match_commands(input_text: str) -> list[Command]:
     Returns:
         A new list — callers may freely mutate without side effects.
     """
-    token = _parse_token(input_text)
-    if not input_text.lstrip().startswith("/"):
+    if not isinstance(input_text, str) or not input_text.lstrip().startswith("/"):
         return []
+    token = _parse_token(input_text)
 
     # Resolve aliases up front so ``/q`` shows the ``quit`` row.
     if token in _ALIASES:
@@ -148,6 +150,8 @@ def find_exact(name: str) -> Command | None:
     Returns ``None`` if no match — callers handle the "unknown command"
     response themselves so error UX stays consistent.
     """
+    if not isinstance(name, str):
+        return None
     key = name.lstrip("/").strip()
     key = _ALIASES.get(key, key)
     for cmd in SLASH_COMMANDS:

--- a/agent/tests/test_cli_interactive.py
+++ b/agent/tests/test_cli_interactive.py
@@ -62,6 +62,15 @@ class TestSlashRouter:
         from cli.commands.slash_router import match_commands
 
         assert match_commands("plain text") == []
+    def test_match_commands_handles_none_input(self) -> None:
+        from cli.commands.slash_router import match_commands
+
+        assert match_commands(None) == []
+
+    def test_find_exact_handles_none_input(self) -> None:
+        from cli.commands.slash_router import find_exact
+
+        assert find_exact(None) is None
 
     def test_handler_module_uses_cli_package(self) -> None:
         from cli.commands.slash_router import SLASH_COMMANDS


### PR DESCRIPTION
match_commands and find_exact in slash_router raise AttributeError when passed input_str=None. Return empty matches when input_str is None.