### PR TITLE
fix(lockup-expiry): handle integer symbol code in get_lockup_expiry

### DIFF
--- a/agent/src/tools/lockup_expiry_tool.py
+++ b/agent/src/tools/lockup_expiry_tool.py
@@ -235,8 +235,9 @@ def get_lockup_expiry(code: str | None, horizon_days: int) -> str:
     """
     horizon = _clamp_horizon(horizon_days)
     bare_code: str | None = None
-    if code and code.strip():
-        bare_code = _normalize_code(code)
+    code_str = str(code).strip() if code is not None else ""
+    if code_str:
+        bare_code = _normalize_code(code_str)
         if bare_code is None:
             return json.dumps(
                 {

--- a/agent/tests/test_lockup_expiry_integer_code.py
+++ b/agent/tests/test_lockup_expiry_integer_code.py
@@ -1,0 +1,14 @@
+"""Test suite for LockupExpiryTool non-string symbol code handling."""
+
+import json
+import pytest
+from src.tools.lockup_expiry_tool import LockupExpiryTool
+
+
+def test_lockup_expiry_tool_integer_code_handling():
+    """Verify LockupExpiryTool.execute handles integer stock codes without raising AttributeError on .strip()."""
+    tool = LockupExpiryTool()
+    res_str = tool.execute(code=600519)
+    res = json.loads(res_str)
+    assert res["ok"] is True
+    assert res["data"]["code"] == "600519"


### PR DESCRIPTION
When LockupExpiryTool or get_lockup_expiry receives an integer stock code (e.g., code=600519, common when LLMs pass unquoted numbers in tool call JSON), calling code.strip() raises AttributeError: 'int' object has no attribute 'strip'.

This change coerces code to a string before stripping, allowing numeric stock codes to be normalized and queried correctly.