### PR TITLE
fix(memory): keep .md extension on hierarchy-routed memory entries

### DIFF
--- a/agent/src/memory/persistent.py
+++ b/agent/src/memory/persistent.py
@@ -486,13 +486,18 @@ class PersistentMemory:
             digest = hashlib.sha256(stripped_name.encode("utf-8")).hexdigest()[:6]
             slug = f"{slug}_{digest}" if slug else digest
 
+        filename = f"{memory_type}_{slug}.md"
+
         from src.config.accessor import get_env_config
+        # route_entry() treats its second argument as the leaf filename
+        # verbatim, so the .md extension must be included here; a bare slug
+        # produced extension-less files that scan_all() could not see,
+        # silently dropping hierarchy-routed entries from list_entries().
         if get_env_config().memory.hierarchy_enabled:
             from src.memory.hierarchy import MemoryHierarchy
             hierarchy = MemoryHierarchy(self._dir)
-            path = hierarchy.route_entry(memory_type, slug)
+            path = hierarchy.route_entry(memory_type, filename)
         else:
-            filename = f"{memory_type}_{slug}.md"
             path = self._dir / filename
         safe_name = stripped_name.replace("\n", " ").replace("\r", " ")
         safe_desc = (description or stripped_name).replace("\n", " ").replace("\r", " ")

--- a/agent/tests/test_persistent_memory.py
+++ b/agent/tests/test_persistent_memory.py
@@ -225,6 +225,24 @@ class TestAdd:
         assert any(line.startswith("- [Ref](") for line in lines)
         assert any(line.startswith("- [Main](") for line in lines)
 
+    def test_hierarchy_routed_entry_stays_scannable(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        # Regression: with VT_MEMORY_HIERARCHY enabled, add() used to hand the
+        # bare slug to MemoryHierarchy.route_entry(), which treats its argument
+        # as the leaf filename verbatim — the entry was written without the
+        # .md extension and scan_all() (suffix == ".md" filter) could not see
+        # it, so the memory vanished from list_entries()/find().
+        monkeypatch.setenv("VT_MEMORY_HIERARCHY", "1")
+        pm = PersistentMemory(memory_dir=tmp_path)
+        path = pm.add("routed-mem", "body text", "project", description="routed")
+        assert path.suffix == ".md"
+        assert path.parent.name == "project"
+        entries = pm.list_entries()
+        assert len(entries) == 1
+        assert entries[0].title == "routed-mem"
+        assert pm.find("routed-mem") is not None
+
 
 # ---------------------------------------------------------------------------
 # PersistentMemory.find_relevant


### PR DESCRIPTION
## Summary

- Fixes silent data loss: with `VT_MEMORY_HIERARCHY=1`, `PersistentMemory.add()` wrote entries **without the `.md` extension**, making them invisible to every scan/recall path.
- Unifies the filename scheme across flat and hierarchical storage and adds a regression test for the full `add()` → `list_entries()`/`find()` round-trip.

Closes #971

## Why

`add()` handed the bare slug to `MemoryHierarchy.route_entry()`, which uses its second argument as the leaf filename verbatim (its docstring expects "The .md filename for the memory entry"). Routed entries therefore landed at `<category>/<slug>` with no extension, while `scan_all()` filters on `suffix == ".md"` — so every entry added with hierarchy enabled silently vanished from `list_entries()`, `find()`, `find_relevant()`, and agent auto-recall. Flat mode always wrote `{memory_type}_{slug}.md` correctly; only hierarchy-enabled stores were affected.

## Changes

- `agent/src/memory/persistent.py` — compute `filename = f"{memory_type}_{slug}.md"` once and pass the complete filename to `route_entry()`; the flat branch now uses the same filename (behavior unchanged).
- `agent/tests/test_persistent_memory.py` — add `test_hierarchy_routed_entry_stays_scannable`, which fails on unfixed code (`assert '' == '.md'`) and passes with the fix.

**Deliberately out of scope:** migrating pre-existing extension-less orphan files written by the old code (a manual rename to `*.md` restores visibility — noted in #971), and any change to `MEMORY.md` index-link cosmetics.

## Test Plan

- [x] Existing tests pass (`pytest tests/test_persistent_memory.py tests/memory/` → 166 passed; `tests/test_memory_gc.py tests/test_memory_lifecycle.py tests/test_cli_memory.py` → 64 passed)
- [x] New tests added — red without the fix, green with it
- [x] `ruff check` clean on both changed files; `pytest tools/test_ci_env_var_gate.py` passes locally
- [ ] Tested manually — N/A (covered by the regression test)

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines — DCO-signed commit, minimal diff, matches existing style; whole-tree Black is not enforced per CONTRIBUTING.md
- [x] Documentation updated (if user-facing change) — no user-facing doc change needed

**Risk:** none beyond the memory file layer; flat storage output is byte-identical. **Rollback:** revert the single commit.
