### PR TITLE
fix(backtest): route bare US tickers to us_equity in market detection

### DIFF
--- a/agent/backtest/engines/_market_hooks.py
+++ b/agent/backtest/engines/_market_hooks.py
@@ -45,6 +45,12 @@ _MARKET_PATTERNS = [
     # Forex pairs: XXX/YYY or XXXXXX.FX
     (re.compile(r"^[A-Z]{3}/[A-Z]{3}$"), "forex"),
     (re.compile(r"^[A-Z]{6}\.FX$"), "forex"),
+    # Bare US tickers (AAPL, MSFT, SPY, T, ...). Must stay LAST so every
+    # suffixed equity / futures / crypto / forex form above wins first.
+    # ``{1,5}`` covers every standard US ticker length while 6-char bare
+    # forex (EURUSD) and longer crypto codes (BTCUSDT) fall through to the
+    # a_share default.
+    (re.compile(r"^[A-Z]{1,5}$", re.I), "us_equity"),
 ]
 
 _CHINA_EXCHANGES = {"CFFEX", "SHFE", "DCE", "ZCE", "INE", "GFEX"}
@@ -126,8 +132,9 @@ def _detect_market(code: str) -> str:
         code: Ticker / symbol string.
 
     Returns:
-        Market type (a_share/us_equity/hk_equity/crypto/futures/forex);
-        unknown defaults to ``a_share``.
+        Market type (a_share/us_equity/hk_equity/crypto/futures/forex).
+        Bare 1-5 letter alphabetic tickers resolve to ``us_equity``;
+        any other unknown format defaults to ``a_share``.
     """
     for pattern, market in _MARKET_PATTERNS:
         if pattern.match(code):

--- a/agent/src/shadow_account/backtester.py
+++ b/agent/src/shadow_account/backtester.py
@@ -40,7 +40,7 @@ SUPPORTED_MARKETS: tuple[str, ...] = ("china_a", "hk", "us", "crypto")
 _LIQUID_BASKETS: dict[str, list[str]] = {
     "china_a": ["600519.SH", "000858.SZ", "300750.SZ", "600036.SH", "000001.SZ"],
     "hk":      ["00700.HK", "09988.HK", "03690.HK", "00388.HK", "01810.HK"],
-    "us":      ["AAPL", "MSFT", "NVDA", "AMZN", "GOOGL"],
+    "us":      ["AAPL.US", "MSFT.US", "NVDA.US", "AMZN.US", "GOOGL.US"],
     "crypto":  ["BTC-USDT", "ETH-USDT", "SOL-USDT", "BNB-USDT", "XRP-USDT"],
 }
 

--- a/agent/tests/test_market_detection.py
+++ b/agent/tests/test_market_detection.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import pytest
 
-from backtest.engines._market_hooks import _is_china_futures
+from backtest.engines._market_hooks import _is_china_futures, code_currency
 from backtest.runner import (
     _detect_market,
     _detect_source,
@@ -46,6 +46,15 @@ class TestDetectMarket:
             ("AAPL.US", "us_equity"),
             ("TSLA.US", "us_equity"),
             ("NVDA.US", "us_equity"),
+            # US equity — bare tickers without the .US suffix (issue #986)
+            ("AAPL", "us_equity"),
+            ("MSFT", "us_equity"),
+            ("NVDA", "us_equity"),
+            ("AMZN", "us_equity"),
+            ("GOOGL", "us_equity"),
+            ("SPY", "us_equity"),
+            ("T", "us_equity"),
+            ("V", "us_equity"),
             # HK equity
             ("0700.HK", "hk_equity"),
             ("9988.HK", "hk_equity"),
@@ -81,11 +90,68 @@ class TestDetectMarket:
     def test_case_insensitive(self) -> None:
         assert _detect_market("000001.sz") == "a_share"
         assert _detect_market("aapl.us") == "us_equity"
+        assert _detect_market("aapl") == "us_equity"
         assert _detect_market("btc-usdt") == "crypto"
 
     def test_unknown_defaults_to_a_share(self) -> None:
         assert _detect_market("UNKNOWN") == "a_share"
         assert _detect_market("random-string") == "a_share"
+        # Bare codes outside the 1-5 letter US shape keep the old default.
+        assert _detect_market("EURUSD") == "a_share"
+        assert _detect_market("BTCUSDT") == "a_share"
+
+
+# ---------------------------------------------------------------------------
+# Issue #986 — bare US tickers must route to the us_equity chain
+# ---------------------------------------------------------------------------
+
+
+class TestBareUsTickerRouting:
+    """Regression suite for issue #986.
+
+    Bare US tickers (the Shadow Account US basket, agent-generated configs)
+    previously fell through to the a_share default, walked the A-share
+    loader chain, and died with NoAvailableSourceError. The catch-all
+    ``^[A-Z]{1,5}$`` pattern must stay the lowest-priority entry so every
+    suffixed / futures / crypto / forex form keeps winning first.
+    """
+
+    def test_shadow_us_basket_groups_into_us_equity(self) -> None:
+        basket = ["AAPL", "MSFT", "NVDA", "AMZN", "GOOGL"]
+        groups = _group_codes_by_market(basket)
+        assert groups == {"us_equity": basket}
+
+    def test_bare_ticker_source_and_currency(self) -> None:
+        assert _detect_source("AAPL") == "yfinance"
+        assert code_currency("AAPL") == "USD"
+        assert code_currency("AAPL.US") == "USD"
+
+    def test_catch_all_is_lowest_priority(self) -> None:
+        assert _detect_market("600519.SH") == "a_share"
+        assert _detect_market("00700.HK") == "hk_equity"
+        assert _detect_market("BTC-USDT") == "crypto"
+        assert _detect_market("RELIANCE.NS") == "india_equity"
+        assert _detect_market("005930.KS") == "kr_equity"
+        assert _detect_market("RB2410") == "futures"
+        assert _detect_market("ES2503") == "futures"
+        assert _detect_market("CLZ4") == "futures"
+        assert _detect_market("EUR/USD") == "forex"
+
+    def test_shadow_liquid_baskets_route_to_their_own_market(self) -> None:
+        from src.shadow_account.backtester import _LIQUID_BASKETS
+
+        expected = {
+            "china_a": "a_share",
+            "hk": "hk_equity",
+            "us": "us_equity",
+            "crypto": "crypto",
+        }
+        for market, codes in _LIQUID_BASKETS.items():
+            for code in codes:
+                assert _detect_market(code) == expected[market], (
+                    f"{market} basket code {code!r} detected as "
+                    f"{_detect_market(code)!r}, expected {expected[market]!r}"
+                )
 
 
 # ---------------------------------------------------------------------------

--- a/agent/tests/test_shadow_scanner.py
+++ b/agent/tests/test_shadow_scanner.py
@@ -56,7 +56,7 @@ def _bars(closes: list[float], volumes: list[float] | None = None) -> pd.DataFra
 def test_scan_today_signals_matches_price_features() -> None:
     profile = _profile()
     frames = {
-        "AAPL": _bars(
+        "AAPL.US": _bars(
             [10, 10.2, 10.4, 10.5, 10.7, 11.4],
             [100, 100, 100, 100, 100, 180],
         ),
@@ -66,7 +66,7 @@ def test_scan_today_signals_matches_price_features() -> None:
 
     assert matches == [
         {
-            "symbol": "AAPL",
+            "symbol": "AAPL.US",
             "market": "us",
             "rule_id": "R1",
             "reason": "R1 price features matched (hold 3-7d)",
@@ -78,7 +78,7 @@ def test_scan_today_signals_matches_price_features() -> None:
 def test_scan_today_signals_returns_no_match_when_features_fail() -> None:
     profile = _profile()
     frames = {
-        "AAPL": _bars(
+        "AAPL.US": _bars(
             [11.5, 11.2, 11.0, 10.9, 10.7, 10.5],
             [180, 160, 150, 140, 130, 100],
         ),
@@ -90,7 +90,7 @@ def test_scan_today_signals_returns_no_match_when_features_fail() -> None:
 @pytest.mark.unit
 def test_scan_today_signals_skips_missing_and_empty_data() -> None:
     profile = _profile()
-    frames = {"AAPL": pd.DataFrame(), "MSFT": pd.DataFrame({"open": [1, 2]})}
+    frames = {"AAPL.US": pd.DataFrame(), "MSFT.US": pd.DataFrame({"open": [1, 2]})}
 
     assert scan_today_signals(profile, target_date="2026-04-06", price_frames=frames) == []
 
@@ -109,7 +109,10 @@ def test_scan_today_signals_respects_per_market_cap() -> None:
         [10, 10.2, 10.4, 10.5, 10.7, 11.4],
         [100, 100, 100, 100, 100, 180],
     )
-    frames = {symbol: frame for symbol in ["AAPL", "MSFT", "NVDA", "AMZN", "GOOGL"]}
+    frames = {
+        symbol: frame
+        for symbol in ["AAPL.US", "MSFT.US", "NVDA.US", "AMZN.US", "GOOGL.US"]
+    }
 
     matches = scan_today_signals(
         profile,
@@ -118,7 +121,7 @@ def test_scan_today_signals_respects_per_market_cap() -> None:
         price_frames=frames,
     )
 
-    assert [match["symbol"] for match in matches] == ["AAPL", "MSFT"]
+    assert [match["symbol"] for match in matches] == ["AAPL.US", "MSFT.US"]
 
 
 def _ramp(n: int, start: float, step: float) -> list[float]:
@@ -137,11 +140,11 @@ def test_scan_today_signals_matches_rsi_range_condition() -> None:
     profile = _profile({"market": "us", "entry_rsi14": {"min": 50.0, "max": 100.0}})
     closes = _ramp(20, 10.0, 0.2)  # >= 14 bars so RSI is defined
     target = pd.Timestamp("2026-04-01") + pd.Timedelta(days=len(closes) - 1)
-    frames = {"AAPL": _bars(closes)}
+    frames = {"AAPL.US": _bars(closes)}
 
     matches = scan_today_signals(profile, target_date=target.date(), price_frames=frames)
 
-    assert [m["symbol"] for m in matches] == ["AAPL"]
+    assert [m["symbol"] for m in matches] == ["AAPL.US"]
 
 
 @pytest.mark.unit
@@ -150,7 +153,7 @@ def test_scan_today_signals_rejects_out_of_band_rsi() -> None:
     profile = _profile({"market": "us", "entry_rsi14": {"min": 0.0, "max": 30.0}})
     closes = _ramp(20, 10.0, 0.2)
     target = pd.Timestamp("2026-04-01") + pd.Timedelta(days=len(closes) - 1)
-    frames = {"AAPL": _bars(closes)}
+    frames = {"AAPL.US": _bars(closes)}
 
     assert scan_today_signals(profile, target_date=target.date(), price_frames=frames) == []
 
@@ -164,11 +167,11 @@ def test_scan_today_signals_honors_prior_return_dict_band() -> None:
     band; a too-high floor must reject it.
     """
     closes = [10, 10.2, 10.4, 10.5, 10.7, 11.4]
-    frames = {"AAPL": _bars(closes)}
+    frames = {"AAPL.US": _bars(closes)}
 
     inside = _profile({"market": "us", "prior_5d_return": {"min": 0.10, "max": 0.20}})
     assert [m["symbol"] for m in scan_today_signals(
-        inside, target_date="2026-04-06", price_frames=frames)] == ["AAPL"]
+        inside, target_date="2026-04-06", price_frames=frames)] == ["AAPL.US"]
 
     outside = _profile({"market": "us", "prior_5d_return": {"min": 0.50, "max": 1.0}})
     assert scan_today_signals(outside, target_date="2026-04-06", price_frames=frames) == []
@@ -178,7 +181,7 @@ def test_scan_today_signals_honors_prior_return_dict_band() -> None:
 def test_scan_today_signals_no_match_when_rsi_history_insufficient() -> None:
     """Too few bars to compute RSI → the RSI-bearing rule cannot match."""
     profile = _profile({"market": "us", "entry_rsi14": {"min": 0.0, "max": 100.0}})
-    frames = {"AAPL": _bars(_ramp(6, 10.0, 0.2))}  # < 14 bars, RSI undefined
+    frames = {"AAPL.US": _bars(_ramp(6, 10.0, 0.2))}  # < 14 bars, RSI undefined
 
     assert scan_today_signals(profile, target_date="2026-04-06", price_frames=frames) == []
 


### PR DESCRIPTION
## Summary

- Fix `_detect_market` classifying bare US tickers (`AAPL`, `MSFT`, ...) as `a_share` by appending a lowest-priority `^[A-Z]{1,5}$` catch-all to `_MARKET_PATTERNS`
- Normalize the Shadow Account US liquid basket to the suffixed project convention (`AAPL.US`), in line with the other three baskets

## Why

Closes #986

`_MARKET_PATTERNS` in `agent/backtest/engines/_market_hooks.py` only recognizes US equities in the suffixed `XXX.US` form. Bare tickers match no pattern and fall through to the default `a_share`. The Shadow Account backtest's own generated US candidate universe uses bare tickers (`AAPL`, `MSFT`, `NVDA`, `AMZN`, `GOOGL`), so the US bucket is routed through the A-share loader chain and never reaches yfinance — the fetch dies with `NoAvailableSourceError: incomplete data for a_share; missing symbols: [...]`.

Reproduced on `main` before the fix:

- `_detect_market('AAPL')` → `'a_share'` (expected `'us_equity'`); `_detect_source` → `tushare`, `code_currency` → `CNY`
- `fetch_data_map({'codes': ['AAPL', 'MSFT'], 'source': 'auto', ...})` → `NoAvailableSourceError: incomplete data for a_share; missing symbols: ['AAPL', 'MSFT']` — exact error from the issue
- Positive control: suffixed `AAPL.US` / `MSFT.US` fetch fine through the us_equity chain (the chain itself is healthy)

## Changes

- `agent/backtest/engines/_market_hooks.py`: append `(re.compile(r"^[A-Z]{1,5}$", re.I), "us_equity")` as the **last** (lowest-priority) entry of `_MARKET_PATTERNS`, so every suffixed equity / futures / crypto / forex form still wins first; update the `_detect_market` docstring. `{1,5}` covers every standard US ticker length (incl. 1-char `T`/`V`) while 6-char bare forex (`EURUSD`) and longer crypto codes (`BTCUSDT`) keep the historical default path
- `agent/src/shadow_account/backtester.py`: US liquid basket now uses suffixed codes (`AAPL.US`, ...), consistent with the china_a / hk / crypto baskets and robust independently of the detector
- `agent/tests/test_market_detection.py`: +12 regression tests — bare-ticker routing, priority guards (`RB2410`/`ES2503`/`CLZ4` futures and all suffixed forms unchanged), boundary cases (`EURUSD`/`BTCUSDT`/`UNKNOWN` still default to `a_share`), `code_currency('AAPL') == 'USD'`, and a guard asserting every Shadow liquid-basket code routes to its own market
- `agent/tests/test_shadow_scanner.py`: align 8 price-frame stubs with the suffixed basket codes

## Test Plan

- [x] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`) — full suite: **8069 passed, 14 skipped**; the 4 `test_tushare_loader.py::TestTushareE2E` failures are pre-existing on a clean tree (verified via `git stash` comparison; network/token dependent, unrelated to this change)
- [x] New tests added — 12 new cases in `test_market_detection.py` (76 total in file); focused battery of 298 tests across market-detection / shadow / composite / grounding suites all green
- [x] Tested manually:
  - `_detect_market('AAPL')` → `'us_equity'`, `_detect_source` → `yfinance`, `code_currency` → `USD`
  - `fetch_data_map` with bare `['AAPL', 'MSFT']` and `source='auto'` now fetches through the US chain (10 bars each)
  - Shadow US-only path verified end to end: basket selection → fetch (5 symbols) → `GlobalEquityEngine` routing

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines (DCO sign-off on the commit; ruff clean; no unrelated formatting churn — pre-existing Black drift on these files left untouched)
- [x] Documentation updated (if user-facing change) — `_detect_market` docstring updated; no user-facing docs affected

---

Note for reviewers: the default **four-market** Shadow run (`china_a + hk + us + crypto`) still fails after this fix — but at a later, more honest stage: `CompositeEngine._reject_mixed_currency` (the intentional CNY/HKD/USD guard) refuses the mixed-currency code set. Single-market (`markets=["us"]`) and same-currency combos (`us + crypto`) work end to end. The multi-market shadow design vs. the currency guard is a separate pre-existing defect (currently masked by this fetch failure) — happy to open a follow-up issue for it.
