### PR TITLE
feat(backtest): integrate strict USD-M position rebalancing

### DIFF
--- a/agent/backtest/engines/crypto.py
+++ b/agent/backtest/engines/crypto.py
@@ -20,6 +20,7 @@ from backtest.engines._market_hooks import (
     calc_crypto_funding_fee,
     check_crypto_liquidation,
 )
+from backtest.models import Position
 from backtest.perpetual_evidence import (
     SCHEMA_VERSION,
     build_perpetual_summary,
@@ -59,10 +60,6 @@ class CryptoEngine(BaseEngine):
         self.funding_mode = str(config.get("funding_mode", "fixed"))
         self.margin_mode = str(config.get("margin_mode", "isolated"))
         self.liquidation_fee_rate = float(config.get("liquidation_fee_rate", 0.0))
-        if self.perpetual_strict and self.position_adjustment == "rebalance":
-            raise ValueError(
-                "strict USD-M position rebalancing requires margin-state integration"
-            )
         if self.perpetual_strict and self.funding_mode != "data":
             raise ValueError("perpetual_strict requires funding_mode='data'")
         if self.perpetual_strict and self.margin_mode not in {"isolated", "cross"}:
@@ -81,6 +78,7 @@ class CryptoEngine(BaseEngine):
         self._schedule_cache: dict[tuple[str, str], MaintenanceSchedule] = {}
         self._risk_frames: dict[str, MarketRiskFrame] = {}
         self._blocked_symbols: set[str] = set()
+        self._rebalance_risk_checked = False
         self._funding_applied: set = set()   # (symbol, date, hour) — per-slot dedup
         self._funding_daily_done: set = set()  # (symbol, date) — daily fallback dedup
 
@@ -126,6 +124,8 @@ class CryptoEngine(BaseEngine):
 
     def apply_slippage(self, price: float, direction: int) -> float:
         """Slippage: unfavourable direction."""
+        if self.perpetual_strict and self.position_adjustment == "rebalance":
+            return price
         return price * (1 + direction * self.slippage_rate)
 
     def execution_open(self, bar: pd.Series) -> float:
@@ -355,6 +355,7 @@ class CryptoEngine(BaseEngine):
         if not self.perpetual_strict:
             return super().before_rebalance_bar(timestamp, data_map, codes)
         self._blocked_symbols.clear()
+        self._rebalance_risk_checked = False
         self._build_strict_frames(timestamp, data_map, codes)
         self._apply_data_funding()
         return self._evaluate_and_liquidate(timestamp, "mark_open")
@@ -367,7 +368,80 @@ class CryptoEngine(BaseEngine):
     ) -> bool:
         if not self.perpetual_strict:
             return super().after_rebalance_bar(timestamp, data_map, codes)
+        if self.terminal_status == "account_liquidation":
+            return True
+        if self.position_adjustment == "rebalance" and self._rebalance_risk_checked:
+            return False
         return self._evaluate_and_liquidate(timestamp, "adverse")
+
+    def _risk_after_atomic_mutation(self, timestamp: pd.Timestamp) -> None:
+        if not self.perpetual_strict or self.position_adjustment != "rebalance":
+            return
+        self._rebalance_risk_checked = True
+        if self.terminal_status != "account_liquidation":
+            self._evaluate_and_liquidate(timestamp, "adverse")
+
+    def after_position_adjustment(
+        self,
+        *,
+        action: str,
+        timestamp: pd.Timestamp,
+        before: Position,
+        after: Position,
+        execution_price: float,
+        trading_fee: float,
+        realized_pnl: float = 0.0,
+        released_margin: float = 0.0,
+    ) -> None:
+        super().after_position_adjustment(
+            action=action,
+            timestamp=timestamp,
+            before=before,
+            after=after,
+            execution_price=execution_price,
+            trading_fee=trading_fee,
+            realized_pnl=realized_pnl,
+            released_margin=released_margin,
+        )
+        if not self.perpetual_strict:
+            return
+
+        normalized_action = (
+            "reduce" if action == "partial_reduction" else action
+        )
+        if normalized_action not in {"increase", "reduce"}:
+            raise ValueError(f"unexpected position adjustment action: {action}")
+
+        size_delta = after.size - before.size
+        if self.margin_mode == "isolated":
+            if normalized_action == "increase":
+                self._isolated_margins[after.symbol] += self._calc_margin(
+                    after.symbol,
+                    size_delta,
+                    execution_price,
+                    after.leverage,
+                )
+            else:
+                self._isolated_margins[after.symbol] *= after.size / before.size
+
+        signed_delta = after.direction * size_delta
+        self._record_event(
+            timestamp,
+            "market_fill",
+            action=normalized_action,
+            symbol=after.symbol,
+            side="buy" if signed_delta > 0 else "sell",
+            signed_quantity=signed_delta,
+            before_size=before.size,
+            after_size=after.size,
+            execution_price=execution_price,
+            execution_price_source="execution_open",
+            trading_fee=trading_fee,
+            realized_pnl=realized_pnl,
+            released_margin=released_margin,
+            reason="target_rebalance",
+        )
+        self._risk_after_atomic_mutation(timestamp)
 
     def _execute_bars(self, dates, data_map, close_df, target_pos, codes) -> None:
         if self.perpetual_strict:
@@ -381,7 +455,34 @@ class CryptoEngine(BaseEngine):
         if self.perpetual_strict and self.terminal_status == "active":
             self.terminal_status = "completed"
 
+    def _reject_unfunded_atomic_order(
+        self, order, timestamp: pd.Timestamp, action: str
+    ) -> bool:
+        if (
+            not self.perpetual_strict
+            or self.position_adjustment != "rebalance"
+            or order.cost <= self.capital + 1e-7
+        ):
+            return False
+        self._record_event(
+            timestamp,
+            "order_rejected",
+            action=action,
+            symbol=order.symbol,
+            reason="insufficient_capital_after_liquidation",
+            required_capital=order.cost,
+            available_capital=self.capital,
+        )
+        return True
+
     def _execute_open_order(self, order, timestamp: pd.Timestamp) -> None:
+        if self.perpetual_strict and self.position_adjustment == "rebalance" and (
+            self.terminal_status == "account_liquidation"
+            or order.symbol in self._blocked_symbols
+        ):
+            return
+        if self._reject_unfunded_atomic_order(order, timestamp, "open"):
+            return
         super()._execute_open_order(order, timestamp)
         if self.perpetual_strict:
             self._record_event(
@@ -398,6 +499,28 @@ class CryptoEngine(BaseEngine):
             )
         if self.perpetual_strict and self.margin_mode == "isolated":
             self._isolated_margins[order.symbol] = order.margin
+        self._risk_after_atomic_mutation(timestamp)
+
+    def _execute_position_increase(self, order, timestamp: pd.Timestamp) -> None:
+        if self.perpetual_strict and self.position_adjustment == "rebalance" and (
+            self.terminal_status == "account_liquidation"
+            or order.symbol in self._blocked_symbols
+            or order.symbol not in self.positions
+        ):
+            return
+        if self._reject_unfunded_atomic_order(order, timestamp, "increase"):
+            return
+        super()._execute_position_increase(order, timestamp)
+
+    def _execute_partial_reduction(self, order, timestamp: pd.Timestamp) -> None:
+        symbol = order.before.symbol
+        if self.perpetual_strict and self.position_adjustment == "rebalance" and (
+            self.terminal_status == "account_liquidation"
+            or symbol in self._blocked_symbols
+            or symbol not in self.positions
+        ):
+            return
+        super()._execute_partial_reduction(order, timestamp)
 
     def _close_position(
         self,
@@ -426,6 +549,8 @@ class CryptoEngine(BaseEngine):
                 reason=reason,
             )
         self._isolated_margins.pop(symbol, None)
+        if position is not None and reason == "signal":
+            self._risk_after_atomic_mutation(exit_time)
 
     def _write_artifacts(
         self,

--- a/agent/tests/test_crypto_engine.py
+++ b/agent/tests/test_crypto_engine.py
@@ -12,6 +12,7 @@ Validates:
 from __future__ import annotations
 
 import json
+import math
 
 import pandas as pd
 import pytest
@@ -500,10 +501,6 @@ class TestHistoricalFundingRate:
 
 
 class TestStrictPerpetualLifecycle:
-    def test_strict_rebalance_fails_closed_until_margin_integration(self) -> None:
-        with pytest.raises(ValueError, match="strict USD-M position rebalancing"):
-            _strict_engine(position_adjustment="rebalance")
-
     @pytest.mark.parametrize("interval", ["3m", "60m", "4H", "1D"])
     def test_strict_100x_rejects_unsupported_or_coarse_intervals(
         self, interval: str
@@ -748,3 +745,509 @@ class TestStrictPerpetualLifecycle:
             "BTC-USDT-PERP": "position_liquidation",
             "ETH-USDT-PERP": "end_of_backtest",
         }
+
+    @pytest.mark.parametrize("margin_mode", ["isolated", "cross"])
+    def test_rebalance_matches_hand_computed_collateral_and_fill_accounting(
+        self, margin_mode: str
+    ) -> None:
+        class StateCaptureEngine(CryptoEngine):
+            def __init__(self, config: dict) -> None:
+                super().__init__(config)
+                self.states: list[dict] = []
+
+            def after_rebalance_bar(self, timestamp, data_map, codes) -> bool:
+                stop = super().after_rebalance_bar(timestamp, data_map, codes)
+                position = self.positions["BTC-USDT-PERP"]
+                account = self._account_state()
+                self.states.append(
+                    {
+                        "size": position.size,
+                        "entry_price": position.entry_price,
+                        "entry_fee": position.entry_commission,
+                        "capital": self.capital,
+                        "isolated_margin": self._isolated_margins.get(position.symbol),
+                        "wallet_balance": account.wallet_balance,
+                    }
+                )
+                return stop
+
+        dates = pd.date_range("2026-01-01", periods=3, freq="h", tz="UTC")
+        engine = StateCaptureEngine(
+            {
+                "initial_cash": 1_000.0,
+                "leverage": 10.0,
+                "maker_rate": 0.0002,
+                "taker_rate": 0.001,
+                "slippage": 0.0,
+                "perpetual_strict": True,
+                "funding_mode": "data",
+                "margin_mode": margin_mode,
+                "position_adjustment": "rebalance",
+            }
+        )
+
+        _run_strict(
+            engine,
+            {"BTC-USDT-PERP": _strict_frame(dates)},
+            {"BTC-USDT-PERP": [0.25, 0.50, 0.20]},
+        )
+
+        assert [state["size"] for state in engine.states] == pytest.approx(
+            [25.0, 49.875, 19.90025]
+        )
+        assert [state["entry_price"] for state in engine.states] == pytest.approx(
+            [100.0, 100.0, 100.0]
+        )
+        assert [state["entry_fee"] for state in engine.states] == pytest.approx(
+            [2.5, 4.9875, 1.990025]
+        )
+        assert [state["capital"] for state in engine.states] == pytest.approx(
+            [747.5, 496.2625, 793.012525]
+        )
+        assert [state["wallet_balance"] for state in engine.states] == pytest.approx(
+            [997.5, 995.0125, 992.015025]
+        )
+        isolated_margins = [state["isolated_margin"] for state in engine.states]
+        if margin_mode == "isolated":
+            assert isolated_margins == pytest.approx([250.0, 498.75, 199.0025])
+        else:
+            assert isolated_margins == [None, None, None]
+
+        fills = [
+            event
+            for event in engine._perpetual_events
+            if event["event_type"] == "market_fill"
+        ]
+        assert [event["action"] for event in fills] == [
+            "open",
+            "increase",
+            "reduce",
+            "close",
+        ]
+        assert [event["signed_quantity"] for event in fills[:3]] == pytest.approx(
+            [25.0, 24.875, -29.97475]
+        )
+        assert [event["trading_fee"] for event in fills[:3]] == pytest.approx(
+            [2.5, 2.4875, 2.997475]
+        )
+        assert fills[2]["realized_pnl"] == pytest.approx(0.0)
+        assert fills[2]["released_margin"] == pytest.approx(299.7475)
+
+    def test_rebalance_funding_precedes_increase_at_preincrease_size(self) -> None:
+        dates = pd.date_range("2026-01-01", periods=3, freq="h", tz="UTC")
+        engine = _strict_engine(position_adjustment="rebalance", taker_rate=0.001)
+        frame = _strict_frame(
+            dates,
+            funding_rate=[0.0, 0.001, 0.0],
+            settlements=[None, dates[1], None],
+        )
+
+        _run_strict(
+            engine,
+            {"BTC-USDT-PERP": frame},
+            {"BTC-USDT-PERP": [0.25, 0.50, 0.20]},
+        )
+
+        funding = next(
+            event
+            for event in engine._perpetual_events
+            if event["event_type"] == "funding_settlement"
+        )
+        increase = next(
+            event
+            for event in engine._perpetual_events
+            if event["event_type"] == "market_fill" and event["action"] == "increase"
+        )
+        assert funding["signed_quantity"] == pytest.approx(25.0)
+        assert funding["sequence"] < increase["sequence"]
+
+    def test_isolated_reduction_keeps_funding_pnl_and_collateral_consistent(
+        self,
+    ) -> None:
+        class StateCaptureEngine(CryptoEngine):
+            def __init__(self, config: dict) -> None:
+                super().__init__(config)
+                self.states: list[dict] = []
+
+            def after_rebalance_bar(self, timestamp, data_map, codes) -> bool:
+                stop = super().after_rebalance_bar(timestamp, data_map, codes)
+                position = self.positions["BTC-USDT-PERP"]
+                self.states.append(
+                    {
+                        "capital": self.capital,
+                        "wallet_balance": self._account_state().wallet_balance,
+                        "isolated_margin": self._isolated_margins[position.symbol],
+                        "size": position.size,
+                    }
+                )
+                return stop
+
+        dates = pd.date_range("2026-01-01", periods=3, freq="h", tz="UTC")
+        engine = StateCaptureEngine(
+            {
+                **_strict_engine(
+                    position_adjustment="rebalance",
+                    taker_rate=0.001,
+                ).config
+            }
+        )
+        frame = _strict_frame(
+            dates,
+            execution_open=[100.0, 100.0, 110.0],
+            mark=[100.0, 100.0, 110.0],
+            funding_rate=[0.0, 0.001, 0.0],
+            settlements=[None, dates[1], None],
+        )
+
+        _run_strict(
+            engine,
+            {"BTC-USDT-PERP": frame},
+            {"BTC-USDT-PERP": [0.25, 0.50, 0.20]},
+        )
+
+        after_increase, after_reduction = engine.states[1:]
+        assert after_increase == pytest.approx(
+            {
+                "capital": 495.025,
+                "wallet_balance": 992.525,
+                "isolated_margin": 495.0,
+                "size": 49.75,
+            }
+        )
+        assert after_reduction == pytest.approx(
+            {
+                "capital": 945.7052772727273,
+                "wallet_balance": 1216.6189136363636,
+                "isolated_margin": 269.5522613065327,
+                "size": 27.0913636363636,
+            }
+        )
+        reduction = next(
+            event
+            for event in engine._perpetual_events
+            if event["event_type"] == "market_fill" and event["action"] == "reduce"
+        )
+        assert reduction["realized_pnl"] == pytest.approx(226.5863636363636)
+        assert reduction["released_margin"] == pytest.approx(226.5863636363636)
+        assert reduction["trading_fee"] == pytest.approx(2.49245)
+        assert after_reduction["wallet_balance"] == pytest.approx(
+            1_000.0
+            - 2.5  # opening fee
+            - 2.5  # funding paid before the increase
+            - 2.475  # increase fee
+            + reduction["realized_pnl"]
+            - reduction["trading_fee"]
+        )
+
+    def test_cross_rebalance_reduces_before_addition_and_then_checks_risk(self) -> None:
+        dates = pd.date_range("2026-01-01", periods=2, freq="h", tz="UTC")
+        engine = _strict_engine(
+            position_adjustment="rebalance",
+            margin_mode="cross",
+            taker_rate=0.0,
+            maker_rate=0.0,
+        )
+        frames = {
+            symbol: _strict_frame(dates)
+            for symbol in ("BTC-USDT-PERP", "ETH-USDT-PERP")
+        }
+
+        _run_strict(
+            engine,
+            frames,
+            {
+                "BTC-USDT-PERP": [0.40, 0.10],
+                "ETH-USDT-PERP": [0.40, 0.70],
+            },
+        )
+
+        second_bar = [
+            event
+            for event in engine._perpetual_events
+            if event["timestamp"] == dates[1].isoformat()
+        ]
+        reduce_event = next(event for event in second_bar if event.get("action") == "reduce")
+        increase_event = next(
+            event for event in second_bar if event.get("action") == "increase"
+        )
+        risk_events = [
+            event
+            for event in second_bar
+            if event["event_type"] == "risk_snapshot" and event["phase"] == "post_fill"
+        ]
+        assert reduce_event["symbol"] == "BTC-USDT-PERP"
+        assert increase_event["symbol"] == "ETH-USDT-PERP"
+        assert len(risk_events) == 2
+        assert (
+            reduce_event["sequence"]
+            < risk_events[0]["sequence"]
+            < increase_event["sequence"]
+            < risk_events[1]["sequence"]
+        )
+        assert [event["status"] for event in risk_events] == ["healthy", "healthy"]
+
+    def test_strict_100x_rebalance_stays_finite_without_breach(self) -> None:
+        dates = pd.date_range("2026-01-01", periods=3, freq="h", tz="UTC")
+        engine = _strict_engine(
+            interval="1H",
+            leverage=100.0,
+            position_adjustment="rebalance",
+            taker_rate=0.001,
+        )
+
+        _run_strict(
+            engine,
+            {"BTC-USDT-PERP": _strict_frame(dates)},
+            {"BTC-USDT-PERP": [0.02, 0.03, 0.01]},
+        )
+
+        assert {
+            event["action"]
+            for event in engine._perpetual_events
+            if event["event_type"] == "market_fill"
+        } >= {"increase", "reduce"}
+        assert all(
+            math.isfinite(value)
+            for snapshot in engine.equity_snapshots
+            for value in (snapshot.equity, snapshot.capital)
+        )
+        assert all(
+            math.isfinite(float(event[field]))
+            for event in engine._perpetual_events
+            if event["event_type"] == "risk_snapshot"
+            for field in (
+                "margin_balance",
+                "initial_margin",
+                "maintenance_margin",
+                "available_balance",
+            )
+        )
+
+    def test_strict_rebalance_fills_use_raw_execution_open(self) -> None:
+        dates = pd.date_range("2026-01-01", periods=3, freq="h", tz="UTC")
+        engine = _strict_engine(
+            position_adjustment="rebalance",
+            slippage=0.10,
+            taker_rate=0.0,
+            maker_rate=0.0,
+        )
+        frame = _strict_frame(
+            dates,
+            execution_open=[101.0, 102.0, 103.0],
+            mark=[113.3, 113.3, 113.3],
+        )
+
+        _run_strict(
+            engine,
+            {"BTC-USDT-PERP": frame},
+            {"BTC-USDT-PERP": [0.25, 0.50, 0.20]},
+        )
+
+        fills = {
+            event["action"]: event["execution_price"]
+            for event in engine._perpetual_events
+            if event["event_type"] == "market_fill"
+            and event["action"] in {"open", "increase", "reduce"}
+        }
+        assert fills == {"open": 101.0, "increase": 102.0, "reduce": 103.0}
+
+    def test_strict_hold_keeps_configured_slippage_behavior(self) -> None:
+        dates = pd.date_range("2026-01-01", periods=2, freq="h", tz="UTC")
+        engine = _strict_engine(
+            position_adjustment="hold",
+            slippage=0.10,
+            taker_rate=0.0,
+            maker_rate=0.0,
+        )
+
+        _run_strict(
+            engine,
+            {"BTC-USDT-PERP": _strict_frame(dates)},
+            {"BTC-USDT-PERP": [0.25, 0.25]},
+        )
+
+        fills = [
+            event
+            for event in engine._perpetual_events
+            if event["event_type"] == "market_fill"
+        ]
+        assert [event["action"] for event in fills] == ["open", "close"]
+        assert [event["execution_price"] for event in fills] == pytest.approx(
+            [110.0, 90.0]
+        )
+
+    def test_cross_atomic_liquidation_stops_remaining_additions(self) -> None:
+        dates = pd.date_range("2026-01-01", periods=1, freq="h", tz="UTC")
+        engine = _strict_engine(
+            position_adjustment="rebalance",
+            margin_mode="cross",
+            taker_rate=0.0,
+            maker_rate=0.0,
+        )
+        frames = {
+            "BTC-USDT-PERP": _strict_frame(dates, mark_low=[80.0]),
+            "ETH-USDT-PERP": _strict_frame(dates),
+        }
+
+        _run_strict(
+            engine,
+            frames,
+            {
+                "BTC-USDT-PERP": [0.50],
+                "ETH-USDT-PERP": [0.25],
+            },
+        )
+
+        fills = [
+            event
+            for event in engine._perpetual_events
+            if event["event_type"] == "market_fill" and event["action"] == "open"
+        ]
+        assert [event["symbol"] for event in fills] == ["BTC-USDT-PERP"]
+        assert engine.terminal_status == "account_liquidation"
+        assert not engine.positions
+
+    def test_isolated_atomic_liquidation_allows_other_symbol_to_continue(self) -> None:
+        dates = pd.date_range("2026-01-01", periods=1, freq="h", tz="UTC")
+        engine = _strict_engine(
+            position_adjustment="rebalance",
+            margin_mode="isolated",
+            taker_rate=0.0,
+            maker_rate=0.0,
+        )
+        frames = {
+            "BTC-USDT-PERP": _strict_frame(dates, mark_low=[90.0]),
+            "ETH-USDT-PERP": _strict_frame(dates),
+        }
+
+        _run_strict(
+            engine,
+            frames,
+            {
+                "BTC-USDT-PERP": [0.50],
+                "ETH-USDT-PERP": [0.25],
+            },
+        )
+
+        fills = [
+            event
+            for event in engine._perpetual_events
+            if event["event_type"] == "market_fill" and event["action"] == "open"
+        ]
+        assert [event["symbol"] for event in fills] == [
+            "BTC-USDT-PERP",
+            "ETH-USDT-PERP",
+        ]
+        liquidation = next(
+            event
+            for event in engine._perpetual_events
+            if event["event_type"] == "position_liquidation"
+        )
+        assert liquidation["symbol"] == "BTC-USDT-PERP"
+        assert engine.terminal_status == "completed"
+
+    def test_isolated_liquidation_rejects_now_unfunded_addition(self) -> None:
+        dates = pd.date_range("2026-01-01", periods=1, freq="h", tz="UTC")
+        engine = _strict_engine(
+            position_adjustment="rebalance",
+            margin_mode="isolated",
+            taker_rate=0.0,
+            maker_rate=0.0,
+        )
+        frames = {
+            "BTC-USDT-PERP": _strict_frame(dates, mark_low=[80.0]),
+            "ETH-USDT-PERP": _strict_frame(dates),
+        }
+
+        _run_strict(
+            engine,
+            frames,
+            {
+                "BTC-USDT-PERP": [0.50],
+                "ETH-USDT-PERP": [0.25],
+            },
+        )
+
+        opens = [
+            event
+            for event in engine._perpetual_events
+            if event["event_type"] == "market_fill" and event["action"] == "open"
+        ]
+        assert [event["symbol"] for event in opens] == ["BTC-USDT-PERP"]
+        rejected = next(
+            event
+            for event in engine._perpetual_events
+            if event["event_type"] == "order_rejected"
+        )
+        assert rejected["symbol"] == "ETH-USDT-PERP"
+        assert rejected["reason"] == "insufficient_capital_after_liquidation"
+        assert rejected["required_capital"] == pytest.approx(250.0)
+        assert rejected["available_capital"] == pytest.approx(0.0)
+        assert engine.terminal_status == "completed"
+
+    def test_cross_rebalance_increase_precedes_adverse_account_liquidation(
+        self,
+    ) -> None:
+        dates = pd.date_range("2026-01-01", periods=2, freq="h", tz="UTC")
+        engine = _strict_engine(
+            initial_cash=1_000.0,
+            position_adjustment="rebalance",
+            taker_rate=0.0,
+            maker_rate=0.0,
+            margin_mode="cross",
+        )
+        frame = _strict_frame(dates, mark_low=[100.0, 80.0])
+
+        _run_strict(
+            engine,
+            {"BTC-USDT-PERP": frame},
+            {"BTC-USDT-PERP": [0.25, 0.50]},
+        )
+
+        increase = next(
+            event
+            for event in engine._perpetual_events
+            if event["event_type"] == "market_fill" and event["action"] == "increase"
+        )
+        liquidation = next(
+            event
+            for event in engine._perpetual_events
+            if event["event_type"] == "account_liquidation"
+        )
+        assert increase["sequence"] < liquidation["sequence"]
+        assert not engine.positions
+        assert engine.terminal_status == "account_liquidation"
+
+    def test_rebalance_evidence_artifacts_are_deterministic(self, tmp_path) -> None:
+        dates = pd.date_range("2026-01-01", periods=3, freq="h", tz="UTC")
+        frame = _strict_frame(dates)
+        targets = {"BTC-USDT-PERP": [0.25, 0.50, 0.20]}
+
+        results = []
+        for run_name in ("first", "second"):
+            engine = _strict_engine(
+                position_adjustment="rebalance",
+                taker_rate=0.001,
+            )
+            _run_strict(engine, {"BTC-USDT-PERP": frame}, targets)
+            metrics = _write_strict_artifacts(
+                engine,
+                {"BTC-USDT-PERP": frame},
+                targets,
+                tmp_path / run_name,
+            )
+            events, summary = _read_strict_evidence(tmp_path / run_name)
+            results.append((events, summary, metrics))
+
+        first_events, first_summary, first_metrics = results[0]
+        second_events, second_summary, second_metrics = results[1]
+        assert first_events == second_events
+        assert first_summary == second_summary
+        assert first_metrics == second_metrics
+        assert [
+            event["action"]
+            for event in first_events
+            if event["event_type"] == "market_fill"
+        ] == ["open", "increase", "reduce", "close"]
+        assert first_summary["total_trading_fee"] == pytest.approx(9.975)
+        assert first_metrics["perpetual_trading_fees"] == pytest.approx(9.975)


### PR DESCRIPTION
## Summary

- enable `position_adjustment=rebalance` for strict Binance USD-M historical backtests;
- keep isolated and cross collateral, delta taker fees, released margin, realized P&L, and fill evidence consistent across increases and reductions;
- evaluate adverse-mark risk after every atomic mutation, stopping a cross-liquidated basket while allowing healthy isolated symbols to continue.

## Why

Closes #952.

The generic rebalance ledger landed in #951, but strict USD-M mode still failed closed at construction time. This PR supplies the exchange-specific collateral, risk, funding-order, and evidence lifecycle required to use that core safely.

## Changes

- removes the temporary strict + rebalance guard;
- preserves raw `execution_open` prices for strict rebalance fills without changing legacy strict `hold` slippage behavior;
- updates isolated collateral on same-direction increases and proportional reductions;
- records deterministic `market_fill` evidence for increase/reduce deltas;
- keeps historical funding before target fills and verifies it uses the pre-increase position size;
- evaluates adverse mark risk after each committed reduction, open, or increase;
- stops remaining additions after cross account liquidation;
- isolates position liquidation and permits other funded symbols to continue;
- revalidates preplanned orders after intervening liquidation and emits `order_rejected` evidence instead of crashing when capital is no longer sufficient;
- adds hand-computed isolated/cross fixtures for `0.25 -> 0.50 -> 0.20`, including weighted entry, wallet/collateral, funding, fees, released margin, and realized P&L.

## Test Plan

- [x] `pytest agent/tests/test_crypto_engine.py agent/tests/test_perpetual_risk.py agent/tests/test_base_engine.py agent/tests/test_realized_turnover.py agent/tests/test_engine_metrics_json.py agent/tests/test_ccxt_perpetual_loader.py -q --tb=short` ? 226 passed
- [x] broad backtest/engine/perpetual/loader selection ? 738 passed, 1 skipped
- [x] `ruff check agent/backtest/engines/crypto.py agent/tests/test_crypto_engine.py`
- [x] `python -m py_compile agent/backtest/engines/crypto.py agent/tests/test_crypto_engine.py`
- [x] `git diff --check`
- [ ] full `agent/tests` collection locally ? blocked before test execution by the unchanged upstream `scheduled_routes.py` HTTP 204 contract under local FastAPI 0.110.3 (21 API collection errors).
- [x] upstream CI ? all 4 jobs passed; main test job completed in 7m54s.

## Safety / network risk

Historical and synthetic backtest only. No live endpoint, connector, credential, API-key, broker-write, OAuth, or order-placement imports are added. Tests make no network calls.

## Fidelity and limitations

- Adverse mark extrema are evaluated deterministically after each atomic mutation.
- Multi-symbol same-bar extrema retain the existing `conservative_intrabar_assumption`; they are not claimed to occur at the same millisecond.
- This remains a single-asset USDT, one-way model without open-order margin, hedge mode, portfolio margin, COIN-M, or exact reproduction of Binance's historical liquidation engine.

## Rollback

Revert this single commit. The default remains `position_adjustment=hold`, and strict rebalance is opt-in.

## Checklist

- [x] No protected agent/provider/session area changed
- [x] No hardcoded credentials or local paths
- [x] DCO sign-off present
- [x] No user-facing documentation change required; behavior is opt-in and covered by the existing config contract
