### PR TITLE
fix(tools): accept dict payloads in technical_indicators

### DIFF
--- a/agent/src/tools/technical_indicator_tool.py
+++ b/agent/src/tools/technical_indicator_tool.py
@@ -173,13 +173,23 @@ class TechnicalIndicatorTool(BaseTool):
             return json.dumps({"ok": False, "error": f"Failed to fetch data: {exc}"})
 
         df = data.get(symbol)
-        if df is None or df.empty:
+        if isinstance(df, dict):
+            # Some loaders return a dict-like per-symbol payload.
+            if not df:
+                return json.dumps({"ok": False, "error": f"No data returned for {symbol}"})
+        elif df is None or df.empty:
             return json.dumps({"ok": False, "error": f"No data returned for {symbol}"})
 
         close = df.get("close") if isinstance(df, pd.DataFrame) else None
         if close is None:
             # Some loaders return a dict-like structure; try common key names.
-            if hasattr(df, "to_dict"):
+            if isinstance(df, dict):
+                # Plain dict payload (e.g. a loader that returns records).
+                for key in ("close", "Close", "CLOSE", "adj_close"):
+                    if key in df:
+                        close = df[key]
+                        break
+            elif hasattr(df, "to_dict"):
                 d = df.to_dict() if callable(df.to_dict) else dict(df)
                 for key in ("close", "Close", "CLOSE", "adj_close"):
                     if key in d:

--- a/agent/tests/test_technical_indicator_tool.py
+++ b/agent/tests/test_technical_indicator_tool.py
@@ -170,6 +170,26 @@ class TestTechnicalIndicatorToolIntegration:
         assert result["ok"] is True
         assert result["indicators"]["rsi_14"] is not None
 
+    def test_execute_dict_payload(self, monkeypatch, sample_close):
+        """Loader returns a plain dict per symbol — must not crash on .empty."""
+        payload = {
+            "AAPL": {
+                "close": sample_close.tolist(),
+                "open": [float(v * 0.99) for v in sample_close.tolist()],
+            }
+        }
+        monkeypatch.setattr(
+            "src.tools.technical_indicator_tool.fetch_market_data",
+            lambda **kw: payload,
+        )
+        tool = TechnicalIndicatorTool()
+        result = json.loads(tool.execute(symbol="AAPL"))
+        assert result["ok"] is True
+        assert result["symbol"] == "AAPL"
+        assert result["indicators"]["rsi_14"] is not None
+        assert result["indicators"]["macd"] is not None
+        assert result["latest_close"] == float(sample_close.iloc[-1])
+
     def test_execute_fetch_failure(self, monkeypatch):
         """Loader raises → error envelope."""
         monkeypatch.setattr(


### PR DESCRIPTION
## Problem

The `technical_indicators` tool crashes when a data loader returns a plain dict per symbol instead of a pandas DataFrame:

```
AttributeError: 'dict' object has no attribute 'empty'
  File "agent/src/tools/technical_indicator_tool.py", line 176, in execute
    if df is None or df.empty:
```

The `.empty` check assumes a DataFrame, but `data.get(symbol)` can be a dict for some loader/interval combinations. The crash surfaces to the agent as a tool failure, which makes the agent retry the call repeatedly — stalling research runs (observed on real runs where `get_market_data` was invoked dozens of times in a loop).

## Fix

Handle both payload shapes in `execute()`:

- Guard the `empty` check so a dict payload never raises.
- Extract the close column directly from the dict (trying the same `close` / `Close` / `CLOSE` / `adj_close` key set already used for DataFrame payloads).

## Verification

- `pytest agent/tests/test_technical_indicator_tool.py` — 24 passed (added a regression test for a dict payload)
- `ruff check` — clean
- On a live agent run, the `AttributeError` disappeared and `technical_indicators` returned results normally
