### PR TITLE
fix(trade-journal): return default float when parsing non-finite string inputs in _to_float

### DIFF
--- a/agent/src/tools/trade_journal_parsers.py
+++ b/agent/src/tools/trade_journal_parsers.py
@@ -10,6 +10,7 @@ Excel (.xlsx/.xls) always opens as utf-8 internally via openpyxl/xlrd.
 from __future__ import annotations
 
 import re
+import math
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
@@ -212,7 +213,10 @@ def _to_float(val: Any, default: float = 0.0) -> float:
     try:
         s = str(val).strip().replace("\u2212", "-")
         s = _CURRENCY_TOKEN_RE.sub("", s).replace(",", "").strip()
-        return float(s) if s else default
+        if not s:
+            return default
+        parsed = float(s)
+        return parsed if math.isfinite(parsed) else default
     except (ValueError, TypeError):
         return default
 

--- a/agent/tests/test_trade_journal_parser_to_float_nan.py
+++ b/agent/tests/test_trade_journal_parser_to_float_nan.py
@@ -1,0 +1,22 @@
+"""Regression test for _to_float handling of NaN strings in trade journal parsers.
+
+Locks out a bug where _to_float returned float("nan") (where math.isnan is True)
+when parsing "nan" or "NaN" cell strings instead of returning the specified default float.
+"""
+
+import math
+from src.tools.trade_journal_parsers import _to_float
+
+
+def test_to_float_nan_string_returns_default():
+    """Prove that _to_float returns default when given 'nan' or non-finite values."""
+    res_nan = _to_float("nan", default=0.0)
+    assert not math.isnan(res_nan), f"Expected 0.0 for 'nan', got {res_nan}"
+    assert res_nan == 0.0
+
+    res_upper_nan = _to_float("NaN", default=0.0)
+    assert not math.isnan(res_upper_nan), f"Expected 0.0 for 'NaN', got {res_upper_nan}"
+    assert res_upper_nan == 0.0
+
+    res_inf = _to_float("inf", default=0.0)
+    assert res_inf == 0.0


### PR DESCRIPTION
When trade journal CSVs contained nan or NaN cell strings in numeric columns, _to_float() returned float('nan') instead of the specified default float, propagating NaN into trade records and breaking downstream serializers. This checks math.isfinite() in _to_float() and adds a regression test.