### PR TITLE
fix(runner): pre-seed mootdx config in sandbox home

### DIFF
--- a/agent/src/core/runner.py
+++ b/agent/src/core/runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import shutil
@@ -142,6 +143,31 @@ def _prepare_sandbox_home(real_home: Path | None) -> Path:
     try:
         os.chmod(sandbox, 0o755)
     except OSError:
+        pass
+    # Pre-seed mootdx's config.json so its setup() doesn't crash on an empty
+    # HOME. mootdx's config.py runs `finally: load_config()`, which re-reads the
+    # file even after bestip(sync=False) fails to write it — the FileNotFoundError
+    # from the finally block is uncaught and surfaces as asyncio "Exception in
+    # callback" noise. Copy the real HOME's config when available: it carries
+    # bestip-selected servers, so mootdx connects without re-running bestip.
+    # Library defaults alone leave BESTIP empty, which trips a ValueError inside
+    # mootdx; a valid empty object is the last-resort fallback.
+    try:
+        mootdx_dir = sandbox / ".mootdx"
+        mootdx_dir.mkdir(parents=True, exist_ok=True)
+        src_cfg = (real_home / ".mootdx" / "config.json") if real_home else None
+        if src_cfg and src_cfg.is_file():
+            payload = src_cfg.read_text(encoding="utf-8")
+        else:
+            from mootdx.config import settings as mootdx_defaults
+
+            payload = json.dumps(mootdx_defaults, ensure_ascii=False)
+    except Exception:  # mootdx missing / unreadable config
+        payload = "{}"
+    try:
+        (mootdx_dir / "config.json").write_text(payload, encoding="utf-8")
+    except OSError:
+        # Best-effort: the market-data tool falls back to other A-share sources.
         pass
     return sandbox
 

--- a/agent/tests/test_runner_env.py
+++ b/agent/tests/test_runner_env.py
@@ -137,6 +137,23 @@ def test_prepare_sandbox_home_reexposes_only_loader_paths(tmp_path: Path) -> Non
     assert (vt / "cache").exists()
 
 
+def test_prepare_sandbox_home_preseeds_mootdx_config(tmp_path: Path) -> None:
+    sandbox = _prepare_sandbox_home(tmp_path)
+    try:
+        cfg = sandbox / ".mootdx" / "config.json"
+        # mootdx's setup() runs `finally: load_config()`, re-reading the file
+        # even after bestip(sync=False) fails to write it — the sandbox HOME
+        # must ship a valid config or mootdx raises an uncaught FileNotFoundError.
+        assert cfg.exists()
+        import json
+
+        assert isinstance(json.loads(cfg.read_text(encoding="utf-8")), dict)
+    finally:
+        import shutil
+
+        shutil.rmtree(sandbox, ignore_errors=True)
+
+
 def test_make_rlimit_preexec_returns_callable_on_posix() -> None:
     # Structural check only — the returned closure mutates *this* process's
     # rlimits if called directly, so it must never be invoked in-process here;


### PR DESCRIPTION
## Problem
When the backtest runner fetches A-share quotes via `mootdx`, the ephemeral sandbox HOME has no `~/.mootdx/config.json`. mootdx's `config.py:setup()` runs `finally: load_config()`, which re-reads the file even after `bestip(sync=False)` fails to write it — raising an uncaught `FileNotFoundError` that surfaces as asyncio `Exception in callback callback(key='HQ'|'EX'|'GP')` noise (hundreds of tracebacks per A-share fetch).

## Fix
In `_prepare_sandbox_home`, pre-seed `~/.mootdx/config.json` into the sandbox:
- Prefer copying the real HOME's config (carries bestip-selected servers, so mootdx connects without re-running bestip).
- Fall back to library defaults, then a valid empty `{}`.

This makes `setup()` succeed without `bestip`, eliminating the crash regardless of network conditions.

## Verification
- Live test in a sandbox HOME: `Quotes.factory()` + `client.bars("600519")` fetched real A-share bars (no FileNotFoundError / ValueError).
- Regression test `test_prepare_sandbox_home_preseeds_mootdx_config` added (`test_runner_env.py`, suite 13 passed).