### PR TITLE
fix(shadow): honor the configured runtime root

### DIFF
--- a/agent/src/shadow_account/storage.py
+++ b/agent/src/shadow_account/storage.py
@@ -1,9 +1,9 @@
-"""Shadow Account persistence (~/.vibe-trading/shadow_accounts/).
+"""Shadow Account persistence under the configured runtime root.
 
 Layout:
-    ~/.vibe-trading/shadow_accounts/<shadow_id>.json   ShadowProfile
-    ~/.vibe-trading/shadow_runs/<shadow_id>/           backtest run dir
-    ~/.vibe-trading/shadow_reports/<shadow_id>.pdf     rendered report
+    <runtime-root>/shadow_accounts/<shadow_id>.json   ShadowProfile
+    <runtime-root>/shadow_runs/<shadow_id>/           backtest run dir
+    <runtime-root>/shadow_reports/<shadow_id>.pdf     rendered report
 """
 
 from __future__ import annotations
@@ -15,12 +15,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from src.config.paths import get_runtime_root
 from src.shadow_account.models import ShadowProfile, ShadowRule
 
 
 def _root() -> Path:
     """Return the Shadow Account root directory (auto-created)."""
-    root = Path.home() / ".vibe-trading"
+    root = get_runtime_root()
     root.mkdir(parents=True, exist_ok=True)
     return root
 

--- a/agent/tests/test_runner_env.py
+++ b/agent/tests/test_runner_env.py
@@ -115,14 +115,17 @@ def test_backtest_runtime_env_adds_exact_current_run_root(
     ]
 
 
-def test_execute_keeps_real_home_run_valid_after_home_is_sandboxed(
+@pytest.mark.parametrize("run_bucket", ("runs", "shadow_runs"))
+def test_execute_keeps_runtime_run_valid_after_home_is_sandboxed(
     monkeypatch,
     tmp_path: Path,
+    run_bucket: str,
 ) -> None:
     real_home = tmp_path / "real-home"
-    run_dir = real_home / ".vibe-trading" / "runs" / "run-1"
+    run_dir = real_home / ".vibe-trading" / run_bucket / "run-1"
     run_dir.mkdir(parents=True)
     monkeypatch.setenv("HOME", str(real_home))
+    monkeypatch.delenv("VIBE_TRADING_HOME", raising=False)
     monkeypatch.delenv("VIBE_TRADING_ALLOWED_RUN_ROOTS", raising=False)
 
     entry = _probe_entry(

--- a/agent/tests/test_user_state_paths.py
+++ b/agent/tests/test_user_state_paths.py
@@ -80,6 +80,24 @@ def test_state_dir_helpers_live_under_runtime_root(
     assert get_uploads_dir() == root / "uploads"
 
 
+def test_shadow_account_dirs_live_under_runtime_root(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from src.shadow_account.storage import profiles_dir, reports_dir, runs_dir
+    from src.tools.path_utils import _default_run_roots
+
+    root = tmp_path / "state-root"
+    monkeypatch.setenv("VIBE_TRADING_HOME", str(root))
+
+    assert profiles_dir() == root / "shadow_accounts"
+    assert reports_dir() == root / "shadow_reports"
+    shadow_run = runs_dir("shadow_test")
+    assert shadow_run == root / "shadow_runs" / "shadow_test"
+    assert shadow_run.parent.resolve() in {
+        candidate.resolve() for candidate in _default_run_roots()
+    }
+
+
 def test_legacy_cli_constants_derive_from_runtime_root() -> None:
     from cli import _legacy
     from src.config import paths


### PR DESCRIPTION
## Summary

- Store Shadow profiles, runs, and reports under the canonical runtime root so VIBE_TRADING_HOME is honored.
- Keep generated Shadow run directories inside the default safe_run_dir policy.
- Extend the sandbox-HOME regression to both normal runs and Shadow runs.

## Why

#1012 fixed the reported parent-process to sandbox-HOME validation boundary by forwarding the exact parent-validated run directory. One related inconsistency remained: Shadow storage still used Path.home() directly and ignored VIBE_TRADING_HOME. This follow-up makes storage and the run allowlist derive from the same runtime-root contract.

Fixes #988

## Verification

- 131 focused Shadow, runtime-root, runner-environment, and path-safety tests passed.
- Ruff, py_compile, and diff checks passed.
- Privacy scan found no credentials, private paths, or internal documentation.
