### PR TITLE
fix(financial-statements): classify Yahoo .SS suffix as A-share in _classify_market

### DIFF
--- a/agent/src/tools/financial_statements_tool.py
+++ b/agent/src/tools/financial_statements_tool.py
@@ -390,7 +390,7 @@ def _classify_market(code: str) -> str | None:
         The market label, or ``None`` when the suffix is unrecognized.
     """
     suffix = code.rpartition(".")[2].strip().upper()
-    if suffix in ("SH", "SZ", "BJ"):
+    if suffix in ("SH", "SZ", "BJ", "SS"):
         return "a_share"
     if suffix == "US":
         return "us"

--- a/agent/tests/test_financial_statements_yahoo_ss_suffix.py
+++ b/agent/tests/test_financial_statements_yahoo_ss_suffix.py
@@ -1,0 +1,18 @@
+"""Regression test for _classify_market handling Yahoo .SS suffix in financial_statements_tool.
+
+Locks out a bug where _classify_market returned None for Shanghai A-share symbols using Yahoo's
+standard .SS suffix (e.g. "600519.SS"), rejecting valid financial statement queries.
+"""
+
+from src.tools.financial_statements_tool import _classify_market
+
+
+def test_classify_market_supports_yahoo_ss_suffix():
+    """Prove that _classify_market classifies both .SH and Yahoo .SS as 'a_share'."""
+    assert _classify_market("600519.SH") == "a_share"
+    assert _classify_market("000001.SZ") == "a_share"
+    assert _classify_market("430139.BJ") == "a_share"
+    
+    # Yahoo Shanghai suffix .SS (previously returned None on un-fixed code)
+    assert _classify_market("600519.SS") == "a_share"
+    assert _classify_market("600000.SS") == "a_share"


### PR DESCRIPTION
_classify_market() returned None for Shanghai A-share symbols using Yahoo's standard .SS suffix (e.g., 600519.SS), rejecting valid financial statement requests. This adds 'SS' to the recognized A-share suffixes in _classify_market() and adds a regression test.