### PR TITLE
feat(reports): expose and improve nested backtest report listing

### DIFF
--- a/agent/src/api/models.py
+++ b/agent/src/api/models.py
@@ -43,6 +43,7 @@ class RunInfo(BaseModel):
     """Compact run row for list views."""
 
     run_id: str
+    display_name: Optional[str] = None
     status: str
     created_at: str
     prompt: Optional[str] = None

--- a/agent/src/api/runs_routes.py
+++ b/agent/src/api/runs_routes.py
@@ -5,6 +5,7 @@ Mounted by ``agent/api_server.py`` via ``register_runs_routes(app, ...)``.
 
 from __future__ import annotations
 
+import base64
 import csv
 import json
 from datetime import datetime
@@ -44,6 +45,42 @@ def _load_csv_to_dict(path: Path, limit: Optional[int] = None) -> List[Dict[str,
         return []
 
 
+def _encode_run_relative_path(relative_path: Path) -> str:
+    """Encode a nested run directory as an opaque, URL-safe legacy run ID."""
+    raw = relative_path.as_posix().encode("utf-8")
+    return "nested_" + base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _decode_run_id(runs_dir: Path, run_id: str) -> Path:
+    """Resolve a top-level or encoded nested run ID under ``runs_dir`` safely."""
+    if not run_id.startswith("nested_"):
+        return runs_dir / run_id
+    encoded = run_id.removeprefix("nested_")
+    try:
+        raw = base64.urlsafe_b64decode(encoded + "=" * (-len(encoded) % 4)).decode("utf-8")
+        relative = Path(raw)
+        if relative.is_absolute() or ".." in relative.parts:
+            raise ValueError("unsafe relative path")
+        resolved_root = runs_dir.resolve()
+        resolved = (resolved_root / relative).resolve()
+        resolved.relative_to(resolved_root)
+        return resolved
+    except (UnicodeDecodeError, ValueError, OSError) as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="invalid run_id") from exc
+
+
+def _report_run_dirs(runs_dir: Path) -> List[Path]:
+    """Return top-level runs plus nested backtest leaves that carry run cards.
+
+    Discovery is deliberately limited to ``*/backtests/*/run_card.json``: it
+    supports persisted strategy sub-runs without recursively indexing arbitrary
+    artifacts or turning every symbol into a report row.
+    """
+    top_level = [path for path in runs_dir.iterdir() if path.is_dir()]
+    nested = [card.parent for card in runs_dir.glob("*/backtests/*/run_card.json")]
+    return sorted({*top_level, *nested}, key=lambda path: path.name, reverse=True)
+
+
 def _run_response_payload(response: Any) -> Dict[str, Any]:
     """Return a JSON-ready payload for opt-in run response variants."""
     return response.model_dump(mode="json")
@@ -53,6 +90,7 @@ def _build_response_from_run_dir(
     run_dir: Path,
     elapsed: float,
     *,
+    response_run_id: Optional[str] = None,
     include_analysis: bool = False,
     chart_symbol: Optional[str] = None,
     chart_payload: str = "full",
@@ -67,7 +105,7 @@ def _build_response_from_run_dir(
     RAGSelection = host.RAGSelection
     Artifact = host.Artifact
 
-    run_id = run_dir.name
+    run_id = response_run_id or run_dir.name
 
     response = RunResponse(
         status="unknown",
@@ -88,6 +126,13 @@ def _build_response_from_run_dir(
             response.status = state_status or "unknown"
     else:
         response.status = "unknown"
+
+    if response.status == "unknown" and (
+        (run_dir / "run_card.json").exists() or (run_dir / "artifacts" / "metrics.csv").exists()
+    ):
+        # Strategy sub-runs are persisted below a parent session and commonly
+        # omit their own state.json, while still carrying completed artifacts.
+        response.status = "success"
 
     planner_path = run_dir / "planner_output.json"
     response.planner_output = _load_json_file(planner_path)
@@ -246,6 +291,10 @@ def register_runs_routes(
         h = _sys.modules.get("api_server") or _sys.modules.get("agent.api_server")
         return h.RUNS_DIR
 
+    def _resolve_run_dir(run_id: str) -> Path:
+        _host_validate_path_param(run_id, "run_id")
+        return _decode_run_id(_host_RUNS_DIR(), run_id)
+
     # Pydantic models for response_model (resolved at registration time)
     RunResponse = host.RunResponse
     RunInfo = host.RunInfo
@@ -262,8 +311,7 @@ def register_runs_routes(
         Returns:
             Map filename -> source text.
         """
-        _host_validate_path_param(run_id, "run_id")
-        run_dir = _host_RUNS_DIR() / run_id / "code"
+        run_dir = _resolve_run_dir(run_id) / "code"
         if not run_dir.exists():
             raise HTTPException(status_code=404, detail=f"Code directory for run {run_id} not found")
         result = {}
@@ -283,8 +331,7 @@ def register_runs_routes(
         Returns:
             Object with pine script content and exists flag.
         """
-        _host_validate_path_param(run_id, "run_id")
-        pine_path = _host_RUNS_DIR() / run_id / "artifacts" / "strategy.pine"
+        pine_path = _resolve_run_dir(run_id) / "artifacts" / "strategy.pine"
         if not pine_path.exists():
             return {"exists": False, "content": None}
         return {
@@ -306,10 +353,9 @@ def register_runs_routes(
         The default response stays unchanged for existing consumers. Chart-heavy
         optimizations are opt-in via query parameters.
         """
-        _host_validate_path_param(run_id, "run_id")
         if chart_payload not in (None, "summary"):
             raise HTTPException(status_code=400, detail="invalid chart_payload")
-        run_dir = _host_RUNS_DIR() / run_id
+        run_dir = _resolve_run_dir(run_id)
 
         if not run_dir.exists():
             raise HTTPException(
@@ -322,6 +368,7 @@ def register_runs_routes(
         response = _build_response_from_run_dir(
             run_dir,
             elapsed=0.0,
+            response_run_id=run_id,
             include_analysis=True,
             chart_symbol=chart_symbol,
             chart_payload=chart_payload or "full",
@@ -346,15 +393,16 @@ def register_runs_routes(
         if not runs_dir.exists():
             return []
 
-        run_dirs = sorted(
-            [d for d in runs_dir.iterdir() if d.is_dir()],
-            key=lambda x: x.name,
-            reverse=True
-        )
+        report_dirs = _report_run_dirs(runs_dir)
 
         results = []
-        for d in run_dirs[:limit]:
-            run_id = d.name
+        for d in report_dirs[:limit]:
+            relative_path = d.relative_to(runs_dir)
+            run_id = (
+                relative_path.name
+                if len(relative_path.parts) == 1
+                else _encode_run_relative_path(relative_path)
+            )
 
             # Status from state.json or artifacts
             status_val = "unknown"
@@ -422,6 +470,20 @@ def register_runs_routes(
                     pass
 
             run_context = load_run_context(d)
+            run_card = _load_json_file(d / "run_card.json") or {}
+            backtest = run_card.get("backtest") or {}
+            if not run_context.get("codes"):
+                run_context["codes"] = [str(code) for code in backtest.get("codes") or []]
+            if not run_context.get("start_date"):
+                run_context["start_date"] = backtest.get("start_date")
+            if not run_context.get("end_date"):
+                run_context["end_date"] = backtest.get("end_date")
+            if total_return is None:
+                value = (run_card.get("metrics") or {}).get("total_return")
+                total_return = float(value) if value is not None else None
+            if sharpe is None:
+                value = (run_card.get("metrics") or {}).get("sharpe")
+                sharpe = float(value) if value is not None else None
             results.append(RunInfo(
                 run_id=run_id,
                 status=status_val,

--- a/agent/src/api/runs_routes.py
+++ b/agent/src/api/runs_routes.py
@@ -486,6 +486,7 @@ def register_runs_routes(
                 sharpe = float(value) if value is not None else None
             results.append(RunInfo(
                 run_id=run_id,
+                display_name=d.name if len(relative_path.parts) > 1 else None,
                 status=status_val,
                 created_at=created_at,
                 prompt=prompt or "Manual Analysis",

--- a/agent/src/api/runs_routes.py
+++ b/agent/src/api/runs_routes.py
@@ -45,6 +45,20 @@ def _load_csv_to_dict(path: Path, limit: Optional[int] = None) -> List[Dict[str,
         return []
 
 
+def _safe_float(value: Any) -> Optional[float]:
+    """Coerce a persisted metric value to float, tolerating non-numeric values.
+
+    run_card.json metrics can carry human-readable strings (e.g. ``"12.3%"``);
+    a bad value must degrade to ``None`` instead of crashing the whole listing.
+    """
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def _encode_run_relative_path(relative_path: Path) -> str:
     """Encode a nested run directory as an opaque, URL-safe legacy run ID."""
     raw = relative_path.as_posix().encode("utf-8")
@@ -414,6 +428,13 @@ def register_runs_routes(
             elif (d / "review_report.json").exists():
                 status_val = "success"
 
+            if status_val == "unknown" and (
+                (d / "run_card.json").exists() or (d / "artifacts" / "metrics.csv").exists()
+            ):
+                # Strategy sub-runs commonly omit their own state.json while
+                # still carrying completed artifacts; mirror the detail endpoint.
+                status_val = "success"
+
             # Parse created_at from run_id (YYYYMMDD_HHMMSS or run_YYYYMMDD_HHMMSS)
             created_at = "Unknown"
             if run_id.startswith("run_"):
@@ -479,11 +500,9 @@ def register_runs_routes(
             if not run_context.get("end_date"):
                 run_context["end_date"] = backtest.get("end_date")
             if total_return is None:
-                value = (run_card.get("metrics") or {}).get("total_return")
-                total_return = float(value) if value is not None else None
+                total_return = _safe_float((run_card.get("metrics") or {}).get("total_return"))
             if sharpe is None:
-                value = (run_card.get("metrics") or {}).get("sharpe")
-                sharpe = float(value) if value is not None else None
+                sharpe = _safe_float((run_card.get("metrics") or {}).get("sharpe"))
             results.append(RunInfo(
                 run_id=run_id,
                 display_name=d.name if len(relative_path.parts) > 1 else None,

--- a/agent/src/ui_services.py
+++ b/agent/src/ui_services.py
@@ -352,25 +352,29 @@ def build_indicator_series(
     return output
 
 
-def _load_ohlcv_artifacts(run_dir: Path) -> List[Dict[str, Any]]:
-    """Read individual ohlcv_*.csv files saved by the backtest engine.
+def _load_ohlcv_artifacts(
+    run_dir: Path, symbols: Optional[set[str]] = None
+) -> List[Dict[str, Any]]:
+    """Read saved OHLCV artifacts, optionally opening only selected symbols.
 
-    The engine writes ``ohlcv_{code}.csv`` per symbol with columns
-    ``trade_date,open,high,low,close,volume``. This function reads
-    them all and returns a flat list of normalized rows.
-
-    Args:
-        run_dir: The run directory under ``runs/``.
-
-    Returns:
-        Normalized OHLC rows, empty list if no files found.
+    ``symbols`` is used by the report detail chart endpoint.  It prevents a
+    single-symbol request from parsing every ``ohlcv_*.csv`` file in a large
+    portfolio run.
     """
     artifacts = run_dir / "artifacts"
     if not artifacts.is_dir():
         return []
-    ohlcv_files = sorted(artifacts.glob("ohlcv_*.csv"))
-    if not ohlcv_files:
-        return []
+    if symbols:
+        ohlcv_files = []
+        for code in sorted(symbols):
+            # Symbols are file-name components, never relative paths.
+            if Path(code).name != code:
+                continue
+            candidate = artifacts / f"ohlcv_{code}.csv"
+            if candidate.is_file():
+                ohlcv_files.append(candidate)
+    else:
+        ohlcv_files = sorted(artifacts.glob("ohlcv_*.csv"))
     rows: List[Dict[str, Any]] = []
     for f in ohlcv_files:
         code = f.stem.removeprefix("ohlcv_")
@@ -387,21 +391,21 @@ def _load_ohlcv_artifacts(run_dir: Path) -> List[Dict[str, Any]]:
     return _normalize_price_rows(rows)
 
 
-def load_price_series(run_dir: Path) -> List[Dict[str, Any]]:
-    """Load chart-ready price rows: price_series.csv > ohlcv_*.csv > API reconstruct.
-
-    Args:
-        run_dir: The run directory under ``runs/``.
-
-    Returns:
-        Normalized OHLC rows sorted by (code, date).
-    """
+def load_price_series(
+    run_dir: Path, symbols: Optional[set[str]] = None
+) -> List[Dict[str, Any]]:
+    """Load chart-ready rows, avoiding unrelated OHLCV files when possible."""
     artifact_path = run_dir / "artifacts" / "price_series.csv"
     if artifact_path.exists():
-        return _normalize_price_rows(load_csv_records(artifact_path))
-    rows = _load_ohlcv_artifacts(run_dir)
+        rows = _normalize_price_rows(load_csv_records(artifact_path))
+        return [row for row in rows if not symbols or str(row.get("code") or "") in symbols]
+    rows = _load_ohlcv_artifacts(run_dir, symbols)
     if rows:
         return rows
+    if symbols:
+        # A targeted chart request must not turn into a full-portfolio network
+        # reconstruction when its persisted artifact is missing.
+        return []
     return reconstruct_price_series(run_dir)
 
 
@@ -515,12 +519,10 @@ def build_run_analysis(
             "run_logs": collect_run_logs(run_dir),
         }
 
-    price_rows = load_price_series(run_dir)
+    selected_symbols = {symbol for symbol in (symbols or []) if symbol}
+    price_rows = load_price_series(run_dir, selected_symbols or None)
     if include_symbol_list and not chart_symbols:
         chart_symbols = sorted({str(row.get("code") or "") for row in price_rows if row.get("code")})
-    selected_symbols = {symbol for symbol in (symbols or []) if symbol}
-    if selected_symbols:
-        price_rows = [row for row in price_rows if str(row.get("code") or "") in selected_symbols]
     periods = infer_indicator_periods(run_dir)
     trades = load_csv_records(run_dir / "artifacts" / "trades.csv")
 

--- a/agent/tests/test_nested_run_reports.py
+++ b/agent/tests/test_nested_run_reports.py
@@ -1,0 +1,148 @@
+"""Regression coverage for nested backtest reports in agent run directories."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+import api_server
+
+
+def _client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    monkeypatch.setattr(api_server, "RUNS_DIR", runs_dir)
+    monkeypatch.setattr(api_server, "_API_KEY", "")
+    monkeypatch.delenv("API_AUTH_KEY", raising=False)
+    return TestClient(api_server.app, client=("127.0.0.1", 50000))
+
+
+def _write_nested_report(runs_dir: Path) -> Path:
+    parent = runs_dir / "20260728_135942_02_5e8bb3"
+    parent.mkdir()
+    (parent / "state.json").write_text('{"status": "success"}\n', encoding="utf-8")
+    child = parent / "backtests" / "hk21_123"
+    artifacts = child / "artifacts"
+    artifacts.mkdir(parents=True)
+    (child / "state.json").write_text('{"status": "success"}\n', encoding="utf-8")
+    (child / "config.json").write_text(
+        json.dumps(
+            {
+                "codes": ["00700.HK", "03690.HK"],
+                "start_date": "2021-07-28",
+                "end_date": "2026-07-27",
+                "source": "longbridge",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (child / "run_card.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "backtest": {
+                    "codes": ["00700.HK", "03690.HK"],
+                    "start_date": "2021-07-28",
+                    "end_date": "2026-07-27",
+                },
+                "metrics": {"total_return": 0.1, "sharpe": 1.2},
+            }
+        ),
+        encoding="utf-8",
+    )
+    with (artifacts / "metrics.csv").open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["final_value", "total_return", "annual_return", "max_drawdown", "sharpe", "win_rate", "trade_count"])
+        writer.writeheader()
+        writer.writerow({"final_value": 110000, "total_return": 0.1, "annual_return": 0.05, "max_drawdown": -0.1, "sharpe": 1.2, "win_rate": 0.5, "trade_count": 2})
+    (child / "code").mkdir()
+    (child / "code" / "signal_engine.py").write_text("class SignalEngine: pass\n", encoding="utf-8")
+    (artifacts / "strategy.pine").write_text("//@version=6\n", encoding="utf-8")
+    return child
+
+
+def test_nested_backtest_is_listed_and_opened_via_safe_report_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client = _client(tmp_path, monkeypatch)
+    _write_nested_report(tmp_path / "runs")
+
+    listed = client.get("/runs?limit=20")
+
+    assert listed.status_code == 200
+    rows = listed.json()
+    report = next(row for row in rows if row["codes"] == ["00700.HK", "03690.HK"])
+    report_id = report["run_id"]
+    assert "/" not in report_id
+    assert report["total_return"] == 0.1
+
+    detail = client.get(f"/runs/{report_id}?chart_payload=summary")
+
+    assert detail.status_code == 200
+    assert detail.json()["status"] == "success"
+    assert detail.json()["run_card"]["backtest"]["codes"] == ["00700.HK", "03690.HK"]
+    assert client.get(f"/runs/{report_id}/code").json() == {"signal_engine.py": "class SignalEngine: pass\n"}
+    assert client.get(f"/runs/{report_id}/pine").json() == {"exists": True, "content": "//@version=6\n"}
+
+
+def test_nested_report_rejects_encoded_path_traversal(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _client(tmp_path, monkeypatch)
+
+    response = client.get("/runs/nested_Li4vZXNjYXBl")
+
+    assert response.status_code == 400
+
+
+def test_single_symbol_chart_reads_only_its_ohlcv_artifact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from src import ui_services
+
+    run_dir = tmp_path / "run"
+    artifacts = run_dir / "artifacts"
+    artifacts.mkdir(parents=True)
+    (artifacts / "ohlcv_00700.HK.csv").write_text(
+        "trade_date,open,high,low,close,volume\n2026-01-01,1,2,1,2,10\n",
+        encoding="utf-8",
+    )
+    (artifacts / "ohlcv_03690.HK.csv").write_text(
+        "trade_date,open,high,low,close,volume\n2026-01-01,3,4,3,4,20\n",
+        encoding="utf-8",
+    )
+    reads: list[str] = []
+    real_load = ui_services.load_csv_records
+
+    def tracked_load(path: Path):
+        reads.append(path.name)
+        return real_load(path)
+
+    monkeypatch.setattr(ui_services, "load_csv_records", tracked_load)
+
+    payload = ui_services.build_run_analysis(run_dir, symbols=["00700.HK"], include_symbol_list=True)
+
+    assert set(payload["price_series"]) == {"00700.HK"}
+    assert "ohlcv_00700.HK.csv" in reads
+    assert "ohlcv_03690.HK.csv" not in reads
+
+
+def test_missing_selected_ohlcv_does_not_reconstruct_entire_portfolio(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from src import ui_services
+
+    run_dir = tmp_path / "run"
+    (run_dir / "artifacts").mkdir(parents=True)
+    called = False
+
+    def fail_reconstruct(path: Path):
+        nonlocal called
+        called = True
+        return []
+
+    monkeypatch.setattr(ui_services, "reconstruct_price_series", fail_reconstruct)
+
+    assert ui_services.load_price_series(run_dir, {"MISSING"}) == []
+    assert called is False

--- a/agent/tests/test_nested_run_reports.py
+++ b/agent/tests/test_nested_run_reports.py
@@ -77,6 +77,7 @@ def test_nested_backtest_is_listed_and_opened_via_safe_report_id(
     report = next(row for row in rows if row["codes"] == ["00700.HK", "03690.HK"])
     report_id = report["run_id"]
     assert "/" not in report_id
+    assert report["display_name"] == "hk21_123"
     assert report["total_return"] == 0.1
 
     detail = client.get(f"/runs/{report_id}?chart_payload=summary")

--- a/agent/tests/test_nested_run_reports.py
+++ b/agent/tests/test_nested_run_reports.py
@@ -147,3 +147,58 @@ def test_missing_selected_ohlcv_does_not_reconstruct_entire_portfolio(
 
     assert ui_services.load_price_series(run_dir, {"MISSING"}) == []
     assert called is False
+
+
+def test_list_run_card_with_non_numeric_metrics_degrades_to_null(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """run_card metrics carrying human-readable strings must not crash /runs."""
+    client = _client(tmp_path, monkeypatch)
+    parent = tmp_path / "runs" / "20260728_135942_02_5e8bb3"
+    child = parent / "backtests" / "hk21_123"
+    (child / "artifacts").mkdir(parents=True)
+    (child / "run_card.json").write_text(
+        json.dumps(
+            {
+                "backtest": {
+                    "codes": ["00700.HK"],
+                    "start_date": "2021-07-28",
+                    "end_date": "2026-07-27",
+                },
+                "metrics": {"total_return": "12.3%", "sharpe": "n/a"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    listed = client.get("/runs?limit=20")
+
+    assert listed.status_code == 200
+    report = next(row for row in listed.json() if row["display_name"] == "hk21_123")
+    assert report["total_return"] is None
+    assert report["sharpe"] is None
+    assert report["status"] == "success"
+
+
+def test_list_run_card_only_subrun_reports_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A sub-run with completed artifacts but no state.json lists as success."""
+    client = _client(tmp_path, monkeypatch)
+    parent = tmp_path / "runs" / "20260728_135942_02_5e8bb3"
+    child = parent / "backtests" / "hk21_123"
+    artifacts = child / "artifacts"
+    artifacts.mkdir(parents=True)
+    (child / "run_card.json").write_text(
+        json.dumps({"backtest": {"codes": ["00700.HK"]}}), encoding="utf-8"
+    )
+    with (artifacts / "metrics.csv").open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["total_return"])
+        writer.writeheader()
+        writer.writerow({"total_return": 0.1})
+
+    listed = client.get("/runs?limit=20")
+
+    assert listed.status_code == 200
+    report = next(row for row in listed.json() if row["display_name"] == "hk21_123")
+    assert report["status"] == "success"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -397,6 +397,7 @@ export interface ChannelPairingCommandResponse {
 
 export interface RunListItem {
   run_id: string;
+  display_name?: string;
   status: string;
   created_at: string;
   prompt?: string;

--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -209,7 +209,7 @@ function ReportRow({ run }: { run: RunListItem }) {
           <div className="flex flex-wrap items-center gap-2">
             <StatusBadge status={run.status} />
             <Link to={`/runs/${run.run_id}`} className="truncate font-mono text-sm font-medium hover:text-primary">
-              {run.run_id}
+              {run.display_name || run.run_id}
             </Link>
             <span className="text-xs text-muted-foreground">
               {formatRunDate(run.created_at, t("reports.unknown", { defaultValue: "Unknown" }))}

--- a/frontend/src/pages/RunDetail.tsx
+++ b/frontend/src/pages/RunDetail.tsx
@@ -234,17 +234,17 @@ export function RunDetail() {
   async function handleAddChartSymbol(symbol: string) {
     if (!symbol) return;
     setSelectedSymbol(symbol);
-    setChartPickerSymbol(symbol);
     setSelectedSymbols((prev) => prev.includes(symbol) ? prev : [...prev, symbol]);
     await loadChartSymbol(symbol);
+    setChartPickerSymbol("");
   }
 
   async function handleCurrentChartOnly(symbol: string) {
     if (!symbol) return;
     setSelectedSymbol(symbol);
-    setChartPickerSymbol(symbol);
     setSelectedSymbols([symbol]);
     await loadChartSymbol(symbol);
+    setChartPickerSymbol("");
   }
 
   function handleRemoveChartSymbol(symbol: string) {

--- a/frontend/src/pages/RunDetail.tsx
+++ b/frontend/src/pages/RunDetail.tsx
@@ -577,6 +577,7 @@ function ChartTab({
     .map((symbol) => [symbol, chartCache[symbol]?.price_series?.[symbol] || []] as const)
     .filter(([, bars]) => bars.length > 0);
   const hasEquity = run.equity_curve && run.equity_curve.length > 0;
+  const canLoadAllCharts = chartSymbols.length <= 20;
   const progressPercent = bulkProgress.total > 0 ? Math.round((bulkProgress.done / bulkProgress.total) * 100) : 0;
 
   if (chartSymbols.length === 0 && entries.length === 0 && !hasEquity) {
@@ -596,16 +597,26 @@ function ChartTab({
             <label className="text-xs font-medium text-muted-foreground" htmlFor="chart-symbol-select">
               {i18n.t("runDetail.symbol")}
             </label>
-            <select
-              id="chart-symbol-select"
-              value={chartPickerSymbol}
-              onChange={(event) => onPickSymbol(event.target.value)}
-              className="h-8 rounded-md border border-border/60 bg-background px-2 text-sm"
-            >
-              {chartSymbols.map((symbol) => (
-                <option key={symbol} value={symbol}>{symbol}</option>
-              ))}
-            </select>
+            {canLoadAllCharts ? (
+              <select
+                id="chart-symbol-select"
+                value={chartPickerSymbol}
+                onChange={(event) => onPickSymbol(event.target.value)}
+                className="h-8 rounded-md border border-border/60 bg-background px-2 text-sm"
+              >
+                {chartSymbols.map((symbol) => (
+                  <option key={symbol} value={symbol}>{symbol}</option>
+                ))}
+              </select>
+            ) : (
+              <input
+                id="chart-symbol-select"
+                value={chartPickerSymbol}
+                onChange={(event) => onPickSymbol(event.target.value.trim())}
+                placeholder={i18n.t("runDetail.symbol")}
+                className="h-8 w-44 rounded-md border border-border/60 bg-background px-2 text-sm"
+              />
+            )}
             <button
               onClick={() => onCurrentOnly(chartPickerSymbol)}
               className="rounded-md border border-border/60 px-3 py-1.5 text-xs font-medium hover:bg-muted/60"
@@ -621,14 +632,20 @@ function ChartTab({
             >
               {i18n.t("runDetail.addSymbol")}
             </button>
-            <button
-              onClick={() => void onLoadAll()}
-              className="rounded-md border border-border/60 px-3 py-1.5 text-xs font-medium hover:bg-muted/60"
-              disabled={bulkLoading}
-            >
-              {bulkLoading ? <Loader2 className="mr-1 inline h-3.5 w-3.5 animate-spin" /> : null}
-              {i18n.t("runDetail.loadAll")}
-            </button>
+            {canLoadAllCharts ? (
+              <button
+                onClick={() => void onLoadAll()}
+                className="rounded-md border border-border/60 px-3 py-1.5 text-xs font-medium hover:bg-muted/60"
+                disabled={bulkLoading}
+              >
+                {bulkLoading ? <Loader2 className="mr-1 inline h-3.5 w-3.5 animate-spin" /> : null}
+                {i18n.t("runDetail.loadAll")}
+              </button>
+            ) : (
+              <span className="text-xs text-muted-foreground">
+                {chartSymbols.length} {i18n.t("runDetail.symbol")} · {i18n.t("runDetail.pickSymbolToLoad")}
+              </span>
+            )}
             {bulkLoading && (
               <button
                 onClick={onCancelLoadAll}

--- a/frontend/src/pages/RunDetail.tsx
+++ b/frontend/src/pages/RunDetail.tsx
@@ -1,5 +1,5 @@
 import i18n from '@/i18n';
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { useParams, useNavigate } from "react-router";
@@ -578,6 +578,11 @@ function ChartTab({
     .filter(([, bars]) => bars.length > 0);
   const hasEquity = run.equity_curve && run.equity_curve.length > 0;
   const canLoadAllCharts = chartSymbols.length <= 20;
+  const symbolMatches = useMemo(() => {
+    if (canLoadAllCharts || !chartPickerSymbol.trim()) return [];
+    const query = chartPickerSymbol.trim().toLowerCase();
+    return chartSymbols.filter((symbol) => symbol.toLowerCase().includes(query)).slice(0, 20);
+  }, [canLoadAllCharts, chartPickerSymbol, chartSymbols]);
   const progressPercent = bulkProgress.total > 0 ? Math.round((bulkProgress.done / bulkProgress.total) * 100) : 0;
 
   if (chartSymbols.length === 0 && entries.length === 0 && !hasEquity) {
@@ -609,13 +614,29 @@ function ChartTab({
                 ))}
               </select>
             ) : (
-              <input
-                id="chart-symbol-select"
-                value={chartPickerSymbol}
-                onChange={(event) => onPickSymbol(event.target.value.trim())}
-                placeholder={i18n.t("runDetail.symbol")}
-                className="h-8 w-44 rounded-md border border-border/60 bg-background px-2 text-sm"
-              />
+              <div className="relative">
+                <input
+                  id="chart-symbol-select"
+                  value={chartPickerSymbol}
+                  onChange={(event) => onPickSymbol(event.target.value.trim())}
+                  placeholder={i18n.t("runDetail.symbol")}
+                  className="h-8 w-44 rounded-md border border-border/60 bg-background px-2 text-sm"
+                />
+                {symbolMatches.length > 0 && (
+                  <div className="absolute z-10 mt-1 max-h-48 w-44 overflow-y-auto rounded-md border bg-popover p-1 shadow-md">
+                    {symbolMatches.map((symbol) => (
+                      <button
+                        key={symbol}
+                        type="button"
+                        onClick={() => onPickSymbol(symbol)}
+                        className="block w-full rounded px-2 py-1 text-left font-mono text-xs hover:bg-muted"
+                      >
+                        {symbol}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
             )}
             <button
               onClick={() => onCurrentOnly(chartPickerSymbol)}

--- a/frontend/src/pages/__tests__/RunDetail.test.tsx
+++ b/frontend/src/pages/__tests__/RunDetail.test.tsx
@@ -71,6 +71,24 @@ describe("RunDetail page", () => {
     expect(screen.queryByText("OLD_CODE")).not.toBeInTheDocument();
   });
 
+  it("hides Load All when a report has more than 20 symbols", async () => {
+    const symbols = Array.from({ length: 21 }, (_, index) => `S${index}`);
+    apiMock.getRun.mockResolvedValue({
+      status: "success",
+      run_id: "large",
+      prompt: "Large portfolio",
+      chart_symbols: symbols,
+      equity_curve: [{ time: "2026-01-01", equity: 100 }],
+    });
+    apiMock.getRunCode.mockResolvedValue({});
+
+    renderRunDetail("/runs/large");
+
+    expect(await screen.findByText("Large portfolio")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Load All" })).not.toBeInTheDocument();
+    expect(screen.getByText(/21.*Symbol/)).toBeInTheDocument();
+  });
+
   it("ignores a chart response that finishes after the route changes", async () => {
     const oldChart = deferred<RunData>();
     apiMock.getRun.mockImplementation((runId: string, params: Record<string, string>) => {

--- a/frontend/src/pages/__tests__/RunDetail.test.tsx
+++ b/frontend/src/pages/__tests__/RunDetail.test.tsx
@@ -87,6 +87,9 @@ describe("RunDetail page", () => {
     expect(await screen.findByText("Large portfolio")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Load All" })).not.toBeInTheDocument();
     expect(screen.getByText(/21.*Symbol/)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText("Symbol"), { target: { value: "S1" } });
+    expect(screen.getByRole("button", { name: "S1" })).toBeInTheDocument();
   });
 
   it("ignores a chart response that finishes after the route changes", async () => {

--- a/frontend/src/pages/__tests__/RunDetail.test.tsx
+++ b/frontend/src/pages/__tests__/RunDetail.test.tsx
@@ -89,7 +89,14 @@ describe("RunDetail page", () => {
     expect(screen.getByText(/21.*Symbol/)).toBeInTheDocument();
 
     fireEvent.change(screen.getByPlaceholderText("Symbol"), { target: { value: "S1" } });
-    expect(screen.getByRole("button", { name: "S1" })).toBeInTheDocument();
+    const suggestion = screen.getByRole("button", { name: "S1" });
+    expect(suggestion).toBeInTheDocument();
+    fireEvent.click(suggestion);
+    expect(screen.getByDisplayValue("S1")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show only" }));
+    await waitFor(() => expect(screen.getByPlaceholderText("Symbol")).toHaveValue(""));
+    expect(screen.queryByRole("button", { name: "S1" })).not.toBeInTheDocument();
   });
 
   it("ignores a chart response that finishes after the route changes", async () => {


### PR DESCRIPTION
## What

Exposes nested backtest sub-runs (persisted under `runs/<session>/backtests/<strategy>/`) in the reports listing and detail API, and surfaces them in the frontend with a symbol picker/search. Sub-runs commonly omit their own `state.json`, so status inference falls back to completed artifacts (`run_card.json` / `artifacts/metrics.csv`).

## Changes

- **API**: nested run directories are encoded as URL-safe opaque run IDs (`nested_...`) with path-traversal protection; listing and detail endpoints discover and serve them.
- **Metrics**: `run_card.json` metrics are coerced safely, so non-numeric values (e.g. `"12.3%"`) degrade to `null` instead of crashing the listing.
- **Status**: list status inference mirrors the detail endpoint for artifact-complete sub-runs without `state.json`.
- **Frontend**: `RunDetail` renders nested report charts with a symbol dropdown (≤20 symbols) or a searchable picker with suggestions (>20); `Reports` handles nested entries.
- **Tests**: nested report discovery, safe run IDs, path-traversal rejection, single-symbol artifact reads, and metrics/status robustness.

## Testing

- `pytest agent/tests/test_nested_run_reports.py`
- `frontend`: `npx tsc --noEmit` and `npx vitest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)