### PR TITLE
fix(memory): apply importance decay to FTS5 ranking

### DIFF
--- a/agent/src/memory/persistent.py
+++ b/agent/src/memory/persistent.py
@@ -386,8 +386,21 @@ class PersistentMemory:
                     if all_entries is None:
                         all_entries = self._scan_entries()
                     entry_map = {e.id: e for e in all_entries}
-                    fts_results = [entry_map[m.entry_id] for m in matches if m.entry_id in entry_map]
-                    if fts_results:
+                    fts_pairs = [
+                        (m, entry_map[m.entry_id]) for m in matches if m.entry_id in entry_map
+                    ]
+                    if fts_pairs:
+                        if _is_decay_enabled():
+                            # FTS5's rank is more negative for stronger matches;
+                            # negate it onto the same scale the token-scan
+                            # fallback below uses and apply the same importance
+                            # weighting, so decay isn't silently inert whenever
+                            # FTS produces a result.
+                            fts_pairs.sort(
+                                key=lambda pair: -pair[0].rank * (0.5 + 0.5 * pair[1].importance),
+                                reverse=True,
+                            )
+                        fts_results = [entry for _, entry in fts_pairs]
                         return fts_results[:max_results]
             except Exception:
                 logger.debug("FTS5 search failed, falling back to scan", exc_info=True)

--- a/agent/tests/memory/test_tier2_integration.py
+++ b/agent/tests/memory/test_tier2_integration.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import time
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -191,6 +192,112 @@ class TestFtsAddThenSearchFinds:
         results = mem.find_relevant("backtest")
         assert len(results) >= 1
         assert any("quant" in e.title.lower() for e in results)
+
+
+# ---------------------------------------------------------------------------
+# 4b. FTS: importance decay must still influence ranking (VT_MEMORY=full
+# enables fts_index_enabled and decay_enabled together)
+# ---------------------------------------------------------------------------
+
+
+class TestFtsRankingRespectsImportanceDecay:
+    """FTS5 candidate retrieval must not silently bypass importance-decay
+    weighting when both features are enabled together, the exact combination
+    the documented VT_MEMORY=full preset turns on."""
+
+    @staticmethod
+    def _write_entry(tmp_path, filename, name, quality_score, days_ago, access_count, body, entry_id):
+        last_accessed = (datetime.now() - timedelta(days=days_ago)).isoformat()
+        created = datetime.now().isoformat()
+        path = tmp_path / filename
+        path.write_text(
+            "---\n"
+            f"name: {name}\n"
+            f"description: {name}\n"
+            "type: project\n"
+            f"id: {entry_id}\n"
+            f"created_at: {created}\n"
+            f"updated_at: {created}\n"
+            "keywords: []\n"
+            f"quality_score: {quality_score}\n"
+            f"access_count: {access_count}\n"
+            f"last_accessed: {last_accessed}\n"
+            "importance: 0.5\n"
+            "related_memories: []\n"
+            "---\n\n"
+            f"{body}\n",
+            encoding="utf-8",
+        )
+        return path
+
+    def _seed_entries(self, tmp_path):
+        # Fresh, heavily-accessed entry: high decayed importance, weaker
+        # lexical match (query term appears once, diluted by other words).
+        self._write_entry(
+            tmp_path, "project_fresh.md", "fresh important entry",
+            quality_score=0.95, days_ago=0, access_count=50,
+            body="trading context and other unrelated filler words here",
+            entry_id="fresh1",
+        )
+        # Ancient, never-accessed entry: near-zero decayed importance,
+        # stronger lexical match (query term repeated in a short body).
+        self._write_entry(
+            tmp_path, "project_stale.md", "stale unimportant entry",
+            quality_score=0.05, days_ago=400, access_count=0,
+            body="trading trading focus notes only",
+            entry_id="stale1",
+        )
+
+    def test_fts_ranking_reordered_by_importance_when_decay_enabled(self, tmp_path, monkeypatch, fts_db):
+        """With FTS and decay both on, an entry with much higher decayed
+        importance should outrank a purely stronger lexical match, not just
+        get returned somewhere in the result set."""
+        monkeypatch.setenv("VT_MEMORY_FTS_INDEX", "true")
+        monkeypatch.setenv("VT_MEMORY_DECAY", "true")
+        reset_env_config()
+
+        self._seed_entries(tmp_path)
+        mem = PersistentMemory(tmp_path)
+        entries = mem._scan_entries()
+
+        # Sanity check: the importance gap this test relies on is real.
+        importance = {e.title: e.importance for e in entries}
+        assert importance["fresh important entry"] > 0.9
+        assert importance["stale unimportant entry"] < 0.01
+
+        from src.memory.search_index import get_shared_index
+        get_shared_index().rebuild_all(
+            [(e.id, e.title, e.description, "", e.body) for e in entries]
+        )
+
+        results = mem.find_relevant("trading")
+        titles = [r.title for r in results]
+        assert titles[0] == "fresh important entry", (
+            "decayed importance should outrank a purely stronger lexical match "
+            f"once FTS and decay are combined, got order: {titles}"
+        )
+
+    def test_fts_ranking_unchanged_when_decay_disabled(self, tmp_path, monkeypatch, fts_db):
+        """Control: with decay off, FTS ordering is untouched by this fix,
+        pure lexical relevance still wins, exactly as before the change."""
+        monkeypatch.setenv("VT_MEMORY_FTS_INDEX", "true")
+        monkeypatch.setenv("VT_MEMORY_DECAY", "false")
+        reset_env_config()
+
+        self._seed_entries(tmp_path)
+        mem = PersistentMemory(tmp_path)
+        entries = mem._scan_entries()
+
+        from src.memory.search_index import get_shared_index
+        get_shared_index().rebuild_all(
+            [(e.id, e.title, e.description, "", e.body) for e in entries]
+        )
+
+        results = mem.find_relevant("trading")
+        titles = [r.title for r in results]
+        assert titles[0] == "stale unimportant entry", (
+            f"with decay disabled, pure FTS lexical relevance should win, got order: {titles}"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

FTS5 full-text search silently bypassed the existing importance-decay ranking weight whenever it returned results, making decay inert under the documented `VT_MEMORY=full` configuration. This applies the existing importance multiplier to FTS candidate results too, so decay has a real effect regardless of which retrieval path served a query.

## Problem

`PersistentMemory.find_relevant()` (`agent/src/memory/persistent.py`) has two retrieval paths: an FTS5 fast path and a token-scan fallback. The fallback applies an importance-decay multiplier (`token_score * (0.5 + 0.5 * entry.importance)`) before ranking. The FTS path returns its results directly, without ever reaching that weighting code. `VT_MEMORY=full`, the documented "all features" preset (`agent/src/config/env_schema.py`), turns on both `fts_index_enabled` and `decay_enabled` together, so in that officially supported configuration, importance decay has zero effect on memory ranking: a stale, low-quality memory that matches the query more strongly can outrank a fresh, important one.

## Root Cause

Confirmed two ways:
- Live instrumentation: with both `VT_MEMORY_DECAY` and `VT_MEMORY_FTS_INDEX` enabled, `_is_decay_enabled()` (the gate the fallback path's weighting code checks) is called 0 times during a `find_relevant()` call that gets an FTS match, proving the decay-weighting code is unreachable on that path, not just theoretically weaker.
- History: importance decay was benchmarked and merged before FTS5 (Tier 2) existed. FTS5 was added later as a faster candidate-retrieval path with no revisit of the existing decay-weighting guarantee, and `search_index.py`'s own ranking is pure SQLite FTS5 relevance with no importance or decay signal anywhere in it. No test, doc, or CHANGELOG entry addresses the combination; the two existing tests for these features each set only one of the two flags.

## Changes

- `agent/src/memory/persistent.py`: `find_relevant()`'s FTS branch now applies the same importance multiplier the fallback path already uses to FTS5's own relevance rank (`-match.rank`, since SQLite FTS5's `rank` column is more negative for stronger matches), before returning results. When decay is disabled, FTS ordering is completely unchanged.
- `agent/tests/memory/test_tier2_integration.py`: two new tests. One proves an entry with much higher decayed importance outranks a purely stronger lexical match once FTS and decay are combined, not just that a function got called. The other is a control proving FTS-only ordering is untouched when decay is off.

## Tests

- [x] Confirmed the new "combined" test fails on unpatched `main` with the real, wrong ranking order, and passes with the fix (verified via reverting just the source change)
- [x] `pytest agent/tests/memory/test_tier2_integration.py -v` (12 passed)
- [x] `pytest agent/tests/ -k "memory" -q` (243 passed, 5 skipped, 0 failed)
- [x] `black --check` / `ruff check` on both changed files: diffed against the same check on the unpatched files, every finding is pre-existing and unrelated to this change, nothing new introduced

## Impact

Under the documented `VT_MEMORY=full` configuration, memory retrieval ranking now actually reflects importance decay as intended, instead of silently ignoring it whenever FTS5 produces a match (the common case once FTS is enabled). No behavior change for installations running FTS without decay, or decay without FTS.

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`): this only touches `agent/src/memory/` and `agent/tests/`
- [x] No hardcoded sensitive values
- [x] Code follows CONTRIBUTING.md guidelines
- [x] Documentation updated: docstring explains why the importance weighting is applied to FTS results
- [x] DCO signed-off