### PR TITLE
fix(financial-rigor): check math.isfinite in benford_check to prevent OverflowError on infinity

### DIFF
--- a/agent/src/tools/financial_rigor_tool.py
+++ b/agent/src/tools/financial_rigor_tool.py
@@ -297,7 +297,7 @@ def benford_check(values: list[Any]) -> dict[str, Any]:
     digits: list[int] = []
     for raw in values:
         v = abs(float(raw))
-        if v > 0:
+        if v > 0 and math.isfinite(v):
             sig = 10 ** (math.log10(v) - math.floor(math.log10(v)))
             d = int(sig)
             if 1 <= d <= 9:

--- a/agent/tests/test_financial_rigor_benford_inf.py
+++ b/agent/tests/test_financial_rigor_benford_inf.py
@@ -1,0 +1,19 @@
+"""Regression test for benford_check handling infinite values in financial_rigor_tool.
+
+Locks out a bug where benford_check crashed with OverflowError: cannot convert float infinity
+to integer when input values list contained inf or -inf.
+"""
+
+from src.tools.financial_rigor_tool import benford_check
+
+
+def test_benford_check_handles_infinite_values():
+    """Prove that benford_check safely skips inf/-inf values without raising OverflowError."""
+    # Values containing infinity
+    values = [10.0, 20.0, 30.0, float("inf"), float("-inf")]
+    
+    # On un-fixed code, math.floor(math.log10(inf)) raised OverflowError.
+    # On fixed code, non-finite values are safely skipped.
+    res = benford_check(values)
+    assert isinstance(res, dict)
+    assert res["sample_size"] == 3


### PR DESCRIPTION
benford_check() raised OverflowError: cannot convert float infinity to integer when input values contained inf or -inf because math.floor(math.log10(inf)) failed to convert infinity to integer. This filters out non-finite inputs with math.isfinite() in benford_check() and adds a regression test.