### PR TITLE
fix(scheduled-research): reject job ids the delete route cannot accept

### DIFF
--- a/agent/src/api/scheduled_routes.py
+++ b/agent/src/api/scheduled_routes.py
@@ -6,6 +6,7 @@ Mounted by ``agent/api_server.py`` via ``register_scheduled_routes(app, ...)``.
 from __future__ import annotations
 
 import logging
+import re
 import sys as _sys
 import time
 import uuid
@@ -25,6 +26,11 @@ logger = logging.getLogger(__name__)
 
 _SCHEDULED_RESEARCH_SCHEDULER_ENV = "VIBE_TRADING_ENABLE_SCHEDULER"
 _SCHEDULED_RESEARCH_TRUE_VALUES = {"1", "true", "yes", "on"}
+
+# Mirrors ``_SAFE_PATH_PARAM_RE`` in src/api/helpers.py, which the delete route
+# enforces on the job id. Kept in sync so a job can never be created under an
+# id the delete route refuses.
+_SAFE_JOB_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
 
 
 # ---------------------------------------------------------------------------
@@ -111,7 +117,12 @@ class CreateScheduledRunRequest(BaseModel):
     """Request body for POST /scheduled-runs."""
 
     id: Optional[str] = Field(
-        None, description="Job id; auto-generated UUID when omitted"
+        None,
+        description=(
+            "Job id; auto-generated UUID when omitted. Must match the id rule "
+            "the delete route enforces: letters, digits, '_' and '-', 1-128 "
+            "characters."
+        ),
     )
     prompt: str = Field(
         ..., min_length=1, description="Research prompt or backtest description"
@@ -206,6 +217,18 @@ def register_scheduled_routes(
         )
 
         from src.scheduled_research.executor import next_due
+
+        # A job whose id the delete route rejects can never be cancelled
+        # through the API, so the id is held to that same rule at creation
+        # rather than at first attempted delete.
+        if request.id is not None and not _SAFE_JOB_ID_RE.fullmatch(request.id):
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "job id must be 1-128 characters of letters, digits, "
+                    "'_' or '-'"
+                ),
+            )
 
         try:
             validate_schedule(request.schedule)

--- a/agent/tests/test_scheduled_routes.py
+++ b/agent/tests/test_scheduled_routes.py
@@ -320,3 +320,42 @@ def test_create_interval_with_timezone_keeps_immediate_first_fire(
 
     assert response.status_code == 201
     assert before <= response.json()["next_run_at"] <= after
+
+
+def test_create_rejects_ids_the_delete_route_would_refuse(
+    client: TestClient, store: ScheduledResearchJobStore
+):
+    for bad_id in ("my scan.v1", "a/b", "café", "x" * 129):
+        response = client.post(
+            "/scheduled-runs",
+            json={"id": bad_id, "prompt": "scan", "schedule": "60000"},
+        )
+        assert response.status_code == 422, bad_id
+        assert "job id" in response.json()["detail"]
+        assert store.get(bad_id) is None
+
+
+def test_created_job_is_always_deletable(
+    client: TestClient, store: ScheduledResearchJobStore
+):
+    created = client.post(
+        "/scheduled-runs",
+        json={"prompt": "scan", "schedule": "60000"},
+    )
+    assert created.status_code == 201
+    job_id = created.json()["id"]
+
+    assert client.delete(f"/scheduled-runs/{job_id}").status_code == 204
+    assert store.get(job_id) is None
+
+
+def test_create_accepts_ids_within_the_id_rule(
+    client: TestClient, store: ScheduledResearchJobStore
+):
+    for good_id in ("daily-scan", "scan_2026", "A" * 128):
+        response = client.post(
+            "/scheduled-runs",
+            json={"id": good_id, "prompt": "scan", "schedule": "60000"},
+        )
+        assert response.status_code == 201, good_id
+        assert client.delete(f"/scheduled-runs/{good_id}").status_code == 204


### PR DESCRIPTION
## Problem

`POST /scheduled-runs` accepts any `id`, but `DELETE /scheduled-runs/{job_id}` validates the path parameter against `^[A-Za-z0-9_-]{1,128}$`. An id containing a space, dot, slash or non-ASCII character — or longer than 128 — therefore creates a job the API can never cancel. The two sides have disagreed since the routes were split out; nothing recent introduced it.

Reproduced against a running server:

```
POST /scheduled-runs {"id":"my scan.v1","prompt":"p","schedule":"60000"}   -> 201 Created
DELETE /scheduled-runs/my%20scan.v1                                        -> 400 {"detail":"invalid job_id"}
GET /scheduled-runs                                                        -> "my scan.v1" still present
```

With `VIBE_TRADING_ENABLE_SCHEDULER=1` that job dispatches a research session on every firing, the web UI's Delete button errors every time, and the only way to remove it is hand-editing `~/.vibe-trading/scheduled_research/scheduled_research_jobs.json`.

## Fix

The create route holds the id to the same rule the delete route enforces and answers 422 with an actionable message, so a bad id is rejected at creation instead of at the first attempted delete. Generated UUIDs already satisfy the rule and existing persisted jobs are untouched — only new creates are validated.

After the fix, same sequence:

```
POST {"id":"my scan.v1", ...}  -> 422 {"detail":"job id must be 1-128 characters of letters, digits, '_' or '-'"}
POST {no id} then DELETE       -> 201, then 204
```

## Tests

Three route tests: ids the delete route would refuse are rejected at create (space, slash, non-ASCII, 129 chars), any created job is deletable, and valid ids (including a 128-character one) still create and delete.

## Validation

- `pytest --ignore=agent/tests/e2e_backtest --ignore=agent/tests/test_e2e_harness_v2.py`: 7,153 passed, 0 failed.
- Reproduction and fix confirmed against a live `vibe-trading serve` instance on an isolated `VIBE_TRADING_HOME`.
- Not run: `agent/tests/e2e_backtest` and the e2e harness (excluded per the contributor guide's default command).
