### PR TITLE
fix(scheduled-research): stop interval creates from requiring a resolvable zone

### DIFF
--- a/agent/src/api/scheduled_routes.py
+++ b/agent/src/api/scheduled_routes.py
@@ -271,8 +271,10 @@ def register_scheduled_routes(
         from src.scheduled_research.models import (
             JobStatus,
             ScheduledResearchJob,
+            is_interval_schedule,
             validate_schedule,
             validate_timezone,
+            validate_timezone_shape,
         )
 
         from src.scheduled_research.executor import next_due
@@ -291,7 +293,16 @@ def register_scheduled_routes(
 
         try:
             validate_schedule(request.schedule)
-            validate_timezone(request.timezone)
+            # Interval schedules ignore the timezone, and the executor
+            # deliberately skips resolving it for them so an interval job keeps
+            # advancing on a host whose timezone database lacks the key. The
+            # create path follows the same rule: only a cron schedule, whose
+            # evaluation actually needs the zone, resolves it. Both forms still
+            # reject a blank value.
+            if is_interval_schedule(request.schedule):
+                validate_timezone_shape(request.timezone)
+            else:
+                validate_timezone(request.timezone)
         except ValueError as exc:
             raise HTTPException(status_code=422, detail=str(exc)) from exc
 
@@ -299,7 +310,7 @@ def register_scheduled_routes(
         next_run_at = request.next_run_at
         if next_run_at is None:
             next_run_at = now_ms
-            if request.timezone is not None and not request.schedule.strip().isdigit():
+            if request.timezone is not None and not is_interval_schedule(request.schedule):
                 # A timezone-carrying cron job's contract is the authored wall
                 # clock, so its first fire is the first authored occurrence —
                 # not the creation moment. Interval jobs and timezone-less

--- a/agent/src/scheduled_research/models.py
+++ b/agent/src/scheduled_research/models.py
@@ -90,6 +90,23 @@ def parse_cron_field(part: str, low: int, high: int) -> Optional[Set[int]]:
     return values
 
 
+def is_interval_schedule(schedule: str) -> bool:
+    """Return whether *schedule* is the interval-milliseconds form.
+
+    The one place that answers "interval or cron?", so callers that treat the
+    two forms differently — the executor's advancement path, the create route's
+    timezone handling — cannot disagree about which is which.
+
+    Args:
+        schedule: A schedule string in either accepted form.
+
+    Returns:
+        ``True`` for a bare positive-integer interval, ``False`` otherwise
+        (including malformed input, which the validators reject separately).
+    """
+    return bool(_INTERVAL_MS_RE.fullmatch(str(schedule).strip()))
+
+
 def validate_schedule(schedule: str) -> None:
     """Raise ``ValueError`` when *schedule* is malformed.
 

--- a/agent/tests/test_scheduled_routes.py
+++ b/agent/tests/test_scheduled_routes.py
@@ -359,3 +359,52 @@ def test_create_accepts_ids_within_the_id_rule(
         )
         assert response.status_code == 201, good_id
         assert client.delete(f"/scheduled-runs/{good_id}").status_code == 204
+def test_create_interval_accepts_a_timezone_it_will_never_use(
+    client: TestClient, store: ScheduledResearchJobStore
+):
+    # The composer attaches the browser zone to every create. An interval
+    # schedule ignores it, and the executor never resolves it, so a key this
+    # host cannot resolve must not block the create.
+    response = client.post(
+        "/scheduled-runs",
+        json={
+            "id": "interval-unknown-zone",
+            "prompt": "scan",
+            "schedule": "60000",
+            "timezone": "Mars/Olympus_Mons",
+        },
+    )
+
+    assert response.status_code == 201
+    saved = store.get("interval-unknown-zone")
+    assert saved is not None
+    assert saved.timezone == "Mars/Olympus_Mons"
+
+
+def test_create_cron_still_rejects_an_unresolvable_timezone(
+    client: TestClient, store: ScheduledResearchJobStore
+):
+    response = client.post(
+        "/scheduled-runs",
+        json={
+            "id": "cron-unknown-zone",
+            "prompt": "scan",
+            "schedule": "0 9 * * *",
+            "timezone": "Mars/Olympus_Mons",
+        },
+    )
+
+    assert response.status_code == 422
+    assert "IANA timezone" in response.json()["detail"]
+    assert store.get("cron-unknown-zone") is None
+
+
+def test_create_rejects_a_blank_timezone_for_both_schedule_forms(
+    client: TestClient, store: ScheduledResearchJobStore
+):
+    for schedule in ("60000", "0 9 * * *"):
+        response = client.post(
+            "/scheduled-runs",
+            json={"prompt": "scan", "schedule": schedule, "timezone": "   "},
+        )
+        assert response.status_code == 422, schedule


### PR DESCRIPTION
## Problem

The `timezone` field is documented as ignored by interval schedules, and `next_due` deliberately skips resolving it for them so an interval job keeps advancing on a host whose timezone database lacks the key. The timezone check added to the create route in #954 resolves it unconditionally, so an interval schedule can be rejected over a field that has no effect on it:

```
POST {"schedule":"60000","timezone":"Not/AZone"}  -> 422 "timezone 'Not/AZone' is not a recognized IANA timezone key"
```

This is reachable in normal use: the web composer attaches the browser's zone to every create, so any browser/server tzdata skew (a recently added or renamed IANA key, or a Windows host without the `tzdata` package) breaks interval creates.

## Fix

Interval creates now check only that the timezone is a non-empty string; cron creates, which actually evaluate it, still resolve it against the timezone database. A blank value is still rejected for both. The interval-vs-cron check moves into `is_interval_schedule` beside the validators, replacing an inline `isdigit()` copy in the route so the two paths cannot disagree about which form a schedule takes.

After the fix:

```
interval + unresolvable tz  -> 201
cron + unresolvable tz      -> 422 (unchanged)
interval + blank tz         -> 422 (unchanged)
```

## Tests

Three route tests covering these cases, with the blank-timezone one checked across both schedule forms.

## Validation

- `pytest --ignore=agent/tests/e2e_backtest --ignore=agent/tests/test_e2e_harness_v2.py`: 9,537 passed, 0 failed.
- Confirmed against a live `vibe-trading serve` instance on an isolated `VIBE_TRADING_HOME`.
- Not run: `agent/tests/e2e_backtest` and the e2e harness (excluded per the contributor guide's default command).
