### PR TITLE
fix(alpha-compare): coerce non-iterable raw inputs to empty list in _coerce_ids

### DIFF
--- a/agent/src/tools/alpha_compare_tool.py
+++ b/agent/src/tools/alpha_compare_tool.py
@@ -30,7 +30,12 @@ def _coerce_ids(raw: Any) -> list[str]:
     Returns:
         Ordered, de-duplicated list of non-empty id strings.
     """
-    items = re.split(r"[\s,]+", raw) if isinstance(raw, str) else (raw or [])
+    if isinstance(raw, str):
+        items = re.split(r"[\s,]+", raw)
+    elif isinstance(raw, (list, tuple, set)):
+        items = raw
+    else:
+        items = []
     seen: set[str] = set()
     out: list[str] = []
     for item in items:

--- a/agent/tests/test_alpha_compare_coerce_non_iterable.py
+++ b/agent/tests/test_alpha_compare_coerce_non_iterable.py
@@ -1,0 +1,16 @@
+"""Regression test for _coerce_ids handling non-iterable inputs in alpha_compare_tool.
+
+Locks out a bug where _coerce_ids raised TypeError: 'int' object is not iterable
+when alpha_ids parameter was passed a non-string non-sequence (e.g. 123, True).
+"""
+
+from src.tools.alpha_compare_tool import _coerce_ids
+
+
+def test_coerce_ids_handles_non_iterable_raw_input():
+    """Prove that _coerce_ids returns an empty list for non-iterable input types without raising TypeError."""
+    assert _coerce_ids(123) == []
+    assert _coerce_ids(True) == []
+    assert _coerce_ids(None) == []
+    assert _coerce_ids("alpha1, alpha2") == ["alpha1", "alpha2"]
+    assert _coerce_ids(["alpha1", "alpha2"]) == ["alpha1", "alpha2"]


### PR DESCRIPTION
_coerce_ids() raised TypeError: 'int' object is not iterable when alpha_ids was passed a non-string non-sequence value (such as an integer, boolean, or dict). This updates _coerce_ids() to return [] when raw is not a string or sequence and adds a regression test.