### PR TITLE
fix(memory): write hierarchy-routed entries with the .md extension

### DIFF
--- a/agent/src/memory/persistent.py
+++ b/agent/src/memory/persistent.py
@@ -490,7 +490,7 @@ class PersistentMemory:
         if get_env_config().memory.hierarchy_enabled:
             from src.memory.hierarchy import MemoryHierarchy
             hierarchy = MemoryHierarchy(self._dir)
-            path = hierarchy.route_entry(memory_type, slug)
+            path = hierarchy.route_entry(memory_type, f"{slug}.md")
         else:
             filename = f"{memory_type}_{slug}.md"
             path = self._dir / filename

--- a/agent/tests/memory/test_tier2_integration.py
+++ b/agent/tests/memory/test_tier2_integration.py
@@ -70,6 +70,18 @@ class TestHierarchyAddRoutesToSubdir:
         assert path.parent == tmp_path / "user"
         assert path.exists()
 
+    def test_hierarchy_add_writes_discoverable_md(self, tmp_path, monkeypatch):
+        """With VT_MEMORY_HIERARCHY=true, add() must write a .md that list_entries sees."""
+        monkeypatch.setenv("VT_MEMORY_HIERARCHY", "true")
+        reset_env_config()
+
+        mem = PersistentMemory(tmp_path)
+        path = mem.add("visible entry", "content that must be discoverable", "project")
+
+        assert path is not None
+        assert path.suffix == ".md"
+        assert "visible entry" in {e.title for e in mem.list_entries()}
+
 
 # ---------------------------------------------------------------------------
 # 2. Hierarchy: scan_all finds both flat and routed entries


### PR DESCRIPTION
## Problem

With `VT_MEMORY_HIERARCHY=1` (e.g. via `VT_MEMORY=full`), `PersistentMemory.add()` writes the routed entry file without the `.md` extension: it passes the bare slug to `MemoryHierarchy.route_entry()`, which uses its second argument as the leaf filename verbatim, while every discovery path (`scan_all()` and therefore `list_entries()` / `find()` / agent auto-recall) filters on the `.md` suffix. The entry lands at `<memory_dir>/<category>/<slug>` and is silently invisible forever. No error anywhere.

## What changed

`add()` now passes `f"{slug}.md"` to `route_entry()`, matching the extension the discovery side filters on and the flat-layout branch's own `{type}_{slug}.md` shape. One line; the routing contract stays caller-supplies-the-filename.

A regression test closes the hole the bug shipped through: the existing routing test only asserted the file exists on disk, which an extension-less file satisfies. The new one asserts the written path ends in `.md` and that `list_entries()` actually sees the entry. Verified red against the old line, green with it. Full `test_tier2_integration` suite passes (10 tests).

Closes #971
