### PR TITLE
fix(mcp): tolerate JSON-string list/dict arguments from MCP clients

### DIFF
--- a/agent/mcp_server.py
+++ b/agent/mcp_server.py
@@ -56,7 +56,7 @@ import sys
 from copy import deepcopy
 from importlib import import_module
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 
 # Ensure agent/ is on sys.path
 AGENT_DIR = Path(__file__).resolve().parent
@@ -64,6 +64,8 @@ if str(AGENT_DIR) not in sys.path:
     sys.path.insert(0, str(AGENT_DIR))
 
 from fastmcp import Context, FastMCP
+from pydantic import BeforeValidator
+
 from cli._version import __version__ as APP_VERSION
 from src.market_data import (
     DEFAULT_MAX_ROWS,
@@ -403,6 +405,54 @@ def _blank_to_none(value: str | None) -> str | None:
     return value or None
 
 
+def _coerce_json_string(value: Any) -> Any:
+    """Decode JSON array/object strings some MCP clients send for list/dict args.
+
+    FastMCP publishes optional list/dict parameters as ``anyOf`` schemas, and
+    several MCP clients (observed with Claude Desktop / Claude Code) do not
+    surface ``anyOf`` to the model as a concrete type — the model then serializes
+    the argument as a JSON string (``'["us"]'``), which strict pydantic
+    validation rejects before the tool body ever runs (issue #987). This
+    validator is attached as a ``BeforeValidator`` to every list/dict MCP
+    parameter, so it runs *before* type checking and decodes such a string into
+    the list/dict it encodes.
+
+    Non-string values pass through untouched. A string that is not a JSON array
+    or object is returned unchanged so pydantic still raises its normal, precise
+    type error rather than a confusing JSON parse failure.
+
+    Args:
+        value: The raw argument received from the MCP client.
+
+    Returns:
+        The decoded list/dict when the value is a JSON array/object string,
+        otherwise the value unchanged.
+    """
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped[:1] in ("[", "{"):
+            try:
+                return json.loads(stripped)
+            except (json.JSONDecodeError, ValueError):
+                return value
+    return value
+
+
+# Lenient list/dict parameter types for the @mcp.tool signatures below
+# (issue #987). Each wraps the real type with _coerce_json_string so a
+# JSON-encoded string from a client is decoded before pydantic validates it,
+# while the published JSON schema — and thus every well-behaved client — is left
+# exactly as before.
+_lenient = BeforeValidator(_coerce_json_string)
+_lenient_str_list = Annotated[list[str], _lenient]
+_lenient_str_list_opt = Annotated[list[str] | None, _lenient]
+_lenient_float_list_opt = Annotated[list[float] | None, _lenient]
+_lenient_dict_list = Annotated[list[dict[str, Any]], _lenient]
+_lenient_dict_list_opt = Annotated[list[dict[str, Any]] | None, _lenient]
+_lenient_dict_any_opt = Annotated[dict[str, Any] | None, _lenient]
+_lenient_dict_str_str = Annotated[dict[str, str], _lenient]
+
+
 def _audit_rows_from_payload(value: list[dict[str, Any]] | None):
     """Parse MCP completion audit rows."""
     from src.goal import AuditRow
@@ -478,7 +528,7 @@ def load_skill(name: str) -> str:
 def start_research_goal(
     objective: str,
     session_id: str = "",
-    criteria: list[str] | None = None,
+    criteria: _lenient_str_list_opt = None,
     ui_summary: str = "",
     protocol: str = "thesis_review",
     risk_tier: str = "research_general",
@@ -555,17 +605,17 @@ def add_goal_evidence(
     source_provider: str | None = None,
     source_type: str | None = None,
     source_uri: str | None = None,
-    symbol_universe: list[str] | None = None,
-    benchmark: list[str] | None = None,
+    symbol_universe: _lenient_str_list_opt = None,
+    benchmark: _lenient_str_list_opt = None,
     timeframe: str | None = None,
     method: str | None = None,
-    assumptions: dict[str, Any] | None = None,
+    assumptions: _lenient_dict_any_opt = None,
     artifact_path: str | None = None,
     artifact_hash: str | None = None,
     data_as_of: str | None = None,
     confidence: str | None = None,
     caveat: str | None = None,
-    contradicts_claim_ids: list[str] | None = None,
+    contradicts_claim_ids: _lenient_str_list_opt = None,
 ) -> str:
     """Append traceable evidence to a finance research goal.
 
@@ -643,7 +693,7 @@ def update_research_goal_status(
     expected_goal_id: str,
     status: str,
     session_id: str = "",
-    audit: list[dict[str, Any]] | None = None,
+    audit: _lenient_dict_list_opt = None,
     recap: str | None = None,
 ) -> str:
     """Update a finance research goal status after an audit.
@@ -788,7 +838,7 @@ def analyze_options(
 
 @mcp.tool
 def analyze_options_payoff(
-    legs: list[dict[str, Any]],
+    legs: _lenient_dict_list,
     entry_spot: float,
     expiry_days: float,
     risk_free_rate: float = 0.05,
@@ -798,7 +848,7 @@ def analyze_options_payoff(
     spot_min: float | None = None,
     spot_max: float | None = None,
     spot_points: int = 121,
-    scenario_iv_values: list[float] | None = None,
+    scenario_iv_values: _lenient_float_list_opt = None,
 ) -> str:
     """Analyze a multi-leg option strategy's payoff and spot/IV scenarios.
 
@@ -1209,7 +1259,7 @@ def list_swarm_presets() -> str:
 @mcp.tool
 async def run_swarm(
     preset_name: str,
-    variables: dict[str, str],
+    variables: _lenient_dict_str_str,
     wait_seconds: int = 3600,
     start_only: bool = False,
     ctx: Context | None = None,
@@ -1347,7 +1397,7 @@ def _cap_rows(records: list, max_rows: int) -> list | dict[str, object]:
 
 @mcp.tool
 def get_market_data(
-    codes: list[str],
+    codes: _lenient_str_list,
     start_date: str,
     end_date: str,
     source: str = "auto",
@@ -1453,7 +1503,7 @@ def _execute_key_gated(name: str, params: dict[str, Any]) -> str:
 
 
 @mcp.tool
-def get_fund_flow(codes: list[str], period: str = "daily", days: int = 30) -> str:
+def get_fund_flow(codes: _lenient_str_list, period: str = "daily", days: int = 30) -> str:
     """Fetch order-bucket net capital inflow (main/super-large/large/medium/small).
 
     Markets: A-share (.SH/.SZ/.BJ), Hong Kong (.HK) and US (.US). Use this to
@@ -1706,7 +1756,7 @@ def get_options_chain(ticker: str, expiration: int | None = None) -> str:
 
 
 @mcp.tool
-def get_stock_profile(ticker: str, sections: list[str] | None = None) -> str:
+def get_stock_profile(ticker: str, sections: _lenient_str_list_opt = None) -> str:
     """Fetch a read-only company profile for a US or HK listing (Yahoo Finance).
 
     Returns valuation key statistics, analyst price targets and
@@ -2269,7 +2319,7 @@ def run_shadow_backtest(
     shadow_id: str,
     window_start: str = "",
     window_end: str = "",
-    markets: list[str] | None = None,
+    markets: _lenient_str_list_opt = None,
     journal_path: str = "",
 ) -> str:
     """Run a multi-market backtest (A股/港股/美股/crypto) on a Shadow Account

--- a/agent/tests/test_mcp_json_string_args.py
+++ b/agent/tests/test_mcp_json_string_args.py
@@ -1,0 +1,194 @@
+"""MCP list/dict parameters must tolerate JSON-string arguments (issue #987).
+
+FastMCP publishes optional list/dict parameters as ``anyOf`` schemas, and some
+MCP clients (observed with Claude Desktop / Claude Code) do not surface ``anyOf``
+to the model as a concrete type — the model then serializes the argument as a
+JSON string (``'["us"]'``). Strict pydantic validation used to reject that string
+before the tool body ran::
+
+    1 validation error for call[run_shadow_backtest]
+    markets
+      Input should be a valid list [type=list_type, input_value='["us"]', ...]
+
+Every list/dict MCP parameter now carries a ``BeforeValidator``
+(``_coerce_json_string``) that decodes such a string before type checking. The
+published JSON schema is deliberately unchanged, so well-behaved clients that
+send real arrays/objects are unaffected.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+# (tool, param) pairs that are list/dict-typed in agent/mcp_server.py.
+LIST_DICT_PARAMS = {
+    "start_research_goal": ("criteria",),
+    "add_goal_evidence": (
+        "symbol_universe",
+        "benchmark",
+        "assumptions",
+        "contradicts_claim_ids",
+    ),
+    "update_research_goal_status": ("audit",),
+    "analyze_options_payoff": ("legs", "scenario_iv_values"),
+    "run_swarm": ("variables",),
+    "get_market_data": ("codes",),
+    "get_fund_flow": ("codes",),
+    "get_stock_profile": ("sections",),
+    "run_shadow_backtest": ("markets",),
+}
+
+
+@pytest.fixture(scope="module")
+def mcp_server():
+    """Import agent/mcp_server.py without executing main()."""
+    agent_dir = Path(__file__).resolve().parent.parent
+    if str(agent_dir) not in sys.path:
+        sys.path.insert(0, str(agent_dir))
+    return importlib.import_module("mcp_server")
+
+
+@pytest.fixture(scope="module")
+def tool_parameters(mcp_server) -> dict:
+    tools = asyncio.run(mcp_server.mcp.list_tools())
+    return {t.name: t.parameters for t in tools}
+
+
+def _declares_container(schema: dict) -> bool:
+    """True when a property schema declares array/object, directly or via anyOf."""
+
+    def _is_container(node: dict) -> bool:
+        return isinstance(node, dict) and node.get("type") in ("array", "object")
+
+    return _is_container(schema) or any(
+        _is_container(branch) for branch in schema.get("anyOf", [])
+    )
+
+
+def _text(result) -> str:
+    content = getattr(result, "content", None) or []
+    return content[0].text if content else str(result)
+
+
+# ---------------------------------------------------------------------------
+# Schema guard — the fix must not regress these to the client-visible {} shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("tool", sorted(LIST_DICT_PARAMS))
+def test_list_dict_params_keep_a_typed_schema(tool, tool_parameters) -> None:
+    props = tool_parameters[tool].get("properties", {})
+    for param in LIST_DICT_PARAMS[tool]:
+        assert param in props, f"{tool}.{param} missing from the input schema"
+        assert props[param] != {}, f"{tool}.{param} regressed to an empty schema"
+        assert _declares_container(props[param]), (
+            f"{tool}.{param} lost its array/object type: {props[param]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Coercion helper unit behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_json_string_decodes_arrays_and_objects(mcp_server) -> None:
+    coerce = mcp_server._coerce_json_string
+    assert coerce('["us", "hk"]') == ["us", "hk"]
+    assert coerce('{"target": "AAPL.US"}') == {"target": "AAPL.US"}
+    assert coerce("  [1, 2]  ") == [1, 2]
+
+
+def test_coerce_json_string_passes_through_everything_else(mcp_server) -> None:
+    coerce = mcp_server._coerce_json_string
+    # Real containers, None and numbers are untouched.
+    assert coerce(["us"]) == ["us"]
+    assert coerce({"a": 1}) == {"a": 1}
+    assert coerce(None) is None
+    assert coerce(42) == 42
+    # Non-JSON strings pass through so pydantic raises its normal type error.
+    assert coerce("us") == "us"
+    assert coerce("not json") == "not json"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through fastmcp.call_tool (the real validation path)
+# ---------------------------------------------------------------------------
+
+
+def test_optional_string_list_is_coerced(mcp_server, tmp_path, monkeypatch) -> None:
+    """run_shadow_backtest.markets as a JSON string must not fail validation."""
+    from src.goal import GoalStore
+
+    monkeypatch.setattr(mcp_server, "_goal_store", GoalStore(db_path=tmp_path / "g.db"))
+    monkeypatch.setattr(mcp_server, "_mcp_session_id", None)
+
+    result = asyncio.run(
+        mcp_server.mcp.call_tool(
+            "start_research_goal",
+            {"objective": "probe #987", "criteria": '["c1", "c2"]'},
+        )
+    )
+    text = _text(result)
+    assert '"status": "ok"' in text
+    assert "c1" in text and "c2" in text
+
+
+def test_required_dict_list_is_coerced(mcp_server) -> None:
+    """analyze_options_payoff.legs (required list[dict]) as a JSON string."""
+    result = asyncio.run(
+        mcp_server.mcp.call_tool(
+            "analyze_options_payoff",
+            {
+                "legs": '[{"option_type": "call", "strike": 100, "qty": 1, "premium": 5.0}]',
+                "entry_spot": 100.0,
+                "expiry_days": 30.0,
+            },
+        )
+    )
+    text = _text(result)
+    assert '"status": "ok"' in text
+    assert "list_type" not in text
+
+
+def test_real_containers_still_work(mcp_server, tmp_path, monkeypatch) -> None:
+    """Well-behaved clients sending real arrays/objects are unaffected."""
+    from src.goal import GoalStore
+
+    monkeypatch.setattr(mcp_server, "_goal_store", GoalStore(db_path=tmp_path / "g.db"))
+    monkeypatch.setattr(mcp_server, "_mcp_session_id", None)
+
+    result = asyncio.run(
+        mcp_server.mcp.call_tool(
+            "start_research_goal",
+            {"objective": "probe #987 real list", "criteria": ["c1", "c2"]},
+        )
+    )
+    text = _text(result)
+    assert '"status": "ok"' in text
+    assert "c1" in text and "c2" in text
+
+
+def test_non_json_string_still_fails_cleanly(mcp_server) -> None:
+    """A non-JSON string is passed through and rejected, not silently coerced."""
+    try:
+        result = asyncio.run(
+            mcp_server.mcp.call_tool(
+                "analyze_options_payoff",
+                {
+                    "legs": "definitely-not-json",
+                    "entry_spot": 100.0,
+                    "expiry_days": 30.0,
+                },
+            )
+        )
+    except Exception as exc:  # noqa: BLE001 - fastmcp surfaces validation errors
+        assert "list_type" in str(exc) or "valid list" in str(exc)
+        return
+    # If this fastmcp version returns an error envelope instead of raising,
+    # it must still be a failure, not a coerced success.
+    assert getattr(result, "isError", False) or '"status": "error"' in _text(result)


### PR DESCRIPTION
## Summary

- MCP tools with list/dict-typed parameters reject JSON-**string** arguments sent by some MCP clients — e.g. `run_shadow_backtest(markets='["us"]')` fails with `Input should be a valid list [type=list_type, input_value='["us"]', input_type=str]`.
- Attaches a pydantic `BeforeValidator` to every list/dict MCP parameter so a JSON-encoded string is decoded before validation. The published schema is unchanged, so well-behaved clients are unaffected.

## Why

FastMCP publishes optional list/dict parameters as `anyOf` schemas. Several MCP clients (observed with Claude Desktop / Claude Code) do not surface `anyOf` to the model as a concrete type, so the model serializes the array/object argument as a JSON **string**. Strict pydantic validation then rejects the call before the tool body runs:

```
1 validation error for call[run_shadow_backtest]
markets
  Input should be a valid list [type=list_type, input_value='["us"]', input_type=str]
```

Consequence: `markets` cannot be passed over MCP at all, and — combined with the default all-markets universe — `run_shadow_backtest` cannot be scoped to a single market, so one unreachable data source fails the whole run. The same rejection affects every list/dict MCP parameter.

I reproduced the exact error over MCP stdio, and confirmed the server already emits a typed `anyOf` schema across fastmcp 3.0/3.2/3.4 (the `{}` in the report is the client's rendering of `anyOf`). The robust, client-agnostic fix is therefore lenient input handling at the MCP boundary, as suggested in the issue.

Closes #987

## Changes

- `agent/mcp_server.py`:
  - Added `_coerce_json_string`, a pydantic `BeforeValidator` that decodes JSON array/object strings (`'[...]'` / `'{...}'`) and passes everything else through untouched (real containers, `None`, numbers, and non-JSON strings — the latter still hit pydantic's normal, precise type error).
  - Defined lenient `Annotated` aliases and applied them to all **13** list/dict parameters across **9** tools: `start_research_goal` (`criteria`), `add_goal_evidence` (`symbol_universe`, `benchmark`, `assumptions`, `contradicts_claim_ids`), `update_research_goal_status` (`audit`), `analyze_options_payoff` (`legs`, `scenario_iv_values`), `run_swarm` (`variables`), `get_market_data` (`codes`), `get_fund_flow` (`codes`), `get_stock_profile` (`sections`), `run_shadow_backtest` (`markets`).
  - The published JSON schema is byte-identical to before; real arrays/objects keep working.
- `agent/tests/test_mcp_json_string_args.py`: new regression suite (15 tests) — a schema guard (no regression to `{}`), helper unit behaviour, and end-to-end coercion through `fastmcp.call_tool` for both an optional `list[str]` and a required `list[dict]` param.

Risk note (agent-authored change): MCP-boundary only. No changes to protected areas, broker connectors, credentials, or order paths; every affected tool is read-only / research-only.

## Test Plan

- [x] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [x] New tests added (if applicable)
- [x] Tested manually (describe below)

Manually reproduced #987 over MCP stdio before the fix (exact `list_type` error); after the fix `markets='["us"]'` is coerced and the tool body runs. New tests: **15 passed**. Full suite: **8072 passed, 13 skipped** — the only 5 failures (`test_provider_header_isolation`, `test_tushare_loader::TestTushareE2E`) also fail on clean `main` (verified by re-running with this change stashed) and are unrelated to MCP.

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] Documentation updated (if user-facing change) — N/A: tool interfaces/schemas are unchanged; behaviour fix only
