### PR TITLE
fix(memory): match exact title anchors when updating MEMORY.md

### DIFF
--- a/agent/src/memory/persistent.py
+++ b/agent/src/memory/persistent.py
@@ -606,8 +606,9 @@ class PersistentMemory:
         if self._index_path.exists():
             lines = self._index_path.read_text(encoding="utf-8").split("\n")
             updated = False
+            target_prefix = f"- [{title}]("
             for i, line in enumerate(lines):
-                if f"[{title}]" in line:
+                if line.startswith(target_prefix):
                     lines[i] = new_line
                     updated = True
                     break

--- a/agent/tests/test_persistent_memory.py
+++ b/agent/tests/test_persistent_memory.py
@@ -215,6 +215,16 @@ class TestAdd:
         assert len(results) == 1
         assert results[0].title == "人民币汇率"
 
+    def test_update_index_exact_title_match(self, tmp_path: Path) -> None:
+        pm = PersistentMemory(memory_dir=tmp_path)
+        pm.add("Ref", "referencing main", "project", description="See details in [Main]")
+        pm.add("Main", "main content", "project", description="Main memory entry")
+        index_content = (tmp_path / "MEMORY.md").read_text(encoding="utf-8")
+        lines = [line for line in index_content.splitlines() if line.strip()]
+        assert len(lines) == 2
+        assert any(line.startswith("- [Ref](") for line in lines)
+        assert any(line.startswith("- [Main](") for line in lines)
+
 
 # ---------------------------------------------------------------------------
 # PersistentMemory.find_relevant


### PR DESCRIPTION
Updating a memory entry could rewrite the wrong MEMORY.md line when another entry's description already contained the same `[title]` substring.

Repro: index line `- [Alpha](a.md) — see [Ref](old) here` plus a real `- [Ref](ref.md)` entry; saving title `Ref` replaced the Alpha line.

Match the markdown link target with a line prefix check instead of a bare substring search, and cover the collision in tests.
