### PR TITLE
feat(backtest): persist USD-M fidelity evidence

### DIFF
--- a/agent/backtest/engines/base.py
+++ b/agent/backtest/engines/base.py
@@ -153,9 +153,13 @@ def _align(
         (dates, close_df, positions_df, returns_df)
     """
     # Build unified sorted date index from all symbols' trading calendars
-    all_idx_arrays = [data_map[c].index.values for c in codes]
-    merged = np.unique(np.concatenate(all_idx_arrays))
-    dates = pd.DatetimeIndex(merged)
+    indexes = [data_map[c].index for c in codes]
+    merged = np.unique(np.concatenate([index.asi8 for index in indexes]))
+    common_tz = indexes[0].tz
+    if all(index.tz == common_tz for index in indexes) and common_tz is not None:
+        dates = pd.DatetimeIndex(pd.to_datetime(merged, utc=True).tz_convert(common_tz))
+    else:
+        dates = pd.DatetimeIndex(merged)
 
     n_dates = len(dates)
     n_codes = len(codes)

--- a/agent/backtest/engines/crypto.py
+++ b/agent/backtest/engines/crypto.py
@@ -10,12 +10,20 @@ Market rules:
 
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Any
+
 import pandas as pd
 
 from backtest.engines.base import BaseEngine
 from backtest.engines._market_hooks import (
     calc_crypto_funding_fee,
     check_crypto_liquidation,
+)
+from backtest.perpetual_evidence import (
+    SCHEMA_VERSION,
+    build_perpetual_summary,
+    write_perpetual_evidence,
 )
 from backtest.perpetual_risk import (
     AccountState,
@@ -24,6 +32,7 @@ from backtest.perpetual_risk import (
     MaintenanceSchedule,
     MarketRiskFrame,
     PositionState,
+    RiskSnapshot,
     evaluate_isolated,
 )
 
@@ -56,7 +65,13 @@ class CryptoEngine(BaseEngine):
             raise ValueError("margin_mode must be 'isolated' or 'cross'")
         if self.perpetual_strict and not 0 <= self.liquidation_fee_rate < 1:
             raise ValueError("liquidation_fee_rate must be between zero and one")
+        self._validate_strict_resolution(config)
         self.terminal_status = "active"
+        self._perpetual_events: list[dict[str, Any]] = []
+        self._run_interval = str(config.get("interval", "1D"))
+        self._maintenance_bracket_versions: dict[str, str] = {}
+        self._market_risk_sources: set[str] = set()
+        self._liquidation_price_source: str | None = None
         self._strict_funding_applied: set[tuple[str, pd.Timestamp]] = set()
         self._isolated_margins: dict[str, float] = {}
         self._schedule_cache: dict[tuple[str, str], MaintenanceSchedule] = {}
@@ -64,6 +79,29 @@ class CryptoEngine(BaseEngine):
         self._blocked_symbols: set[str] = set()
         self._funding_applied: set = set()   # (symbol, date, hour) — per-slot dedup
         self._funding_daily_done: set = set()  # (symbol, date) — daily fallback dedup
+
+    def _validate_strict_resolution(self, config: dict[str, Any]) -> None:
+        if not self.perpetual_strict or self.default_leverage < 100:
+            return
+        interval = str(config.get("interval", "1D")).strip().lower()
+        if interval not in {"1m", "5m", "15m", "30m", "1h"}:
+            raise ValueError(
+                "strict 100x requires a supported interval <= 1H "
+                "(1m/5m/15m/30m/1H); 1H is only a resolution boundary, "
+                "not a liquidation-sequence guarantee"
+            )
+
+    def run_backtest(
+        self,
+        config: dict[str, Any],
+        loader: Any,
+        signal_engine: Any,
+        run_dir: Path,
+        bars_per_year: int = 252,
+    ) -> dict[str, Any]:
+        self._validate_strict_resolution(config)
+        self._run_interval = str(config.get("interval", "1D"))
+        return super().run_backtest(config, loader, signal_engine, run_dir, bars_per_year)
 
     def can_execute(self, symbol: str, direction: int, bar: pd.Series) -> bool:
         """Crypto: 24/7, long/short/close all allowed."""
@@ -101,6 +139,9 @@ class CryptoEngine(BaseEngine):
         if pd.isna(version):
             raise ValueError(f"missing maintenance bracket version for {symbol}")
         version = str(version)
+        previous = self._maintenance_bracket_versions.setdefault(symbol, version)
+        if previous != version:
+            raise ValueError(f"maintenance bracket version changed for {symbol}")
         key = (symbol, version)
         if key not in self._schedule_cache:
             self._schedule_cache[key] = MaintenanceSchedule.from_loader_columns(
@@ -147,7 +188,53 @@ class CryptoEngine(BaseEngine):
                 schedule=self._schedule(symbol, bar),
                 source=str(self.config.get("market_risk_source", "ccxt:binanceusdm")),
             )
+            self._market_risk_sources.add(risks[symbol].source)
         self._risk_frames = risks
+
+    def _record_event(self, timestamp: pd.Timestamp, event_type: str, **details: Any) -> None:
+        if not self.perpetual_strict:
+            return
+        self._perpetual_events.append(
+            {
+                "schema_version": SCHEMA_VERSION,
+                "sequence": len(self._perpetual_events) + 1,
+                "timestamp": pd.Timestamp(timestamp).isoformat(),
+                "event_type": event_type,
+                **details,
+            }
+        )
+
+    def _record_risk_snapshot(
+        self,
+        timestamp: pd.Timestamp,
+        price_field: str,
+        snapshot: RiskSnapshot,
+    ) -> None:
+        self._record_event(
+            timestamp,
+            "risk_snapshot",
+            phase="pre_fill" if price_field == "mark_open" else "post_fill",
+            price_source=("mark_open" if price_field == "mark_open" else "adverse_mark_extrema"),
+            status=snapshot.status,
+            margin_balance=snapshot.margin_balance,
+            initial_margin=snapshot.initial_margin,
+            maintenance_margin=snapshot.maintenance_margin,
+            available_balance=snapshot.available_balance,
+            liquidation_targets=list(snapshot.liquidation_targets),
+            fidelity_flags=list(snapshot.fidelity_flags),
+            positions=[
+                {
+                    "symbol": risk.symbol,
+                    "mark_price": risk.mark_price,
+                    "notional": risk.notional,
+                    "unrealized_pnl": risk.unrealized_pnl,
+                    "initial_margin": risk.initial_margin,
+                    "maintenance_margin": risk.maintenance_margin,
+                    "margin_balance": risk.margin_balance,
+                }
+                for risk in snapshot.per_position
+            ],
+        )
 
     def _apply_data_funding(self) -> None:
         for symbol, position in self.positions.items():
@@ -166,6 +253,16 @@ class CryptoEngine(BaseEngine):
             if self.margin_mode == "isolated":
                 self._isolated_margins[symbol] -= payment
             self._strict_funding_applied.add(key)
+            self._record_event(
+                settlement,
+                "funding_settlement",
+                symbol=symbol,
+                signed_quantity=position.direction * position.size,
+                mark_price=frame.mark_open,
+                price_source="mark_open",
+                funding_rate=frame.funding_rate,
+                funding_pnl=-payment,
+            )
 
     def _account_state(self) -> AccountState:
         positions = tuple(
@@ -203,18 +300,45 @@ class CryptoEngine(BaseEngine):
             if self.margin_mode == "isolated"
             else CrossMarginRiskModel().evaluate(account, self._risk_frames, price_field)
         )
+        self._record_risk_snapshot(timestamp, price_field, snapshot)
         if snapshot.status == "healthy":
             return False
         prices = {risk.symbol: risk.mark_price for risk in snapshot.per_position}
+        price_source = "mark_open" if price_field == "mark_open" else "adverse_mark_extrema"
+        liquidation_details = []
         for symbol in snapshot.liquidation_targets:
             position = self.positions[symbol]
             price = prices[symbol]
             fee = position.size * price * self.liquidation_fee_rate
-            self._close_position(symbol, price, timestamp, snapshot.status)
-            self.capital -= fee
+            self._liquidation_price_source = price_source
+            try:
+                self._close_position(symbol, price, timestamp, snapshot.status)
+                self.capital -= fee
+            finally:
+                self._liquidation_price_source = None
+            liquidation_details.append((symbol, price, fee))
         if snapshot.status == "account_liquidation":
             self.terminal_status = "account_liquidation"
+            self._record_event(
+                timestamp,
+                "account_liquidation",
+                symbols=sorted(symbol for symbol, _, _ in liquidation_details),
+                liquidation_prices={symbol: price for symbol, price, _ in liquidation_details},
+                price_source=price_source,
+                liquidation_fee=sum(fee for _, _, fee in liquidation_details),
+                fidelity_flags=list(snapshot.fidelity_flags),
+            )
             return True
+        for symbol, price, fee in liquidation_details:
+            self._record_event(
+                timestamp,
+                "position_liquidation",
+                symbol=symbol,
+                liquidation_price=price,
+                price_source=price_source,
+                liquidation_fee=fee,
+                fidelity_flags=list(snapshot.fidelity_flags),
+            )
         self._blocked_symbols.update(snapshot.liquidation_targets)
         return False
 
@@ -255,6 +379,19 @@ class CryptoEngine(BaseEngine):
 
     def _execute_open_order(self, order, timestamp: pd.Timestamp) -> None:
         super()._execute_open_order(order, timestamp)
+        if self.perpetual_strict:
+            self._record_event(
+                timestamp,
+                "market_fill",
+                action="open",
+                symbol=order.symbol,
+                side="buy" if order.direction == 1 else "sell",
+                signed_quantity=order.direction * order.size,
+                execution_price=order.price,
+                execution_price_source="execution_open",
+                trading_fee=order.commission,
+                reason="signal",
+            )
         if self.perpetual_strict and self.margin_mode == "isolated":
             self._isolated_margins[order.symbol] = order.margin
 
@@ -265,8 +402,72 @@ class CryptoEngine(BaseEngine):
         exit_time: pd.Timestamp,
         reason: str,
     ) -> None:
+        position = self.positions.get(symbol)
         super()._close_position(symbol, exit_price, exit_time, reason)
+        if self.perpetual_strict and position is not None:
+            trade = self.trades[-1]
+            price_source = self._liquidation_price_source
+            if price_source is None:
+                price_source = "mark_close" if reason == "end_of_backtest" else "execution_open"
+            self._record_event(
+                exit_time,
+                "market_fill",
+                action="close",
+                symbol=symbol,
+                side="sell" if position.direction == 1 else "buy",
+                signed_quantity=-position.direction * position.size,
+                execution_price=exit_price,
+                execution_price_source=price_source,
+                trading_fee=trade.commission - position.entry_commission,
+                reason=reason,
+            )
         self._isolated_margins.pop(symbol, None)
+
+    def _write_artifacts(
+        self,
+        run_dir: Path,
+        data_map: dict[str, pd.DataFrame],
+        dates: pd.DatetimeIndex,
+        equity_series: pd.Series,
+        bench_equity: pd.Series,
+        bench_ret: pd.Series,
+        target_pos: pd.DataFrame,
+        metrics: dict,
+        codes: list[str],
+    ) -> None:
+        summary = None
+        if self.perpetual_strict:
+            summary = build_perpetual_summary(
+                config={**self.config, "interval": self._run_interval},
+                events=self._perpetual_events,
+                trades=self.trades,
+                terminal_status=self.terminal_status,
+                maintenance_bracket_versions=self._maintenance_bracket_versions,
+                market_risk_sources=sorted(self._market_risk_sources),
+            )
+            metrics.update(
+                {
+                    "perpetual_funding_settlements": summary["funding_settlement_count"],
+                    "perpetual_funding_pnl": summary["total_funding_pnl"],
+                    "perpetual_liquidation_events": summary["liquidation_event_count"],
+                    "perpetual_liquidated_positions": summary["liquidated_position_count"],
+                    "perpetual_trading_fees": summary["total_trading_fee"],
+                    "perpetual_liquidation_fees": summary["total_liquidation_fee"],
+                }
+            )
+        super()._write_artifacts(
+            run_dir,
+            data_map,
+            dates,
+            equity_series,
+            bench_equity,
+            bench_ret,
+            target_pos,
+            metrics,
+            codes,
+        )
+        if summary is not None:
+            write_perpetual_evidence(run_dir, self._perpetual_events, summary)
 
     def on_bar(self, symbol: str, bar: pd.Series, timestamp: pd.Timestamp) -> None:
         """Crypto per-bar hooks: funding fee + liquidation check."""

--- a/agent/backtest/perpetual_evidence.py
+++ b/agent/backtest/perpetual_evidence.py
@@ -1,0 +1,84 @@
+"""Strict USD-M audit evidence, never read back into accounting decisions."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+SCHEMA_VERSION = "1"
+RESOLUTION_LIMITATION = (
+    "At 100x, an interval of at most 1 hour is only a resolution boundary; "
+    "exact liquidation sequence precision is not guaranteed."
+)
+
+
+def build_perpetual_summary(
+    *,
+    config: Mapping[str, Any],
+    events: Sequence[Mapping[str, Any]],
+    trades: Sequence[Any],
+    terminal_status: str,
+    maintenance_bracket_versions: Mapping[str, str],
+    market_risk_sources: Sequence[str],
+) -> dict[str, Any]:
+    """Build a strict-JSON-safe summary from append-only audit evidence."""
+    funding = [event for event in events if event["event_type"] == "funding_settlement"]
+    liquidation_types = {"position_liquidation", "account_liquidation"}
+    liquidations = [event for event in events if event["event_type"] in liquidation_types]
+    flags = sorted({flag for event in events for flag in event.get("fidelity_flags", [])})
+    liquidated_positions = sum(len(event.get("symbols", [event.get("symbol")])) for event in liquidations)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "margin_mode": str(config.get("margin_mode", "isolated")),
+        "funding_mode": str(config.get("funding_mode", "fixed")),
+        "interval": str(config.get("interval", "1D")),
+        "leverage": float(config.get("leverage", 1.0)),
+        "taker_rate": float(config.get("taker_rate", 0.0005)),
+        "liquidation_fee_rate": float(config.get("liquidation_fee_rate", 0.0)),
+        "terminal_status": terminal_status,
+        "event_count": len(events),
+        "funding_settlement_count": len(funding),
+        "total_funding_pnl": sum(float(event["funding_pnl"]) for event in funding),
+        "liquidation_event_count": len(liquidations),
+        "liquidated_position_count": liquidated_positions,
+        "total_trading_fee": sum(float(trade.commission) for trade in trades),
+        "total_liquidation_fee": sum(float(event["liquidation_fee"]) for event in liquidations),
+        "fee_model": {
+            "market_fill_rate": "taker_rate",
+            "maker_rate_used": False,
+            "funding_separate": True,
+            "liquidation_separate": True,
+        },
+        "maintenance_bracket_versions": dict(sorted(maintenance_bracket_versions.items())),
+        "market_risk_sources": sorted(set(market_risk_sources)),
+        "fidelity_flags": flags,
+        "resolution_limitation": RESOLUTION_LIMITATION,
+        "assumptions": [
+            "single_asset_usdt",
+            "no_open_order_margin",
+            "one_way_positions",
+            "bar_extrema_order_unknown",
+            "not_an_identical_binance_liquidation_engine_reproduction",
+        ],
+    }
+
+
+def write_perpetual_evidence(
+    run_dir: Path,
+    events: Sequence[Mapping[str, Any]],
+    summary: Mapping[str, Any],
+) -> None:
+    """Write ordered lifecycle JSONL and its aggregate summary."""
+    out = Path(run_dir) / "artifacts"
+    out.mkdir(parents=True, exist_ok=True)
+    event_lines = [json.dumps(event, sort_keys=True, allow_nan=False) for event in events]
+    (out / "perpetual_events.jsonl").write_text(
+        "\n".join(event_lines) + ("\n" if event_lines else ""),
+        encoding="utf-8",
+    )
+    (out / "perpetual_summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )

--- a/agent/tests/test_base_engine.py
+++ b/agent/tests/test_base_engine.py
@@ -87,6 +87,19 @@ def _simple_data_and_signals():
 
 
 class TestAlign:
+    def test_common_timezone_is_preserved(self) -> None:
+        dates = pd.date_range("2026-01-01", periods=3, freq="h", tz="UTC")
+        frame = pd.DataFrame({"open": [100.0] * 3, "close": [100.0] * 3}, index=dates)
+        signals = pd.Series([0.0, 1.0, 0.0], index=dates)
+
+        out_dates, close_df, pos_df, _ = _align(
+            {"BTC-USDT-PERP": frame}, {"BTC-USDT-PERP": signals}, ["BTC-USDT-PERP"]
+        )
+
+        assert str(out_dates.tz) == "UTC"
+        assert close_df.index.equals(dates)
+        assert pos_df.index.equals(dates)
+
     def test_output_shapes(self) -> None:
         data_map, signal_map, dates = _simple_data_and_signals()
         out_dates, close_df, pos_df, ret_df = _align(data_map, signal_map, ["A", "B"])

--- a/agent/tests/test_crypto_engine.py
+++ b/agent/tests/test_crypto_engine.py
@@ -11,6 +11,8 @@ Validates:
 
 from __future__ import annotations
 
+import json
+
 import pandas as pd
 import pytest
 
@@ -108,6 +110,69 @@ def _run_strict(
         pd.DataFrame(targets, index=dates),
         codes,
     )
+
+
+def _write_strict_artifacts(
+    engine: CryptoEngine,
+    data_map: dict[str, pd.DataFrame],
+    targets: dict[str, list[float]],
+    run_dir,
+) -> dict:
+    dates = next(iter(data_map.values())).index
+    equity = pd.Series(
+        [snapshot.equity for snapshot in engine.equity_snapshots],
+        index=[snapshot.timestamp for snapshot in engine.equity_snapshots],
+    )
+    benchmark_return = pd.Series(0.0, index=dates)
+    metrics: dict = {}
+    engine._write_artifacts(
+        run_dir,
+        data_map,
+        dates,
+        equity,
+        pd.Series(engine.initial_capital, index=dates),
+        benchmark_return,
+        pd.DataFrame(targets, index=dates),
+        metrics,
+        list(data_map),
+    )
+    return metrics
+
+
+def _read_strict_evidence(run_dir) -> tuple[list[dict], dict]:
+    artifacts = run_dir / "artifacts"
+    events = [
+        json.loads(line)
+        for line in (artifacts / "perpetual_events.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    summary = json.loads(
+        (artifacts / "perpetual_summary.json").read_text(encoding="utf-8")
+    )
+    return events, summary
+
+
+def _run_liquidation_case(margin_mode: str):
+    dates = pd.date_range("2026-01-01", periods=2, freq="h", tz="UTC")
+    frames = {
+        symbol: _strict_frame(dates, mark_low=[100.0, low])
+        for symbol, low in (
+            ("BTC-USDT-PERP", 80.0),
+            ("ETH-USDT-PERP", 100.0),
+        )
+    }
+    engine = _strict_engine(
+        initial_cash=2_000.0,
+        interval="1H",
+        taker_rate=0.0,
+        maker_rate=0.0,
+        liquidation_fee_rate=0.01,
+        margin_mode=margin_mode,
+    )
+    targets = {symbol: [0.5, 0.5] for symbol in frames}
+    _run_strict(engine, frames, targets)
+    return engine, frames, targets
 
 
 # ---------------------------------------------------------------------------
@@ -435,6 +500,35 @@ class TestHistoricalFundingRate:
 
 
 class TestStrictPerpetualLifecycle:
+    @pytest.mark.parametrize("interval", ["3m", "60m", "4H", "1D"])
+    def test_strict_100x_rejects_unsupported_or_coarse_intervals(
+        self, interval: str
+    ) -> None:
+        with pytest.raises(ValueError, match="resolution boundary"):
+            _strict_engine(leverage=100.0, interval=interval)
+
+    @pytest.mark.parametrize("interval", ["1m", "30m", "1H"])
+    def test_strict_100x_accepts_at_most_one_hour(self, interval: str) -> None:
+        engine = _strict_engine(leverage=100.0, interval=interval)
+        assert engine.default_leverage == 100.0
+
+    def test_strict_100x_revalidates_run_config_before_loading(
+        self, tmp_path
+    ) -> None:
+        class LoaderThatMustNotRun:
+            def fetch(self, *args, **kwargs):
+                raise AssertionError("loader ran before strict interval validation")
+
+        engine = _strict_engine(leverage=100.0, interval="1H")
+        run_config = {
+            **engine.config,
+            "codes": ["BTC-USDT-PERP"],
+            "interval": "1D",
+        }
+
+        with pytest.raises(ValueError, match="resolution boundary"):
+            engine.run_backtest(run_config, LoaderThatMustNotRun(), object(), tmp_path)
+
     def test_market_fills_use_execution_open_and_taker_rate(self) -> None:
         dates = pd.date_range("2026-01-01", periods=2, freq="h", tz="UTC")
         frame = _strict_frame(
@@ -545,3 +639,108 @@ class TestStrictPerpetualLifecycle:
         assert engine.terminal_status == "account_liquidation"
         assert len(engine.equity_snapshots) == 2
         assert engine.equity_snapshots[-1].timestamp == dates[1]
+
+    def test_evidence_records_funding_before_fill_and_separate_fee_totals(
+        self, tmp_path
+    ) -> None:
+        dates = pd.date_range("2026-01-01", periods=3, freq="h", tz="UTC")
+        frame = _strict_frame(
+            dates,
+            funding_rate=[0.0, 0.001, 0.0],
+            settlements=[None, dates[1], None],
+        )
+        engine = _strict_engine(
+            interval="1H",
+            taker_rate=0.001,
+            liquidation_fee_rate=0.02,
+        )
+        targets = {"BTC-USDT-PERP": [0.5, 0.0, 0.0]}
+
+        _run_strict(engine, {"BTC-USDT-PERP": frame}, targets)
+        metrics = _write_strict_artifacts(
+            engine, {"BTC-USDT-PERP": frame}, targets, tmp_path
+        )
+
+        events, summary = _read_strict_evidence(tmp_path)
+        settlement = next(
+            event for event in events if event["event_type"] == "funding_settlement"
+        )
+        close_fill = next(
+            event
+            for event in events
+            if event["event_type"] == "market_fill" and event["action"] == "close"
+        )
+        assert settlement["timestamp"] == dates[1].isoformat()
+        assert settlement["funding_pnl"] == pytest.approx(-5.0)
+        assert settlement["sequence"] < close_fill["sequence"]
+        assert close_fill["execution_price_source"] == "execution_open"
+
+        assert summary["funding_settlement_count"] == 1
+        assert summary["total_funding_pnl"] == pytest.approx(-5.0)
+        assert summary["total_trading_fee"] == pytest.approx(10.0)
+        assert summary["total_liquidation_fee"] == 0.0
+        assert summary["leverage"] == 10.0
+        assert summary["taker_rate"] == 0.001
+        assert summary["liquidation_fee_rate"] == 0.02
+        assert summary["fee_model"] == {
+            "market_fill_rate": "taker_rate",
+            "maker_rate_used": False,
+            "funding_separate": True,
+            "liquidation_separate": True,
+        }
+        assert metrics["perpetual_funding_pnl"] == pytest.approx(-5.0)
+        assert metrics["perpetual_trading_fees"] == pytest.approx(10.0)
+
+    def test_evidence_records_cross_liquidation_and_intrabar_limitation(
+        self, tmp_path
+    ) -> None:
+        engine, frames, targets = _run_liquidation_case("cross")
+        metrics = _write_strict_artifacts(engine, frames, targets, tmp_path)
+
+        events, summary = _read_strict_evidence(tmp_path)
+        liquidation = next(
+            event for event in events if event["event_type"] == "account_liquidation"
+        )
+        assert liquidation["symbols"] == ["BTC-USDT-PERP", "ETH-USDT-PERP"]
+        assert liquidation["price_source"] == "adverse_mark_extrema"
+        assert liquidation["liquidation_fee"] == pytest.approx(180.0)
+
+        assert summary["terminal_status"] == "account_liquidation"
+        assert summary["liquidation_event_count"] == 1
+        assert summary["liquidated_position_count"] == 2
+        assert summary["total_liquidation_fee"] == pytest.approx(180.0)
+        assert summary["maintenance_bracket_versions"] == {
+            "BTC-USDT-PERP": "fixture-v1",
+            "ETH-USDT-PERP": "fixture-v1",
+        }
+        assert summary["fidelity_flags"] == ["conservative_intrabar_assumption"]
+        assert "not guaranteed" in summary["resolution_limitation"]
+        assert metrics["perpetual_liquidation_events"] == 1
+        assert metrics["perpetual_liquidation_fees"] == pytest.approx(180.0)
+
+    def test_evidence_keeps_isolated_liquidation_position_scoped(
+        self, tmp_path
+    ) -> None:
+        engine, frames, targets = _run_liquidation_case("isolated")
+        _write_strict_artifacts(engine, frames, targets, tmp_path)
+
+        events, _ = _read_strict_evidence(tmp_path)
+        liquidations = [
+            event
+            for event in events
+            if event["event_type"]
+            in {
+                "position_liquidation",
+                "account_liquidation",
+            }
+        ]
+        assert [event["event_type"] for event in liquidations] == [
+            "position_liquidation"
+        ]
+        assert liquidations[0]["symbol"] == "BTC-USDT-PERP"
+        assert liquidations[0]["liquidation_fee"] == pytest.approx(80.0)
+        assert engine.terminal_status == "completed"
+        assert {trade.symbol: trade.exit_reason for trade in engine.trades} == {
+            "BTC-USDT-PERP": "position_liquidation",
+            "ETH-USDT-PERP": "end_of_backtest",
+        }


### PR DESCRIPTION
## Stack note

Fourth bounded slice of the historical USD-M work discussed in #462. It follows the merged lifecycle integration in #903 and adds audit evidence without introducing another accounting source of truth.

## Summary

- Fail closed for strict 100x runs unless the interval is one of the repository-supported intraday resolutions at or below 1 hour.
- Preserve a common timezone through `_align`, which is required for UTC-aware USD-M frames to reach the merged strict lifecycle.
- Persist ordered market-fill, funding, risk-snapshot, isolated-liquidation, and cross-account-liquidation events.
- Emit a strict summary with funding/trading/liquidation fee totals, maintenance-bracket versions, market-risk sources, terminal status, and fidelity limitations.
- Keep legacy `CryptoEngine` behavior unchanged unless `perpetual_strict=True` is selected.

## Why

#903 executes the correct funding and liquidation order, but its lifecycle was not yet auditable from run artifacts. It also exposed one pipeline gap: `_align()` stripped a shared UTC timezone, so loader-shaped UTC perpetual frames failed strict synchronization when invoked through normal `run_backtest()`.

This slice makes the strict path reproducible and inspectable while keeping account decisions in the existing engine and pure risk model. The event list is write-only evidence and is never read back into accounting or liquidation decisions.

## Changes

- Add `perpetual_events.jsonl` with full timestamps and monotonic sequence numbers for:
  - `market_fill` (open/close, execution source, taker fee);
  - `funding_settlement` (signed quantity, mark-open rate and P&L);
  - `risk_snapshot` (pre-fill mark-open or post-fill adverse marks);
  - `position_liquidation` for isolated mode;
  - `account_liquidation` for terminal cross mode.
- Add `perpetual_summary.json` with scalar counts/totals, configured rates, bracket versions, sources, assumptions, and fidelity flags.
- Add scalar perpetual totals to normal metrics/run-card output.
- Reject unsupported/coarse strict-100x intervals before data loading. This also rejects aliases such as `60m` that the current CCXT loader would otherwise silently route to daily data.
- Preserve timezone only when every aligned input uses the same timezone; existing timezone-naive behavior remains unchanged.

## Test plan

- [x] `pytest agent/tests/test_perpetual_risk.py agent/tests/test_ccxt_perpetual_loader.py agent/tests/test_crypto_engine.py agent/tests/test_base_engine.py agent/tests/test_engine_metrics_json.py -q --tb=short` — 143 passed.
- [x] Synthetic `CryptoEngine.run_backtest()` smoke with UTC-aware 1H frames — funding P&L `-10.0`, terminal status `completed`, and both new artifacts discovered by `run_card.json`.
- [x] `python -m py_compile agent/backtest/engines/base.py agent/backtest/engines/crypto.py agent/backtest/perpetual_evidence.py` — passed.
- [x] `ruff check` on the changed footprint — passed (`base.py` uses the same pre-existing E402 ignore documented in #903).
- [x] `git diff --check` — passed.
- [ ] Full non-e2e suite was attempted locally but stopped during collection: 20 API tests hit the pre-existing `scheduled_routes.py` DELETE-204/FastAPI 0.110.3 assertion. The same failure was reproduced from the clean #903 baseline; no scheduled-route file is changed here. CI is authoritative for the full suite.
- [ ] Black was not available in the local virtualenv; no whole-file formatting cleanup was mixed into this PR.

## Safety and network risk

- Historical backtest only.
- No Binance credentials, live API calls, broker writes, OAuth, paper trading, or order placement.
- Tests and smoke data are synthetic and network-free.
- No connector, API-route, mandate, or deployment changes.

## Fidelity notes

This remains a conservative bar-based research model, not an identical reproduction of Binance liquidation sequencing. At 100x, 1 hour is a maximum resolution boundary, not a sequence-precision guarantee. Adverse extrema across symbols may not occur at the same millisecond; affected snapshots persist `conservative_intrabar_assumption`.

## Out of scope

- Same-direction position resizing and scale-in/scale-out accounting.
- Open orders, maker fills, hedge mode, non-USDT collateral, multi-assets mode, portfolio margin, partial liquidation, ADL, insurance-fund behavior, or order-book replay.
- Shadow Account reconciliation and live execution.

## Rollback

Revert this PR. The new evidence path and interval gate are opt-in behind `perpetual_strict=True`; there is no data migration or live state.