### PR TITLE
fix(loaders): resample lowercase 4h requests in yfinance loader

### DIFF
--- a/agent/backtest/loaders/yfinance_loader.py
+++ b/agent/backtest/loaders/yfinance_loader.py
@@ -203,7 +203,12 @@ def _normalize_frame(frame: pd.DataFrame, requested_interval: str) -> pd.DataFra
     normalized = normalized.dropna(subset=["open", "high", "low", "close"])
     normalized = validate_ohlc(normalized)
 
-    if requested_interval == "4H" and not normalized.empty:
+    # ``requested_interval`` reaches here with whatever case the caller used
+    # (``_INTERVAL_MAP`` accepts both ``4H`` and ``4h``). A case-sensitive
+    # check here let lowercase ``4h`` fetch hourly data via
+    # ``_to_yfinance_interval`` but skip this resample, silently returning
+    # native 1h bars mislabeled as 4H.
+    if str(requested_interval).strip().upper() == "4H" and not normalized.empty:
         normalized = normalized.resample("4h").agg(
             {
                 "open": "first",

--- a/agent/tests/test_yfinance_lowercase_4h_resample.py
+++ b/agent/tests/test_yfinance_lowercase_4h_resample.py
@@ -1,0 +1,53 @@
+"""yfinance loader must resample to 4-hour bars for lowercase ``4h`` too.
+
+``_to_yfinance_interval`` already treats ``4h``/``4H`` the same when picking
+the Yahoo interval to download (see test_yfinance_lowercase_4h_1w.py), but
+``_normalize_frame``'s resample trigger was a case-sensitive ``== "4H"``
+check. A request for ``interval="4h"`` therefore fetched hourly bars from
+Yahoo and then silently skipped the resample step, returning raw 1-hour
+bars mislabeled as 4-hour data.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from backtest.loaders.yfinance_loader import _normalize_frame
+
+
+def _hourly_frame() -> pd.DataFrame:
+    """Eight sequential 1-hour OHLCV bars starting at midnight."""
+    index = pd.date_range("2024-01-01 00:00", periods=8, freq="1h")
+    values = list(range(1, 9))
+    return pd.DataFrame(
+        {
+            "open": values,
+            "high": [v + 0.5 for v in values],
+            "low": [v - 0.5 for v in values],
+            "close": values,
+            "volume": [100] * 8,
+        },
+        index=index,
+    )
+
+
+def test_uppercase_4H_resamples_hourly_bars_to_four_hour() -> None:
+    normalized = _normalize_frame(_hourly_frame(), "4H")
+    assert len(normalized) == 2
+
+
+def test_lowercase_4h_also_resamples_hourly_bars_to_four_hour() -> None:
+    """Regression for the case-sensitivity bug: lowercase ``4h`` must resample
+    identically to ``4H`` instead of passing raw hourly bars through."""
+    normalized = _normalize_frame(_hourly_frame(), "4h")
+    assert len(normalized) == 2
+
+
+def test_mixed_case_4h_also_resamples() -> None:
+    normalized = _normalize_frame(_hourly_frame(), "4h ")
+    assert len(normalized) == 2
+
+
+def test_other_intervals_are_not_resampled() -> None:
+    normalized = _normalize_frame(_hourly_frame(), "1H")
+    assert len(normalized) == 8


### PR DESCRIPTION
## Summary

- Fix a case-sensitivity bug in the yfinance loader: `interval="4h"` (lowercase) silently returns raw 1-hour bars instead of resampled 4-hour bars.
- Add regression coverage for the resample trigger, which had none.

## Why

`_INTERVAL_MAP` already treats `"4H"` and `"4h"` identically when choosing which Yahoo interval to download (both resolve to `"1h"`, fixed for the download step in #833). But `_normalize_frame`'s resample-to-4h trigger used a case-sensitive `requested_interval == "4H"` check. A caller passing lowercase `"4h"`:

1. Correctly downloads hourly data from yfinance
2. Silently skips the resample step, returning native 1-hour bars mislabeled as 4-hour data

Same bug class as #467 (interval requested but not honored, wrong granularity returned silently), and the same root issue #833 addressed — just one function downstream of where #833 fixed it. Every other loader with case-variant interval tests (`okx.py`, `ccxt_loader.py`, `futu.py`, `mt5_loader.py`) already handles this correctly at the point that changes bar granularity; yfinance's case-insensitivity was only fixed for interval *selection*, not *resampling*.

## Changes

- `agent/backtest/loaders/yfinance_loader.py`: normalize `requested_interval` case before comparing against `"4H"` in the resample trigger.
- `agent/tests/test_yfinance_lowercase_4h_resample.py`: new regression tests — `4H`, `4h`, and `"4h "` (whitespace) all resample identically; unrelated intervals (`1H`) are left untouched.

## Test Plan

- [x] New tests added (`agent/tests/test_yfinance_lowercase_4h_resample.py`)
- [x] `pytest agent/tests/test_yfinance_lowercase_4h_resample.py agent/tests/test_yfinance_interval_map.py agent/tests/test_yfinance_lowercase_4h_1w.py -q` — 10 passed
- [x] `pytest agent/tests/ -k "yfinance or loader" -q` — 627 passed, 11 skipped (network-dependent), 0 failed
- [x] Confirmed the bug reproduces on unpatched `main` (8 bars returned instead of 2) before applying the fix, and resolves after
- [x] `black --check` / `ruff check` on both changed files — no new issues introduced (verified via `git stash` diff that pre-existing findings predate this change)

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) — this only touches `agent/backtest/loaders/` and `agent/tests/`
- [x] No hardcoded sensitive values
- [x] Code follows CONTRIBUTING.md guidelines
- [x] Documentation updated — inline comment explains the case-sensitivity root cause
- [x] DCO signed-off