### PR TITLE
fix(trade-journal): recognize slash-delimited crypto trading pairs in market inference

### DIFF
--- a/agent/src/tools/trade_journal_parsers.py
+++ b/agent/src/tools/trade_journal_parsers.py
@@ -525,7 +525,7 @@ def _infer_market_from_symbol(symbol: str) -> str:
         return "hk"
     if s.endswith(".SH") or s.endswith(".SZ") or s.endswith(".BJ"):
         return "china_a"
-    if "-" in s and any(quote in s for quote in ("USDT", "USDC", "BTC", "USD")):
+    if ("-" in s or "/" in s) and any(quote in s for quote in ("USDT", "USDC", "BTC", "USD")):
         return "crypto"
     # Binance-style concatenated pairs (BTCUSDT) are purely alphabetic, so the
     # isalpha() US-equity branch below would mis-label them without this check.

--- a/agent/tests/test_trade_journal_parser_slash_crypto.py
+++ b/agent/tests/test_trade_journal_parser_slash_crypto.py
@@ -1,0 +1,17 @@
+"""Regression test for _infer_market_from_symbol handling slash-delimited crypto symbols in trade_journal_parsers.
+
+Locks out a bug where _infer_market_from_symbol returned "other" instead of "crypto" for
+slash-formatted crypto trading pairs (e.g. "ETH/USDT" or "BTC/USD").
+"""
+
+from src.tools.trade_journal_parsers import _infer_market_from_symbol
+
+
+def test_infer_market_from_symbol_supports_slash_crypto_pairs():
+    """Prove that _infer_market_from_symbol classifies slash-delimited crypto pairs as 'crypto'."""
+    assert _infer_market_from_symbol("BTC-USDT") == "crypto"
+    
+    # Slash delimited crypto pairs (previously returned "other" on un-fixed code)
+    assert _infer_market_from_symbol("ETH/USDT") == "crypto"
+    assert _infer_market_from_symbol("BTC/USD") == "crypto"
+    assert _infer_market_from_symbol("SOL/USDC") == "crypto"


### PR DESCRIPTION
_infer_market_from_symbol() misclassified slash-delimited crypto pairs (e.g., ETH/USDT, BTC/USD) as 'other' instead of 'crypto' because it only checked for '-' in symbol strings. This updates _infer_market_from_symbol() to check for both '-' and '/' when matching quote currency tokens and adds a regression test.