### PR TITLE
fix(memory): skip compression pipeline in run_gc dry runs

### DIFF
--- a/agent/src/memory/lifecycle.py
+++ b/agent/src/memory/lifecycle.py
@@ -240,9 +240,11 @@ class MemoryLifecycle:
 
         self._append_gc_log(actions, dry_run)
 
-        # Tier 2: Trigger compression for aged entries
+        # Tier 2: Trigger compression for aged entries. Skipped on dry_run:
+        # compression rewrites entry bodies and frontmatter in place, and a
+        # dry run must not mutate the files it is only auditing.
         from src.config.accessor import get_env_config
-        if get_env_config().memory.compression_enabled:
+        if not dry_run and get_env_config().memory.compression_enabled:
             try:
                 from src.memory.compression import CompressionPipeline
                 pipeline = CompressionPipeline(self._memory._dir)

--- a/agent/tests/test_memory_gc.py
+++ b/agent/tests/test_memory_gc.py
@@ -172,6 +172,61 @@ class TestRunGC:
         assert (tmp_path / "archive" / "project_very-low.md").exists()
         assert not (tmp_path / "project_very-low.md").exists()
 
+    def test_gc_dry_run_skips_compression(self, tmp_path: Path, monkeypatch) -> None:
+        """dry_run=True must not rewrite entries via the compression pipeline."""
+        monkeypatch.setenv("VT_MEMORY_GC", "1")
+        monkeypatch.setenv("VT_MEMORY_COMPRESSION", "1")
+        # Younger than MIN_AGE_DAYS so Tier-1 skips it, but last_accessed is
+        # older than DAILY_THRESHOLD_DAYS (7) so Tier-2 would compress it.
+        now = time.time()
+        created_iso = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(now - 2 * 86400))
+        accessed_iso = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(now - 9 * 86400))
+        body = " ".join(
+            f"Sentence number {i} discusses trading topic {i} in detail."
+            for i in range(12)
+        )
+        path = _create_memory_file(
+            tmp_path,
+            "aged-raw",
+            content=body,
+            keywords=["alpha", "momentum"],
+            created_at=created_iso,
+            last_accessed=accessed_iso,
+        )
+        before = path.read_text(encoding="utf-8")
+        pm = PersistentMemory(memory_dir=tmp_path)
+        lc = MemoryLifecycle(pm)
+        actions = lc.run_gc(dry_run=True)
+        assert actions == []
+        assert path.read_text(encoding="utf-8") == before
+
+    def test_gc_execute_applies_compression(self, tmp_path: Path, monkeypatch) -> None:
+        """dry_run=False still applies Tier-2 compression to eligible entries."""
+        monkeypatch.setenv("VT_MEMORY_GC", "1")
+        monkeypatch.setenv("VT_MEMORY_COMPRESSION", "1")
+        now = time.time()
+        created_iso = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(now - 2 * 86400))
+        accessed_iso = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(now - 9 * 86400))
+        body = " ".join(
+            f"Sentence number {i} discusses trading topic {i} in detail."
+            for i in range(12)
+        )
+        path = _create_memory_file(
+            tmp_path,
+            "aged-raw-exec",
+            content=body,
+            keywords=["alpha", "momentum"],
+            created_at=created_iso,
+            last_accessed=accessed_iso,
+        )
+        before = path.read_text(encoding="utf-8")
+        pm = PersistentMemory(memory_dir=tmp_path)
+        lc = MemoryLifecycle(pm)
+        lc.run_gc(dry_run=False)
+        after = path.read_text(encoding="utf-8")
+        assert after != before
+        assert "compression_level: daily" in after
+
 
 # ---------------------------------------------------------------------------
 # 2. find_relevant importance weighting


### PR DESCRIPTION
## Summary

- Fixes a dry-run contract violation: `MemoryLifecycle.run_gc(dry_run=True)` still ran the Tier-2 compression pipeline when `VT_MEMORY_COMPRESSION` was enabled, rewriting entry bodies and frontmatter it was only supposed to audit.
- Gates the compression pass on `not dry_run` and adds regression tests for both modes.

## Why

`run_gc()` documents `dry_run` as "log actions without modifying files". Tier-1 archive/delete honors it, but the Tier-2 block checked only `compression_enabled`. After `_append_gc_log(actions, dry_run)`, `CompressionPipeline.apply_compression()` + `_write_compressed()` atomically rewrite each eligible entry (raw -> daily TF-IDF sentence extraction, plus the `compression_level`/`updated_at` frontmatter fields). So an audit-type invocation (dry run, preview, "what would GC do?") silently mutated exactly the entries it was inspecting.

## Changes

- `agent/src/memory/lifecycle.py` — `if not dry_run and get_env_config().memory.compression_enabled:` (one-line gate + explanatory comment).
- `agent/tests/test_memory_gc.py` — two regression tests in `TestRunGC`:
  - `test_gc_dry_run_skips_compression`: an entry too young for Tier-1 but past the compression access-age threshold stays byte-identical under `dry_run=True` (fails on unfixed code with a visible rewrite: `compression_level: daily` added, body reduced to the extracted sentences).
  - `test_gc_execute_applies_compression`: `dry_run=False` still compresses the same-shape entry to `daily`.

**Deliberately out of scope:** the `gc.log` dry-run audit record (`_append_gc_log`) is intentional logging marked `mode=dry_run` and is preserved; nothing else in the GC flow is touched.

## Test Plan

- [x] Existing tests pass (`pytest tests/test_memory_gc.py tests/test_memory_lifecycle.py tests/memory/` -> 141 passed)
- [x] New tests added — red without the fix, green with it
- [x] `ruff check` clean on both changed files; `pytest tools/test_ci_env_var_gate.py` passes locally
- [ ] Tested manually — N/A (covered by the regression tests)

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines — DCO-signed commit, minimal diff, matches existing style
- [x] Documentation updated (if user-facing change) — no user-facing doc change needed

**Risk:** none beyond the memory GC path; execute-mode behavior is unchanged (positive-control test). **Rollback:** revert the single commit.
