### PR TITLE
fix(sandbox): preserve canonical run root after HOME isolation

### DIFF
--- a/agent/src/core/runner.py
+++ b/agent/src/core/runner.py
@@ -448,6 +448,24 @@ class Runner:
             }
         )
 
+        # ``execute()`` replaces HOME with an ephemeral sandbox directory.  The
+        # backtest entry point validates ``run_dir`` again in that child
+        # process, so its HOME-derived default roots no longer include a run
+        # created under the real ``~/.vibe-trading/runs``.  Carry the exact
+        # current run directory across the boundary as an explicit root.  Using
+        # the run itself (rather than its parent) keeps the sandbox grant as
+        # narrow as possible while ensuring artifacts land in the canonical
+        # directory indexed by the Reports API.
+        allowed_run_roots = [
+            item.strip()
+            for item in env.get("VIBE_TRADING_ALLOWED_RUN_ROOTS", "").split(",")
+            if item.strip()
+        ]
+        current_run_root = str(run_dir.resolve())
+        if current_run_root not in allowed_run_roots:
+            allowed_run_roots.append(current_run_root)
+        env["VIBE_TRADING_ALLOWED_RUN_ROOTS"] = ",".join(allowed_run_roots)
+
         if pythonpath_extra:
             existing = env.get("PYTHONPATH", "")
             env["PYTHONPATH"] = str(pythonpath_extra) + (os.pathsep + existing if existing else "")

--- a/agent/tests/test_runner_env.py
+++ b/agent/tests/test_runner_env.py
@@ -99,6 +99,51 @@ def test_backtest_runtime_env_prepends_runtime_pythonpath(
     assert env["PYTHONPATH"] == f"{pythonpath_extra}{os.pathsep}existing-path"
 
 
+def test_backtest_runtime_env_adds_exact_current_run_root(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    configured_root = tmp_path / "configured-runs"
+    run_dir = tmp_path / "state-root" / "runs" / "run-1"
+    monkeypatch.setenv("VIBE_TRADING_ALLOWED_RUN_ROOTS", str(configured_root))
+
+    env = Runner(timeout=1)._build_runtime_env(run_dir)
+
+    assert env["VIBE_TRADING_ALLOWED_RUN_ROOTS"].split(",") == [
+        str(configured_root),
+        str(run_dir.resolve()),
+    ]
+
+
+def test_execute_keeps_real_home_run_valid_after_home_is_sandboxed(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    real_home = tmp_path / "real-home"
+    run_dir = real_home / ".vibe-trading" / "runs" / "run-1"
+    run_dir.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(real_home))
+    monkeypatch.delenv("VIBE_TRADING_ALLOWED_RUN_ROOTS", raising=False)
+
+    entry = _probe_entry(
+        tmp_path,
+        "import sys\n"
+        "from src.tools.path_utils import safe_run_dir\n"
+        "print(safe_run_dir(sys.argv[1]))\n",
+    )
+    agent_root = Path(runner_mod.__file__).resolve().parents[2]
+
+    result = Runner(timeout=60).execute(
+        entry,
+        run_dir,
+        cwd=agent_root,
+        cli_args=[str(run_dir)],
+    )
+
+    assert result.success, result.stderr
+    assert str(run_dir.resolve()) in result.stdout
+
+
 # --------------------------------------------------------------------------- #
 # VT-001 runtime defense-in-depth: ephemeral HOME, UID-drop fallback, rlimits.
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

- Preserve the exact active backtest `run_dir` when the subprocess receives an ephemeral `HOME`.
- Keep the added allowlist scope limited to the current run instead of its parent directory.
- Add unit and end-to-end regression coverage for configured roots and HOME isolation.

## Why

`Runner.execute()` replaces `HOME` before starting the generated-code subprocess. The backtest entry point then rebuilds its default run-root allowlist from that temporary home and rejects a canonical run created under the real `~/.vibe-trading/runs`.

This causes repeated `backtest` tool failures and can make agents switch to alternate run directories that are not indexed by the Reports API.

## Changes

- Append the resolved current run directory to `VIBE_TRADING_ALLOWED_RUN_ROOTS` in the sanitized subprocess environment.
- Preserve any operator-configured run roots and avoid duplicate entries.
- Cover both environment construction and the real ephemeral-HOME subprocess path.

## Test Plan

- [x] Targeted existing and new tests pass:
  `pytest -q agent/tests/test_runner_env.py agent/tests/test_file_tool_sandbox_security.py agent/tests/test_path_safety.py`
- [x] 46 tests pass in the Docker builder runtime.
- [x] New regression tests added.
- [x] Tested manually in the hardened Docker deployment with a canonical `~/.vibe-trading/runs/...` backtest.

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] Documentation updated (not user-facing)
