### PR TITLE
fix(backtest): route yfinance crypto to CryptoEngine

### DIFF
--- a/agent/backtest/engines/_market_hooks.py
+++ b/agent/backtest/engines/_market_hooks.py
@@ -34,6 +34,9 @@ _MARKET_PATTERNS = [
     (re.compile(r"^\d{6}\.(KS|KQ)$", re.I), "kr_equity"),
     (re.compile(r"^[A-Z]+-USDT$", re.I), "crypto"),
     (re.compile(r"^[A-Z]+/USDT$", re.I), "crypto"),
+    # yfinance's native crypto spelling (BTC-USD, ETH-USD). Distinct from
+    # USDT pairs only in the quote currency; both belong to CryptoEngine.
+    (re.compile(r"^[A-Z]+-USD$", re.I), "crypto"),
     # China futures: product+delivery.exchange (e.g. IF2406.CFFEX, rb2410.SHFE)
     (re.compile(r"^[A-Za-z]{1,2}\d{3,4}\.(ZCE|DCE|SHFE|INE|CFFEX|GFEX)$", re.I), "futures"),
     # Global futures: product+month-code (e.g. ESZ4, CLF25, GCM2025)

--- a/agent/backtest/runner.py
+++ b/agent/backtest/runner.py
@@ -1039,6 +1039,14 @@ def _create_market_engine(source: str, config: dict, codes: List[str]):
         from backtest.engines.china_a import ChinaAEngine
         return ChinaAEngine(config)
     elif source == "yfinance":
+        # yfinance serves crypto pairs (BTC-USDT, BTC-USD) next to equities,
+        # so route on the instrument market here too. Handing crypto to
+        # GlobalEquityEngine applies zero-commission equity rules while the
+        # CryptoEngine fee keys (taker_rate/maker_rate/slippage) sit ignored
+        # in the config, and nothing warns.
+        if "crypto" in markets:
+            from backtest.engines.crypto import CryptoEngine
+            return CryptoEngine(config)
         from backtest.engines.global_equity import GlobalEquityEngine
         market = _detect_submarket(codes)
         return GlobalEquityEngine(config, market=market)

--- a/agent/tests/test_yfinance_crypto_routing.py
+++ b/agent/tests/test_yfinance_crypto_routing.py
@@ -1,0 +1,44 @@
+"""Tests that yfinance-loaded crypto routes to CryptoEngine.
+
+The yfinance branch used to hand every symbol to GlobalEquityEngine, whose
+fee keys (slippage_us / hk_commission) never read the CryptoEngine keys
+(taker_rate / maker_rate / slippage), so an explicit fee config was silently
+ignored and two runs with different fees produced byte-identical metrics.
+"""
+
+from __future__ import annotations
+
+from backtest.engines.crypto import CryptoEngine
+from backtest.engines.global_equity import GlobalEquityEngine
+from backtest.runner import _create_market_engine
+
+
+class TestYfinanceCryptoRouting:
+    def test_usdt_pair_routes_to_crypto_engine(self) -> None:
+        engine = _create_market_engine("yfinance", {"initial_cash": 100_000}, ["BTC-USDT"])
+        assert isinstance(engine, CryptoEngine)
+
+    def test_usd_pair_routes_to_crypto_engine(self) -> None:
+        # yfinance's native crypto spelling
+        engine = _create_market_engine("yfinance", {"initial_cash": 100_000}, ["BTC-USD"])
+        assert isinstance(engine, CryptoEngine)
+
+    def test_us_equity_still_routes_to_global_equity_engine(self) -> None:
+        engine = _create_market_engine("yfinance", {"initial_cash": 100_000}, ["AAPL.US"])
+        assert isinstance(engine, GlobalEquityEngine)
+
+    def test_fee_keys_reach_the_engine(self) -> None:
+        engine = _create_market_engine(
+            "yfinance",
+            {
+                "initial_cash": 100_000,
+                "taker_rate": 0.001,
+                "maker_rate": 0.001,
+                "slippage": 0.001,
+            },
+            ["ETH-USDT"],
+        )
+        assert isinstance(engine, CryptoEngine)
+        assert engine.taker_rate == 0.001
+        assert engine.maker_rate == 0.001
+        assert engine.slippage_rate == 0.001


### PR DESCRIPTION
Fixes #965.

The yfinance branch of `_create_market_engine` routed on the loader name alone, so every symbol fetched from Yahoo went to `GlobalEquityEngine`. That engine reads `slippage_us` / `slippage_hk` / `hk_commission`, so a crypto config's `taker_rate` / `maker_rate` / `slippage` were never looked at, and nothing errored or warned. Two runs differing only in fees came out byte-identical, which is how the reporter caught it.

The fix routes that branch on the instrument market, the same way the fallback branch already does for `local`/`stooq`. Crypto pairs now get `CryptoEngine` and the fee keys actually reach it.

One adjacent gap had to come along for the fix to cover what Yahoo really serves: the market classifier only knew `BTC-USDT` / `BTC/USDT`, while Yahoo's native crypto spelling is `BTC-USD`. Without it, `BTC-USD` still missed the crypto branch, so `^[A-Z]+-USD$` is added next to the USDT patterns. Nothing else in the pattern list uses the dash-USD shape, so no existing classification moves.

## Verification

New `test_yfinance_crypto_routing.py`: USDT and USD spellings route to `CryptoEngine`, `AAPL.US` still routes to `GlobalEquityEngine`, and an explicit fee config lands on the engine instance (`taker_rate` / `maker_rate` / `slippage_rate`). Routing/engine/composite subset: 769 passed, the only 2 failures (`test_akshare_loader` forex) reproduce on a clean main checkout without this change, so they are pre-existing and unrelated.

## Scope and risk

In scope: engine routing for the yfinance branch and the `-USD` crypto spelling in the market classifier. Deliberately out of scope: composite-engine fee plumbing and any loader changes. No broker, MCP, network, or credential surface is touched; the change is backtest-local. Rollback is a single-commit revert; the pre-change behavior is reachable by reverting without side effects.
