### PR TITLE
fix(block-trades): support bare 6-digit A-share code resolution in _resolve_code

### DIFF
--- a/agent/src/tools/block_trades_tool.py
+++ b/agent/src/tools/block_trades_tool.py
@@ -22,6 +22,7 @@ from typing import Any
 
 from backtest.loaders.eastmoney_client import get_json, resolve_secid
 from src.agent.tools import BaseTool
+from src.tools.trade_journal_parsers import _qualify_a_share
 
 logger = logging.getLogger(__name__)
 
@@ -58,13 +59,16 @@ def _resolve_code(symbol: str) -> str | None:
         The bare 6-digit code (e.g. ``"600519"``), or ``None`` when the symbol
         is not a resolvable A-share.
     """
-    secid = resolve_secid(symbol)
+    s = symbol.strip() if symbol else ""
+    if s and "." not in s and len(s) == 6 and s.isdigit():
+        s = _qualify_a_share(s)
+    secid = resolve_secid(s)
     if not secid or "." not in secid:
         return None
     market = secid.split(".", 1)[0]
     if market not in ("0", "1"):  # 0=SZ/BJ, 1=SH; HK/US are not A-share blocks.
         return None
-    code = symbol.rpartition(".")[0].strip().upper()
+    code = secid.split(".", 1)[1].strip().upper()
     return code or None
 
 

--- a/agent/tests/test_block_trades_bare_code.py
+++ b/agent/tests/test_block_trades_bare_code.py
@@ -1,0 +1,19 @@
+"""Regression test for _resolve_code handling bare 6-digit A-share symbols in block_trades_tool.
+
+Locks out a bug where _resolve_code returned None for bare 6-digit A-share codes
+(e.g. "600519" or "000001") because symbol.rpartition(".")[0] returned an empty string
+when symbol contained no dot.
+"""
+
+from src.tools.block_trades_tool import _resolve_code
+
+
+def test_resolve_code_accepts_bare_a_share_code():
+    """Prove that _resolve_code resolves both market-suffixed and bare A-share tickers."""
+    # Market-suffixed A-shares
+    assert _resolve_code("600519.SH") == "600519"
+    assert _resolve_code("000001.SZ") == "000001"
+    
+    # Bare 6-digit A-shares (previously returned None on un-fixed code)
+    assert _resolve_code("600519") == "600519"
+    assert _resolve_code("000001") == "000001"


### PR DESCRIPTION
_resolve_code() returned None when given a bare 6-digit A-share code such as 600519 because symbol.rpartition('.')[0] evaluated to an empty string when symbol contained no dot. This qualifies bare 6-digit symbols before resolve_secid() lookup and extracts the code from secid.split('.', 1)[1], adding a regression test.