### PR TITLE
fix(trade-journal): coerce string datetime cells in pair_trades_fifo before computing timedelta

### DIFF
--- a/agent/src/tools/trade_journal_tool.py
+++ b/agent/src/tools/trade_journal_tool.py
@@ -60,7 +60,9 @@ def pair_trades_fifo(df: pd.DataFrame) -> list[dict[str, Any]]:
         while remaining > 1e-9 and q:
             lot = q[0]
             take = min(lot["qty"], remaining)
-            hold = (row.datetime - lot["dt"]).total_seconds() / 86400.0
+            sell_dt = pd.to_datetime(row.datetime)
+            buy_dt = pd.to_datetime(lot["dt"])
+            hold = (sell_dt - buy_dt).total_seconds() / 86400.0 if pd.notna(sell_dt) and pd.notna(buy_dt) else 0.0
             gross = (row.price - lot["price"]) * take
             # Proportional fee allocation
             buy_fee = lot["fee"] * (take / lot["qty"]) if lot["qty"] else 0.0

--- a/agent/tests/test_trade_journal_fifo_str_datetime.py
+++ b/agent/tests/test_trade_journal_fifo_str_datetime.py
@@ -1,0 +1,38 @@
+"""Regression test for pair_trades_fifo handling string datetime columns in trade_journal_tool.
+
+Locks out a bug where pair_trades_fifo raised TypeError: unsupported operand type(s)
+for -: 'str' and 'str' when df["datetime"] contained string timestamps instead of Timestamps.
+"""
+
+import pandas as pd
+from src.tools.trade_journal_tool import pair_trades_fifo
+
+
+def test_pair_trades_fifo_supports_string_datetime_column():
+    """Prove that pair_trades_fifo handles string datetime values without raising TypeError."""
+    df = pd.DataFrame([
+        {
+            "datetime": "2026-01-01 09:30:00",
+            "symbol": "AAPL",
+            "side": "buy",
+            "quantity": 10.0,
+            "price": 150.0,
+            "fee": 1.0,
+        },
+        {
+            "datetime": "2026-01-03 09:30:00",
+            "symbol": "AAPL",
+            "side": "sell",
+            "quantity": 10.0,
+            "price": 160.0,
+            "fee": 1.0,
+        },
+    ])
+
+    # On un-fixed code, subtracting string datetimes in pair_trades_fifo raised TypeError.
+    # On fixed code, it correctly calculates roundtrip hold_days = 2.0 and pnl.
+    rts = pair_trades_fifo(df)
+    assert len(rts) == 1
+    assert rts[0]["symbol"] == "AAPL"
+    assert rts[0]["hold_days"] == 2.0
+    assert rts[0]["pnl"] == 98.0


### PR DESCRIPTION
pair_trades_fifo() raised TypeError: unsupported operand type(s) for -: 'str' and 'str' when df['datetime'] contained string timestamps instead of pd.Timestamp objects. This coerces row.datetime and lot['dt'] with pd.to_datetime() before computing holding timedelta and adds a regression test.