### PR TITLE
feat: add Phase 01 Taiwan offline quant data foundation

### DIFF
--- a/agent/SKILL.md
+++ b/agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vibe-trading
 version: 0.1.13
-description: Professional finance research toolkit — backtesting (9 engines + benchmark comparison panel), factor analysis, Alpha Zoo (462 pre-built alphas across qlib158/alpha101/gtja191/academic/fundamental), options pricing, 88 finance skills, 30 multi-agent swarm teams, Trade Journal analyzer, and Shadow Account (extract → backtest → render) across 24 market-data sources (tushare, yfinance, okx, binance, akshare, baostock, tencent, mootdx, ccxt, futu, mt5, local, eastmoney, sina, stooq, yahoo, pykrx, india_broker, qveris, longbridge, plus optional-key finnhub/alphavantage/tiingo/fmp).
+description: Professional finance research toolkit — backtesting (9 engines + benchmark comparison panel), factor analysis, Alpha Zoo (462 pre-built alphas across qlib158/alpha101/gtja191/academic/fundamental), options pricing, 88 finance skills, 30 multi-agent swarm teams, Trade Journal analyzer, and Shadow Account (extract → backtest → render) across 25 market-data sources (tushare, yfinance, okx, binance, akshare, baostock, tencent, mootdx, ccxt, futu, mt5, local, tw_snapshot, eastmoney, sina, stooq, yahoo, pykrx, india_broker, qveris, longbridge, plus optional-key finnhub/alphavantage/tiingo/fmp).
 dependencies:
   python: ">=3.11"
   pip:
@@ -74,7 +74,7 @@ Feed a CSV broker export (同花顺 / 东财 / 富途 / generic), and the agent 
 5. `scan_shadow_signals` — list today's symbols that match your shadow's entry cadence (research only).
 
 ### Backtesting
-Create and run quantitative strategies across 9 engines (ChinaA, GlobalEquity, IndiaEquity, KoreaEquity, Crypto, ChinaFutures, GlobalFutures, Forex + options) with 24 market-data sources (auto-detect + ordered fallback):
+Create and run quantitative strategies across 9 engines (ChinaA, GlobalEquity, IndiaEquity, KoreaEquity, Crypto, ChinaFutures, GlobalFutures, Forex + options) with 25 market-data sources (auto-detect + ordered fallback):
 - **HK/US equities** via yfinance / stooq / yahoo (free, no API key); optionally via **Longbridge** historical OHLCV (`longbridge`, requires the optional SDK and `LONGBRIDGE_APP_KEY` / `LONGBRIDGE_APP_SECRET` / `LONGBRIDGE_ACCESS_TOKEN`). To force it for a run, set `"source": "longbridge"` in `config.json`.
 - **India equities (NSE/BSE)** via yahoo / yfinance using `<SYMBOL>.NS` (NSE, e.g. `RELIANCE.NS`) or `<SCRIP>.BO` (BSE, e.g. `500325.BO`) — free, no API key. The `IndiaEquityEngine` models T+1 delivery, no overnight shorts (set `allow_short` for intraday), configurable circuit bands, 1-share lots, and the STT/stamp-duty/exchange/GST cost stack. Optionally back-fill from your live broker via the `india_broker` source (Shoonya/Dhan; requires broker login).
 - **Korea equities (KRX: KOSPI/KOSDAQ)** via pykrx using `<CODE>.KS` (KOSPI, e.g. `005930.KS`) or `<CODE>.KQ` (KOSDAQ, e.g. `247540.KQ`) — free, no API key (`pip install "vibe-trading-ai[krx]"`; yahoo/yfinance fallback needs no extra). pykrx serves **daily bars only** (an intraday request falls through to another source) and its adjusted series is Naver-backed rather than a verbatim KRX print. The `KoreaEquityEngine` models same-day round trips (no T+1), the ±30% daily price limit measured from the previous close and quantized to the KRX tick grid, tick-rounded fills, the 0.20% sell-side transaction tax (2026 rate), and 1-share lots. It is **long-only**: `allow_short` is refused, because KRX covered-short and uptick rules cannot be enforced on daily bars.
@@ -145,7 +145,7 @@ Use `load_skill(name)` to access full methodology docs with code templates.
 | `analyze_options` | Black-Scholes price + Greeks | None |
 | `analyze_options_payoff` | Multi-leg expiry payoff + spot/IV scenarios | None |
 | `pattern_recognition` | Detect chart patterns (H&S, double top, etc.) | None |
-| `get_market_data` | Fetch OHLCV data (auto-detect + ordered fallback across 24 sources) | None* |
+| `get_market_data` | Fetch OHLCV data (auto-detect + ordered fallback across 25 sources) | None* |
 | `get_fund_flow` | Capital fund-flow (main/retail net inflow) | None* |
 | `get_dragon_tiger` | Dragon-tiger list (龙虎榜) top buyer/seller seats | None* |
 | `get_northbound_flow` | Northbound (Stock Connect) net flow | None* |

--- a/agent/backtest/engines/_market_hooks.py
+++ b/agent/backtest/engines/_market_hooks.py
@@ -23,6 +23,10 @@ from backtest.models import Position
 # ── Symbol -> market classification (shared by runner.py + composite.py) ──
 
 _MARKET_PATTERNS = [
+    # Taiwan equities: TWSE (.TW) and TPEX (.TWO). Keep this before the
+    # generic unknown -> A-share default so Taiwan never reaches a mainland
+    # or global network source by accident.
+    (re.compile(r"^\d{4,6}\.(TW|TWO)$", re.I), "taiwan_equity"),
     (re.compile(r"^\d{6}\.(SZ|SH|BJ)$", re.I), "a_share"),
     (re.compile(r"^(51|15|56)\d{4}\.(SZ|SH)$", re.I), "a_share"),
     (re.compile(r"^[A-Z]+\.US$", re.I), "us_equity"),
@@ -67,16 +71,22 @@ _CN_FUTURES_PRODUCTS = {
 }
 
 
-def _detect_market(code: str) -> str:
+def _detect_market(code: str, market_hint: str | None = None) -> str:
     """Infer market type from symbol format.
 
     Args:
         code: Ticker / symbol string.
+        market_hint: Optional explicit hint for a bare Taiwan numeric code.
 
     Returns:
-        Market type (a_share/us_equity/hk_equity/crypto/futures/forex);
+        Market type (taiwan_equity/a_share/us_equity/hk_equity/crypto/
+        futures/forex);
         unknown defaults to ``a_share``.
     """
+    hint = str(market_hint or "").strip().upper()
+    if hint in {"TW", "TWSE", "TWO", "TPEX", "TAIWAN", "TAIWAN_EQUITY"}:
+        if re.fullmatch(r"\d{4,6}", str(code).strip()):
+            return "taiwan_equity"
     for pattern, market in _MARKET_PATTERNS:
         if pattern.match(code):
             return market

--- a/agent/backtest/loaders/registry.py
+++ b/agent/backtest/loaders/registry.py
@@ -55,6 +55,7 @@ VALID_SOURCES: set[str] = {
     "longbridge",
     "mt5",
     "local",
+    "tw_snapshot",
     "auto",
 }
 
@@ -105,6 +106,7 @@ def _ensure_registered() -> None:
         "backtest.loaders.longbridge",
         "backtest.loaders.mt5_loader",
         "backtest.loaders.local_loader",
+        "src.tw_quant.data.loader",
     ]
     import importlib
     for mod in _loader_modules:
@@ -121,7 +123,7 @@ def _ensure_registered() -> None:
 # unavailable ``local`` request can degrade into an unrelated network source.
 # An explicit ``local`` request that is unavailable is a config problem the user
 # must see, not something to paper over with a Yahoo/Tencent fetch.
-_NO_NETWORK_FALLBACK_SOURCES: frozenset[str] = frozenset({"local", "qveris"})  # QVERIS-INTEGRATION
+_NO_NETWORK_FALLBACK_SOURCES: frozenset[str] = frozenset({"local", "qveris", "tw_snapshot"})  # QVERIS-INTEGRATION
 
 
 # ---------------------------------------------------------------------------
@@ -147,6 +149,8 @@ FALLBACK_CHAINS: dict[str, list[str]] = {
     # mt5 leads when a local MetaTrader 5 terminal is attached (Windows-only,
     # broker feed); otherwise it reports unavailable and the chain proceeds.
     "forex":     ["mt5", "akshare", "yfinance", "local"],
+    # Taiwan is intentionally snapshot-only in Phase 01.
+    "taiwan_equity": ["tw_snapshot"],
 }
 
 

--- a/agent/backtest/runner.py
+++ b/agent/backtest/runner.py
@@ -528,6 +528,7 @@ def _validate_signal_engine_class(engine_cls) -> None:
 
 # Back-compat: market type -> legacy source name (for engine selection & metrics)
 _MARKET_TO_SOURCE = {
+    "taiwan_equity": "tw_snapshot",
     "a_share": "tushare",
     "us_equity": "yfinance",
     "hk_equity": "yfinance",
@@ -541,7 +542,7 @@ _MARKET_TO_SOURCE = {
 }
 
 
-def _detect_source(code: str) -> str:
+def _detect_source(code: str, market_hint: str | None = None) -> str:
     """Infer legacy source name from symbol (back-compat for metrics/engine).
 
     Args:
@@ -550,11 +551,11 @@ def _detect_source(code: str) -> str:
     Returns:
         Source name (tushare/okx/yfinance/akshare).
     """
-    market = _detect_market(code)
+    market = _detect_market(code, market_hint=market_hint)
     return _MARKET_TO_SOURCE.get(market, "tushare")
 
 
-def _group_codes_by_market(codes: List[str]) -> Dict[str, List[str]]:
+def _group_codes_by_market(codes: List[str], market_hint: str | None = None) -> Dict[str, List[str]]:
     """Group symbols by detected market type.
 
     Args:
@@ -565,12 +566,12 @@ def _group_codes_by_market(codes: List[str]) -> Dict[str, List[str]]:
     """
     groups: Dict[str, List[str]] = {}
     for code in codes:
-        market = _detect_market(code)
+        market = _detect_market(code, market_hint=market_hint)
         groups.setdefault(market, []).append(code)
     return groups
 
 
-def _group_codes_by_source(codes: List[str]) -> Dict[str, List[str]]:
+def _group_codes_by_source(codes: List[str], market_hint: str | None = None) -> Dict[str, List[str]]:
     """Group symbols by inferred source (back-compat).
 
     Args:
@@ -581,7 +582,7 @@ def _group_codes_by_source(codes: List[str]) -> Dict[str, List[str]]:
     """
     groups: Dict[str, List[str]] = {}
     for code in codes:
-        src = _detect_source(code)
+        src = _detect_source(code, market_hint=market_hint)
         groups.setdefault(src, []).append(code)
     return groups
 
@@ -598,13 +599,17 @@ def _get_loader(source: str):
     try:
         return get_loader_cls_with_fallback(source)
     except NoAvailableSourceError:
+        if source in {"local", "qveris", "tw_snapshot"}:
+            raise
         # Ultimate fallback for unknown sources
         if "tushare" in LOADER_REGISTRY:
             return LOADER_REGISTRY["tushare"]
         raise
 
 
-def _normalize_codes(codes: List[str], source: str) -> List[str]:
+def _normalize_codes(
+    codes: List[str], source: str, market_hint: str | None = None,
+) -> List[str]:
     """Normalize symbol strings for a source.
 
     Args:
@@ -616,6 +621,10 @@ def _normalize_codes(codes: List[str], source: str) -> List[str]:
     """
     if source in ("okx", "ccxt"):
         return [c.replace("/", "-").upper() for c in codes]
+    if source == "tw_snapshot":
+        from src.tw_quant.market.symbols import parse_symbol
+
+        return [parse_symbol(code, market_hint=market_hint).canonical for code in codes]
     return codes
 
 
@@ -955,7 +964,7 @@ def main(run_dir: Path) -> None:
     signal_engine = engine_cls()
 
     # Annualization bars
-    effective_source = _detect_primary_source(codes, source)
+    effective_source = _detect_primary_source(codes, source, market_hint=config.get("market"))
     from backtest.metrics import calc_bars_per_year
     # Cross-market: use calendar-day annualization (bars_per_year=None)
     market_types = {_detect_market(c) for c in codes}
@@ -993,7 +1002,18 @@ def _create_market_engine(source: str, config: dict, codes: List[str]):
         BaseEngine subclass instance.
     """
     # Detect dominant market type from codes
-    markets = {_detect_market(c) for c in codes} if codes else set()
+    markets = {
+        _detect_market(c, market_hint=config.get("market")) for c in codes
+    } if codes else set()
+
+    # Phase 01 deliberately has no Taiwan execution/rule engine. Failing
+    # closed here prevents a Taiwan snapshot from silently using CryptoEngine
+    # or an unrelated equity engine.
+    if "taiwan_equity" in markets:
+        raise ValueError(
+            "Taiwan execution engine is not implemented in Phase 01; "
+            "use the snapshot loader contract only"
+        )
 
     # Cross-market -> CompositeEngine
     if len(markets) > 1:
@@ -1054,7 +1074,9 @@ def _create_market_engine(source: str, config: dict, codes: List[str]):
         return CryptoEngine(config)
 
 
-def _detect_primary_source(codes: List[str], source: str) -> str:
+def _detect_primary_source(
+    codes: List[str], source: str, market_hint: str | None = None,
+) -> str:
     """Pick primary source for annualization (e.g. bars per year).
 
     Args:
@@ -1066,7 +1088,7 @@ def _detect_primary_source(codes: List[str], source: str) -> str:
     """
     if source != "auto":
         return source
-    groups = _group_codes_by_source(codes)
+    groups = _group_codes_by_source(codes, market_hint=market_hint)
     if len(groups) == 1:
         return list(groups.keys())[0]
     # Mixed: use the source with the most symbols
@@ -1089,7 +1111,7 @@ def _fetch_auto(codes: List[str], config: dict, interval: str = "1D") -> dict:
     Returns:
         Merged ``code -> DataFrame`` map.
     """
-    market_groups = _group_codes_by_market(codes)
+    market_groups = _group_codes_by_market(codes, market_hint=config.get("market"))
     merged = {}
     served_by: set[str] = set()
     start_date = config.get("start_date", "")
@@ -1106,7 +1128,9 @@ def _fetch_auto(codes: List[str], config: dict, interval: str = "1D") -> dict:
             loader = LoaderCls()
 
         src_name = getattr(loader, "name", "unknown")
-        normalized_codes = _normalize_codes(market_codes, src_name)
+        normalized_codes = _normalize_codes(
+            market_codes, src_name, market_hint=config.get("market")
+        )
         fields = config.get("extra_fields") if src_name == "tushare" else None
         result = loader.fetch(
             normalized_codes,
@@ -1132,7 +1156,9 @@ def _fetch_auto(codes: List[str], config: dict, interval: str = "1D") -> dict:
             fb_loader = LOADER_REGISTRY[fb_name]()
             if not fb_loader.is_available():
                 continue
-            fb_codes = _normalize_codes(missing, fb_name)
+            fb_codes = _normalize_codes(
+                missing, fb_name, market_hint=config.get("market")
+            )
             fallback_result = fb_loader.fetch(
                 fb_codes, start_date, end_date, interval=interval
             )
@@ -1171,6 +1197,7 @@ def fetch_data_map(config: dict) -> DataFetchResult:
     source = str(config.get("source") or "tushare")
     codes = list(config.get("codes") or [])
     interval = str(config.get("interval") or "1D")
+    market_hint = config.get("market")
 
     if source == "auto":
         data_map = _fetch_auto(codes, config, interval)
@@ -1182,7 +1209,7 @@ def fetch_data_map(config: dict) -> DataFetchResult:
             str(name) for name in recorded or [] if str(name).strip()
         ] or sorted(_group_codes_by_source(codes))
     else:
-        codes = _normalize_codes(codes, source)
+        codes = _normalize_codes(codes, source, market_hint=market_hint)
         primary_source = source
         loader = _get_loader(source)()
         # ``_get_loader`` may hand back a *different* loader when the requested
@@ -1227,7 +1254,9 @@ def fetch_data_map(config: dict) -> DataFetchResult:
                 fallback_loader = LOADER_REGISTRY[fallback_source]()
                 if not fallback_loader.is_available():
                     continue
-                fallback_codes = _normalize_codes(missing, fallback_source)
+                fallback_codes = _normalize_codes(
+                    missing, fallback_source, market_hint=market_hint
+                )
                 fallback_result = fallback_loader.fetch(
                     fallback_codes,
                     config.get("start_date", ""),

--- a/agent/src/config/accessor.py
+++ b/agent/src/config/accessor.py
@@ -22,7 +22,13 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from src.config.env_schema import EnvConfig
 
-__all__ = ["get_env_config", "reset_env_config", "_parse_bool", "get_env_or"]
+__all__ = [
+    "get_env_config",
+    "reset_env_config",
+    "_parse_bool",
+    "get_env_or",
+    "get_env_value",
+]
 
 # ---------------------------------------------------------------------------
 # Module-level singleton state
@@ -130,3 +136,14 @@ def get_env_or(primary: str, fallback: str, default: str = "") -> str:
     if value:
         return value
     return default
+
+
+def get_env_value(name: str, default: str = "") -> str:
+    """Read one environment variable through the central config layer.
+
+    This is the non-alias counterpart to :func:`get_env_or`.  Extension
+    modules can use it for their own settings without reading ``os.environ``
+    directly outside ``src/config/``.
+    """
+    value = os.getenv(name)
+    return value if value else default

--- a/agent/src/tw_quant/__init__.py
+++ b/agent/src/tw_quant/__init__.py
@@ -1,0 +1,6 @@
+"""Offline Taiwan quantitative research extension (Phase 01)."""
+
+from src.tw_quant.data.loader import TaiwanSnapshotLoader
+from src.tw_quant.market.symbols import CanonicalSymbol, parse_symbol
+
+__all__ = ["CanonicalSymbol", "TaiwanSnapshotLoader", "parse_symbol"]

--- a/agent/src/tw_quant/cli.py
+++ b/agent/src/tw_quant/cli.py
@@ -1,0 +1,93 @@
+"""Offline ``tw-data`` command for the Phase 01 data foundation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from src.tw_quant.config import db_path as default_db_path, snapshot_root as default_snapshot_root
+from src.tw_quant.data.importers import import_dataset
+from src.tw_quant.data.snapshots import create_snapshot
+from src.tw_quant.data.verifier import verify_snapshot
+from src.tw_quant.db.migrations import migrate
+
+
+def _path(value: str | None, fallback: Path) -> Path:
+    return Path(value).expanduser() if value else fallback
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="tw-data", description="Offline Taiwan research data foundation")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    migrate_parser = subparsers.add_parser("migrate", help="apply DuckDB schema migrations")
+    migrate_parser.add_argument("--db-path")
+
+    import_parser = subparsers.add_parser("import", help="validate or append CSV/Parquet data")
+    import_parser.add_argument("--dataset", required=True)
+    import_parser.add_argument("--input", required=True)
+    import_parser.add_argument("--source", required=True)
+    import_parser.add_argument("--source-dataset", required=True)
+    import_parser.add_argument("--schema-version", type=int, default=1)
+    import_parser.add_argument("--revision-id")
+    import_parser.add_argument("--mode", choices=("validate_only", "append"), default="validate_only")
+    import_parser.add_argument("--db-path")
+
+    snapshot_parser = subparsers.add_parser("snapshot", help="create or verify immutable snapshots")
+    snapshot_subparsers = snapshot_parser.add_subparsers(dest="snapshot_command", required=True)
+
+    create_parser = snapshot_subparsers.add_parser("create", help="build and seal a snapshot")
+    create_parser.add_argument("--db-path")
+    create_parser.add_argument("--snapshot-root")
+    create_parser.add_argument("--snapshot-id")
+    create_parser.add_argument("--start")
+    create_parser.add_argument("--end")
+    create_parser.add_argument("--repo-root")
+
+    verify_parser = snapshot_subparsers.add_parser("verify", help="verify a snapshot")
+    verify_parser.add_argument("snapshot_id")
+    verify_parser.add_argument("--snapshot-root")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.command == "migrate":
+            result: Any = migrate(_path(args.db_path, default_db_path()))
+        elif args.command == "import":
+            result = import_dataset(
+                args.input,
+                args.dataset,
+                source=args.source,
+                source_dataset=args.source_dataset,
+                schema_version=args.schema_version,
+                revision_id=args.revision_id,
+                mode=args.mode,
+                db_path=_path(args.db_path, default_db_path()) if args.mode == "append" else None,
+            ).to_dict()
+        elif args.snapshot_command == "create":
+            result = create_snapshot(
+                _path(args.db_path, default_db_path()),
+                snapshot_root=_path(args.snapshot_root, default_snapshot_root()),
+                snapshot_id=args.snapshot_id,
+                start=args.start,
+                end=args.end,
+                repo_root=args.repo_root,
+            )
+        else:
+            result = verify_snapshot(
+                args.snapshot_id,
+                _path(args.snapshot_root, default_snapshot_root()),
+            ).to_dict()
+        print(json.dumps(result, ensure_ascii=False, indent=2, default=str))
+        return 0 if result.get("ok", True) else 1
+    except Exception as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}, ensure_ascii=False))
+        return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/agent/src/tw_quant/config.py
+++ b/agent/src/tw_quant/config.py
@@ -1,0 +1,73 @@
+"""Configuration and path-safety helpers for the Taiwan extension."""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+
+class PathSafetyError(ValueError):
+    """Raised when a configured path escapes its permitted root."""
+
+
+_SAFE_SNAPSHOT_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+def data_root() -> Path:
+    """Return the configured state root, without creating it."""
+    configured = os.getenv("TW_QUANT_DATA_ROOT", "").strip()
+    if configured:
+        return Path(configured).expanduser().resolve(strict=False)
+    return (Path.home() / ".vibe-trading" / "tw-quant").resolve(strict=False)
+
+
+def _resolve_configured_path(value: str, *, base: Path) -> Path:
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        path = base / path
+    return path.resolve(strict=False)
+
+
+def db_path() -> Path:
+    """Return the configured DuckDB path, relative to ``data_root`` if needed."""
+    configured = os.getenv("TW_QUANT_DB_PATH", "").strip()
+    return _resolve_configured_path(configured, base=data_root()) if configured else data_root() / "tw_quant.duckdb"
+
+
+def snapshot_root() -> Path:
+    """Return the configured immutable snapshot root."""
+    configured = os.getenv("TW_QUANT_SNAPSHOT_ROOT", "").strip()
+    return _resolve_configured_path(configured, base=data_root()) if configured else data_root() / "snapshots"
+
+
+def ensure_within_root(path: Path, root: Path, *, allow_missing: bool = True) -> Path:
+    """Resolve *path* and reject traversal or symlink escape from *root*.
+
+    ``Path.resolve(strict=False)`` resolves existing symlinks while retaining
+    missing suffixes, which gives the same check for both new and existing
+    snapshot paths.
+    """
+    root_resolved = root.expanduser().resolve(strict=False)
+    path_resolved = path.expanduser().resolve(strict=False)
+    try:
+        path_resolved.relative_to(root_resolved)
+    except ValueError as exc:
+        raise PathSafetyError(f"path escapes allowed root: {path}") from exc
+    if not allow_missing and not path_resolved.exists():
+        raise FileNotFoundError(path_resolved)
+    return path_resolved
+
+
+def ensure_data_path(path: Path, *, allow_missing: bool = True) -> Path:
+    """Validate a state path against the configured data root."""
+    return ensure_within_root(path, data_root(), allow_missing=allow_missing)
+
+
+def ensure_snapshot_id(snapshot_id: str) -> str:
+    """Validate a snapshot identifier as a single safe path segment."""
+    value = str(snapshot_id).strip()
+    if not value or not _SAFE_SNAPSHOT_ID.fullmatch(value) or value in {".", ".."}:
+        raise PathSafetyError(f"invalid snapshot_id: {snapshot_id!r}")
+    return value
+

--- a/agent/src/tw_quant/config.py
+++ b/agent/src/tw_quant/config.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-import os
 import re
 from pathlib import Path
+
+from src.config.accessor import get_env_value
 
 
 class PathSafetyError(ValueError):
@@ -16,7 +17,7 @@ _SAFE_SNAPSHOT_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 def data_root() -> Path:
     """Return the configured state root, without creating it."""
-    configured = os.getenv("TW_QUANT_DATA_ROOT", "").strip()
+    configured = get_env_value("TW_QUANT_DATA_ROOT").strip()
     if configured:
         return Path(configured).expanduser().resolve(strict=False)
     return (Path.home() / ".vibe-trading" / "tw-quant").resolve(strict=False)
@@ -31,13 +32,13 @@ def _resolve_configured_path(value: str, *, base: Path) -> Path:
 
 def db_path() -> Path:
     """Return the configured DuckDB path, relative to ``data_root`` if needed."""
-    configured = os.getenv("TW_QUANT_DB_PATH", "").strip()
+    configured = get_env_value("TW_QUANT_DB_PATH").strip()
     return _resolve_configured_path(configured, base=data_root()) if configured else data_root() / "tw_quant.duckdb"
 
 
 def snapshot_root() -> Path:
     """Return the configured immutable snapshot root."""
-    configured = os.getenv("TW_QUANT_SNAPSHOT_ROOT", "").strip()
+    configured = get_env_value("TW_QUANT_SNAPSHOT_ROOT").strip()
     return _resolve_configured_path(configured, base=data_root()) if configured else data_root() / "snapshots"
 
 
@@ -70,4 +71,3 @@ def ensure_snapshot_id(snapshot_id: str) -> str:
     if not value or not _SAFE_SNAPSHOT_ID.fullmatch(value) or value in {".", ".."}:
         raise PathSafetyError(f"invalid snapshot_id: {snapshot_id!r}")
     return value
-

--- a/agent/src/tw_quant/data/__init__.py
+++ b/agent/src/tw_quant/data/__init__.py
@@ -1,0 +1,8 @@
+"""Data contracts for offline Taiwan research artifacts."""
+
+from src.tw_quant.data.importers import ImportResult, import_dataset
+from src.tw_quant.data.loader import TaiwanSnapshotLoader
+from src.tw_quant.data.snapshots import create_snapshot
+from src.tw_quant.data.verifier import verify_snapshot
+
+__all__ = ["ImportResult", "TaiwanSnapshotLoader", "create_snapshot", "import_dataset", "verify_snapshot"]

--- a/agent/src/tw_quant/data/importers.py
+++ b/agent/src/tw_quant/data/importers.py
@@ -1,0 +1,367 @@
+"""Provider-neutral CSV/Parquet validation and transactional import."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from src.tw_quant.data.schemas import DatasetSchema, schema_for, table_columns
+from src.tw_quant.db.connection import connect_database
+from src.tw_quant.db.migrations import migrate
+from src.tw_quant.market.symbols import SymbolParseError, parse_symbol
+
+
+_TIMESTAMP_COLUMNS = {
+    "listed_at", "delisted_at", "effective_at", "available_at", "ingested_at",
+    "announced_at",
+}
+_DATE_COLUMNS = {"trade_date", "revenue_month"}
+_NUMERIC_COLUMNS = {
+    "open", "high", "low", "close", "volume", "turnover", "trades",
+    "reference_price", "price_limit_up", "price_limit_down", "adjustment_factor",
+    "revenue", "revenue_yoy", "revenue_mom",
+}
+_BOOLEAN_COLUMNS = {"is_suspended", "is_disposition", "is_full_delivery"}
+_FILLABLE_COLUMNS = {"source", "source_dataset", "revision_id", "ingested_at"}
+
+
+@dataclass(frozen=True)
+class ValidationReport:
+    dataset: str
+    rows: int
+    errors: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "dataset": self.dataset,
+            "rows": self.rows,
+            "ok": self.ok,
+            "errors": list(self.errors),
+            "warnings": list(self.warnings),
+        }
+
+
+@dataclass(frozen=True)
+class ImportResult:
+    report: ValidationReport
+    mode: str
+    inserted_rows: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = self.report.to_dict()
+        payload.update({"mode": self.mode, "inserted_rows": self.inserted_rows})
+        return payload
+
+
+def _sql_literal(path: Path) -> str:
+    return "'" + str(path).replace("'", "''") + "'"
+
+
+def read_input(path: str | Path) -> pd.DataFrame:
+    """Read CSV or Parquet without heuristic column mapping."""
+    input_path = Path(path).expanduser().resolve(strict=True)
+    suffix = input_path.suffix.lower()
+    if suffix == ".csv":
+        return pd.read_csv(input_path)
+    if suffix in {".parquet", ".pq"}:
+        import duckdb
+
+        conn = duckdb.connect(database=":memory:")
+        try:
+            return conn.execute(f"SELECT * FROM read_parquet({_sql_literal(input_path)})").df()
+        finally:
+            conn.close()
+    raise ValueError(f"unsupported import file type: {input_path.suffix!r}; use CSV or Parquet")
+
+
+def _nonempty(value: Any) -> bool:
+    return value is not None and str(value).strip() != "" and not pd.isna(value)
+
+
+def _canonical_timestamp(value: Any, column: str) -> pd.Timestamp | None:
+    if value is None or (isinstance(value, float) and math.isnan(value)) or pd.isna(value):
+        return None
+    parsed = pd.to_datetime(value, errors="coerce", utc=True)
+    if pd.isna(parsed):
+        raise ValueError(f"invalid timestamp in {column}: {value!r}")
+    return pd.Timestamp(parsed)
+
+
+def _canonical_date(value: Any, column: str) -> date:
+    parsed = _canonical_timestamp(value, column)
+    if parsed is None:
+        raise ValueError(f"missing date in {column}")
+    return parsed.date()
+
+
+def _canonical_bool(value: Any, column: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None or pd.isna(value):
+        raise ValueError(f"missing boolean in {column}")
+    if isinstance(value, (int, float)) and value in {0, 1}:
+        return bool(value)
+    normalized = str(value).strip().lower()
+    if normalized in {"true", "1"}:
+        return True
+    if normalized in {"false", "0"}:
+        return False
+    raise ValueError(f"invalid boolean in {column}: {value!r}")
+
+
+def _canonical_json(value: Any) -> str | None:
+    if value is None or (isinstance(value, float) and math.isnan(value)) or pd.isna(value):
+        return None
+    if isinstance(value, str):
+        parsed = json.loads(value)
+    else:
+        parsed = value
+    return json.dumps(parsed, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _normal_for_hash(value: Any) -> Any:
+    if value is None or (isinstance(value, float) and math.isnan(value)):
+        return None
+    if isinstance(value, pd.Timestamp):
+        value = value.tz_convert("UTC") if value.tzinfo is not None else value.tz_localize("UTC")
+        return value.isoformat()
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, float):
+        return format(value, ".15g")
+    return str(value)
+
+
+def stable_row_hash(row: dict[str, Any]) -> str:
+    """Hash canonical row content, excluding operational hash/time fields."""
+    payload = {
+        key: _normal_for_hash(value)
+        for key, value in row.items()
+        if key not in {"row_hash", "ingested_at"}
+    }
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _prepare_frame(
+    frame: pd.DataFrame,
+    schema: DatasetSchema,
+    *,
+    source: str,
+    source_dataset: str,
+    revision_id: str | None,
+    ingested_at: str | None,
+) -> tuple[pd.DataFrame | None, ValidationReport]:
+    errors: list[str] = []
+    if not isinstance(frame, pd.DataFrame):
+        return None, ValidationReport(schema.name, 0, ("input is not a DataFrame",))
+
+    columns = {str(column).strip() for column in frame.columns}
+    frame = frame.rename(columns={column: str(column).strip() for column in frame.columns})
+    missing = set(schema.required_columns) - columns
+    missing -= _FILLABLE_COLUMNS
+    unknown = columns - set(schema.columns)
+    if missing:
+        errors.append(f"missing required columns: {sorted(missing)}")
+    if unknown:
+        errors.append(f"unknown columns are not accepted: {sorted(unknown)}")
+    if errors:
+        return None, ValidationReport(schema.name, len(frame), tuple(errors))
+
+    df = frame.copy()
+    if "source" not in df:
+        df["source"] = source
+    if "source_dataset" not in df:
+        df["source_dataset"] = source_dataset
+    if "revision_id" not in df:
+        if not revision_id:
+            digest = hashlib.sha256(repr(sorted(df.columns)).encode("utf-8")).hexdigest()[:12]
+            revision_id = f"import-{digest}"
+        df["revision_id"] = revision_id
+    if "ingested_at" in schema.columns and "ingested_at" not in df:
+        df["ingested_at"] = ingested_at or datetime.now(timezone.utc).isoformat()
+
+    for column in ("source", "source_dataset", "revision_id"):
+        if column in df and not all(_nonempty(value) for value in df[column]):
+            errors.append(f"{column} must not be empty")
+
+    canonical_symbols: list[str] = []
+    for value in df["symbol"]:
+        try:
+            canonical_symbols.append(parse_symbol(str(value)).canonical)
+        except SymbolParseError as exc:
+            errors.append(str(exc))
+            canonical_symbols.append(str(value).strip().upper())
+    df["symbol"] = canonical_symbols
+
+    if schema.name == "security_master":
+        for index, row in df.iterrows():
+            try:
+                parsed = parse_symbol(row["symbol"])
+                if str(row["local_code"]).strip() != parsed.local_code:
+                    errors.append(f"row {index}: local_code does not match symbol")
+                if str(row["market"]).strip().upper() != parsed.market:
+                    errors.append(f"row {index}: market does not match symbol")
+            except SymbolParseError:
+                pass
+
+    for column in _TIMESTAMP_COLUMNS & set(df.columns):
+        values: list[pd.Timestamp | None] = []
+        for value in df[column]:
+            try:
+                values.append(_canonical_timestamp(value, column))
+            except ValueError as exc:
+                errors.append(str(exc))
+                values.append(None)
+        df[column] = values
+        if column == "available_at" and any(value is None for value in values):
+            errors.append("available_at must not be empty")
+
+    for column in _DATE_COLUMNS & set(df.columns):
+        values: list[date] = []
+        for value in df[column]:
+            try:
+                values.append(_canonical_date(value, column))
+            except ValueError as exc:
+                errors.append(str(exc))
+                values.append(date(1970, 1, 1))
+        df[column] = values
+
+    for column in _NUMERIC_COLUMNS & set(df.columns):
+        converted = pd.to_numeric(df[column], errors="coerce")
+        if converted.isna().any() or not converted.map(math.isfinite).all():
+            errors.append(f"{column} contains missing or non-finite values")
+        df[column] = converted.astype("float64")
+
+    for column in _BOOLEAN_COLUMNS & set(df.columns):
+        values: list[bool] = []
+        for value in df[column]:
+            try:
+                values.append(_canonical_bool(value, column))
+            except ValueError as exc:
+                errors.append(str(exc))
+                values.append(False)
+        df[column] = values
+
+    if "quality_flags" in df:
+        values: list[str | None] = []
+        for value in df["quality_flags"]:
+            try:
+                values.append(_canonical_json(value))
+            except (TypeError, ValueError, json.JSONDecodeError) as exc:
+                errors.append(f"quality_flags is not valid JSON: {exc}")
+                values.append(None)
+        df["quality_flags"] = values
+    else:
+        df["quality_flags"] = None
+
+    if schema.name == "daily_price":
+        invalid_ohlc = (
+            (df["open"] <= 0) | (df["high"] <= 0) | (df["low"] <= 0) | (df["close"] <= 0)
+            | (df["high"] < df[["open", "close", "high"]].max(axis=1))
+            | (df["low"] > df[["open", "close", "low"]].min(axis=1))
+            | (df["high"] < df["low"])
+        )
+        if invalid_ohlc.any():
+            errors.append(f"{int(invalid_ohlc.sum())} daily_price row(s) violate OHLC invariants")
+        for column in ("volume", "turnover", "trades"):
+            if (df[column] < 0).any():
+                errors.append(f"{column} must not be negative")
+        if (df["adjustment_factor"] <= 0).any():
+            errors.append("adjustment_factor must be positive")
+    if schema.name == "monthly_revenue" and (df["revenue"] < 0).any():
+        errors.append("revenue must not be negative")
+
+    if df.duplicated(list(schema.business_key), keep=False).any():
+        errors.append(f"duplicate business key/revision in {schema.name}")
+
+    df["row_hash"] = [stable_row_hash(row.to_dict()) for _, row in df.iterrows()]
+    df = df.reindex(columns=table_columns(schema.name))
+    return df, ValidationReport(schema.name, len(df), tuple(dict.fromkeys(errors)))
+
+
+def validate_dataset(
+    frame: pd.DataFrame,
+    dataset: str,
+    *,
+    source: str,
+    source_dataset: str,
+    revision_id: str | None = None,
+    ingested_at: str | None = None,
+) -> tuple[pd.DataFrame | None, ValidationReport]:
+    """Validate and canonicalize a provider-neutral dataset."""
+    schema = schema_for(dataset)
+    return _prepare_frame(
+        frame,
+        schema,
+        source=source,
+        source_dataset=source_dataset,
+        revision_id=revision_id,
+        ingested_at=ingested_at,
+    )
+
+
+def import_dataset(
+    input_path: str | Path,
+    dataset: str,
+    *,
+    source: str,
+    source_dataset: str,
+    schema_version: int = 1,
+    mode: str = "validate_only",
+    db_path: str | Path | None = None,
+    revision_id: str | None = None,
+    ingested_at: str | None = None,
+) -> ImportResult:
+    """Validate or transactionally append one complete input batch."""
+    if schema_version != 1:
+        raise ValueError(f"unsupported Taiwan schema_version: {schema_version}")
+    if mode not in {"validate_only", "append"}:
+        raise ValueError("mode must be validate_only or append")
+    frame = read_input(input_path)
+    canonical, report = validate_dataset(
+        frame,
+        dataset,
+        source=source,
+        source_dataset=source_dataset,
+        revision_id=revision_id,
+        ingested_at=ingested_at,
+    )
+    if not report.ok or mode == "validate_only":
+        return ImportResult(report=report, mode=mode, inserted_rows=0)
+    if db_path is None:
+        raise ValueError("db_path is required for append mode")
+
+    migrate(db_path)
+    conn = connect_database(db_path)
+    try:
+        conn.execute("BEGIN TRANSACTION")
+        view_name = "tw_quant_import_batch"
+        conn.register(view_name, canonical)
+        columns = ", ".join(table_columns(dataset))
+        conn.execute(f"INSERT INTO {dataset} ({columns}) SELECT {columns} FROM {view_name}")
+        conn.unregister(view_name)
+        conn.execute("COMMIT")
+    except Exception:
+        try:
+            conn.execute("ROLLBACK")
+        except Exception:
+            pass
+        raise
+    finally:
+        conn.close()
+    return ImportResult(report=report, mode=mode, inserted_rows=len(canonical))

--- a/agent/src/tw_quant/data/loader.py
+++ b/agent/src/tw_quant/data/loader.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from typing import Any
 
 import pandas as pd
 
 from backtest.loaders.registry import register
+from src.config.accessor import get_env_value
 from src.tw_quant.config import snapshot_root as default_snapshot_root
 from src.tw_quant.data.verifier import verify_snapshot
 from src.tw_quant.market.symbols import SymbolParseError, parse_symbol
@@ -35,8 +35,12 @@ class TaiwanSnapshotLoader:
     requires_auth = False
 
     def __init__(self, snapshot_id: str | None = None, snapshot_root: str | Path | None = None) -> None:
-        self.snapshot_id = snapshot_id or os.getenv("TW_QUANT_SNAPSHOT_ID", "").strip() or None
-        self.snapshot_root = Path(snapshot_root or os.getenv("TW_QUANT_SNAPSHOT_ROOT", "") or default_snapshot_root())
+        self.snapshot_id = snapshot_id or get_env_value("TW_QUANT_SNAPSHOT_ID").strip() or None
+        self.snapshot_root = Path(
+            snapshot_root
+            or get_env_value("TW_QUANT_SNAPSHOT_ROOT")
+            or default_snapshot_root()
+        )
         self._provenance: dict[str, Any] = {}
 
     @property

--- a/agent/src/tw_quant/data/loader.py
+++ b/agent/src/tw_quant/data/loader.py
@@ -1,0 +1,178 @@
+"""Snapshot-only Taiwan loader with an existing Vibe-Trading adapter."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from backtest.loaders.registry import register
+from src.tw_quant.config import snapshot_root as default_snapshot_root
+from src.tw_quant.data.verifier import verify_snapshot
+from src.tw_quant.market.symbols import SymbolParseError, parse_symbol
+
+
+class SnapshotLoadError(RuntimeError):
+    """Raised when a Taiwan snapshot cannot satisfy a load request."""
+
+
+class SnapshotRequiredError(SnapshotLoadError):
+    """Raised when a request does not identify an immutable snapshot."""
+
+
+def _sql_literal(value: str | Path) -> str:
+    return "'" + str(value).replace("'", "''") + "'"
+
+
+@register
+class TaiwanSnapshotLoader:
+    """Read daily Taiwan data only from a verified immutable snapshot."""
+
+    name = "tw_snapshot"
+    markets = {"taiwan_equity"}
+    requires_auth = False
+
+    def __init__(self, snapshot_id: str | None = None, snapshot_root: str | Path | None = None) -> None:
+        self.snapshot_id = snapshot_id or os.getenv("TW_QUANT_SNAPSHOT_ID", "").strip() or None
+        self.snapshot_root = Path(snapshot_root or os.getenv("TW_QUANT_SNAPSHOT_ROOT", "") or default_snapshot_root())
+        self._provenance: dict[str, Any] = {}
+
+    @property
+    def provenance(self) -> dict[str, Any]:
+        return dict(self._provenance)
+
+    def is_available(self) -> bool:
+        """Return True only when an explicit snapshot can be verified."""
+        if not self.snapshot_id:
+            return False
+        try:
+            report = verify_snapshot(self.snapshot_id, self.snapshot_root)
+        except Exception:
+            return False
+        return report.ok
+
+    def load(
+        self,
+        symbols: list[str],
+        start: str,
+        end: str,
+        fields: list[str] | None = None,
+        snapshot_id: str | None = None,
+        adjustment_mode: str = "raw",
+        *,
+        market_hint: str | None = None,
+    ) -> dict[str, pd.DataFrame]:
+        """Load daily bars from one verified snapshot, with no fallback."""
+        selected_snapshot = snapshot_id or self.snapshot_id
+        if not selected_snapshot:
+            raise SnapshotRequiredError("snapshot_id is required for Taiwan snapshot loads")
+        if adjustment_mode not in {"raw", "none"}:
+            raise SnapshotLoadError(
+                f"unsupported adjustment_mode {adjustment_mode!r}; Phase 01 supports raw only"
+            )
+        try:
+            start_date = pd.Timestamp(start).date()
+            end_date = pd.Timestamp(end).date()
+        except Exception as exc:
+            raise SnapshotLoadError(f"invalid Taiwan load date range: {start!r}, {end!r}") from exc
+        if start_date > end_date:
+            raise SnapshotLoadError(f"start date {start!r} is after end date {end!r}")
+
+        canonical: list[str] = []
+        for symbol in symbols:
+            try:
+                canonical.append(parse_symbol(symbol, market_hint=market_hint).canonical)
+            except SymbolParseError as exc:
+                raise SnapshotLoadError(str(exc)) from exc
+        if not canonical:
+            return {}
+
+        report = verify_snapshot(selected_snapshot, self.snapshot_root)
+        if not report.ok:
+            raise SnapshotLoadError(
+                f"snapshot verification failed for {selected_snapshot}: " + "; ".join(report.errors)
+            )
+        table = next((entry for entry in report.tables if entry.get("dataset") == "daily_price"), None)
+        if table is None:
+            raise SnapshotLoadError("verified snapshot does not contain daily_price")
+        data_path = (self.snapshot_root / selected_snapshot / table["path"]).resolve(strict=True)
+
+        allowed_fields = {
+            "open", "high", "low", "close", "volume", "turnover", "trades",
+            "reference_price", "price_limit_up", "price_limit_down", "is_suspended",
+            "is_disposition", "is_full_delivery", "adjustment_factor", "effective_at",
+            "available_at", "ingested_at", "source", "source_dataset", "revision_id",
+            "quality_flags", "row_hash",
+        }
+        selected_fields = list(fields or (
+            "open", "high", "low", "close", "volume", "turnover", "trades",
+            "reference_price", "price_limit_up", "price_limit_down", "is_suspended",
+            "is_disposition", "is_full_delivery", "adjustment_factor", "effective_at",
+            "available_at", "ingested_at", "source", "source_dataset", "revision_id",
+            "quality_flags", "row_hash",
+        ))
+        unknown = set(selected_fields) - allowed_fields
+        if unknown:
+            raise SnapshotLoadError(f"daily_price fields are unavailable: {sorted(unknown)}")
+        if not selected_fields:
+            raise SnapshotLoadError("at least one daily_price field is required")
+
+        import duckdb
+
+        placeholders = ", ".join("?" for _ in canonical)
+        select_fields = ", ".join(["symbol", "trade_date", *selected_fields])
+        sql = (
+            f"SELECT {select_fields} FROM read_parquet({_sql_literal(data_path)}) "
+            f"WHERE symbol IN ({placeholders}) "
+            f"AND trade_date >= DATE {_sql_literal(start_date.isoformat())} "
+            f"AND trade_date <= DATE {_sql_literal(end_date.isoformat())} "
+            "ORDER BY symbol, trade_date"
+        )
+        conn = duckdb.connect(database=":memory:")
+        try:
+            frame = conn.execute(sql, canonical).df()
+        finally:
+            conn.close()
+
+        result: dict[str, pd.DataFrame] = {}
+        if frame.empty:
+            raise SnapshotLoadError(
+                f"symbols are absent from snapshot or have no rows in requested date range "
+                f"for {canonical}: "
+                f"{start_date}..{end_date}"
+            )
+        frame["trade_date"] = pd.to_datetime(frame["trade_date"], utc=True).dt.tz_convert(None)
+        for symbol, group in frame.groupby("symbol", sort=False):
+            output = group.drop(columns=["symbol"]).set_index("trade_date").sort_index()
+            result[str(symbol)] = output
+        missing = [symbol for symbol in canonical if symbol not in result]
+        if missing:
+            raise SnapshotLoadError(f"symbols are absent from snapshot/date range: {missing}")
+        self.snapshot_id = selected_snapshot
+        self._provenance = {
+            "snapshot_id": selected_snapshot,
+            "table": "daily_price",
+            "table_sha256": table["sha256"],
+            "source_datasets": table.get("source_datasets", []),
+            "revision_ids": table.get("revision_ids", []),
+            "rule_profile": "TW_EQUITY_PHASE01_PLACEHOLDER",
+        }
+        return result
+
+    def fetch(
+        self,
+        codes: list[str],
+        start_date: str,
+        end_date: str,
+        *,
+        interval: str = "1D",
+        fields: list[str] | None = None,
+    ) -> dict[str, pd.DataFrame]:
+        """Adapt ``load`` to Vibe-Trading's canonical loader contract."""
+        if interval != "1D":
+            raise SnapshotLoadError(
+                f"Taiwan snapshot loader supports daily bars only in Phase 01, got {interval!r}"
+            )
+        return self.load(codes, start_date, end_date, fields=fields)

--- a/agent/src/tw_quant/data/loader.py
+++ b/agent/src/tw_quant/data/loader.py
@@ -106,7 +106,7 @@ class TaiwanSnapshotLoader:
             "available_at", "ingested_at", "source", "source_dataset", "revision_id",
             "quality_flags", "row_hash",
         }
-        selected_fields = list(fields or (
+        selected_fields = list(fields if fields is not None else (
             "open", "high", "low", "close", "volume", "turnover", "trades",
             "reference_price", "price_limit_up", "price_limit_down", "is_suspended",
             "is_disposition", "is_full_delivery", "adjustment_factor", "effective_at",

--- a/agent/src/tw_quant/data/manifest.py
+++ b/agent/src/tw_quant/data/manifest.py
@@ -1,0 +1,32 @@
+"""Manifest serialization and content-hash helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def read_manifest(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("snapshot manifest must be a JSON object")
+    return payload
+

--- a/agent/src/tw_quant/data/schemas.py
+++ b/agent/src/tw_quant/data/schemas.py
@@ -1,0 +1,143 @@
+"""Canonical Phase 01 table schemas and DuckDB definitions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DatasetSchema:
+    name: str
+    required_columns: tuple[str, ...]
+    optional_columns: tuple[str, ...] = ()
+    business_key: tuple[str, ...] = ()
+    event_column: str | None = None
+
+    @property
+    def columns(self) -> tuple[str, ...]:
+        return self.required_columns + self.optional_columns
+
+
+DATASET_SCHEMAS: dict[str, DatasetSchema] = {
+    "security_master": DatasetSchema(
+        name="security_master",
+        required_columns=(
+            "symbol", "local_code", "market", "security_type", "name",
+            "listed_at", "delisted_at", "industry_code", "effective_at",
+            "available_at", "source", "source_dataset", "revision_id",
+        ),
+        optional_columns=("quality_flags", "row_hash"),
+        business_key=("symbol", "effective_at", "revision_id"),
+        event_column="effective_at",
+    ),
+    "daily_price": DatasetSchema(
+        name="daily_price",
+        required_columns=(
+            "symbol", "trade_date", "open", "high", "low", "close",
+            "volume", "turnover", "trades", "reference_price",
+            "price_limit_up", "price_limit_down", "is_suspended",
+            "is_disposition", "is_full_delivery", "adjustment_factor",
+            "effective_at", "available_at", "ingested_at", "source",
+            "source_dataset", "revision_id",
+        ),
+        optional_columns=("quality_flags", "row_hash"),
+        business_key=("symbol", "trade_date", "revision_id"),
+        event_column="trade_date",
+    ),
+    "monthly_revenue": DatasetSchema(
+        name="monthly_revenue",
+        required_columns=(
+            "symbol", "revenue_month", "revenue", "revenue_yoy", "revenue_mom",
+            "announced_at", "effective_at", "available_at", "ingested_at",
+            "source", "source_dataset", "revision_id",
+        ),
+        optional_columns=("quality_flags", "row_hash"),
+        business_key=("symbol", "revenue_month", "revision_id"),
+        event_column="revenue_month",
+    ),
+}
+
+
+TABLE_DDL: dict[str, str] = {
+    "security_master": """
+        CREATE TABLE IF NOT EXISTS security_master (
+            symbol VARCHAR NOT NULL,
+            local_code VARCHAR NOT NULL,
+            market VARCHAR NOT NULL,
+            security_type VARCHAR NOT NULL,
+            name VARCHAR NOT NULL,
+            listed_at TIMESTAMPTZ,
+            delisted_at TIMESTAMPTZ,
+            industry_code VARCHAR NOT NULL,
+            effective_at TIMESTAMPTZ NOT NULL,
+            available_at TIMESTAMPTZ NOT NULL,
+            source VARCHAR NOT NULL,
+            source_dataset VARCHAR NOT NULL,
+            revision_id VARCHAR NOT NULL,
+            quality_flags VARCHAR,
+            row_hash VARCHAR NOT NULL,
+            UNIQUE(symbol, effective_at, revision_id)
+        )
+    """,
+    "daily_price": """
+        CREATE TABLE IF NOT EXISTS daily_price (
+            symbol VARCHAR NOT NULL,
+            trade_date DATE NOT NULL,
+            open DOUBLE NOT NULL,
+            high DOUBLE NOT NULL,
+            low DOUBLE NOT NULL,
+            close DOUBLE NOT NULL,
+            volume DOUBLE NOT NULL,
+            turnover DOUBLE NOT NULL,
+            trades DOUBLE NOT NULL,
+            reference_price DOUBLE NOT NULL,
+            price_limit_up DOUBLE NOT NULL,
+            price_limit_down DOUBLE NOT NULL,
+            is_suspended BOOLEAN NOT NULL,
+            is_disposition BOOLEAN NOT NULL,
+            is_full_delivery BOOLEAN NOT NULL,
+            adjustment_factor DOUBLE NOT NULL,
+            effective_at TIMESTAMPTZ NOT NULL,
+            available_at TIMESTAMPTZ NOT NULL,
+            ingested_at TIMESTAMPTZ NOT NULL,
+            source VARCHAR NOT NULL,
+            source_dataset VARCHAR NOT NULL,
+            revision_id VARCHAR NOT NULL,
+            quality_flags VARCHAR,
+            row_hash VARCHAR NOT NULL,
+            UNIQUE(symbol, trade_date, revision_id)
+        )
+    """,
+    "monthly_revenue": """
+        CREATE TABLE IF NOT EXISTS monthly_revenue (
+            symbol VARCHAR NOT NULL,
+            revenue_month DATE NOT NULL,
+            revenue DOUBLE NOT NULL,
+            revenue_yoy DOUBLE NOT NULL,
+            revenue_mom DOUBLE NOT NULL,
+            announced_at TIMESTAMPTZ,
+            effective_at TIMESTAMPTZ NOT NULL,
+            available_at TIMESTAMPTZ NOT NULL,
+            ingested_at TIMESTAMPTZ NOT NULL,
+            source VARCHAR NOT NULL,
+            source_dataset VARCHAR NOT NULL,
+            revision_id VARCHAR NOT NULL,
+            quality_flags VARCHAR,
+            row_hash VARCHAR NOT NULL,
+            UNIQUE(symbol, revenue_month, revision_id)
+        )
+    """,
+}
+
+
+def schema_for(dataset: str) -> DatasetSchema:
+    try:
+        return DATASET_SCHEMAS[dataset]
+    except KeyError as exc:
+        raise ValueError(f"unsupported Taiwan dataset: {dataset!r}") from exc
+
+
+def table_columns(dataset: str) -> tuple[str, ...]:
+    """Return the physical column order used by DuckDB and Parquet."""
+    return schema_for(dataset).columns
+

--- a/agent/src/tw_quant/data/snapshots.py
+++ b/agent/src/tw_quant/data/snapshots.py
@@ -1,0 +1,147 @@
+"""Immutable DuckDB-to-Parquet snapshot builder."""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import subprocess
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from src.tw_quant.config import ensure_snapshot_id, ensure_within_root, snapshot_root as default_snapshot_root
+from src.tw_quant.data.manifest import sha256_file, write_json
+from src.tw_quant.data.schemas import schema_for
+from src.tw_quant.data.verifier import verify_snapshot
+from src.tw_quant.db.connection import connect_database
+from src.tw_quant.db.migrations import migrate
+
+
+def _sql_literal(value: str | Path) -> str:
+    return "'" + str(value).replace("'", "''") + "'"
+
+
+def _git_provenance(repo_root: str | Path | None) -> tuple[str, bool]:
+    cwd = Path(repo_root or Path.cwd())
+    try:
+        commit = subprocess.run(
+            ["git", "-C", str(cwd), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        dirty = subprocess.run(
+            ["git", "-C", str(cwd), "diff", "--quiet"],
+            check=False,
+        ).returncode != 0
+        return commit or "unknown", dirty
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown", True
+
+
+def _source_metadata(conn: Any, dataset: str) -> dict[str, Any]:
+    rows = conn.execute(
+        f"SELECT DISTINCT source, source_dataset, revision_id FROM {dataset} "
+        "ORDER BY source, source_dataset, revision_id"
+    ).fetchall()
+    return {
+        "sources": sorted({str(row[0]) for row in rows}),
+        "datasets": sorted({str(row[1]) for row in rows}),
+        "revisions": sorted({str(row[2]) for row in rows}),
+    }
+
+
+def create_snapshot(
+    db_path: str | Path,
+    *,
+    snapshot_root: str | Path | None = None,
+    snapshot_id: str | None = None,
+    start: str | None = None,
+    end: str | None = None,
+    repo_root: str | Path | None = None,
+) -> dict[str, Any]:
+    """Create, verify, and atomically seal an immutable snapshot."""
+    migrate(db_path)
+    root = Path(snapshot_root or default_snapshot_root()).expanduser().resolve(strict=False)
+    root.mkdir(parents=True, exist_ok=True)
+    root = root.resolve(strict=True)
+    staging = ensure_within_root(root / f".staging-{uuid.uuid4().hex}", root)
+    created_at = datetime.now(timezone.utc)
+    code_commit, dirty = _git_provenance(repo_root)
+    conn = connect_database(db_path, read_only=True)
+    try:
+        staging.mkdir(parents=True, exist_ok=False)
+        data_dir = staging / "data"
+        data_dir.mkdir()
+        tables: dict[str, dict[str, Any]] = {}
+        for dataset in ("security_master", "daily_price", "monthly_revenue"):
+            schema = schema_for(dataset)
+            output = data_dir / f"{dataset}.parquet"
+            predicates: list[str] = []
+            if start:
+                start_value = pd.Timestamp(start).date().isoformat()
+                predicates.append(f"{schema.event_column} >= DATE {_sql_literal(start_value)}")
+            if end:
+                end_value = pd.Timestamp(end).date().isoformat()
+                predicates.append(f"{schema.event_column} <= DATE {_sql_literal(end_value)}")
+            where = f" WHERE {' AND '.join(predicates)}" if predicates else ""
+            conn.execute(
+                f"COPY (SELECT * FROM {dataset}{where}) TO {_sql_literal(output)} "
+                "(FORMAT PARQUET, COMPRESSION ZSTD)"
+            )
+            count, min_time, max_time = conn.execute(
+                f"SELECT COUNT(*), MIN({schema.event_column}), MAX({schema.event_column}) FROM {dataset}{where}"
+            ).fetchone()
+            source_meta = _source_metadata(conn, dataset)
+            tables[dataset] = {
+                "path": f"data/{dataset}.parquet",
+                "rows": int(count),
+                "sha256": sha256_file(output),
+                "min_event_time": str(min_time) if min_time is not None else None,
+                "max_event_time": str(max_time) if max_time is not None else None,
+                "sources": source_meta["sources"],
+                "source_datasets": source_meta["datasets"],
+                "revision_ids": source_meta["revisions"],
+            }
+
+        quality = {
+            "status": "ok",
+            "tables": {name: {"rows": entry["rows"], "errors": []} for name, entry in tables.items()},
+        }
+        write_json(staging / "quality.json", quality)
+        content_hash = hashlib.sha256(
+            "".join(tables[name]["sha256"] for name in sorted(tables)).encode("ascii")
+        ).hexdigest()[:12]
+        final_id = ensure_snapshot_id(snapshot_id or f"twq-{created_at.strftime('%Y%m%d')}-{content_hash}")
+        target = ensure_within_root(root / final_id, root)
+        if target.exists() or target.is_symlink():
+            raise FileExistsError(f"snapshot already exists and will not be overwritten: {target}")
+        manifest = {
+            "snapshot_id": final_id,
+            "created_at": created_at.isoformat(),
+            "schema_version": 1,
+            "code_commit": code_commit,
+            "dirty": dirty,
+            "timezone": "Asia/Taipei",
+            "tables": tables,
+            "sources": {name: {"primary": entry["sources"], "revisions": entry["revision_ids"]} for name, entry in tables.items()},
+            "rule_profile": "TW_EQUITY_PHASE01_PLACEHOLDER",
+            "quality_report": "quality.json",
+            "license_policy": "metadata-only-or-redistributable",
+            "builder_version": "tw_quant.phase01",
+        }
+        write_json(staging / "manifest.json", manifest)
+        report = verify_snapshot(staging, _allow_staging=True)
+        if not report.ok:
+            raise RuntimeError("new snapshot failed self-verification: " + "; ".join(report.errors))
+        staging.replace(target)
+        return manifest
+    except Exception:
+        if staging.exists():
+            shutil.rmtree(staging)
+        raise
+    finally:
+        conn.close()

--- a/agent/src/tw_quant/data/verifier.py
+++ b/agent/src/tw_quant/data/verifier.py
@@ -1,0 +1,189 @@
+"""Independent immutable snapshot verifier."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from src.tw_quant.config import PathSafetyError, ensure_snapshot_id, ensure_within_root
+from src.tw_quant.data.manifest import read_manifest, sha256_file
+from src.tw_quant.data.schemas import schema_for
+
+
+@dataclass(frozen=True)
+class VerificationReport:
+    snapshot_id: str | None
+    ok: bool
+    errors: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+    tables: tuple[dict[str, Any], ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "snapshot_id": self.snapshot_id,
+            "ok": self.ok,
+            "errors": list(self.errors),
+            "warnings": list(self.warnings),
+            "tables": list(self.tables),
+        }
+
+
+def _sql_literal(path: Path) -> str:
+    return "'" + str(path).replace("'", "''") + "'"
+
+
+def _snapshot_path(snapshot: str | Path, snapshot_root: str | Path | None) -> Path:
+    value = Path(snapshot).expanduser()
+    if value.exists() or value.is_absolute() or len(value.parts) > 1:
+        return value.resolve(strict=False)
+    if snapshot_root is None:
+        raise ValueError("snapshot_root is required when snapshot is an ID")
+    snapshot_id = ensure_snapshot_id(str(snapshot))
+    root = Path(snapshot_root).expanduser().resolve(strict=False)
+    return ensure_within_root(root / snapshot_id, root)
+
+
+def _validate_physical_types(dataset: str, columns: list[tuple[str, str]]) -> list[str]:
+    errors: list[str] = []
+    actual = {name: dtype.upper() for name, dtype in columns}
+    expected = schema_for(dataset)
+    missing = set(expected.columns) - set(actual)
+    extra = set(actual) - set(expected.columns)
+    if missing:
+        errors.append(f"{dataset}: missing Parquet columns: {sorted(missing)}")
+    if extra:
+        errors.append(f"{dataset}: unexpected Parquet columns: {sorted(extra)}")
+    for name in expected.columns:
+        if name not in actual:
+            continue
+        dtype = actual[name]
+        if name in {"is_suspended", "is_disposition", "is_full_delivery"} and "BOOL" not in dtype:
+            errors.append(f"{dataset}.{name}: expected BOOLEAN, got {dtype}")
+        if name in {"symbol", "local_code", "market", "security_type", "name", "industry_code", "source", "source_dataset", "revision_id", "quality_flags", "row_hash"}:
+            if not any(token in dtype for token in ("VARCHAR", "TEXT", "STRING")):
+                errors.append(f"{dataset}.{name}: expected string, got {dtype}")
+    return errors
+
+
+def verify_snapshot(
+    snapshot: str | Path,
+    snapshot_root: str | Path | None = None,
+    *,
+    _allow_staging: bool = False,
+) -> VerificationReport:
+    """Verify manifest, paths, hashes, row counts, columns, and types."""
+    errors: list[str] = []
+    warnings: list[str] = []
+    tables_report: list[dict[str, Any]] = []
+    try:
+        snapshot_path = _snapshot_path(snapshot, snapshot_root)
+        manifest_path = snapshot_path / "manifest.json"
+        if not manifest_path.is_file():
+            return VerificationReport(None, False, ("manifest.json is missing",))
+        manifest = read_manifest(manifest_path)
+        snapshot_id = str(manifest.get("snapshot_id", "")).strip() or None
+        if snapshot_id is None:
+            errors.append("manifest snapshot_id is missing")
+        else:
+            try:
+                ensure_snapshot_id(snapshot_id)
+            except PathSafetyError as exc:
+                errors.append(str(exc))
+            if not _allow_staging and snapshot_path.name != snapshot_id:
+                errors.append("snapshot ID does not match snapshot directory")
+        for field in ("created_at", "schema_version", "code_commit", "timezone", "tables", "quality_report"):
+            if field not in manifest:
+                errors.append(f"manifest field is missing: {field}")
+        quality_relative = Path(str(manifest.get("quality_report", "quality.json")))
+        if quality_relative.is_absolute() or ".." in quality_relative.parts:
+            errors.append("quality report path escapes snapshot")
+        else:
+            try:
+                quality_path = ensure_within_root(
+                    snapshot_path / quality_relative, snapshot_path, allow_missing=False
+                )
+                if not quality_path.is_file():
+                    errors.append("quality report is missing")
+            except (PathSafetyError, FileNotFoundError) as exc:
+                errors.append(f"quality report: {exc}")
+
+        table_entries = manifest.get("tables")
+        if not isinstance(table_entries, dict) or not table_entries:
+            errors.append("manifest tables must be a non-empty object")
+            table_entries = {}
+        missing_datasets = {"security_master", "daily_price", "monthly_revenue"} - set(table_entries)
+        if missing_datasets:
+            errors.append(f"manifest tables are incomplete: {sorted(missing_datasets)}")
+
+        import duckdb
+
+        conn = duckdb.connect(database=":memory:")
+        try:
+            for dataset, entry in table_entries.items():
+                try:
+                    schema_for(dataset)
+                except ValueError as exc:
+                    errors.append(str(exc))
+                    continue
+                if not isinstance(entry, dict):
+                    errors.append(f"manifest table entry is not an object: {dataset}")
+                    continue
+                relative = entry.get("path")
+                if not isinstance(relative, str) or not relative.strip():
+                    errors.append(f"manifest path is missing: {dataset}")
+                    continue
+                relative_path = Path(relative)
+                if relative_path.is_absolute() or ".." in relative_path.parts:
+                    errors.append(f"manifest path escapes snapshot: {relative}")
+                    continue
+                try:
+                    data_path = ensure_within_root(snapshot_path / relative_path, snapshot_path, allow_missing=False)
+                except (PathSafetyError, FileNotFoundError) as exc:
+                    errors.append(f"{dataset}: {exc}")
+                    continue
+                if data_path.is_symlink():
+                    errors.append(f"{dataset}: symlinked data files are not allowed")
+                    continue
+                actual_hash = sha256_file(data_path)
+                if actual_hash != str(entry.get("sha256", "")):
+                    errors.append(f"{dataset}: SHA-256 mismatch")
+                try:
+                    described = conn.execute(f"DESCRIBE SELECT * FROM read_parquet({_sql_literal(data_path)})").fetchall()
+                    type_errors = _validate_physical_types(dataset, [(row[0], row[1]) for row in described])
+                    errors.extend(type_errors)
+                    count, min_time, max_time = conn.execute(
+                        f"SELECT COUNT(*), MIN({schema_for(dataset).event_column}), MAX({schema_for(dataset).event_column}) "
+                        f"FROM read_parquet({_sql_literal(data_path)})"
+                    ).fetchone()
+                except Exception as exc:
+                    errors.append(f"{dataset}: Parquet read failed: {exc}")
+                    continue
+                if int(count) != int(entry.get("rows", -1)):
+                    errors.append(f"{dataset}: row count mismatch")
+                expected_min = entry.get("min_event_time")
+                expected_max = entry.get("max_event_time")
+                if (expected_min is None) != (min_time is None) or (expected_max is None) != (max_time is None):
+                    errors.append(f"{dataset}: event time range mismatch")
+                tables_report.append({
+                    "dataset": dataset,
+                    "path": relative,
+                    "rows": int(count),
+                    "sha256": actual_hash,
+                    "min_event_time": str(min_time) if min_time is not None else None,
+                    "max_event_time": str(max_time) if max_time is not None else None,
+                })
+        finally:
+            conn.close()
+
+        data_dir = snapshot_path / "data"
+        listed = {str(entry.get("path")) for entry in table_entries.values() if isinstance(entry, dict)}
+        if data_dir.is_dir():
+            for candidate in data_dir.rglob("*"):
+                if candidate.is_file() and candidate.relative_to(snapshot_path).as_posix() not in listed:
+                    warnings.append(f"unlisted snapshot file ignored: {candidate.relative_to(snapshot_path)}")
+    except (OSError, ValueError, json.JSONDecodeError, PathSafetyError) as exc:
+        errors.append(str(exc))
+        snapshot_id = locals().get("snapshot_id")
+    return VerificationReport(snapshot_id, not errors, tuple(dict.fromkeys(errors)), tuple(warnings), tuple(tables_report))

--- a/agent/src/tw_quant/data/verifier.py
+++ b/agent/src/tw_quant/data/verifier.py
@@ -164,7 +164,12 @@ def verify_snapshot(
                     errors.append(f"{dataset}: row count mismatch")
                 expected_min = entry.get("min_event_time")
                 expected_max = entry.get("max_event_time")
-                if (expected_min is None) != (min_time is None) or (expected_max is None) != (max_time is None):
+                if (
+                    (expected_min is None) != (min_time is None)
+                    or (expected_max is None) != (max_time is None)
+                    or (expected_min is not None and str(min_time) != str(expected_min))
+                    or (expected_max is not None and str(max_time) != str(expected_max))
+                ):
                     errors.append(f"{dataset}: event time range mismatch")
                 tables_report.append({
                     "dataset": dataset,

--- a/agent/src/tw_quant/db/__init__.py
+++ b/agent/src/tw_quant/db/__init__.py
@@ -1,0 +1,6 @@
+"""DuckDB storage helpers."""
+
+from src.tw_quant.db.connection import connect_database
+from src.tw_quant.db.migrations import migrate
+
+__all__ = ["connect_database", "migrate"]

--- a/agent/src/tw_quant/db/connection.py
+++ b/agent/src/tw_quant/db/connection.py
@@ -1,0 +1,17 @@
+"""Safe DuckDB connection factory."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.tw_quant.config import ensure_data_path
+
+
+def connect_database(path: str | Path, *, read_only: bool = False):
+    """Open the Phase 01 DuckDB database after validating its path."""
+    import duckdb
+
+    db_path = ensure_data_path(Path(path))
+    if not read_only:
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+    return duckdb.connect(str(db_path), read_only=read_only)

--- a/agent/src/tw_quant/db/migrations.py
+++ b/agent/src/tw_quant/db/migrations.py
@@ -1,0 +1,77 @@
+"""Versioned, idempotent DuckDB migrations for Phase 01."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+from pathlib import Path
+
+from src.tw_quant.data.schemas import TABLE_DDL
+from src.tw_quant.db.connection import connect_database
+
+
+_MIGRATIONS: tuple[tuple[int, str], ...] = (
+    (
+        1,
+        "\n".join(
+            [
+                "CREATE TABLE IF NOT EXISTS schema_migrations (",
+                "  version INTEGER PRIMARY KEY,",
+                "  applied_at TIMESTAMPTZ NOT NULL,",
+                "  checksum VARCHAR NOT NULL",
+                ");",
+                *[TABLE_DDL[name].strip() + ";" for name in TABLE_DDL],
+            ]
+        ),
+    ),
+)
+
+
+def migration_checksum(sql: str) -> str:
+    return hashlib.sha256(sql.encode("utf-8")).hexdigest()
+
+
+def migrate(path: str | Path):
+    """Apply all migrations and reject checksum drift.
+
+    Returns a small machine-readable summary. The database transaction is
+    rolled back if any DDL or checksum check fails.
+    """
+    conn = connect_database(path)
+    applied: list[int] = []
+    try:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS schema_migrations "
+            "(version INTEGER PRIMARY KEY, applied_at TIMESTAMPTZ NOT NULL, checksum VARCHAR NOT NULL)"
+        )
+        conn.execute("BEGIN TRANSACTION")
+        for version, sql in _MIGRATIONS:
+            checksum = migration_checksum(sql)
+            row = conn.execute(
+                "SELECT checksum FROM schema_migrations WHERE version = ?", [version]
+            ).fetchone()
+            if row is not None:
+                if str(row[0]) != checksum:
+                    raise RuntimeError(
+                        f"migration checksum mismatch for version {version}: "
+                        f"database={row[0]}, code={checksum}"
+                    )
+                continue
+            for statement in (part.strip() for part in sql.split(";")):
+                if statement:
+                    conn.execute(statement)
+            conn.execute(
+                "INSERT INTO schema_migrations(version, applied_at, checksum) VALUES (?, ?, ?)",
+                [version, datetime.now(timezone.utc), checksum],
+            )
+            applied.append(version)
+        conn.execute("COMMIT")
+        return {"applied": applied, "versions": [version for version, _ in _MIGRATIONS]}
+    except Exception:
+        try:
+            conn.execute("ROLLBACK")
+        except Exception:
+            pass
+        raise
+    finally:
+        conn.close()

--- a/agent/src/tw_quant/market/__init__.py
+++ b/agent/src/tw_quant/market/__init__.py
@@ -1,0 +1,5 @@
+"""Taiwan symbol and market helpers."""
+
+from src.tw_quant.market.symbols import CanonicalSymbol, parse_symbol
+
+__all__ = ["CanonicalSymbol", "parse_symbol"]

--- a/agent/src/tw_quant/market/symbols.py
+++ b/agent/src/tw_quant/market/symbols.py
@@ -1,0 +1,89 @@
+"""Fail-closed Taiwan symbol parsing."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+class SymbolParseError(ValueError):
+    """Raised when a Taiwan symbol is empty, invalid, or ambiguous."""
+
+
+_SYMBOL_RE = re.compile(r"^(?P<local>\d{4,6})(?:\.(?P<suffix>[A-Za-z]+))?$")
+_MARKET_ALIASES = {
+    "TW": "TWSE",
+    "TWSE": "TWSE",
+    "TWO": "TPEX",
+    "TPEX": "TPEX",
+}
+
+
+@dataclass(frozen=True)
+class CanonicalSymbol:
+    """Canonical Taiwan instrument identity used by Phase 01."""
+
+    local_code: str
+    market: str
+    canonical: str
+    vendor_symbols: tuple[str, ...] = ()
+    valid_from: str | None = None
+    valid_to: str | None = None
+
+
+def _market_hint(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = str(value).strip().upper()
+    if normalized in {"TAIWAN", "TAIWAN_EQUITY"}:
+        return None
+    return _MARKET_ALIASES.get(normalized)
+
+
+def parse_symbol(symbol: str, market_hint: str | None = None) -> CanonicalSymbol:
+    """Parse ``2330.TW``/``6488.TWO`` without guessing ambiguous codes.
+
+    Bare numeric codes are accepted only with an explicit ``TWSE``/``TPEX``
+    hint. Provider-specific vendor mappings are deliberately not inferred.
+    """
+    raw = str(symbol).strip()
+    if not raw:
+        raise SymbolParseError("Taiwan symbol must not be empty")
+    match = _SYMBOL_RE.fullmatch(raw)
+    if not match:
+        raise SymbolParseError(f"invalid Taiwan symbol: {symbol!r}")
+
+    local_code = match.group("local")
+    suffix = match.group("suffix")
+    hinted_market = _market_hint(market_hint)
+    if suffix:
+        market = _MARKET_ALIASES.get(suffix.upper())
+        if market is None:
+            raise SymbolParseError(f"unknown Taiwan market suffix: {suffix!r}")
+        if hinted_market is not None and hinted_market != market:
+            raise SymbolParseError(
+                f"symbol suffix {suffix!r} conflicts with market hint {market_hint!r}"
+            )
+    else:
+        if hinted_market is None:
+            raise SymbolParseError(
+                f"bare Taiwan code {raw!r} is ambiguous; provide TWSE/TPEX hint"
+            )
+        market = hinted_market
+
+    canonical_suffix = "TW" if market == "TWSE" else "TWO"
+    return CanonicalSymbol(
+        local_code=local_code,
+        market=market,
+        canonical=f"{local_code}.{canonical_suffix}",
+    )
+
+
+def is_taiwan_symbol(symbol: str, market_hint: str | None = None) -> bool:
+    """Return whether *symbol* is a valid, unambiguous Taiwan symbol."""
+    try:
+        parsed = parse_symbol(symbol, market_hint=market_hint)
+    except SymbolParseError:
+        return False
+    return parsed.market in {"TWSE", "TPEX"}
+

--- a/agent/tests/test_env_schema.py
+++ b/agent/tests/test_env_schema.py
@@ -10,6 +10,7 @@ Covers:
 - Thread safety
 - _parse_bool utility
 - get_env_or utility
+- get_env_value utility
 - _parse_env_bool (EnvBool BeforeValidator)
 """
 
@@ -23,6 +24,7 @@ from src.config.accessor import (
     _parse_bool,
     get_env_config,
     get_env_or,
+    get_env_value,
     reset_env_config,
 )
 from src.config.env_schema import (
@@ -471,6 +473,27 @@ class TestGetEnvOr:
         monkeypatch.setenv("PRIMARY", "")
         monkeypatch.setenv("FALLBACK", "")
         assert get_env_or("PRIMARY", "FALLBACK", "default") == "default"
+
+
+# ===================================================================
+# TestGetEnvValue
+# ===================================================================
+
+
+class TestGetEnvValue:
+    """Verify the single-variable config accessor."""
+
+    def test_set_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("EXTENSION_SETTING", "configured")
+        assert get_env_value("EXTENSION_SETTING") == "configured"
+
+    def test_missing_value_uses_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("EXTENSION_SETTING", raising=False)
+        assert get_env_value("EXTENSION_SETTING", "default") == "default"
+
+    def test_empty_value_uses_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("EXTENSION_SETTING", "")
+        assert get_env_value("EXTENSION_SETTING", "default") == "default"
 
 
 # ===================================================================

--- a/agent/tests/test_registry.py
+++ b/agent/tests/test_registry.py
@@ -132,7 +132,10 @@ class TestProtocol:
 
 class TestFallbackChains:
     def test_all_expected_markets_present(self) -> None:
-        expected = {"a_share", "us_equity", "hk_equity", "india_equity", "kr_equity", "crypto", "futures", "fund", "macro", "forex"}
+        expected = {
+            "a_share", "us_equity", "hk_equity", "india_equity", "kr_equity",
+            "crypto", "futures", "fund", "macro", "forex", "taiwan_equity",
+        }
         assert expected == set(FALLBACK_CHAINS.keys())
 
     def test_chains_are_non_empty(self) -> None:
@@ -170,6 +173,9 @@ class TestFallbackChains:
     def test_a_share_includes_baostock(self) -> None:
         """'baostock' must remain a reachable A-share fallback."""
         assert "baostock" in FALLBACK_CHAINS["a_share"]
+
+    def test_taiwan_chain_is_snapshot_only(self) -> None:
+        assert FALLBACK_CHAINS["taiwan_equity"] == ["tw_snapshot"]
 
     def test_unchanged_chains_preserved(self) -> None:
         """crypto/futures/fund/macro/forex chains must be left untouched."""

--- a/agent/tests/test_tw_quant_config_cli.py
+++ b/agent/tests/test_tw_quant_config_cli.py
@@ -1,0 +1,237 @@
+"""Configuration and command-line contract tests for Phase 01."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from src.tw_quant.cli import main
+from src.tw_quant.config import (
+    PathSafetyError,
+    data_root,
+    db_path,
+    ensure_data_path,
+    ensure_snapshot_id,
+    ensure_within_root,
+    snapshot_root,
+)
+
+
+def _security_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "symbol": "2330.TW",
+                "local_code": "2330",
+                "market": "TWSE",
+                "security_type": "common_stock",
+                "name": "Synthetic Semiconductor",
+                "listed_at": "2020-01-01T00:00:00+08:00",
+                "delisted_at": None,
+                "industry_code": "24",
+                "effective_at": "2020-01-01T00:00:00+00:00",
+                "available_at": "2020-01-01T00:00:00+00:00",
+            }
+        ]
+    )
+
+
+def _price_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "symbol": "2330.TW",
+                "trade_date": "2026-01-02",
+                "open": 99.5,
+                "high": 101.0,
+                "low": 99.0,
+                "close": 100.0,
+                "volume": 1000.0,
+                "turnover": 100000.0,
+                "trades": 10.0,
+                "reference_price": 99.5,
+                "price_limit_up": 110.0,
+                "price_limit_down": 90.0,
+                "is_suspended": False,
+                "is_disposition": False,
+                "is_full_delivery": False,
+                "adjustment_factor": 1.0,
+                "effective_at": "2026-01-02T00:00:00+00:00",
+                "available_at": "2026-01-02T09:00:00+00:00",
+                "ingested_at": "2026-01-03T00:00:00+00:00",
+            }
+        ]
+    )
+
+
+def _revenue_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "symbol": "2330.TW",
+                "revenue_month": "2025-12-01",
+                "revenue": 1000.0,
+                "revenue_yoy": 0.1,
+                "revenue_mom": 0.02,
+                "announced_at": "2026-01-10T06:00:00+00:00",
+                "effective_at": "2025-12-01T00:00:00+00:00",
+                "available_at": "2026-01-10T06:00:00+00:00",
+                "ingested_at": "2026-01-11T00:00:00+00:00",
+            }
+        ]
+    )
+
+
+def _write_input_files(tmp_path: Path) -> dict[str, Path]:
+    frames = {
+        "security_master": _security_frame(),
+        "daily_price": _price_frame(),
+        "monthly_revenue": _revenue_frame(),
+    }
+    paths: dict[str, Path] = {}
+    for dataset, frame in frames.items():
+        path = tmp_path / f"{dataset}.csv"
+        frame.to_csv(path, index=False)
+        paths[dataset] = path
+    return paths
+
+
+def test_config_uses_data_root_for_relative_paths(tmp_path: Path, monkeypatch) -> None:
+    configured_root = tmp_path / "state"
+    monkeypatch.setenv("TW_QUANT_DATA_ROOT", str(configured_root))
+    monkeypatch.setenv("TW_QUANT_DB_PATH", "db/research.duckdb")
+    monkeypatch.setenv("TW_QUANT_SNAPSHOT_ROOT", "sealed-snapshots")
+
+    assert data_root() == configured_root.resolve()
+    assert db_path() == (configured_root / "db" / "research.duckdb").resolve()
+    assert snapshot_root() == (configured_root / "sealed-snapshots").resolve()
+
+
+def test_config_rejects_paths_outside_root_and_missing_required_paths(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+
+    with pytest.raises(PathSafetyError, match="escapes allowed root"):
+        ensure_within_root(root / ".." / "outside", root)
+    with pytest.raises(FileNotFoundError):
+        ensure_within_root(root / "not-created", root, allow_missing=False)
+
+
+@pytest.mark.parametrize("snapshot_id", ["", ".", "..", "../escape", "bad id", "-bad", "bad\\id"])
+def test_snapshot_id_must_be_one_safe_path_segment(snapshot_id: str) -> None:
+    with pytest.raises(PathSafetyError, match="invalid snapshot_id"):
+        ensure_snapshot_id(snapshot_id)
+
+
+def test_ensure_data_path_uses_configured_root(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("TW_QUANT_DATA_ROOT", str(tmp_path))
+
+    valid = ensure_data_path(tmp_path / "nested" / "file.parquet")
+    assert valid == (tmp_path / "nested" / "file.parquet").resolve()
+    with pytest.raises(PathSafetyError):
+        ensure_data_path(tmp_path.parent / "outside.parquet")
+
+
+def test_cli_migrate_and_validate_import(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.setenv("TW_QUANT_DATA_ROOT", str(tmp_path))
+    db = tmp_path / "tw_quant.duckdb"
+    csv_path = tmp_path / "daily_price.csv"
+    _price_frame().to_csv(csv_path, index=False)
+
+    assert main(["migrate", "--db-path", str(db)]) == 0
+    migration_output = json.loads(capsys.readouterr().out)
+    assert migration_output["applied"] == [1]
+
+    assert main(
+        [
+            "import",
+            "--dataset",
+            "daily_price",
+            "--input",
+            str(csv_path),
+            "--source",
+            "fixture",
+            "--source-dataset",
+            "synthetic",
+            "--mode",
+            "validate_only",
+        ]
+    ) == 0
+    import_output = json.loads(capsys.readouterr().out)
+    assert import_output["ok"] is True
+    assert import_output["mode"] == "validate_only"
+    assert import_output["inserted_rows"] == 0
+
+
+def test_cli_import_create_and_verify_snapshot(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.setenv("TW_QUANT_DATA_ROOT", str(tmp_path))
+    db = tmp_path / "tw_quant.duckdb"
+    snapshot_root = tmp_path / "snapshots"
+    paths = _write_input_files(tmp_path)
+
+    for dataset, path in paths.items():
+        assert main(
+            [
+                "import",
+                "--dataset",
+                dataset,
+                "--input",
+                str(path),
+                "--source",
+                "fixture",
+                "--source-dataset",
+                "synthetic",
+                "--revision-id",
+                "cli-r1",
+                "--mode",
+                "append",
+                "--db-path",
+                str(db),
+            ]
+        ) == 0
+        assert json.loads(capsys.readouterr().out)["inserted_rows"] == 1
+
+    assert main(
+        [
+            "snapshot",
+            "create",
+            "--db-path",
+            str(db),
+            "--snapshot-root",
+            str(snapshot_root),
+            "--snapshot-id",
+            "cli-r1",
+        ]
+    ) == 0
+    create_output = json.loads(capsys.readouterr().out)
+    assert create_output["snapshot_id"] == "cli-r1"
+
+    assert main(["snapshot", "verify", "cli-r1", "--snapshot-root", str(snapshot_root)]) == 0
+    verify_output = json.loads(capsys.readouterr().out)
+    assert verify_output["ok"] is True
+    assert verify_output["snapshot_id"] == "cli-r1"
+
+
+def test_cli_reports_invalid_input_as_json_error(tmp_path: Path, capsys) -> None:
+    path = tmp_path / "not-supported.json"
+    path.write_text("{}", encoding="utf-8")
+
+    assert main(
+        [
+            "import",
+            "--dataset",
+            "daily_price",
+            "--input",
+            str(path),
+            "--source",
+            "fixture",
+            "--source-dataset",
+            "synthetic",
+        ]
+    ) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert output["ok"] is False
+    assert "unsupported import file type" in output["error"]

--- a/agent/tests/test_tw_quant_data.py
+++ b/agent/tests/test_tw_quant_data.py
@@ -532,6 +532,17 @@ def test_snapshot_loader_fails_closed_for_invalid_requests(tmp_path: Path) -> No
         loader.fetch(["2330.TW"], "2026-01-01", "2026-01-02", interval="1H")
 
 
+def test_snapshot_loader_reads_environment_defaults(tmp_path: Path, monkeypatch) -> None:
+    snapshot_root = tmp_path / "snapshots"
+    monkeypatch.setenv("TW_QUANT_SNAPSHOT_ID", "from-env")
+    monkeypatch.setenv("TW_QUANT_SNAPSHOT_ROOT", str(snapshot_root))
+
+    loader = TaiwanSnapshotLoader()
+
+    assert loader.snapshot_id == "from-env"
+    assert loader.snapshot_root == snapshot_root
+
+
 def test_snapshot_loader_supports_selected_fields_and_bare_codes(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/agent/tests/test_tw_quant_data.py
+++ b/agent/tests/test_tw_quant_data.py
@@ -1,0 +1,218 @@
+"""Importer, snapshot, verifier, and loader integration tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+import duckdb
+
+from src.tw_quant.data.importers import import_dataset, stable_row_hash
+from src.tw_quant.data.loader import SnapshotLoadError, TaiwanSnapshotLoader
+from src.tw_quant.data.snapshots import create_snapshot
+from src.tw_quant.data.verifier import verify_snapshot
+from src.tw_quant.db.migrations import migrate
+
+
+def _security_frame() -> pd.DataFrame:
+    return pd.DataFrame([
+        {
+            "symbol": "2330.TW", "local_code": "2330", "market": "TWSE",
+            "security_type": "common_stock", "name": "Synthetic Semiconductor",
+            "listed_at": "2020-01-01T00:00:00+08:00", "delisted_at": None,
+            "industry_code": "24", "effective_at": "2020-01-01T00:00:00+00:00",
+            "available_at": "2020-01-01T00:00:00+00:00",
+        },
+        {
+            "symbol": "6488.TWO", "local_code": "6488", "market": "TPEX",
+            "security_type": "common_stock", "name": "Synthetic TPEX",
+            "listed_at": "2020-01-01T00:00:00+08:00", "delisted_at": None,
+            "industry_code": "24", "effective_at": "2020-01-01T00:00:00+00:00",
+            "available_at": "2020-01-01T00:00:00+00:00",
+        },
+    ])
+
+
+def _price_frame() -> pd.DataFrame:
+    rows = []
+    for symbol, base in (("2330.TW", 100.0), ("6488.TWO", 50.0)):
+        for offset, day in enumerate(("2026-01-02", "2026-01-05", "2026-01-06")):
+            close = base + offset
+            rows.append({
+                "symbol": symbol, "trade_date": day, "open": close - 0.5,
+                "high": close + 1.0, "low": close - 1.0, "close": close,
+                "volume": 1000.0, "turnover": 100000.0, "trades": 10.0,
+                "reference_price": close - 0.5, "price_limit_up": close * 1.1,
+                "price_limit_down": close * 0.9, "is_suspended": False,
+                "is_disposition": False, "is_full_delivery": False,
+                "adjustment_factor": 1.0, "effective_at": f"{day}T00:00:00+00:00",
+                "available_at": f"{day}T09:00:00+00:00",
+                "ingested_at": "2026-01-07T00:00:00+00:00",
+            })
+    return pd.DataFrame(rows)
+
+
+def _revenue_frame() -> pd.DataFrame:
+    return pd.DataFrame([{
+        "symbol": "2330.TW", "revenue_month": "2025-12-01", "revenue": 1000.0,
+        "revenue_yoy": 0.1, "revenue_mom": 0.02,
+        "announced_at": "2026-01-10T06:00:00+00:00",
+        "effective_at": "2025-12-01T00:00:00+00:00",
+        "available_at": "2026-01-10T06:00:00+00:00",
+        "ingested_at": "2026-01-11T00:00:00+00:00",
+    }])
+
+
+def _write_csvs(tmp_path: Path) -> dict[str, Path]:
+    paths = {}
+    for dataset, frame in (
+        ("security_master", _security_frame()),
+        ("daily_price", _price_frame()),
+        ("monthly_revenue", _revenue_frame()),
+    ):
+        path = tmp_path / f"{dataset}.csv"
+        frame.to_csv(path, index=False)
+        paths[dataset] = path
+    return paths
+
+
+def test_row_hash_is_stable_and_excludes_ingest_time() -> None:
+    row = {"symbol": "2330.TW", "close": 100.0, "ingested_at": "2026-01-01T00:00:00Z"}
+    changed_ingest = {**row, "ingested_at": "2027-01-01T00:00:00Z"}
+    assert stable_row_hash(row) == stable_row_hash(changed_ingest)
+
+
+def test_validate_only_does_not_write_database(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("TW_QUANT_DATA_ROOT", str(tmp_path))
+    path = _write_csvs(tmp_path)["daily_price"]
+    result = import_dataset(
+        path, "daily_price", source="fixture", source_dataset="synthetic",
+        mode="validate_only",
+    )
+    assert result.report.ok
+    assert result.inserted_rows == 0
+    assert not (tmp_path / "tw_quant.duckdb").exists()
+
+
+def test_validate_only_accepts_duckdb_written_parquet_input(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("TW_QUANT_DATA_ROOT", str(tmp_path))
+    parquet_path = tmp_path / "daily_price.parquet"
+    frame = _price_frame()
+    with duckdb.connect(database=":memory:") as conn:
+        conn.register("price_frame", frame)
+        conn.execute(f"COPY price_frame TO '{parquet_path}' (FORMAT PARQUET)")
+    result = import_dataset(
+        parquet_path, "daily_price", source="fixture", source_dataset="synthetic",
+        mode="validate_only",
+    )
+    assert result.report.ok
+    assert result.report.rows == len(frame)
+
+
+def test_csv_path_with_spaces_is_supported(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("TW_QUANT_DATA_ROOT", str(tmp_path))
+    data_dir = tmp_path / "fixture data with spaces"
+    data_dir.mkdir()
+    path = data_dir / "daily price.csv"
+    _price_frame().to_csv(path, index=False)
+    result = import_dataset(
+        path, "daily_price", source="fixture", source_dataset="synthetic",
+        mode="validate_only",
+    )
+    assert result.report.ok
+
+
+def test_append_rolls_back_on_duplicate_revision(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("TW_QUANT_DATA_ROOT", str(tmp_path))
+    db_path = tmp_path / "tw_quant.duckdb"
+    frame = _price_frame()
+    path = tmp_path / "daily_price.csv"
+    frame.to_csv(path, index=False)
+    first = import_dataset(
+        path, "daily_price", source="fixture", source_dataset="synthetic",
+        mode="append", db_path=db_path, revision_id="r1",
+    )
+    assert first.inserted_rows == len(frame)
+    with pytest.raises(Exception, match="Constraint|constraint|duplicate|Duplicate"):
+        import_dataset(
+            path, "daily_price", source="fixture", source_dataset="synthetic",
+            mode="append", db_path=db_path, revision_id="r1",
+        )
+    with duckdb.connect(str(db_path), read_only=True) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM daily_price").fetchone()[0]
+    assert count == len(frame)
+
+
+def test_fixture_to_snapshot_to_loader_and_offline_tamper_detection(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("TW_QUANT_DATA_ROOT", str(tmp_path))
+    db_path = tmp_path / "tw_quant.duckdb"
+    snapshot_dir = tmp_path / "snapshots"
+    paths = _write_csvs(tmp_path)
+    migrate(db_path)
+    for dataset, path in paths.items():
+        result = import_dataset(
+            path, dataset, source="fixture", source_dataset="synthetic",
+            mode="append", db_path=db_path, revision_id="r1",
+        )
+        assert result.report.ok
+        assert result.inserted_rows > 0
+
+    manifest = create_snapshot(
+        db_path, snapshot_root=snapshot_dir, snapshot_id="twq-fixture-r1"
+    )
+    report = verify_snapshot("twq-fixture-r1", snapshot_dir)
+    assert report.ok
+    loader = TaiwanSnapshotLoader(snapshot_id="twq-fixture-r1", snapshot_root=snapshot_dir)
+    data = loader.fetch(["2330.TW"], "2026-01-01", "2026-01-31")
+    assert list(data) == ["2330.TW"]
+    assert list(data["2330.TW"]["close"]) == [100.0, 101.0, 102.0]
+    assert loader.provenance["snapshot_id"] == manifest["snapshot_id"]
+    with pytest.raises(SnapshotLoadError, match="absent"):
+        loader.fetch(["9999.TW"], "2026-01-01", "2026-01-31")
+    with pytest.raises(SnapshotLoadError, match="no rows"):
+        loader.fetch(["2330.TW"], "2030-01-01", "2030-01-31")
+
+    data_path = snapshot_dir / "twq-fixture-r1" / "data" / "daily_price.parquet"
+    with data_path.open("ab") as stream:
+        stream.write(b"tampered")
+    tampered = verify_snapshot("twq-fixture-r1", snapshot_dir)
+    assert not tampered.ok
+    assert any("SHA-256" in error for error in tampered.errors)
+    with pytest.raises(SnapshotLoadError, match="verification failed"):
+        loader.fetch(["2330.TW"], "2026-01-01", "2026-01-31")
+
+
+def test_duplicate_snapshot_refuses_overwrite(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("TW_QUANT_DATA_ROOT", str(tmp_path))
+    db_path = tmp_path / "tw_quant.duckdb"
+    paths = _write_csvs(tmp_path)
+    for dataset, path in paths.items():
+        import_dataset(
+            path, dataset, source="fixture", source_dataset="synthetic",
+            mode="append", db_path=db_path, revision_id="r1",
+        )
+    first = create_snapshot(db_path, snapshot_root=tmp_path / "snapshots", snapshot_id="twq-fixed")
+    second = create_snapshot(db_path, snapshot_root=tmp_path / "snapshots", snapshot_id="twq-fixed-copy")
+    assert first["tables"]["daily_price"]["sha256"] == second["tables"]["daily_price"]["sha256"]
+    with pytest.raises(FileExistsError, match="will not be overwritten"):
+        create_snapshot(db_path, snapshot_root=tmp_path / "snapshots", snapshot_id="twq-fixed")
+
+
+def test_manifest_path_traversal_is_rejected(tmp_path) -> None:
+    snapshot = tmp_path / "snapshot"
+    snapshot.mkdir()
+    (snapshot / "quality.json").write_text("{}", encoding="utf-8")
+    (snapshot / "manifest.json").write_text(json.dumps({
+        "snapshot_id": "twq-path",
+        "created_at": "2026-01-01T00:00:00Z",
+        "schema_version": 1,
+        "code_commit": "unknown",
+        "timezone": "Asia/Taipei",
+        "tables": {"daily_price": {"path": "../outside.parquet", "rows": 0, "sha256": ""}},
+        "quality_report": "quality.json",
+    }), encoding="utf-8")
+    report = verify_snapshot(snapshot, _allow_staging=True)
+    assert not report.ok
+    assert any("escapes" in error for error in report.errors)

--- a/agent/tests/test_tw_quant_data.py
+++ b/agent/tests/test_tw_quant_data.py
@@ -3,14 +3,24 @@
 from __future__ import annotations
 
 import json
+import shutil
 from pathlib import Path
 
 import pandas as pd
 import pytest
 import duckdb
 
-from src.tw_quant.data.importers import import_dataset, stable_row_hash
-from src.tw_quant.data.loader import SnapshotLoadError, TaiwanSnapshotLoader
+from src.tw_quant.data.importers import (
+    import_dataset,
+    read_input,
+    stable_row_hash,
+    validate_dataset,
+)
+from src.tw_quant.data.loader import (
+    SnapshotLoadError,
+    SnapshotRequiredError,
+    TaiwanSnapshotLoader,
+)
 from src.tw_quant.data.snapshots import create_snapshot
 from src.tw_quant.data.verifier import verify_snapshot
 from src.tw_quant.db.migrations import migrate
@@ -184,6 +194,124 @@ def test_fixture_to_snapshot_to_loader_and_offline_tamper_detection(tmp_path, mo
         loader.fetch(["2330.TW"], "2026-01-01", "2026-01-31")
 
 
+def test_verify_snapshot_reports_missing_manifest(tmp_path: Path) -> None:
+    report = verify_snapshot(tmp_path / "missing-snapshot")
+
+    assert not report.ok
+    assert report.snapshot_id is None
+    assert "manifest.json is missing" in report.errors
+
+
+def test_verify_snapshot_rejects_malformed_or_incomplete_manifest(tmp_path: Path) -> None:
+    snapshot = tmp_path / "staging"
+    snapshot.mkdir()
+    manifest_path = snapshot / "manifest.json"
+    manifest_path.write_text("[]", encoding="utf-8")
+
+    malformed = verify_snapshot(snapshot, _allow_staging=True)
+    assert not malformed.ok
+    assert any("JSON object" in error for error in malformed.errors)
+
+    manifest_path.write_text(
+        json.dumps({"snapshot_id": "staging", "quality_report": "quality.json"}),
+        encoding="utf-8",
+    )
+    (snapshot / "quality.json").write_text("{}", encoding="utf-8")
+    incomplete = verify_snapshot(snapshot, _allow_staging=True)
+    assert not incomplete.ok
+    assert any("manifest field is missing" in error for error in incomplete.errors)
+    assert any("manifest tables are incomplete" in error for error in incomplete.errors)
+
+
+def _seed_snapshot(tmp_path: Path, monkeypatch, snapshot_id: str = "twq-verifier") -> tuple[Path, Path]:
+    monkeypatch.setenv("TW_QUANT_DATA_ROOT", str(tmp_path))
+    db_path = tmp_path / "tw_quant.duckdb"
+    snapshot_root = tmp_path / "snapshots"
+    for dataset, path in _write_csvs(tmp_path).items():
+        import_dataset(
+            path,
+            dataset,
+            source="fixture",
+            source_dataset="synthetic",
+            mode="append",
+            db_path=db_path,
+            revision_id="r1",
+        )
+    create_snapshot(db_path, snapshot_root=snapshot_root, snapshot_id=snapshot_id)
+    return snapshot_root, snapshot_root / snapshot_id
+
+
+def test_verify_snapshot_rejects_manifest_row_and_time_metadata_drift(tmp_path, monkeypatch) -> None:
+    snapshot_root, snapshot = _seed_snapshot(tmp_path, monkeypatch)
+    manifest_path = snapshot / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["tables"]["daily_price"]["rows"] += 1
+    manifest["tables"]["daily_price"]["min_event_time"] = "1900-01-01"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    report = verify_snapshot("twq-verifier", snapshot_root)
+
+    assert not report.ok
+    assert any("row count mismatch" in error for error in report.errors)
+    assert any("event time range mismatch" in error for error in report.errors)
+
+
+def test_verify_snapshot_warns_about_unlisted_files_and_directory_mismatch(tmp_path, monkeypatch) -> None:
+    snapshot_root, snapshot = _seed_snapshot(tmp_path, monkeypatch, "twq-warning")
+    (snapshot / "data" / "unlisted-note.txt").write_text("ignored", encoding="utf-8")
+
+    report = verify_snapshot("twq-warning", snapshot_root)
+    assert report.ok
+    assert any("unlisted snapshot file ignored" in warning for warning in report.warnings)
+
+    copied = snapshot_root / "different-directory"
+    shutil.copytree(snapshot, copied)
+    mismatch = verify_snapshot(copied)
+    assert not mismatch.ok
+    assert any("does not match snapshot directory" in error for error in mismatch.errors)
+
+
+def test_verify_snapshot_checks_physical_column_types(tmp_path, monkeypatch) -> None:
+    snapshot_root, snapshot = _seed_snapshot(tmp_path, monkeypatch, "twq-types")
+    data_path = snapshot / "data" / "daily_price.parquet"
+    replacement = tmp_path / "daily_price-wrong-type.parquet"
+    with duckdb.connect(database=":memory:") as conn:
+        conn.execute(
+            "COPY (SELECT * EXCLUDE(is_suspended), "
+            "CAST(is_suspended AS VARCHAR) AS is_suspended "
+            f"FROM read_parquet('{data_path}')) TO '{replacement}' (FORMAT PARQUET)"
+        )
+    replacement.replace(data_path)
+
+    report = verify_snapshot("twq-types", snapshot_root)
+
+    assert not report.ok
+    assert any("expected BOOLEAN" in error for error in report.errors)
+
+
+def test_verify_snapshot_rejects_symlinked_data_file(tmp_path, monkeypatch) -> None:
+    snapshot_root, snapshot = _seed_snapshot(tmp_path, monkeypatch, "twq-symlink")
+    data_path = snapshot / "data" / "daily_price.parquet"
+    original_is_symlink = Path.is_symlink
+
+    def pretend_symlink(path: Path) -> bool:
+        return path == data_path or original_is_symlink(path)
+
+    monkeypatch.setattr(Path, "is_symlink", pretend_symlink)
+    report = verify_snapshot("twq-symlink", snapshot_root)
+
+    assert not report.ok
+    assert any("symlinked data files are not allowed" in error for error in report.errors)
+
+
+def test_snapshot_loader_rejects_explicit_empty_field_list(tmp_path, monkeypatch) -> None:
+    snapshot_root, _ = _seed_snapshot(tmp_path, monkeypatch, "twq-empty-fields")
+    loader = TaiwanSnapshotLoader(snapshot_id="twq-empty-fields", snapshot_root=snapshot_root)
+
+    with pytest.raises(SnapshotLoadError, match="at least one daily_price field"):
+        loader.load(["2330.TW"], "2026-01-01", "2026-01-31", fields=[])
+
+
 def test_duplicate_snapshot_refuses_overwrite(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("TW_QUANT_DATA_ROOT", str(tmp_path))
     db_path = tmp_path / "tw_quant.duckdb"
@@ -216,3 +344,234 @@ def test_manifest_path_traversal_is_rejected(tmp_path) -> None:
     report = verify_snapshot(snapshot, _allow_staging=True)
     assert not report.ok
     assert any("escapes" in error for error in report.errors)
+
+
+def test_validate_dataset_fills_provider_metadata_and_canonicalizes_values() -> None:
+    frame = _price_frame().iloc[:1].copy()
+    frame["symbol"] = "2330.tw"
+    frame["is_suspended"] = "1"
+    frame["is_disposition"] = "false"
+    frame["is_full_delivery"] = 0
+    frame["quality_flags"] = '{"z": 2, "a": 1}'
+    frame = frame.drop(columns=["ingested_at"])
+
+    canonical, report = validate_dataset(
+        frame,
+        "daily_price",
+        source="fixture",
+        source_dataset="synthetic",
+        revision_id="r-canonical",
+        ingested_at="2026-01-07T00:00:00Z",
+    )
+
+    assert report.ok
+    assert canonical is not None
+    assert canonical.loc[0, "symbol"] == "2330.TW"
+    assert canonical.loc[0, "source"] == "fixture"
+    assert canonical.loc[0, "source_dataset"] == "synthetic"
+    assert canonical.loc[0, "revision_id"] == "r-canonical"
+    assert canonical.loc[0, "quality_flags"] == '{"a":1,"z":2}'
+    assert bool(canonical.loc[0, "is_suspended"]) is True
+    assert bool(canonical.loc[0, "is_disposition"]) is False
+    assert bool(canonical.loc[0, "is_full_delivery"]) is False
+
+
+def test_validate_dataset_rejects_missing_and_unknown_columns() -> None:
+    frame = _price_frame().drop(columns=["close"]).assign(unexpected="no")
+
+    canonical, report = validate_dataset(
+        frame,
+        "daily_price",
+        source="fixture",
+        source_dataset="synthetic",
+    )
+
+    assert canonical is None
+    assert not report.ok
+    assert any("missing required columns" in error for error in report.errors)
+    assert any("unknown columns" in error for error in report.errors)
+
+
+def test_validate_dataset_rejects_bad_values_and_business_invariants() -> None:
+    frame = _price_frame().iloc[:1].copy()
+    frame["is_suspended"] = frame["is_suspended"].astype(object)
+    frame.loc[0, "available_at"] = None
+    frame.loc[0, "close"] = 0
+    frame.loc[0, "volume"] = -1
+    frame.loc[0, "adjustment_factor"] = 0
+    frame.loc[0, "is_suspended"] = "maybe"
+    frame.loc[0, "quality_flags"] = "not-json"
+
+    canonical, report = validate_dataset(
+        frame,
+        "daily_price",
+        source="fixture",
+        source_dataset="synthetic",
+    )
+
+    assert canonical is not None
+    assert not report.ok
+    expected_errors = (
+        "available_at must not be empty",
+        "violate OHLC invariants",
+        "volume must not be negative",
+        "adjustment_factor must be positive",
+        "invalid boolean in is_suspended",
+        "quality_flags is not valid JSON",
+    )
+    for expected in expected_errors:
+        assert any(expected in error for error in report.errors), report.errors
+
+
+def test_validate_dataset_rejects_security_identity_mismatch() -> None:
+    frame = _security_frame().iloc[:1].copy()
+    frame.loc[0, "local_code"] = "9999"
+    frame.loc[0, "market"] = "TPEX"
+
+    canonical, report = validate_dataset(
+        frame,
+        "security_master",
+        source="fixture",
+        source_dataset="synthetic",
+    )
+
+    assert canonical is not None
+    assert not report.ok
+    assert any("local_code does not match" in error for error in report.errors)
+    assert any("market does not match" in error for error in report.errors)
+
+
+def test_validate_dataset_rejects_negative_revenue_and_duplicate_business_key() -> None:
+    revenue = _revenue_frame()
+    revenue.loc[0, "revenue"] = -1
+    _, revenue_report = validate_dataset(
+        revenue,
+        "monthly_revenue",
+        source="fixture",
+        source_dataset="synthetic",
+        revision_id="r1",
+    )
+    assert any("revenue must not be negative" in error for error in revenue_report.errors)
+
+    duplicate = pd.concat([_price_frame().iloc[:1], _price_frame().iloc[:1]], ignore_index=True)
+    _, duplicate_report = validate_dataset(
+        duplicate,
+        "daily_price",
+        source="fixture",
+        source_dataset="synthetic",
+        revision_id="r1",
+    )
+    assert any("duplicate business key" in error for error in duplicate_report.errors)
+
+
+def test_read_input_rejects_unsupported_file_type(tmp_path: Path) -> None:
+    path = tmp_path / "daily_price.json"
+    path.write_text("{}", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="unsupported import file type"):
+        read_input(path)
+
+
+def test_import_dataset_rejects_invalid_options(tmp_path: Path) -> None:
+    path = tmp_path / "daily_price.csv"
+    _price_frame().to_csv(path, index=False)
+
+    with pytest.raises(ValueError, match="unsupported Taiwan schema_version"):
+        import_dataset(path, "daily_price", source="fixture", source_dataset="synthetic", schema_version=2)
+    with pytest.raises(ValueError, match="mode must be"):
+        import_dataset(path, "daily_price", source="fixture", source_dataset="synthetic", mode="replace")
+    with pytest.raises(ValueError, match="db_path is required"):
+        import_dataset(
+            path,
+            "daily_price",
+            source="fixture",
+            source_dataset="synthetic",
+            mode="append",
+        )
+
+
+def test_create_snapshot_honors_event_date_filter(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("TW_QUANT_DATA_ROOT", str(tmp_path))
+    db_path = tmp_path / "tw_quant.duckdb"
+    snapshot_root = tmp_path / "snapshots"
+    paths = _write_csvs(tmp_path)
+    for dataset, path in paths.items():
+        import_dataset(
+            path,
+            dataset,
+            source="fixture",
+            source_dataset="synthetic",
+            mode="append",
+            db_path=db_path,
+            revision_id="r1",
+        )
+
+    manifest = create_snapshot(
+        db_path,
+        snapshot_root=snapshot_root,
+        snapshot_id="twq-date-filter",
+        start="2026-01-05",
+        end="2026-01-05",
+    )
+
+    assert manifest["tables"]["daily_price"]["rows"] == 2
+    assert manifest["tables"]["daily_price"]["min_event_time"] == "2026-01-05"
+    assert manifest["tables"]["daily_price"]["max_event_time"] == "2026-01-05"
+    assert manifest["tables"]["security_master"]["rows"] == 0
+    assert manifest["tables"]["monthly_revenue"]["rows"] == 0
+    assert verify_snapshot("twq-date-filter", snapshot_root).ok
+
+
+def test_snapshot_loader_fails_closed_for_invalid_requests(tmp_path: Path) -> None:
+    loader = TaiwanSnapshotLoader(snapshot_root=tmp_path)
+
+    assert not loader.is_available()
+    with pytest.raises(SnapshotRequiredError, match="snapshot_id is required"):
+        loader.load(["2330.TW"], "2026-01-01", "2026-01-02")
+    with pytest.raises(SnapshotLoadError, match="daily bars only"):
+        loader.fetch(["2330.TW"], "2026-01-01", "2026-01-02", interval="1H")
+
+
+def test_snapshot_loader_supports_selected_fields_and_bare_codes(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("TW_QUANT_DATA_ROOT", str(tmp_path))
+    db_path = tmp_path / "tw_quant.duckdb"
+    snapshot_root = tmp_path / "snapshots"
+    paths = _write_csvs(tmp_path)
+    for dataset, path in paths.items():
+        import_dataset(
+            path,
+            dataset,
+            source="fixture",
+            source_dataset="synthetic",
+            mode="append",
+            db_path=db_path,
+            revision_id="r1",
+        )
+    create_snapshot(db_path, snapshot_root=snapshot_root, snapshot_id="twq-fields")
+    loader = TaiwanSnapshotLoader(snapshot_id="twq-fields", snapshot_root=snapshot_root)
+
+    result = loader.load(
+        ["2330"],
+        "2026-01-02",
+        "2026-01-05",
+        fields=["close", "volume"],
+        market_hint="TWSE",
+    )
+
+    assert list(result) == ["2330.TW"]
+    assert list(result["2330.TW"].columns) == ["close", "volume"]
+    assert list(result["2330.TW"]["close"]) == [100.0, 101.0]
+    assert loader.provenance["table"] == "daily_price"
+
+    with pytest.raises(SnapshotLoadError, match="unsupported adjustment_mode"):
+        loader.load(["2330.TW"], "2026-01-01", "2026-01-02", adjustment_mode="adjusted")
+    with pytest.raises(SnapshotLoadError, match="start date"):
+        loader.load(["2330.TW"], "2026-01-03", "2026-01-02")
+    with pytest.raises(SnapshotLoadError, match="invalid Taiwan load date range"):
+        loader.load(["2330.TW"], "not-a-date", "2026-01-02")
+    with pytest.raises(SnapshotLoadError, match="unavailable"):
+        loader.load(["2330.TW"], "2026-01-01", "2026-01-02", fields=["not_a_field"])
+    with pytest.raises(SnapshotLoadError, match="unknown Taiwan market suffix"):
+        loader.load(["2330.US"], "2026-01-01", "2026-01-02")

--- a/agent/tests/test_tw_quant_migrations.py
+++ b/agent/tests/test_tw_quant_migrations.py
@@ -1,0 +1,34 @@
+"""Migration and importer contract tests for Phase 01."""
+
+from __future__ import annotations
+
+import pytest
+import duckdb
+
+from src.tw_quant.db import migrations
+from src.tw_quant.db.migrations import migrate
+
+
+def test_migration_is_idempotent_and_records_checksum(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("TW_QUANT_DATA_ROOT", str(tmp_path))
+    db_path = tmp_path / "twq.duckdb"
+    first = migrate(db_path)
+    second = migrate(db_path)
+    assert first["applied"] == [1]
+    assert second["applied"] == []
+    with duckdb.connect(str(db_path), read_only=True) as conn:
+        version, checksum = conn.execute(
+            "SELECT version, checksum FROM schema_migrations"
+        ).fetchone()
+    assert version == 1
+    assert checksum == migrations.migration_checksum(migrations._MIGRATIONS[0][1])
+
+
+def test_migration_rejects_checksum_drift(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("TW_QUANT_DATA_ROOT", str(tmp_path))
+    db_path = tmp_path / "twq.duckdb"
+    migrate(db_path)
+    original = migrations._MIGRATIONS
+    monkeypatch.setattr(migrations, "_MIGRATIONS", ((1, original[0][1] + "\n-- drift"),))
+    with pytest.raises(RuntimeError, match="checksum mismatch"):
+        migrate(db_path)

--- a/agent/tests/test_tw_quant_symbols.py
+++ b/agent/tests/test_tw_quant_symbols.py
@@ -1,0 +1,64 @@
+"""Phase 01 Taiwan symbol and routing tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from backtest.engines._market_hooks import _detect_market
+from backtest.loaders.base import NoAvailableSourceError
+from backtest.loaders.registry import get_loader_cls_with_fallback
+from backtest.runner import _create_market_engine, _detect_source, _group_codes_by_market, _normalize_codes
+from src.tw_quant.market.symbols import SymbolParseError, parse_symbol
+
+
+@pytest.mark.parametrize(
+    ("raw", "local_code", "market", "canonical"),
+    [
+        ("2330.TW", "2330", "TWSE", "2330.TW"),
+        ("6488.TWO", "6488", "TPEX", "6488.TWO"),
+        ("2330.tw", "2330", "TWSE", "2330.TW"),
+    ],
+)
+def test_parse_canonical_symbols(raw: str, local_code: str, market: str, canonical: str) -> None:
+    parsed = parse_symbol(raw)
+    assert parsed.local_code == local_code
+    assert parsed.market == market
+    assert parsed.canonical == canonical
+
+
+def test_parse_bare_code_requires_explicit_market_hint() -> None:
+    with pytest.raises(SymbolParseError):
+        parse_symbol("2330")
+    assert parse_symbol("2330", "TWSE").canonical == "2330.TW"
+    assert parse_symbol("6488", "TPEX").canonical == "6488.TWO"
+
+
+@pytest.mark.parametrize("raw", ["", "2330.US", "23.TW", "2330.TW.extra", "ABCD.TW"])
+def test_parse_rejects_invalid_or_unknown_symbols(raw: str) -> None:
+    with pytest.raises(SymbolParseError):
+        parse_symbol(raw)
+
+
+def test_taiwan_market_detection_and_source_mapping() -> None:
+    assert _detect_market("2330.TW") == "taiwan_equity"
+    assert _detect_market("6488.TWO") == "taiwan_equity"
+    assert _detect_market("2330", market_hint="tw") == "taiwan_equity"
+    assert _detect_source("2330.TW") == "tw_snapshot"
+    assert _group_codes_by_market(["2330.TW", "6488.TWO"]) == {
+        "taiwan_equity": ["2330.TW", "6488.TWO"]
+    }
+
+
+def test_tw_snapshot_normalizes_explicit_bare_code() -> None:
+    assert _normalize_codes(["2330"], "tw_snapshot", market_hint="TWSE") == ["2330.TW"]
+
+
+def test_taiwan_engine_path_fails_closed_until_rule_engine_exists() -> None:
+    with pytest.raises(ValueError, match="not implemented in Phase 01"):
+        _create_market_engine("tw_snapshot", {"market": "TWSE"}, ["2330"])
+
+
+def test_taiwan_snapshot_source_never_falls_back_to_network(monkeypatch) -> None:
+    monkeypatch.delenv("TW_QUANT_SNAPSHOT_ID", raising=False)
+    with pytest.raises(NoAvailableSourceError, match="tw_snapshot"):
+        get_loader_cls_with_fallback("tw_snapshot")

--- a/project-specs/implementation/ADR-0001-taiwan-quant-extension-boundary.md
+++ b/project-specs/implementation/ADR-0001-taiwan-quant-extension-boundary.md
@@ -1,0 +1,49 @@
+# ADR 0001: Taiwan Quant Extension Boundary
+
+- Status: Accepted
+- Scope: Phase 01 only
+- Baseline: `feature/tw-quant-phase-01` at `a5eb30fd00d6ee71cd5099d15f57de5ae47010ff`
+
+## Decision
+
+Taiwan quantitative research support is implemented as a thin extension under
+`agent/src/tw_quant/`. It owns local schema, import, immutable snapshot,
+verification, symbol parsing, and the snapshot-only loader. It does not create
+a parallel backtest core or provider integration layer.
+
+The existing `backtest.loaders.registry`, market detection, and runner receive
+only the smallest compatibility patches needed to opt into the Taiwan
+snapshot loader. Existing market fallback chains remain unchanged. Taiwan
+symbols never silently fall through to a network source.
+
+## Rationale
+
+- The repository's install boundary is `agent/`, with `src*` and `backtest*`
+  packages discovered by setuptools.
+- Existing loaders use a registry decorator and a `fetch()` contract returning
+  `{symbol: pandas.DataFrame}`. The extension adapts to that contract instead
+  of duplicating it.
+- Existing local storage supports DuckDB and Parquet, but there is no shared
+  migration or immutable snapshot subsystem. Phase 01 therefore adds one in
+  the extension and uses DuckDB's native Parquet reader/writer so it does not
+  require a second Parquet engine.
+- Formal backtests are snapshot-only. Provider SDK, HTTP, MCP, credentials,
+  and source fallback belong to later ingestion work and are intentionally
+  absent here.
+- The current `BaseEngine` exposes generic execution hooks but no Taiwan rule
+  profile. Phase 01 does not implement a Taiwan execution engine or change
+  the base algorithm. A full Taiwan backtest path must fail closed until that
+  engine is designed in a later phase.
+
+## Consequences
+
+- A snapshot ID is required by the Taiwan loader; registry discovery can use
+  `TW_QUANT_SNAPSHOT_ID` and `TW_QUANT_SNAPSHOT_ROOT` for explicit offline
+  operation.
+- The loader verifies the manifest and file hashes before every load and reads
+  only manifest-listed Parquet files.
+- `tw-data` is a thin offline CLI over the extension APIs. It performs
+  migration, validation/import, snapshot creation, and verification only.
+- Phase 02 FinMind/FinLab MCP or SDK integration, provider ingestion, Taiwan
+  execution/cost rules, and live trading remain out of scope.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ Issues = "https://github.com/HKUDS/Vibe-Trading/issues"
 [project.scripts]
 vibe-trading = "cli:main"
 vibe-trading-mcp = "mcp_server:main"
+tw-data = "src.tw_quant.cli:main"
 
 [tool.setuptools]
 package-dir = {"" = "agent"}


### PR DESCRIPTION
## Summary

- Reconcile the Phase 01 Taiwan offline quant data foundation with the latest `main` branch after PR #839 was closed.
- Keep snapshot-only Taiwan routing through `tw_snapshot`.
- Preserve Phase 01 data import, schema, manifest, verification, symbol parsing, configuration, and test coverage.
- Update the packaged skill manifest to match the current 25-source loader registry.

## Scope

- Phase 01 only.
- No Phase 02.
- No FinMind, FinLab, MCP provider integration, credentials, or live trading.

## Conflict resolution

- Started from the latest `upstream/main`.
- Reapplied only the seven Phase 01 commits.
- Resolved conflicts in the backtest runner, loader registry tests, and skill manifest while preserving newer main-branch behavior.

## Validation

- Repository safety gates: passed.
- Manifest/loader registry count check: passed, 25 sources.
- Merge conflict marker scan: passed.
- Full pytest suite: not run locally because this environment does not provide a usable pytest/Python command; GitHub Actions should perform the full CI validation.
