### PR TITLE
fix(scheduled-research): keep one bad record from breaking the whole store

### DIFF
--- a/agent/src/scheduled_research/executor.py
+++ b/agent/src/scheduled_research/executor.py
@@ -347,8 +347,26 @@ class ScheduledResearchExecutor:
             return
         job = current
 
+        # A persisted schedule the current grammar rejects (an older release
+        # accepted a form since narrowed) must surface as a failed job, not as
+        # an exception on the way to dispatch: that would leave the record
+        # PENDING and due, retrying on every tick forever with nothing visible
+        # to the user.
+        try:
+            validate_schedule(job.schedule)
+        except ValueError as exc:
+            logger.error("scheduled research job %s has an invalid schedule", job.id, exc_info=True)
+            job.status = JobStatus.FAILED
+            job.failure_kind = "schedule"
+            job.last_error = _persisted_error(exc)
+            job.last_run_at = now_ms
+            self._persist_completion(job)
+            return
+
         job.status = JobStatus.RUNNING
-        self._store.upsert(job)
+        # Lifecycle writes bypass validation: this record is already persisted,
+        # and a write that cannot land would strand the job mid-flight.
+        self._store.upsert(job, validate=False)
 
         dispatch_error: Exception | None = None
         try:
@@ -430,4 +448,4 @@ class ScheduledResearchExecutor:
         if not self._same_record(current, job):
             logger.info("scheduled research job %s replaced during dispatch; skipping completion write", job.id)
             return
-        self._store.upsert(job)
+        self._store.upsert(job, validate=False)

--- a/agent/src/scheduled_research/models.py
+++ b/agent/src/scheduled_research/models.py
@@ -8,12 +8,15 @@ to a follow-up PR once the product shape is confirmed.
 
 from __future__ import annotations
 
+import logging
 import re
 import time
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, Optional, Set
 from zoneinfo import ZoneInfo
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Schedule validation
@@ -274,15 +277,20 @@ class ScheduledResearchJob:
             raise TypeError("'last_error' must be a string or null")
         if failure_kind is not None and failure_kind not in {"dispatch", "schedule"}:
             raise ValueError("'failure_kind' must be 'dispatch', 'schedule', or null")
-        # Type-checked only: resolving the zone at load time would let one
-        # unresolvable key quarantine the whole store file. Absent -> None
-        # (UTC); a blank string normalizes to None too, so every loaded record
-        # satisfies the shape check the store re-runs on lifecycle writes.
-        tz = data.get("timezone")
-        if tz is not None and not isinstance(tz, str):
-            raise TypeError("'timezone' must be a string or null")
-        if tz is not None and not tz.strip():
-            tz = None
+        # Never raises: the store quarantines the whole file when a single
+        # record fails to load, so an unusable timezone value degrades that
+        # one job to UTC — the semantics it had before the field existed —
+        # instead of taking every other job down with it. Absent, blank, and
+        # non-string values all normalize to None.
+        raw_tz = data.get("timezone")
+        tz = raw_tz if isinstance(raw_tz, str) and raw_tz.strip() else None
+        if raw_tz is not None and tz is None:
+            logger.warning(
+                "scheduled research job %s has an unusable timezone %r; "
+                "evaluating its schedule in UTC",
+                job_id,
+                raw_tz,
+            )
         status = JobStatus(data["status"])
         raw_config = data.get("config")
         config: Dict[str, Any] = raw_config if isinstance(raw_config, dict) else {}

--- a/agent/src/scheduled_research/store.py
+++ b/agent/src/scheduled_research/store.py
@@ -135,7 +135,7 @@ class ScheduledResearchJobStore:
         os.replace(tmp, target)
         self._fsync_dir(target.parent)
 
-    def upsert(self, job: ScheduledResearchJob) -> None:
+    def upsert(self, job: ScheduledResearchJob, *, validate: bool = True) -> None:
         """Insert or replace a job by id.
 
         Validates the schedule string and the timezone's shape before
@@ -146,13 +146,21 @@ class ScheduledResearchJobStore:
 
         Args:
             job: The job to store.
+            validate: When ``False``, skip schedule/timezone validation. Set by
+                the executor when recording lifecycle state (RUNNING, FAILED,
+                a retry time) for a job that is *already* persisted: such a
+                write must always land, otherwise a record whose schedule no
+                longer validates could never be marked failed and would retry
+                every tick forever. Creation paths keep the default.
 
         Raises:
-            ValueError: When ``job.schedule`` or ``job.timezone`` is malformed.
+            ValueError: When ``job.schedule`` or ``job.timezone`` is malformed
+                and *validate* is true.
             CorruptStoreError: When the existing store cannot be parsed.
         """
-        validate_schedule(job.schedule)
-        validate_timezone_shape(job.timezone)
+        if validate:
+            validate_schedule(job.schedule)
+            validate_timezone_shape(job.timezone)
         jobs = self.load()
         jobs[job.id] = job
         self.save(jobs)

--- a/agent/tests/test_scheduled_research_executor.py
+++ b/agent/tests/test_scheduled_research_executor.py
@@ -673,10 +673,10 @@ def test_executor_marks_job_failed_when_timezone_unresolvable(tmp_path: Path) ->
 
 def test_tick_continues_past_a_job_whose_lifecycle_write_raises(tmp_path: Path) -> None:
     class ExplodingUpsertStore(ScheduledResearchJobStore):
-        def upsert(self, job: ScheduledResearchJob) -> None:
+        def upsert(self, job: ScheduledResearchJob, *, validate: bool = True) -> None:
             if job.id == "bad":
                 raise RuntimeError("disk full")
-            super().upsert(job)
+            super().upsert(job, validate=validate)
 
     store = ExplodingUpsertStore(path=tmp_path / "jobs.json")
     good_store = ScheduledResearchJobStore(path=tmp_path / "jobs.json")
@@ -697,3 +697,44 @@ def test_tick_continues_past_a_job_whose_lifecycle_write_raises(tmp_path: Path) 
     saved = good_store.get("good")
     assert saved is not None
     assert saved.status == JobStatus.COMPLETED
+
+
+def test_job_with_invalid_persisted_schedule_fails_visibly_once(tmp_path: Path) -> None:
+    # A 16-digit interval was accepted by an earlier grammar; it must surface
+    # as a failed job rather than retry forever.
+    store = _store(tmp_path)
+    store.save({"legacy": _job("legacy", schedule="9" * 16, next_run_at=10)})
+    calls: list[str] = []
+
+    async def dispatch(job: ScheduledResearchJob) -> None:
+        calls.append(job.id)
+
+    async def scenario() -> None:
+        executor = ScheduledResearchExecutor(store, dispatch)
+        await executor.tick(100)
+        await executor.tick(200)
+
+    asyncio.run(scenario())
+
+    saved = store.get("legacy")
+    assert saved is not None
+    assert calls == []  # never dispatched
+    assert saved.status == JobStatus.FAILED
+    assert saved.failure_kind == "schedule"
+    assert "interval is too large" in (saved.last_error or "")
+    assert saved.last_run_at == 100  # second tick left it alone
+
+
+def test_lifecycle_writes_survive_a_schedule_the_grammar_now_rejects(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    job = _job("legacy", schedule="9" * 16, next_run_at=10)
+    store.save({job.id: job})
+
+    with pytest.raises(ValueError):
+        store.upsert(job)  # creation-style write still validates
+
+    job.status = JobStatus.FAILED
+    store.upsert(job, validate=False)  # lifecycle write lands
+    saved = store.get("legacy")
+    assert saved is not None
+    assert saved.status == JobStatus.FAILED

--- a/agent/tests/test_scheduled_research_store.py
+++ b/agent/tests/test_scheduled_research_store.py
@@ -327,11 +327,12 @@ class TestScheduledResearchJobStore:
         with pytest.raises(ValueError, match="timezone"):
             store.upsert(job)
 
-    def test_from_dict_rejects_non_string_timezone(self) -> None:
+    def test_from_dict_degrades_non_string_timezone_to_none(self) -> None:
+        # Loading must never raise: the store quarantines the entire file when
+        # one record fails, so an unusable value falls back to UTC semantics.
         raw = _make_job("tz-type").to_dict()
         raw["timezone"] = 13
-        with pytest.raises(TypeError, match="'timezone' must be a string or null"):
-            ScheduledResearchJob.from_dict(raw)
+        assert ScheduledResearchJob.from_dict(raw).timezone is None
 
     def test_from_dict_normalizes_blank_timezone_to_none(self) -> None:
         # A blank string must load as None so every loaded record satisfies
@@ -374,3 +375,25 @@ class TestScheduledResearchJobStore:
         cron_job = _make_job("cron-1", schedule="*/30 * * * *")
         store.upsert(cron_job)
         assert store.get("cron-1") is not None
+
+
+class TestLegacyTimezoneValues:
+    def test_non_string_timezone_degrades_that_job_to_utc(self, tmp_path: Path) -> None:
+        # Before the timezone field existed the key was ignored entirely; a
+        # record carrying a non-string value must still load, and must not
+        # take the rest of the store down with it.
+        store_path = tmp_path / "jobs.json"
+        good = _make_job("good").to_dict()
+        bad = _make_job("bad").to_dict()
+        bad["timezone"] = 123
+        store_path.write_text(
+            json.dumps({"schema_version": 1, "jobs": [good, bad]}), encoding="utf-8"
+        )
+
+        jobs = ScheduledResearchJobStore(path=store_path).load()
+
+        assert set(jobs) == {"good", "bad"}
+        assert jobs["bad"].timezone is None
+        assert jobs["good"].timezone is None
+        assert store_path.exists()  # not quarantined
+        assert not list(tmp_path.glob("*.corrupt-*"))


### PR DESCRIPTION
## Problem

Two ways a single persisted record could take more down with it than itself.

**1. A non-string `timezone` quarantines the whole store.** The timezone type check added to `from_dict` in #954 raises `TypeError` for a non-string value, and the store quarantines the entire file when any record fails to load. Before the field existed the key was simply ignored, so a store that loaded fine on the previous release now does this:

```
store: 3 jobs, one hand-edited to "timezone": 123
GET /scheduled-runs        -> HTTP 500
store dir after            -> scheduled_research_jobs.json.corrupt-20260805T022055Z
                              (all three jobs gone until the file is restored by hand)
```

**2. A schedule the current grammar rejects retries forever, invisibly.** #954 capped intervals at 15 digits; a 16-digit interval accepted by the earlier grammar is still persisted for some users. The cap raises inside the mark-RUNNING write, before the existing `failure_kind="schedule"` path can record it, and the tick loop's per-job guard swallows the exception:

```
scheduled research job wedge16 failed its run cycle
ValueError: interval is too large; expected at most 15 digits of milliseconds

the job record after those ticks: status=pending, failure_kind=None, last_error=None
```

Nothing surfaces to the user; the server logs an error every 60 seconds indefinitely.

## Fix

One invariant: invalid persisted data degrades that job, never the store or the loop.

- Loading no longer raises for an unusable `timezone`. Absent, blank and non-string values all normalize to `None` — the UTC semantics the job had before the field existed — with a warning naming the job. Every other record keeps loading.
- A persisted schedule the grammar rejects is checked before dispatch and marked `FAILED` / `failure_kind="schedule"` once, so it stops retrying and is visible in the API and the UI.
- Lifecycle writes for already-persisted records skip re-validation (`upsert(..., validate=False)`), so a terminal state can always be recorded. Creation paths validate exactly as before.

After the fix, the same seeded store:

```
GET /scheduled-runs  -> 200, jobs visible: ['good', 'badtz', 'wedge16']   (nothing quarantined)
after two ticks      -> good: completed | badtz: completed (UTC) | wedge16: failed, kind=schedule
"failed its run cycle" lines in the log: 0
```

## Tests

Executor: an invalid persisted schedule fails visibly once and never dispatches. A lifecycle write lands for a record whose schedule no longer validates, while creation-style writes still reject it. Store: a non-string timezone degrades that job to UTC and leaves the file unquarantined. One existing test asserted the old `TypeError` and is updated to the new behaviour.

## Validation

- `pytest --ignore=agent/tests/e2e_backtest --ignore=agent/tests/test_e2e_harness_v2.py`: 9,537 passed, 0 failed.
- Both reproductions and both fixes confirmed against a live `vibe-trading serve` instance with the scheduler enabled, on an isolated `VIBE_TRADING_HOME`.
- Not run: `agent/tests/e2e_backtest` and the e2e harness (excluded per the contributor guide's default command).
