### PR TITLE
feat(channels): add Web WeChat QR login

### DIFF
--- a/README.md
+++ b/README.md
@@ -855,6 +855,12 @@ vibe-trading channels login weixin     # run an adapter login hook when needed
 vibe-trading channels pairing --channel telegram list
 ```
 
+For personal WeChat, enable `channels.weixin`, keep the channel runtime stopped,
+then open **Settings → IM Channels → Scan to connect**. The Web UI renders the
+short-lived QR challenge and polls for confirmation; the resulting bot token is
+persisted only by the server and is never returned to the browser. Closing the
+dialog cancels the challenge, and expired codes refresh automatically.
+
 The built-in adapters cover `websocket`, `telegram`, `slack`, `discord`, `matrix`, `whatsapp`, `signal`, `qq`, `napcat`, `weixin`, `wecom`, `feishu`, `dingtalk`, `msteams`, `email`, and `mochat`. Use narrow extras such as `pip install "vibe-trading-ai[telegram]"`, or install the full channel set with `pip install "vibe-trading-ai[channels]"`.
 
 **In-chat slash commands** (channel-agnostic, work in all 16 adapters):
@@ -992,6 +998,9 @@ vibe-trading serve --port 8899
 | `GET` | `/channels/status` | Read IM channel runtime and adapter status |
 | `POST` | `/channels/start` | Start configured IM channel adapters |
 | `POST` | `/channels/stop` | Stop configured IM channel adapters |
+| `POST` | `/channels/{channel}/qr-login` | Start a short-lived browser QR login for a supported adapter |
+| `GET` | `/channels/qr-login/{session_id}` | Poll a browser QR login (credentials are never returned) |
+| `DELETE` | `/channels/qr-login/{session_id}` | Cancel a browser QR login |
 | `POST` | `/channels/pairing/command` | Run a sender-pairing command against the shared store |
 | `POST` | `/scheduled-runs` | Create a scheduled research job (interval-ms or cron) |
 | `GET` | `/scheduled-runs` | List scheduled jobs |
@@ -1017,7 +1026,7 @@ The Web UI Settings page lets local users update the LLM provider/model, base UR
 
 Settings reads are side-effect free: `GET /settings/llm` and `GET /settings/data-sources` never create `agent/.env`, and they only return project-relative paths. Settings reads and writes can expose credential state or update credentials/runtime environment, so they require `API_AUTH_KEY` when configured. If `API_AUTH_KEY` is unset for dev mode, settings access is accepted only from loopback clients.
 
-The same Settings page includes an **IM Channels** panel for local operators. It polls `/channels/status`, shows configured/enabled/available/loaded/running states, surfaces adapter recovery hints, and can start or stop the configured channel runtime without going back to the terminal.
+The same Settings page includes an **IM Channels** panel for local operators. It polls `/channels/status`, shows configured/enabled/available/loaded/running states, surfaces adapter recovery hints, and can start or stop the configured channel runtime without going back to the terminal. QR-capable adapters expose a **Scan to connect** action; personal WeChat is the first supported adapter, and its credentials remain server-side.
 
 ### Scheduled research
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -822,6 +822,11 @@ vibe-trading channels login weixin     # 需要时执行适配器登录流程
 vibe-trading channels pairing --channel telegram list
 ```
 
+个人微信可在启用 `channels.weixin` 并保持通道 runtime 停止后，打开
+**Settings → IM 通道 → 扫码连接**。Web UI 会展示短时二维码并轮询确认状态；
+确认后的 bot token 仅由服务端持久化，绝不会返回浏览器。关闭弹窗会取消本次
+登录，二维码过期时页面会自动刷新。
+
 内置适配器包括 `websocket`、`telegram`、`slack`、`discord`、`matrix`、`whatsapp`、`signal`、`qq`、`napcat`、`weixin`、`wecom`、`feishu`、`dingtalk`、`msteams`、`email` 和 `mochat`。可按需安装单个平台，例如 `pip install "vibe-trading-ai[telegram]"`，也可以一次安装全量通道依赖：`pip install "vibe-trading-ai[channels]"`。
 
 **聊天内斜杠命令**（通道无关，全部 16 个适配器通用）：
@@ -957,6 +962,9 @@ vibe-trading serve --port 8899
 | `GET` | `/channels/status` | 读取 IM 通道运行时与适配器状态 |
 | `POST` | `/channels/start` | 启动已配置的 IM 通道适配器 |
 | `POST` | `/channels/stop` | 停止已配置的 IM 通道适配器 |
+| `POST` | `/channels/{channel}/qr-login` | 为支持的适配器启动短时 Web 扫码登录 |
+| `GET` | `/channels/qr-login/{session_id}` | 轮询 Web 扫码登录状态（不返回凭据） |
+| `DELETE` | `/channels/qr-login/{session_id}` | 取消 Web 扫码登录 |
 | `POST` | `/channels/pairing/command` | 针对共享存储执行 sender pairing 命令 |
 | `POST` | `/scheduled-runs` | 创建定时研究任务（间隔毫秒或 cron） |
 | `GET` | `/scheduled-runs` | 列出定时任务 |
@@ -980,7 +988,7 @@ Web UI Settings 页面允许本地用户更新 LLM provider/model、base URL、g
 
 Settings 读取无副作用：`GET /settings/llm` 和 `GET /settings/data-sources` 永远不会创建 `agent/.env`，并且只返回项目相对路径。Settings 读写可能暴露凭据状态或更新凭据/运行时环境，因此在配置了 `API_AUTH_KEY` 时会要求认证。如果 dev mode 下未设置 `API_AUTH_KEY`，settings 访问只接受 loopback clients。
 
-同一个 Settings 页面也包含 **IM 通道**面板，面向本地 operator。它会轮询 `/channels/status`，展示 configured/enabled/available/loaded/running 状态，暴露适配器恢复提示，并可直接启动或停止已配置的通道 runtime。
+同一个 Settings 页面也包含 **IM 通道**面板，面向本地 operator。它会轮询 `/channels/status`，展示 configured/enabled/available/loaded/running 状态，暴露适配器恢复提示，并可直接启动或停止已配置的通道 runtime。支持二维码登录的适配器会显示**扫码连接**操作；个人微信是首个支持项，确认登录后的凭据只保存在服务端，不会返回浏览器。
 
 ### 定时研究（Scheduled research）
 

--- a/agent/src/api/channels_routes.py
+++ b/agent/src/api/channels_routes.py
@@ -5,10 +5,18 @@ Mounted by ``agent/api_server.py`` via ``register_channels_routes(app, ...)``.
 
 from __future__ import annotations
 
+import logging
+import secrets
+import time
+from dataclasses import dataclass
 from typing import Any, Awaitable, Callable
 
-from fastapi import Depends, FastAPI
+from fastapi import Depends, FastAPI, HTTPException
 from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+_QR_LOGIN_SESSION_TTL_S = 10 * 60
 
 
 # ---------------------------------------------------------------------------
@@ -20,6 +28,13 @@ class ChannelPairingCommandRequest(BaseModel):
 
     channel: str
     command: str
+
+
+@dataclass
+class _QRLoginSession:
+    channel: str
+    adapter: Any
+    created_at: float
 
 
 # ---------------------------------------------------------------------------
@@ -83,6 +98,31 @@ def register_channels_routes(
         h = _sys.modules.get("api_server") or _sys.modules.get("agent.api_server")
         return h._get_channel_runtime()
 
+    qr_login_sessions: dict[str, _QRLoginSession] = {}
+    channel_login_sessions: dict[str, str] = {}
+
+    async def _drop_qr_login_session(session_id: str, *, cancel: bool) -> None:
+        session = qr_login_sessions.pop(session_id, None)
+        if session is None:
+            return
+        if channel_login_sessions.get(session.channel) == session_id:
+            channel_login_sessions.pop(session.channel, None)
+        if cancel:
+            try:
+                await session.adapter.cancel_qr_login()
+            except Exception:  # noqa: BLE001 - cleanup must not mask the API response
+                logger.warning("Failed to clean up QR login session", exc_info=True)
+
+    async def _expire_qr_login_sessions() -> None:
+        now = time.monotonic()
+        expired = [
+            session_id
+            for session_id, session in qr_login_sessions.items()
+            if now - session.created_at >= _QR_LOGIN_SESSION_TTL_S
+        ]
+        for session_id in expired:
+            await _drop_qr_login_session(session_id, cancel=True)
+
     # --- Routes ---
 
     @app.get("/channels/status", dependencies=[Depends(require_auth)])
@@ -94,6 +134,9 @@ def register_channels_routes(
     @app.post("/channels/start", dependencies=[Depends(require_auth)])
     async def channels_start():
         """Start configured IM channel adapters."""
+        await _expire_qr_login_sessions()
+        if qr_login_sessions:
+            raise HTTPException(status_code=409, detail="Cancel the active QR login before starting channels")
         runtime = await _start_channel_runtime()
         return {"status": "started", **runtime.status()}
 
@@ -103,6 +146,72 @@ def register_channels_routes(
         runtime = _get_channel_runtime()
         await runtime.stop()
         return {"status": "stopped", **runtime.status()}
+
+    @app.post("/channels/{channel}/qr-login", dependencies=[Depends(require_auth)])
+    async def channels_qr_login_start(channel: str):
+        """Start an authenticated, short-lived browser QR login session."""
+        await _expire_qr_login_sessions()
+        runtime = _get_channel_runtime()
+        adapter = runtime.manager.get_channel(channel) if runtime.manager is not None else None
+        if adapter is None:
+            raise HTTPException(status_code=404, detail=f"Enabled channel '{channel}' is not loaded")
+        if not bool(getattr(adapter, "qr_login_supported", False)):
+            raise HTTPException(status_code=400, detail=f"Channel '{channel}' does not support QR login")
+        if adapter.is_running:
+            raise HTTPException(status_code=409, detail=f"Stop channel '{channel}' before QR login")
+        if channel in channel_login_sessions:
+            raise HTTPException(status_code=409, detail=f"A QR login for channel '{channel}' is already active")
+
+        session_id = secrets.token_urlsafe(24)
+        qr_login_sessions[session_id] = _QRLoginSession(
+            channel=channel,
+            adapter=adapter,
+            created_at=time.monotonic(),
+        )
+        channel_login_sessions[channel] = session_id
+        try:
+            result = await adapter.begin_qr_login()
+        except Exception as exc:  # noqa: BLE001 - external login failures become a stable API error
+            logger.warning("Failed to start %s QR login", channel, exc_info=True)
+            await _drop_qr_login_session(session_id, cancel=True)
+            raise HTTPException(status_code=502, detail=f"Could not start QR login for '{channel}'") from exc
+
+        response = {"channel": channel, "session_id": session_id, **result}
+        if result.get("status") in {"authenticated", "expired", "failed"}:
+            await _drop_qr_login_session(session_id, cancel=False)
+            response.pop("session_id", None)
+        return response
+
+    @app.get("/channels/qr-login/{session_id}", dependencies=[Depends(require_auth)])
+    async def channels_qr_login_status(session_id: str):
+        """Advance a browser QR login without returning adapter credentials."""
+        await _expire_qr_login_sessions()
+        session = qr_login_sessions.get(session_id)
+        if session is None:
+            raise HTTPException(status_code=404, detail="QR login session was not found or expired")
+        try:
+            result = await session.adapter.poll_qr_login()
+        except Exception as exc:  # noqa: BLE001 - external login failures become a stable API error
+            logger.warning("Failed to poll %s QR login", session.channel, exc_info=True)
+            await _drop_qr_login_session(session_id, cancel=True)
+            raise HTTPException(status_code=502, detail=f"Could not poll QR login for '{session.channel}'") from exc
+
+        response = {"channel": session.channel, "session_id": session_id, **result}
+        if result.get("status") in {"authenticated", "expired", "failed"}:
+            await _drop_qr_login_session(session_id, cancel=False)
+            response.pop("session_id", None)
+        return response
+
+    @app.delete("/channels/qr-login/{session_id}", dependencies=[Depends(require_auth)])
+    async def channels_qr_login_cancel(session_id: str):
+        """Cancel a browser QR login and discard its transient challenge."""
+        await _expire_qr_login_sessions()
+        session = qr_login_sessions.get(session_id)
+        if session is None:
+            return {"status": "cancelled"}
+        channel = session.channel
+        await _drop_qr_login_session(session_id, cancel=True)
+        return {"channel": channel, "status": "cancelled"}
 
     @app.post("/channels/pairing/command", dependencies=[Depends(require_auth)])
     async def channels_pairing_command(payload: ChannelPairingCommandRequest):

--- a/agent/src/channels/base.py
+++ b/agent/src/channels/base.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from pathlib import Path
 from typing import Any
 
 from src.channels.bus.events import InboundMessage, OutboundMessage
@@ -31,6 +30,7 @@ class BaseChannel(ABC):
     send_progress: bool = True
     send_tool_hints: bool = False
     show_reasoning: bool = True
+    qr_login_supported: bool = False
 
     def __init__(self, config: Any, bus: MessageBus) -> None:
         """Initialize the channel.
@@ -54,6 +54,23 @@ class BaseChannel(ABC):
         Override in subclasses that support interactive login.
         """
         return True
+
+    async def begin_qr_login(self) -> dict[str, Any]:
+        """Start a browser-driven QR login challenge.
+
+        Adapters that set ``qr_login_supported`` must return a JSON-safe status
+        payload containing transient ``qr_content`` for the browser to render.
+        Credentials must be persisted by the adapter and must never be included
+        in this payload.
+        """
+        raise NotImplementedError(f"{self.name} does not support QR login")
+
+    async def poll_qr_login(self) -> dict[str, Any]:
+        """Advance an active browser-driven QR login challenge by one poll."""
+        raise NotImplementedError(f"{self.name} does not support QR login")
+
+    async def cancel_qr_login(self) -> None:
+        """Cancel an active browser-driven QR login challenge."""
 
     @abstractmethod
     async def start(self) -> None:

--- a/agent/src/channels/manager.py
+++ b/agent/src/channels/manager.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
-from collections.abc import Callable
 from contextlib import suppress
-from pathlib import Path
 from typing import Any
 
 from src.channels.base import BaseChannel
@@ -118,6 +116,7 @@ class ChannelManager:
                         "available": True,
                         "loaded": True,
                         "running": channel.is_running,
+                        "qr_login_supported": bool(channel.qr_login_supported),
                         "display_name": getattr(cls, "display_name", name),
                         "error": "",
                     }
@@ -467,6 +466,7 @@ class ChannelManager:
                     "enabled": True,
                     "loaded": True,
                     "running": channel.is_running,
+                    "qr_login_supported": bool(channel.qr_login_supported),
                     "display_name": getattr(channel, "display_name", name),
                 }
             )

--- a/agent/src/channels/weixin.py
+++ b/agent/src/channels/weixin.py
@@ -13,6 +13,7 @@ import asyncio
 import base64
 import hashlib
 import json
+import logging
 import os
 import random
 import re
@@ -25,15 +26,14 @@ from typing import Any
 from urllib.parse import quote
 
 import httpx
-import logging; logger = logging.getLogger(__name__)
-from pydantic import Field
+from pydantic import BaseModel, Field
 
+from src.channels.base import BaseChannel
 from src.channels.bus.events import OutboundMessage
 from src.channels.bus.queue import MessageBus
-from src.channels.base import BaseChannel
-from src.channels.utils import get_media_dir, get_runtime_subdir
-from pydantic import BaseModel
-from src.channels.utils import split_message
+from src.channels.utils import get_media_dir, get_runtime_subdir, split_message
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Protocol constants (from openclaw-weixin types.ts)
@@ -142,6 +142,7 @@ class WeixinChannel(BaseChannel):
 
     name = "weixin"
     display_name = "WeChat"
+    qr_login_supported = True
 
     @classmethod
     def default_config(cls) -> dict[str, Any]:
@@ -167,6 +168,12 @@ class WeixinChannel(BaseChannel):
         self._typing_tickets: dict[str, dict[str, Any]] = {}
         self._context_token_at: dict[str, float] = {}
         self._pending_tool_hints: dict[str, list[str]] = {}
+        self._qr_login_active = False
+        self._qr_login_qrcode = ""
+        self._qr_login_content = ""
+        self._qr_login_poll_base_url = self.config.base_url
+        self._qr_login_refresh_count = 0
+        self._qr_login_scanned = False
 
     # ------------------------------------------------------------------
     # State persistence
@@ -337,75 +344,83 @@ class WeixinChannel(BaseChannel):
             raise RuntimeError(f"Failed to get QR code from WeChat API: {data}")
         return qrcode_id, (qrcode_img_content or qrcode_id)
 
+    async def _start_qr_challenge(self) -> dict[str, Any]:
+        self._qr_login_qrcode, self._qr_login_content = await self._fetch_qr_code()
+        self._qr_login_poll_base_url = self.config.base_url
+        self._qr_login_active = True
+        self._qr_login_scanned = False
+        return {"status": "waiting", "qr_content": self._qr_login_content}
+
+    async def _poll_qr_challenge(self) -> dict[str, Any]:
+        if not self._qr_login_active or not self._qr_login_qrcode:
+            raise RuntimeError("No active WeChat QR login challenge")
+
+        try:
+            status_data = await self._api_get_with_base(
+                base_url=self._qr_login_poll_base_url,
+                endpoint="ilink/bot/get_qrcode_status",
+                params={"qrcode": self._qr_login_qrcode},
+                auth=False,
+            )
+        except Exception as exc:
+            if self._is_retryable_qr_poll_error(exc):
+                return {"status": "waiting"}
+            raise
+
+        if not isinstance(status_data, dict):
+            return {"status": "waiting"}
+
+        status = str(status_data.get("status", "") or "")
+        if status == "confirmed":
+            token = str(status_data.get("bot_token", "") or "")
+            if not token:
+                self._qr_login_active = False
+                return {"status": "failed", "message": "WeChat confirmed the login without credentials."}
+            self._token = token
+            base_url = str(status_data.get("baseurl", "") or "")
+            if base_url:
+                self.config.base_url = base_url
+            self._save_state()
+            self._qr_login_active = False
+            self.logger.info("WeChat QR login completed")
+            return {"status": "authenticated"}
+
+        if status == "scaned_but_redirect":
+            self._qr_login_scanned = True
+            redirect_host = str(status_data.get("redirect_host", "") or "").strip()
+            if redirect_host:
+                if redirect_host.startswith("http://") or redirect_host.startswith("https://"):
+                    self._qr_login_poll_base_url = redirect_host
+                else:
+                    self._qr_login_poll_base_url = f"https://{redirect_host}"
+            return {"status": "scanned"}
+
+        if status == "expired":
+            self._qr_login_refresh_count += 1
+            if self._qr_login_refresh_count > MAX_QR_REFRESH_COUNT:
+                self._qr_login_active = False
+                return {"status": "expired"}
+            return await self._start_qr_challenge()
+
+        return {"status": "scanned" if self._qr_login_scanned else "waiting"}
+
     async def _qr_login(self) -> bool:
         """Perform QR code login flow. Returns True on success."""
         try:
-            refresh_count = 0
-            qrcode_id, scan_url = await self._fetch_qr_code()
-            self._print_qr_code(scan_url)
-            current_poll_base_url = self.config.base_url
+            self._qr_login_refresh_count = 0
+            challenge = await self._start_qr_challenge()
+            self._print_qr_code(str(challenge["qr_content"]))
+            last_qr_content = self._qr_login_content
 
             while self._running:
-                try:
-                    status_data = await self._api_get_with_base(
-                        base_url=current_poll_base_url,
-                        endpoint="ilink/bot/get_qrcode_status",
-                        params={"qrcode": qrcode_id},
-                        auth=False,
-                    )
-                except Exception as e:
-                    if self._is_retryable_qr_poll_error(e):
-                        await asyncio.sleep(1)
-                        continue
-                    raise
-
-                if not isinstance(status_data, dict):
-                    await asyncio.sleep(1)
-                    continue
-
-                status = status_data.get("status", "")
-                if status == "confirmed":
-                    token = status_data.get("bot_token", "")
-                    bot_id = status_data.get("ilink_bot_id", "")
-                    base_url = status_data.get("baseurl", "")
-                    user_id = status_data.get("ilink_user_id", "")
-                    if token:
-                        self._token = token
-                        if base_url:
-                            self.config.base_url = base_url
-                        self._save_state()
-                        self.logger.info(
-                            "login successful! bot_id={} user_id={}",
-                            bot_id,
-                            user_id,
-                        )
-                        return True
-                    else:
-                        self.logger.error("Login confirmed but no bot_token in response")
-                        return False
-                elif status == "scaned_but_redirect":
-                    redirect_host = str(status_data.get("redirect_host", "") or "").strip()
-                    if redirect_host:
-                        if redirect_host.startswith("http://") or redirect_host.startswith("https://"):
-                            redirected_base = redirect_host
-                        else:
-                            redirected_base = f"https://{redirect_host}"
-                        if redirected_base != current_poll_base_url:
-                            current_poll_base_url = redirected_base
-                elif status == "expired":
-                    refresh_count += 1
-                    if refresh_count > MAX_QR_REFRESH_COUNT:
-                        self.logger.warning(
-                            "QR code expired too many times ({}/{}), giving up.",
-                            refresh_count - 1,
-                            MAX_QR_REFRESH_COUNT,
-                        )
-                        return False
-                    qrcode_id, scan_url = await self._fetch_qr_code()
-                    current_poll_base_url = self.config.base_url
-                    self._print_qr_code(scan_url)
-                    continue
-                # status == "wait" — keep polling
+                result = await self._poll_qr_challenge()
+                if result["status"] == "authenticated":
+                    return True
+                if result["status"] in {"expired", "failed"}:
+                    return False
+                if self._qr_login_content != last_qr_content:
+                    self._print_qr_code(self._qr_login_content)
+                    last_qr_content = self._qr_login_content
 
                 await asyncio.sleep(1)
 
@@ -413,6 +428,46 @@ class WeixinChannel(BaseChannel):
             self.logger.exception("QR login failed")
 
         return False
+
+    async def begin_qr_login(self) -> dict[str, Any]:
+        """Start a Web UI QR login without exposing the resulting token."""
+        if self.is_running:
+            raise RuntimeError("Stop the WeChat channel before starting QR login")
+        if self._token or self.config.token or self._load_state():
+            return {"status": "authenticated"}
+        if self._qr_login_active:
+            raise RuntimeError("A WeChat QR login is already active")
+
+        self._client = httpx.AsyncClient(
+            timeout=httpx.Timeout(60, connect=30),
+            follow_redirects=True,
+        )
+        self._qr_login_refresh_count = 0
+        try:
+            return await self._start_qr_challenge()
+        except Exception:
+            await self.cancel_qr_login()
+            raise
+
+    async def poll_qr_login(self) -> dict[str, Any]:
+        """Poll a Web UI QR login once and close resources at terminal states."""
+        result = await self._poll_qr_challenge()
+        if result["status"] in {"authenticated", "expired", "failed"}:
+            await self._close_qr_login_client()
+        return result
+
+    async def cancel_qr_login(self) -> None:
+        """Cancel a Web UI QR login and discard only its transient state."""
+        self._qr_login_active = False
+        self._qr_login_qrcode = ""
+        self._qr_login_content = ""
+        self._qr_login_scanned = False
+        await self._close_qr_login_client()
+
+    async def _close_qr_login_client(self) -> None:
+        if self._client:
+            await self._client.aclose()
+            self._client = None
 
     @staticmethod
     def _is_retryable_qr_poll_error(err: Exception) -> bool:

--- a/agent/tests/test_channels_api.py
+++ b/agent/tests/test_channels_api.py
@@ -99,3 +99,45 @@ def test_channels_pairing_command_uses_shared_store(tmp_path: Path, monkeypatch)
     assert response.status_code == 200
     assert response.json()["channel"] == "telegram"
     assert "No pending pairing requests" in response.json()["reply"]
+
+
+def test_weixin_qr_login_never_returns_credentials(tmp_path: Path, monkeypatch) -> None:
+    from src.channels.weixin import WeixinChannel
+
+    async def begin_qr_login(self):
+        return {"status": "waiting", "qr_content": "https://weixin.example/scan"}
+
+    async def poll_qr_login(self):
+        self._token = "server-only-token"
+        return {"status": "authenticated"}
+
+    async def cancel_qr_login(self):
+        return None
+
+    monkeypatch.setattr(WeixinChannel, "begin_qr_login", begin_qr_login)
+    monkeypatch.setattr(WeixinChannel, "poll_qr_login", poll_qr_login)
+    monkeypatch.setattr(WeixinChannel, "cancel_qr_login", cancel_qr_login)
+    client = _client(tmp_path, monkeypatch, channels_config={"weixin": {"enabled": True}})
+
+    started = client.post("/channels/weixin/qr-login")
+
+    assert started.status_code == 200
+    start_payload = started.json()
+    assert start_payload["status"] == "waiting"
+    assert start_payload["qr_content"] == "https://weixin.example/scan"
+    assert "token" not in json.dumps(start_payload).lower()
+
+    completed = client.get(f"/channels/qr-login/{start_payload['session_id']}")
+
+    assert completed.status_code == 200
+    assert completed.json() == {"channel": "weixin", "status": "authenticated"}
+    assert "token" not in completed.text.lower()
+
+
+def test_qr_login_rejects_adapters_without_browser_qr_support(tmp_path: Path, monkeypatch) -> None:
+    client = _client(tmp_path, monkeypatch, channels_config={"email": {"enabled": True}})
+
+    response = client.post("/channels/email/qr-login")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Channel 'email' does not support QR login"

--- a/agent/tests/test_weixin_qr_login.py
+++ b/agent/tests/test_weixin_qr_login.py
@@ -1,0 +1,75 @@
+"""Browser-driven personal WeChat QR login contracts."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from src.channels.bus.queue import MessageBus
+from src.channels.weixin import WeixinChannel
+
+
+def test_qr_login_persists_token_without_returning_it(tmp_path, monkeypatch) -> None:
+    channel = WeixinChannel(
+        {"enabled": True, "state_dir": str(tmp_path)},
+        MessageBus(),
+    )
+
+    async def fetch_qr_code():
+        return "private-qrcode-id", "https://weixin.example/scan"
+
+    async def get_status(**_kwargs):
+        return {
+            "status": "confirmed",
+            "bot_token": "server-only-token",
+            "baseurl": "https://weixin.example/api",
+        }
+
+    monkeypatch.setattr(channel, "_fetch_qr_code", fetch_qr_code)
+    monkeypatch.setattr(channel, "_api_get_with_base", get_status)
+
+    async def run_login():
+        started = await channel.begin_qr_login()
+        completed = await channel.poll_qr_login()
+        return started, completed
+
+    started, completed = asyncio.run(run_login())
+
+    assert started == {"status": "waiting", "qr_content": "https://weixin.example/scan"}
+    assert completed == {"status": "authenticated"}
+    assert "token" not in json.dumps(started).lower()
+    assert "token" not in json.dumps(completed).lower()
+    assert json.loads((tmp_path / "account.json").read_text())["token"] == "server-only-token"
+
+
+def test_expired_qr_login_refreshes_the_browser_challenge(tmp_path, monkeypatch) -> None:
+    channel = WeixinChannel(
+        {"enabled": True, "state_dir": str(tmp_path)},
+        MessageBus(),
+    )
+    challenges = iter(
+        [
+            ("first-id", "https://weixin.example/first"),
+            ("second-id", "https://weixin.example/second"),
+        ]
+    )
+
+    async def fetch_qr_code():
+        return next(challenges)
+
+    async def get_status(**_kwargs):
+        return {"status": "expired"}
+
+    monkeypatch.setattr(channel, "_fetch_qr_code", fetch_qr_code)
+    monkeypatch.setattr(channel, "_api_get_with_base", get_status)
+
+    async def run_login():
+        started = await channel.begin_qr_login()
+        refreshed = await channel.poll_qr_login()
+        await channel.cancel_qr_login()
+        return started, refreshed
+
+    started, refreshed = asyncio.run(run_login())
+
+    assert started["qr_content"] == "https://weixin.example/first"
+    assert refreshed == {"status": "waiting", "qr_content": "https://weixin.example/second"}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "i18next-browser-languagedetector": "^8.2.1",
         "katex": "^0.18.1",
         "lucide-react": "^1.27.0",
+        "qrcode.react": "^4.2.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "react-i18next": "^17.0.11",
@@ -4796,6 +4797,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "http://mirrors.tencentyun.com/npm/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/queue-microtask": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "i18next-browser-languagedetector": "^8.2.1",
     "katex": "^0.18.1",
     "lucide-react": "^1.27.0",
+    "qrcode.react": "^4.2.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-i18next": "^17.0.11",

--- a/frontend/src/components/settings/ChannelQRLoginDialog.tsx
+++ b/frontend/src/components/settings/ChannelQRLoginDialog.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+import { Loader2, RotateCcw, X } from "lucide-react";
+import { QRCodeSVG } from "qrcode.react";
+import { useTranslation } from "react-i18next";
+import type { ChannelQRLoginResponse } from "@/lib/api";
+
+interface ChannelQRLoginDialogProps {
+  open: boolean;
+  channelName: string;
+  login: ChannelQRLoginResponse | null;
+  loading: boolean;
+  error: string | null;
+  onClose: () => void;
+  onRetry: () => void;
+}
+
+export function ChannelQRLoginDialog({
+  open,
+  channelName,
+  login,
+  loading,
+  error,
+  onClose,
+  onRetry,
+}: ChannelQRLoginDialogProps) {
+  const { t } = useTranslation();
+  const closeRef = useRef<HTMLButtonElement>(null);
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  useEffect(() => {
+    if (!open) return;
+    const previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    closeRef.current?.focus();
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onCloseRef.current();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      if (previouslyFocused?.isConnected) previouslyFocused.focus();
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  const status = login?.status;
+  const canRetry = Boolean(error || status === "expired" || status === "failed");
+  const statusText = status
+    ? t(`settings.channels.qr.status.${status}`)
+    : t("settings.channels.qr.preparing");
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/55 p-4" onClick={onClose}>
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="channel-qr-login-title"
+        className="w-full max-w-sm rounded-2xl border bg-background p-5 shadow-xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2 id="channel-qr-login-title" className="text-base font-semibold">
+              {t("settings.channels.qr.title", { channel: channelName })}
+            </h2>
+            <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+              {t("settings.channels.qr.description")}
+            </p>
+          </div>
+          <button
+            ref={closeRef}
+            type="button"
+            onClick={onClose}
+            aria-label={t("settings.channels.qr.close")}
+            className="rounded-md p-1 text-muted-foreground transition hover:bg-muted hover:text-foreground"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="mt-5 flex min-h-64 items-center justify-center rounded-xl border bg-white p-4">
+          {login?.qr_content && status !== "authenticated" ? (
+            <QRCodeSVG
+              value={login.qr_content}
+              size={224}
+              level="M"
+              marginSize={2}
+              title={t("settings.channels.qr.codeTitle", { channel: channelName })}
+            />
+          ) : status === "authenticated" ? (
+            <div className="text-center text-sm font-medium text-emerald-700">
+              {t("settings.channels.qr.connected")}
+            </div>
+          ) : (
+            <Loader2 className="h-8 w-8 animate-spin text-primary" aria-label={t("settings.channels.qr.preparing")} />
+          )}
+        </div>
+
+        <div className="mt-4 text-center">
+          <p aria-live="polite" className="text-sm font-medium">{error || login?.message || statusText}</p>
+          {status === "scanned" && (
+            <p className="mt-1 text-xs text-muted-foreground">{t("settings.channels.qr.confirmOnPhone")}</p>
+          )}
+        </div>
+
+        <div className="mt-5 flex justify-end gap-2">
+          {canRetry && (
+            <button
+              type="button"
+              onClick={onRetry}
+              disabled={loading}
+              className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground disabled:opacity-60"
+            >
+              {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <RotateCcw className="h-4 w-4" />}
+              {t("settings.channels.qr.retry")}
+            </button>
+          )}
+          <button type="button" onClick={onClose} className="rounded-md border px-3 py-2 text-sm text-muted-foreground">
+            {status === "authenticated" ? t("settings.channels.qr.done") : t("settings.channels.qr.cancel")}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -376,7 +376,27 @@
       "stoppedToast": "تم إيقاف قنوات IM",
       "refreshFailed": "فشل تحديث قنوات IM",
       "startFailed": "فشل بدء قنوات IM",
-      "stopFailed": "فشل إيقاف قنوات IM"
+      "stopFailed": "فشل إيقاف قنوات IM",
+      "qr": {
+        "connect": "امسح للاتصال",
+        "title": "اتصال بـ {{channel}}",
+        "description": "افتح WeChat على هاتفك وامسح هذا الرمز. تبقى بيانات تسجيل الدخول على الخادم فقط.",
+        "codeTitle": "رمز QR لـ {{channel}}",
+        "preparing": "جارٍ إعداد رمز QR آمن…",
+        "confirmOnPhone": "تم مسح الرمز. أكّد تسجيل الدخول على هاتفك.",
+        "connected": "تم الاتصال بـ WeChat بنجاح.",
+        "retry": "إعادة المحاولة",
+        "cancel": "إلغاء",
+        "done": "تم",
+        "close": "إغلاق تسجيل الدخول بالرمز",
+        "status": {
+          "waiting": "في انتظار مسح الرمز…",
+          "scanned": "تم مسح الرمز",
+          "authenticated": "متصل",
+          "expired": "انتهت صلاحية رمز QR.",
+          "failed": "فشل تسجيل الدخول إلى WeChat."
+        }
+      }
     },
     "generation": "إعدادات التوليد",
     "dataSourceSettings": "إعدادات مصادر البيانات",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -381,7 +381,27 @@
       "stoppedToast": "IM channels stopped",
       "refreshFailed": "Failed to refresh IM channels",
       "startFailed": "Failed to start IM channels",
-      "stopFailed": "Failed to stop IM channels"
+      "stopFailed": "Failed to stop IM channels",
+      "qr": {
+        "connect": "Scan to connect",
+        "title": "Connect {{channel}}",
+        "description": "Open WeChat on your phone and scan this code. Login credentials stay on the server.",
+        "codeTitle": "QR code for {{channel}}",
+        "preparing": "Preparing a secure QR code…",
+        "confirmOnPhone": "QR code scanned. Confirm the login on your phone.",
+        "connected": "WeChat connected successfully.",
+        "retry": "Try again",
+        "cancel": "Cancel",
+        "done": "Done",
+        "close": "Close QR login",
+        "status": {
+          "waiting": "Waiting for you to scan the code…",
+          "scanned": "Code scanned",
+          "authenticated": "Connected",
+          "expired": "This QR code expired.",
+          "failed": "WeChat login failed."
+        }
+      }
     },
     "generation": "Generation",
     "dataSourceSettings": "Data Source Settings",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -376,7 +376,27 @@
       "stoppedToast": "IM チャンネルを停止しました",
       "refreshFailed": "IM チャンネルの更新に失敗しました",
       "startFailed": "IM チャンネルの開始に失敗しました",
-      "stopFailed": "IM チャンネルの停止に失敗しました"
+      "stopFailed": "IM チャンネルの停止に失敗しました",
+      "qr": {
+        "connect": "スキャンして接続",
+        "title": "{{channel}} に接続",
+        "description": "スマートフォンで WeChat を開き、このコードをスキャンしてください。認証情報はサーバーだけに保存されます。",
+        "codeTitle": "{{channel}} の QR コード",
+        "preparing": "安全な QR コードを準備しています…",
+        "confirmOnPhone": "スキャン済みです。スマートフォンでログインを確認してください。",
+        "connected": "WeChat に接続しました。",
+        "retry": "再試行",
+        "cancel": "キャンセル",
+        "done": "完了",
+        "close": "QR ログインを閉じる",
+        "status": {
+          "waiting": "スキャンを待っています…",
+          "scanned": "スキャン済み",
+          "authenticated": "接続済み",
+          "expired": "QR コードの有効期限が切れました。",
+          "failed": "WeChat ログインに失敗しました。"
+        }
+      }
     },
     "generation": "生成設定",
     "dataSourceSettings": "データソース設定",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -376,7 +376,27 @@
       "stoppedToast": "IM 채널이 중지되었습니다",
       "refreshFailed": "IM 채널 새로 고침 실패",
       "startFailed": "IM 채널 시작 실패",
-      "stopFailed": "IM 채널 중지 실패"
+      "stopFailed": "IM 채널 중지 실패",
+      "qr": {
+        "connect": "스캔하여 연결",
+        "title": "{{channel}} 연결",
+        "description": "휴대폰에서 WeChat을 열고 이 코드를 스캔하세요. 로그인 자격 증명은 서버에만 저장됩니다.",
+        "codeTitle": "{{channel}} QR 코드",
+        "preparing": "안전한 QR 코드를 준비하는 중…",
+        "confirmOnPhone": "스캔되었습니다. 휴대폰에서 로그인을 확인하세요.",
+        "connected": "WeChat이 연결되었습니다.",
+        "retry": "다시 시도",
+        "cancel": "취소",
+        "done": "완료",
+        "close": "QR 로그인 닫기",
+        "status": {
+          "waiting": "코드 스캔 대기 중…",
+          "scanned": "스캔됨",
+          "authenticated": "연결됨",
+          "expired": "QR 코드가 만료되었습니다.",
+          "failed": "WeChat 로그인에 실패했습니다."
+        }
+      }
     },
     "generation": "생성 설정",
     "dataSourceSettings": "데이터 소스 설정",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -376,7 +376,27 @@
       "stoppedToast": "IM 通道已停止",
       "refreshFailed": "刷新 IM 通道失败",
       "startFailed": "启动 IM 通道失败",
-      "stopFailed": "停止 IM 通道失败"
+      "stopFailed": "停止 IM 通道失败",
+      "qr": {
+        "connect": "扫码连接",
+        "title": "连接 {{channel}}",
+        "description": "请打开手机微信扫描二维码。登录凭据仅保存在服务端。",
+        "codeTitle": "{{channel}} 登录二维码",
+        "preparing": "正在生成安全二维码…",
+        "confirmOnPhone": "二维码已扫描，请在手机上确认登录。",
+        "connected": "微信连接成功。",
+        "retry": "重新生成",
+        "cancel": "取消",
+        "done": "完成",
+        "close": "关闭扫码登录",
+        "status": {
+          "waiting": "等待扫码…",
+          "scanned": "已扫码",
+          "authenticated": "已连接",
+          "expired": "二维码已过期。",
+          "failed": "微信登录失败。"
+        }
+      }
     },
     "generation": "生成设置",
     "dataSourceSettings": "数据源设置",

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -94,6 +94,32 @@ describe("api request helper", () => {
     );
   });
 
+  it("uses encoded, authenticated paths for channel QR login", async () => {
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn(() => "remote-test-key"),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    });
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ channel: "weixin personal", status: "authenticated" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { api } = await loadApiModule();
+
+    await api.startChannelQRLogin("weixin personal");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/channels/weixin%20personal/qr-login",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ Authorization: "Bearer remote-test-key" }),
+      }),
+    );
+  });
+
   it("sends the stored API key when fetching a correlation regime timeline", async () => {
     vi.stubGlobal("localStorage", {
       getItem: vi.fn(() => "remote-test-key"),

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -221,6 +221,12 @@ export const api = {
   getChannelStatus: () => request<ChannelRuntimeStatus>("/channels/status"),
   startChannels: () => request<ChannelRuntimeActionResponse>("/channels/start", { method: "POST" }),
   stopChannels: () => request<ChannelRuntimeActionResponse>("/channels/stop", { method: "POST" }),
+  startChannelQRLogin: (channel: string) =>
+    request<ChannelQRLoginResponse>(`/channels/${encodeURIComponent(channel)}/qr-login`, { method: "POST" }),
+  getChannelQRLogin: (sessionId: string) =>
+    request<ChannelQRLoginResponse>(`/channels/qr-login/${encodeURIComponent(sessionId)}`),
+  cancelChannelQRLogin: (sessionId: string) =>
+    request<ChannelQRLoginCancelResponse>(`/channels/qr-login/${encodeURIComponent(sessionId)}`, { method: "DELETE" }),
   runChannelPairingCommand: (body: ChannelPairingCommandRequest) =>
     request<ChannelPairingCommandResponse>("/channels/pairing/command", {
       method: "POST",
@@ -420,6 +426,7 @@ export interface ChannelAdapterStatus {
   available: boolean;
   loaded: boolean;
   running: boolean;
+  qr_login_supported?: boolean;
   error?: string;
   install_hint?: string;
 }
@@ -434,6 +441,21 @@ export interface ChannelRuntimeStatus {
 
 export interface ChannelRuntimeActionResponse extends ChannelRuntimeStatus {
   status: string;
+}
+
+export type ChannelQRLoginStatus = "waiting" | "scanned" | "authenticated" | "expired" | "failed";
+
+export interface ChannelQRLoginResponse {
+  channel: string;
+  status: ChannelQRLoginStatus;
+  session_id?: string;
+  qr_content?: string;
+  message?: string;
+}
+
+export interface ChannelQRLoginCancelResponse {
+  channel?: string;
+  status: "cancelled";
 }
 
 export interface ChannelPairingCommandRequest {

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useState, type FormEvent } from "react";
-import { Database, KeyRound, Loader2, MessageSquareMore, Play, RefreshCw, RotateCcw, Save, Server, SlidersHorizontal, Square } from "lucide-react";
+import { Database, KeyRound, Loader2, MessageSquareMore, Play, QrCode, RefreshCw, RotateCcw, Save, Server, SlidersHorizontal, Square } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { ModelPicker } from "@/components/settings/ModelPicker";
+import { ChannelQRLoginDialog } from "@/components/settings/ChannelQRLoginDialog";
 import { QVerisSettings } from "@/components/settings/QVerisSettings"; // QVERIS-INTEGRATION
-import { api, isAuthRequiredError, type ChannelRuntimeStatus, type DataSourceSettings, type LLMProviderOption, type LLMSettings } from "@/lib/api";
+import { api, isAuthRequiredError, type ChannelQRLoginResponse, type ChannelRuntimeStatus, type DataSourceSettings, type LLMProviderOption, type LLMSettings } from "@/lib/api";
 import { getApiAuthKey, setApiAuthKey } from "@/lib/apiAuth";
 
 interface LLMFormState {
@@ -53,6 +54,11 @@ export function Settings() {
   const [dataSaving, setDataSaving] = useState(false);
   const [channelRefreshing, setChannelRefreshing] = useState(false);
   const [channelAction, setChannelAction] = useState<"start" | "stop" | null>(null);
+  const [qrLoginOpen, setQrLoginOpen] = useState(false);
+  const [qrLoginChannel, setQrLoginChannel] = useState("");
+  const [qrLogin, setQrLogin] = useState<ChannelQRLoginResponse | null>(null);
+  const [qrLoginLoading, setQrLoginLoading] = useState(false);
+  const [qrLoginError, setQrLoginError] = useState<string | null>(null);
   const [settingsLoadError, setSettingsLoadError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -140,6 +146,75 @@ export function Settings() {
     } finally {
       setChannelAction(null);
     }
+  };
+
+  const startChannelQRLogin = async (channel: string) => {
+    setQrLoginOpen(true);
+    setQrLoginChannel(channel);
+    setQrLogin(null);
+    setQrLoginError(null);
+    setQrLoginLoading(true);
+    try {
+      const result = await api.startChannelQRLogin(channel);
+      setQrLogin(result);
+      if (result.status === "authenticated") {
+        toast.success(t("settings.channels.qr.connected"));
+      }
+    } catch (error) {
+      setQrLoginError(error instanceof Error ? error.message : t("settings.unknownError", { defaultValue: "Unknown error" }));
+    } finally {
+      setQrLoginLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    const sessionId = qrLogin?.session_id;
+    if (!qrLoginOpen || !sessionId || !["waiting", "scanned"].includes(qrLogin.status)) return;
+    let active = true;
+    const timer = window.setTimeout(async () => {
+      try {
+        const result = await api.getChannelQRLogin(sessionId);
+        if (!active) return;
+        setQrLogin((current) => ({
+          ...result,
+          qr_content: result.qr_content ?? current?.qr_content,
+        }));
+        if (result.status === "authenticated") {
+          toast.success(t("settings.channels.qr.connected"));
+          void refreshChannelStatus();
+        }
+      } catch (error) {
+        if (active) {
+          setQrLoginError(error instanceof Error ? error.message : t("settings.unknownError", { defaultValue: "Unknown error" }));
+        }
+      }
+    }, 1500);
+    return () => {
+      active = false;
+      window.clearTimeout(timer);
+    };
+  }, [qrLogin, qrLoginOpen, t]);
+
+  const closeChannelQRLogin = () => {
+    const sessionId = qrLogin?.session_id;
+    setQrLoginOpen(false);
+    setQrLogin(null);
+    setQrLoginError(null);
+    if (sessionId) void api.cancelChannelQRLogin(sessionId).catch(() => undefined);
+  };
+
+  const retryChannelQRLogin = () => {
+    const sessionId = qrLogin?.session_id;
+    void (async () => {
+      if (sessionId) {
+        try {
+          await api.cancelChannelQRLogin(sessionId);
+        } catch {
+          // The server may already have expired and removed the old challenge.
+        }
+      }
+      await startChannelQRLogin(qrLoginChannel);
+    })();
   };
 
   const providers = settings?.providers ?? [];
@@ -433,7 +508,18 @@ export function Settings() {
                       </div>
                     </td>
                     <td className="max-w-md px-3 py-2 align-top text-xs text-muted-foreground">
-                      {item.install_hint || item.error || t("settings.channels.noRecovery")}
+                      <div>{item.install_hint || item.error || t("settings.channels.noRecovery")}</div>
+                      {item.qr_login_supported && (
+                        <button
+                          type="button"
+                          onClick={() => void startChannelQRLogin(name)}
+                          disabled={channelBusy || channelStatus.running || item.running}
+                          className="mt-2 inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs font-medium text-foreground transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                          <QrCode className="h-3.5 w-3.5" />
+                          {t("settings.channels.qr.connect")}
+                        </button>
+                      )}
                     </td>
                   </tr>
                 ))}
@@ -748,6 +834,15 @@ export function Settings() {
           </div>
         </div>
       </form>
+      <ChannelQRLoginDialog
+        open={qrLoginOpen}
+        channelName={channelRows.find(([name]) => name === qrLoginChannel)?.[1].display_name || qrLoginChannel}
+        login={qrLogin}
+        loading={qrLoginLoading}
+        error={qrLoginError}
+        onClose={closeChannelQRLogin}
+        onRetry={retryChannelQRLogin}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/__tests__/SettingsChannels.test.tsx
+++ b/frontend/src/pages/__tests__/SettingsChannels.test.tsx
@@ -8,6 +8,9 @@ const apiMock = vi.hoisted(() => ({
   listLLMModels: vi.fn(),
   startChannels: vi.fn(),
   stopChannels: vi.fn(),
+  startChannelQRLogin: vi.fn(),
+  getChannelQRLogin: vi.fn(),
+  cancelChannelQRLogin: vi.fn(),
   updateLLMSettings: vi.fn(),
   updateDataSourceSettings: vi.fn(),
 }));
@@ -94,6 +97,18 @@ function channelStatus(overrides = {}) {
         error: "ModuleNotFoundError",
         install_hint: "pip install 'vibe-trading-ai[telegram]'",
       },
+      weixin: {
+        name: "weixin",
+        display_name: "WeChat",
+        configured: true,
+        enabled: true,
+        available: true,
+        loaded: true,
+        running: false,
+        qr_login_supported: true,
+        error: "",
+        install_hint: "",
+      },
     },
     ...overrides,
   };
@@ -112,6 +127,18 @@ describe("Settings IM channels panel", () => {
     });
     apiMock.startChannels.mockResolvedValue(channelStatus({ running: true }));
     apiMock.stopChannels.mockResolvedValue(channelStatus());
+    apiMock.startChannelQRLogin.mockResolvedValue({
+      channel: "weixin",
+      status: "waiting",
+      session_id: "qr-session",
+      qr_content: "https://weixin.example/scan",
+    });
+    apiMock.getChannelQRLogin.mockResolvedValue({
+      channel: "weixin",
+      status: "waiting",
+      session_id: "qr-session",
+    });
+    apiMock.cancelChannelQRLogin.mockResolvedValue({ status: "cancelled" });
   });
 
   it("renders channel runtime status and refreshes it", async () => {
@@ -134,6 +161,17 @@ describe("Settings IM channels panel", () => {
     fireEvent.click(screen.getByRole("button", { name: "Start channels" }));
 
     await waitFor(() => expect(apiMock.startChannels).toHaveBeenCalledTimes(1));
+  });
+
+  it("opens a browser-rendered QR login for supported channels", async () => {
+    render(<Settings />);
+    await screen.findByText("IM Channels");
+
+    fireEvent.click(screen.getByRole("button", { name: "Scan to connect" }));
+
+    expect(await screen.findByRole("dialog", { name: "Connect WeChat" })).toBeInTheDocument();
+    expect(apiMock.startChannelQRLogin).toHaveBeenCalledWith("weixin");
+    expect(await screen.findByTitle("QR code for WeChat")).toBeInTheDocument();
   });
 
   it("still renders LLM and data source settings when channel status fails", async () => {


### PR DESCRIPTION
## Summary

Add a browser-driven QR login flow for QR-capable IM adapters, with personal WeChat (`weixin`) as the first implementation.

- introduce adapter-level QR login lifecycle hooks and surface support in channel status
- add authenticated start, poll, and cancel REST endpoints backed by short-lived opaque sessions
- refactor the existing WeChat terminal QR flow so CLI and Web share the same challenge state machine
- add a Settings modal that renders the QR code, polls scan/confirmation status, refreshes expired challenges, and supports cancellation/retry
- document the Web flow and add translations for all five frontend locales

## Why

The WeChat adapter already supported QR authentication from the CLI, but Web UI operators had to leave the browser and use an interactive terminal. This adds the missing Web control surface while preserving the existing channel runtime and credential storage.

## User and developer impact

Operators can enable `channels.weixin`, keep the channel runtime stopped, and choose **Settings → IM Channels → Scan to connect**. The resulting bot token is persisted only by the adapter on the server and is never returned to the browser.

The adapter contract is deliberately generic so additional QR-capable channels can implement the same Web flow later.

## Security and lifecycle boundaries

- every QR endpoint uses the existing API authentication dependency
- browser sessions use opaque random IDs and expire after ten minutes
- credentials never appear in REST responses or frontend state
- active QR login blocks channel startup, and running channels reject re-login
- closing the dialog cancels the transient challenge
- no live WeChat login or real credential was used during tests

## Validation

- `API_AUTH_KEY= .venv/bin/python -m pytest --ignore=agent/tests/e2e_backtest --ignore=agent/tests/test_e2e_harness_v2.py --tb=short -q` — **7154 passed, 20 skipped**
- `npm run test:run` — **400 passed**
- `npm run build` — passed
- focused Ruff checks — passed
- focused channel/API tests — **44 passed**

## Out of scope

This PR does not add QR implementations for other adapters and does not change channel configuration automatically. Operators still explicitly enable the WeChat channel in their local configuration.

## Rollback

Revert commit `fc660e7` to remove the Web QR surface and restore the previous terminal-only login flow.
