### PR TITLE
fix(channels): thread message_id into IM outbound so QQ replies are passive

### DIFF
--- a/agent/src/channels/runtime.py
+++ b/agent/src/channels/runtime.py
@@ -189,6 +189,11 @@ class ChannelRuntime:
                         "_channel_runtime": True,
                         "attempt_id": attempt_id,
                         "session_id": session_id,
+                        # QQ (and other platforms) need the originating message id
+                        # to reply as a passive message; without it, replies are
+                        # treated as active messages and rejected for
+                        # non-privileged bots.
+                        "message_id": msg.metadata.get("message_id"),
                     },
                 )
             )
@@ -206,7 +211,11 @@ class ChannelRuntime:
                         "Still working on your previous message — send this again "
                         "once I reply, or use the reset command to start over."
                     ),
-                    metadata={"_channel_runtime": True, "busy": True},
+                    metadata={
+                        "_channel_runtime": True,
+                        "busy": True,
+                        "message_id": msg.metadata.get("message_id"),
+                    },
                 )
             )
         except Exception as exc:  # noqa: BLE001 - channel errors must surface to users
@@ -216,7 +225,11 @@ class ChannelRuntime:
                     channel=msg.channel,
                     chat_id=msg.chat_id,
                     content=f"Channel runtime error: {type(exc).__name__}: {exc}",
-                    metadata={"_channel_runtime": True, "error": True},
+                    metadata={
+                        "_channel_runtime": True,
+                        "error": True,
+                        "message_id": msg.metadata.get("message_id"),
+                    },
                 )
             )
 

--- a/agent/src/channels/runtime.py
+++ b/agent/src/channels/runtime.py
@@ -136,7 +136,11 @@ class ChannelRuntime:
                                 "Not authorized: pairing management is restricted to "
                                 "configured operators."
                             ),
-                            metadata={PAIRING_COMMAND_META_KEY: True, "unauthorized": True},
+                            metadata={
+                                PAIRING_COMMAND_META_KEY: True,
+                                "unauthorized": True,
+                                "message_id": msg.metadata.get("message_id"),
+                            },
                         )
                     )
                     return
@@ -151,7 +155,10 @@ class ChannelRuntime:
                         channel=msg.channel,
                         chat_id=msg.chat_id,
                         content=reply,
-                        metadata={PAIRING_COMMAND_META_KEY: True},
+                        metadata={
+                            PAIRING_COMMAND_META_KEY: True,
+                            "message_id": msg.metadata.get("message_id"),
+                        },
                     )
                 )
                 return
@@ -167,7 +174,11 @@ class ChannelRuntime:
                         channel=msg.channel,
                         chat_id=msg.chat_id,
                         content=reply,
-                        metadata={"_channel_runtime": True, "session_reset": True},
+                        metadata={
+                            "_channel_runtime": True,
+                            "session_reset": True,
+                            "message_id": msg.metadata.get("message_id"),
+                        },
                     )
                 )
                 return

--- a/agent/tests/test_channels_runtime.py
+++ b/agent/tests/test_channels_runtime.py
@@ -265,6 +265,7 @@ def test_channel_runtime_routes_inbound_to_session_and_outbound(tmp_path: Path) 
                     sender_id="user-1",
                     chat_id="chat-1",
                     content="hello from IM",
+                    metadata={"message_id": "orig-msg-42"},
                 )
             )
 
@@ -281,6 +282,10 @@ def test_channel_runtime_routes_inbound_to_session_and_outbound(tmp_path: Path) 
                 "_channel_runtime": True,
                 "attempt_id": "attempt-1",
                 "session_id": "session-1",
+                # The originating message id is threaded through so the QQ
+                # adapter can send the reply as a passive message (msg_id)
+                # instead of an active message QQ rejects for non-privileged bots.
+                "message_id": "orig-msg-42",
             },
         )
 

--- a/agent/tests/test_channels_runtime.py
+++ b/agent/tests/test_channels_runtime.py
@@ -20,6 +20,7 @@ from src.channelsui.mcp_presets_api import normalize_mcp_preset_mentions
 from src.channelsui.transcription_ws import webui_transcription_event
 from src.session.goal_state import goal_state_ws_blob
 from src.session.models import Message, Session
+from src.session.service import SessionBusyError
 from src.session.webui_turns import (
     clear_websocket_turn_started,
     mark_websocket_turn_started,
@@ -317,6 +318,7 @@ def test_channel_runtime_handles_pairing_commands_without_agent(tmp_path: Path, 
                     sender_id="owner",
                     chat_id="chat-1",
                     content="/PAIRING LIST",
+                    metadata={"message_id": "pairing-msg-1"},
                 )
             )
             outbound = await asyncio.wait_for(bus.consume_outbound(), timeout=1)
@@ -328,6 +330,7 @@ def test_channel_runtime_handles_pairing_commands_without_agent(tmp_path: Path, 
         assert outbound.chat_id == "chat-1"
         assert "No pending pairing requests" in outbound.content
         assert outbound.metadata["_pairing_command"] is True
+        assert outbound.metadata["message_id"] == "pairing-msg-1"
 
     asyncio.run(scenario())
 
@@ -366,6 +369,7 @@ def test_channel_runtime_rejects_pairing_from_non_operator(
                     sender_id="stranger",
                     chat_id="chat-1",
                     content=f"/pairing approve {code}",
+                    metadata={"message_id": "pairing-msg-2"},
                 )
             )
             outbound = await asyncio.wait_for(bus.consume_outbound(), timeout=1)
@@ -374,6 +378,7 @@ def test_channel_runtime_rejects_pairing_from_non_operator(
 
         assert service.sent == []
         assert outbound.metadata.get("unauthorized") is True
+        assert outbound.metadata["message_id"] == "pairing-msg-2"
         assert "Not authorized" in outbound.content
         # The code must NOT have been consumed by the rejected attempt.
         assert pairing.is_approved("signal", "victim-sender") is False
@@ -654,7 +659,13 @@ def test_channel_runtime_new_command_with_no_existing_session(tmp_path: Path) ->
         await runtime.start(start_manager=False)
         try:
             await bus.publish_inbound(
-                InboundMessage(channel="telegram", sender_id="u1", chat_id="c1", content="/new")
+                InboundMessage(
+                    channel="telegram",
+                    sender_id="u1",
+                    chat_id="c1",
+                    content="/new",
+                    metadata={"message_id": "reset-msg-1"},
+                )
             )
             reply = await asyncio.wait_for(bus.consume_outbound(), timeout=1)
         finally:
@@ -662,8 +673,61 @@ def test_channel_runtime_new_command_with_no_existing_session(tmp_path: Path) ->
 
         assert "No active session to reset" in reply.content
         assert reply.metadata.get("session_reset") is True
+        assert reply.metadata["message_id"] == "reset-msg-1"
         assert service.sent == []
         assert len(service.created) == 0
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    ("failure", "flag"),
+    [
+        (SessionBusyError("busy"), "busy"),
+        (RuntimeError("boom"), "error"),
+    ],
+)
+def test_channel_runtime_preserves_message_id_for_failure_replies(
+    tmp_path: Path,
+    failure: Exception,
+    flag: str,
+) -> None:
+    async def scenario() -> None:
+        from src.channels.runtime import ChannelRuntime
+
+        bus = MessageBus()
+        service = FakeSessionService()
+
+        async def fail_send(*args: Any, **kwargs: Any) -> dict[str, str]:
+            del args, kwargs
+            raise failure
+
+        service.send_message = fail_send  # type: ignore[method-assign]
+        runtime = ChannelRuntime(
+            bus=bus,
+            session_service=service,
+            manager=None,
+            session_map_path=tmp_path / "channel_sessions.json",
+            reply_timeout_s=1,
+            poll_interval_s=0.01,
+        )
+        await runtime.start(start_manager=False)
+        try:
+            await bus.publish_inbound(
+                InboundMessage(
+                    channel="qq",
+                    sender_id="u1",
+                    chat_id="c1",
+                    content="hello",
+                    metadata={"message_id": "origin-msg-1"},
+                )
+            )
+            reply = await asyncio.wait_for(bus.consume_outbound(), timeout=1)
+        finally:
+            await runtime.stop()
+
+        assert reply.metadata[flag] is True
+        assert reply.metadata["message_id"] == "origin-msg-1"
 
     asyncio.run(scenario())
 


### PR DESCRIPTION
## Problem

QQ official bots (non-privileged, non-whitelisted) cannot send *active* messages to a group. They can only reply to a user message as a *passive* reply, which requires carrying the originating message id in the `msg_id` field. The QQ group passive-reply window is 5 minutes — comfortably covering agent research runs — but the reply must include the source `msg_id`.

Without it, `qq.py`'s `send()` reads `msg.metadata.get("message_id")` as `None`, the reply goes out without `msg_id`, QQ treats it as an active message and rejects it:

```
botpy.errors.ServerError: 主动消息失败, 无权限
(40034105 active message failed, no permission)
```

Net effect: the bot receives and processes group @ messages (ack "⏳ Processing..." is delivered), but the final research reply can never reach the group.

## Root cause

`ChannelRuntime._handle_inbound` publishes the session reply as an `OutboundMessage` with metadata `{_channel_runtime, attempt_id, session_id}` — it never forwards the inbound message's `message_id` (which `qq.py` already records as `metadata={"message_id": data.id}`).

## Fix

Thread the originating `message_id` from the inbound message into the outbound metadata on all three paths (successful reply, busy, and error), so platform adapters can address their reply to the source message.

## Verification

- `pytest agent/tests/test_channels_runtime.py` — 24 passed (test updated to assert `message_id` propagates inbound → outbound)
- `ruff check` — clean
- End-to-end on a real QQ group bot: after the fix, the agent's reply is delivered back to the group as a passive message (previously rejected with 40034105)
