### PR TITLE
fix(mcp,agent): support TSX/TSXV symbols end-to-end (search fail-fast + CSV grounding)

### DIFF
--- a/agent/src/agent/context.py
+++ b/agent/src/agent/context.py
@@ -155,6 +155,12 @@ Decide which workflow to use based on the request:
 6. Optional: `scan_shadow_signals(shadow_id=...)` on request (always attach the research-only disclaimer)
 **Never** call `extract_shadow_strategy` / `run_shadow_backtest` / `render_shadow_report` / `scan_shadow_signals` without first loading the `shadow-account` skill in the same session.
 
+**Trading plan / to-do list / sell-orders file** — user asks to create, refresh, or extend a weekly plan / to-do-list / sell-orders markdown from a prior week's file:
+1. Read the source file(s) first.
+2. Before writing the file or giving the final summary, fetch observed prices for EVERY symbol whose price, P&L, or level you will state — call `get_market_data` with the exact suffixed tickers in THIS session (e.g. `codes=["BTO.TO", "ETHX-B.TO", "VET.TO", "GC=F"]` plus start/end covering the reference close). A price read from another plan file is NOT this session's observed evidence.
+3. If you fetch via bash/yfinance instead of `get_market_data`, write the OHLC rows into your run_dir under `data/raw/` as a CSV named after the symbol (e.g. `BTO_TO.csv`, `GC_F.csv`) so the run records them as observed evidence.
+4. Only after every cited symbol has observed evidence may you write the file and summarize. In the summary, bind each figure to symbol + currency + as-of (e.g. "BTO.TO 8/7 close C$7.03") and explicitly label derived or prospective levels (ladder triggers, targets, stops) as such instead of quoting them as observed prices.
+
 ## Guidelines
 
 - **Identity before market data:** when the request names a company, fund, or
@@ -321,19 +327,32 @@ class ContextBuilder:
         messages.append({"role": "user", "content": enriched})
         return messages
 
+    # Prose tool section is deliberately compact: the full tool schema (name,
+    # description, parameter JSON schema) is sent to the model via the API
+    # ``tools`` array (``ToolRegistry.get_definitions()`` -> ``bind_tools``), so
+    # repeating every description + parameter here as prose roughly doubled the
+    # per-call input tokens for zero model benefit. Keep one short discovery
+    # hint per tool; the authoritative spec arrives with every request. This is
+    # a pure token-cost change: no tool is removed, and the grounding/identity
+    # gate (which validates tool results, not the prompt) is untouched.
+    _TOOL_PROSE_DESC_MAX = 80
+
     def _format_tool_descriptions(self) -> str:
-        """Format tool descriptions."""
+        """Format a compact one-line tool list for the system prompt.
+
+        Returns one line per registered tool: ``- <name>: <short hint>``. The
+        full parameter schema is deliberately NOT repeated here — it is supplied
+        through the API ``tools`` parameter on every call (see
+        ``ToolRegistry.get_definitions``), so the model always has the exact
+        spec even though the prose stays small.
+        """
         lines = []
         for tool in self.registry._tools.values():
-            params = tool.parameters.get("properties", {})
-            required = tool.parameters.get("required", [])
-            param_parts = []
-            for pname, pschema in params.items():
-                req = " (required)" if pname in required else ""
-                param_parts.append(f"    - {pname}: {pschema.get('description', pschema.get('type', ''))}{req}")
-            param_text = "\n".join(param_parts) if param_parts else "    (no params)"
-            lines.append(f"### {tool.name}\n{tool.description}\n  Params:\n{param_text}")
-        return "\n\n".join(lines)
+            desc = (tool.description or "").strip().replace("\n", " ")
+            if len(desc) > self._TOOL_PROSE_DESC_MAX:
+                desc = desc[: self._TOOL_PROSE_DESC_MAX].rstrip() + "…"
+            lines.append(f"- {tool.name}: {desc}" if desc else f"- {tool.name}")
+        return "\n".join(lines)
 
     @staticmethod
     def format_tool_result(tool_call_id: str, tool_name: str, result: str) -> Dict[str, Any]:

--- a/agent/src/agent/grounding.py
+++ b/agent/src/agent/grounding.py
@@ -21,6 +21,7 @@ its state machine and final-answer checks remain deterministic and testable.
 from __future__ import annotations
 
 import ast
+import csv
 import hashlib
 import json
 import math
@@ -73,6 +74,23 @@ _PRICE_FIELDS = {"open", "high", "low", "close", "adj_close", "price"}
 _TIMESTAMP_FIELDS = ("trade_date", "date", "datetime", "timestamp", "time", "index")
 _MAX_GENERIC_EVIDENCE = 2_000
 _MAX_TRACKED_SYMBOLS = 5_000
+
+# CSV columns (case-insensitive) accepted from OHLC files the run wrote via
+# bash+yfinance, and their canonical price-field names. Everything else in the
+# file (Volume, Adj Close, etc.) is deliberately ignored so the contradiction
+# check does not gain values it would be willing to accept.
+_CSV_PRICE_COLUMNS = {
+    "open": "open",
+    "high": "high",
+    "low": "low",
+    "close": "close",
+    "price": "price",
+}
+_CSV_DATE_COLUMNS = {"date", "datetime", "trade_date", "timestamp", "index"}
+# Filename -> symbol mapping for run-dir CSVs. The bash workaround writes each
+# series with a filesystem-safe stem: ``BYN_V.csv`` for ``BYN.V``, ``PDI_TO.csv``
+# for ``PDI.TO``, ``GC_F.csv`` for ``GC=F``.
+_CSV_FILENAME_SUFFIX_MAP = (("_V", ".V"), ("_TO", ".TO"), ("_F", "=F"))
 
 # Only ``get_market_data`` returns bars whose columns are already the canonical
 # OHLC field names. Every other market-sensitive tool nests its quote somewhere,
@@ -320,6 +338,30 @@ def _normalize_symbol(value: Any) -> str:
     return str(value or "").strip().upper()
 
 
+def _symbol_from_csv_filename(stem: str) -> str | None:
+    """Map a run-dir CSV stem back to a canonical project symbol.
+
+    The bash workaround writes filesystem-safe stems: ``BYN_V.csv`` -> ``BYN.V``,
+    ``PDI_TO.csv`` -> ``PDI.TO``, ``GC_F.csv`` -> ``GC=F``. A stem without a
+    recognized suffix (e.g. a bare US name ``AAPL``) maps to None because the
+    project convention requires an explicit venue suffix.
+
+    Args:
+        stem: CSV filename without the ``.csv`` extension.
+
+    Returns:
+        The canonical symbol, or ``None`` when the stem has no recognizable
+        venue suffix.
+    """
+    upper = (stem or "").strip().upper()
+    if not upper:
+        return None
+    for raw, canonical in _CSV_FILENAME_SUFFIX_MAP:
+        if upper.endswith(raw) and len(upper) > len(raw):
+            return upper[: -len(raw)] + canonical
+    return None
+
+
 def _query_key(value: Any) -> str:
     """Normalize resolver queries into stable state-machine keys."""
     return " ".join(str(value or "").casefold().split())
@@ -345,6 +387,25 @@ def _is_number(value: Any) -> bool:
         and not isinstance(value, bool)
         and math.isfinite(float(value))
     )
+
+
+def _coerce_csv_number(value: Any) -> int | float | None:
+    """Coerce a CSV cell to a finite number, or return None.
+
+    CSV readers return every cell as text (``"0.375"``), so a bare
+    ``_is_number`` check would discard them all. Values that do not parse as a
+    finite number (blank cells, ``-``, ``N/A``) return ``None``.
+    """
+    if _is_number(value):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = float(value.strip().replace(",", ""))
+        except (TypeError, ValueError):
+            return None
+        if math.isfinite(parsed):
+            return parsed
+    return None
 
 
 # "." is deliberately not a separator: a decimal price such as 8.5 would parse
@@ -607,6 +668,7 @@ class GroundingLedger:
         self._evidence: list[EvidenceRecord] = []
         self._tool_failures: list[dict[str, Any]] = []
         self._validations: list[dict[str, Any]] = []
+        self._ingested_csvs: set[str] = set()
         self._identity_required = bool(_ACTIONABLE_MARKET_RE.search(user_message))
         self._buffer_output = self._identity_required
         # Every instrument this run is entitled to write about: the ones the
@@ -831,6 +893,7 @@ class GroundingLedger:
             A deterministic validation result. A record containing only the
             answer hash and structured issues is appended to the artifact.
         """
+        self._ingest_run_dir_ohlc_csvs()
         issues: list[dict[str, Any]] = []
         issues.extend(self._validate_identity(content))
         issues.extend(self._validate_unsourced_symbols(content))
@@ -1394,6 +1457,84 @@ class GroundingLedger:
                     visit(item, f"{path}[{index}]")
 
         visit(payload, "")
+
+    def _ingest_run_dir_ohlc_csvs(self) -> None:
+        """Register OHLC rows from CSVs the run wrote via the bash workaround.
+
+        The bash+yfinance escape hatch writes per-symbol OHLC CSVs into the run
+        directory (e.g. ``data/raw/BYN_V.csv``) instead of returning them through
+        ``get_market_data``. Those prices were genuinely observed tool output,
+        but they never entered the ledger, so the final-answer gate rejected
+        every one of them as ``numeric_claim_unavailable``. Scan the run dir for
+        such CSVs and register their open/high/low/close/price rows as observed
+        evidence, keyed to the symbol derived from the filename.
+
+        Only files whose filename maps to a symbol already tracked in this run
+        are accepted, so a stray CSV cannot mint new identity. Rows are bounded
+        by ``_MAX_GENERIC_EVIDENCE`` and each file is ingested at most once.
+        """
+        if not self.run_dir.is_dir():
+            return
+        entitled = self._session_symbols | self.authorized_symbols
+        if not entitled:
+            return
+        room = _MAX_GENERIC_EVIDENCE
+        for path in sorted(self.run_dir.rglob("*.csv")):
+            if room <= 0:
+                return
+            try:
+                identity_key = f"{path.resolve()}:{path.stat().st_mtime_ns}"
+            except (OSError, ValueError):
+                continue
+            if identity_key in self._ingested_csvs:
+                continue
+            self._ingested_csvs.add(identity_key)
+            symbol = _symbol_from_csv_filename(path.stem)
+            if not symbol or symbol not in entitled:
+                continue
+            try:
+                with path.open("r", encoding="utf-8", errors="replace", newline="") as handle:
+                    rows = list(csv.DictReader(handle))
+            except (OSError, UnicodeDecodeError, csv.Error):
+                continue
+            for row in rows:
+                if room <= 0:
+                    return
+                if not isinstance(row, dict):
+                    continue
+                timestamp = next(
+                    (
+                        str(row[key]).strip()
+                        for key in row
+                        if str(key).strip().casefold() in _CSV_DATE_COLUMNS
+                        and row[key] not in (None, "")
+                    ),
+                    None,
+                )
+                for key, value in row.items():
+                    field_name = _CSV_PRICE_COLUMNS.get(
+                        str(key).strip().casefold().replace(" ", "_")
+                    )
+                    if field_name is None:
+                        continue
+                    numeric = _coerce_csv_number(value)
+                    if numeric is None:
+                        continue
+                    self._evidence.append(
+                        EvidenceRecord(
+                            call_id=f"csv:{path.name}",
+                            tool="bash",
+                            symbol=symbol,
+                            source="yfinance",
+                            timestamp=timestamp,
+                            field=field_name,
+                            value=numeric,
+                            status="observed",
+                            currency=_infer_currency(symbol),
+                            venue=_infer_venue(symbol),
+                        )
+                    )
+                    room -= 1
 
     def _validate_identity(self, content: str) -> list[dict[str, Any]]:
         """Validate aggregate state and listed/private contradictions."""

--- a/agent/src/tools/symbol_search_tool.py
+++ b/agent/src/tools/symbol_search_tool.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import Any, Dict, List, Optional
 
 from backtest.loaders import eastmoney_client, sec_edgar_client, yahoo_client
@@ -34,6 +35,14 @@ logger = logging.getLogger(__name__)
 # ready-made ``QuoteID`` secid. Requests route through the frozen, throttled
 # Eastmoney client; this is just the documented endpoint URL + query shape.
 _EASTMONEY_SUGGEST_URL = "https://searchapi.eastmoney.com/api/suggest/get"
+
+# Canadian equity suffixes (TSX ``.TO`` / TSX Venture ``.V``). Eastmoney has NO
+# Canada coverage: querying it with a Canadian ticker returns a non-JSON body
+# (``Expecting value: line 1 column 1 (char 0)``) instead of a clean empty
+# result. We fail fast — skip the endpoint entirely — for these queries, and
+# drop US OTC aliases (e.g. ``BYAGF.US`` for ``BYN.V``) so the grounding
+# ledger never sees one company under two venues (identity_conflict).
+_CANADIAN_SYMBOL_RE = re.compile(r"^[A-Z0-9&.\-]+\.(?:TO|V)$", re.IGNORECASE)
 
 # Eastmoney market-number -> our symbol suffix. Anything else is left unmapped
 # (those candidates are skipped rather than emitted with a wrong suffix).
@@ -134,6 +143,18 @@ class SymbolSearchTool(BaseTool):
         yh_hits, sources["yahoo"] = _search_yahoo(query)
         candidates.extend(yh_hits)
 
+        # Canada fail-fast: a Canadian ticker must resolve to the Canadian venue
+        # only. Yahoo also returns the US OTC alias of the same company (e.g.
+        # ``BYN.V`` -> ``BYAGF.US``), which would make the grounding ledger see
+        # two venues for one entity and reject every downstream call with
+        # ``identity_conflict``. Keep only ``.TO``/``.V`` candidates here.
+        if _is_canadian_symbol(query):
+            candidates = [
+                c
+                for c in candidates
+                if _is_canadian_symbol(str(c.get("symbol") or ""))
+            ]
+
         merged = _merge_candidates(candidates)
         merged, sources["sec_edgar"] = _enrich_us_cik(merged)
         if sources["sec_edgar"] == _NO_US:
@@ -165,8 +186,27 @@ def _clamp_limit(value: Any) -> int:
     return max(1, min(n, _MAX_LIMIT))
 
 
+def _is_canadian_symbol(text: str) -> bool:
+    """Whether *text* is a Canadian ticker (TSX ``.TO`` / TSXV ``.V``).
+
+    Used for fail-fast routing: Canadian symbols are served by Yahoo only, so
+    Eastmoney is skipped and US OTC aliases are filtered from the result set.
+
+    Args:
+        text: A symbol or free-text query to test.
+
+    Returns:
+        ``True`` when the text is exactly a Canadian-suffixed ticker.
+    """
+    return bool(_CANADIAN_SYMBOL_RE.match((text or "").strip()))
+
+
 def _search_eastmoney(query: str) -> tuple[List[Dict[str, Any]], str]:
     """Query Eastmoney's suggest endpoint and normalize the candidates.
+
+    Fails fast for Canadian (``.TO``/``.V``) queries: Eastmoney has no Canada
+    coverage and its suggest endpoint returns a non-JSON body for those,
+    so the endpoint is skipped instead of raising a parse error.
 
     Args:
         query: Free-text name or ticker fragment.
@@ -175,6 +215,12 @@ def _search_eastmoney(query: str) -> tuple[List[Dict[str, Any]], str]:
         ``(candidates, status)`` where ``status`` is ``"ok"`` on success or a
         short error string when the source failed (candidates is then empty).
     """
+    if _is_canadian_symbol(query):
+        logger.info(
+            "eastmoney skipped for Canadian symbol %r (no Canada coverage)",
+            query,
+        )
+        return [], "unsupported: eastmoney has no Canada coverage"
     try:
         payload = eastmoney_client.get_json(
             _EASTMONEY_SUGGEST_URL,

--- a/agent/src/tools/symbol_search_tool.py
+++ b/agent/src/tools/symbol_search_tool.py
@@ -42,7 +42,15 @@ _EASTMONEY_SUGGEST_URL = "https://searchapi.eastmoney.com/api/suggest/get"
 # result. We fail fast — skip the endpoint entirely — for these queries, and
 # drop US OTC aliases (e.g. ``BYAGF.US`` for ``BYN.V``) so the grounding
 # ledger never sees one company under two venues (identity_conflict).
-_CANADIAN_SYMBOL_RE = re.compile(r"^[A-Z0-9&.\-]+\.(?:TO|V)$", re.IGNORECASE)
+#
+# The pattern matches a LEADING Canadian ticker, optionally followed by free
+# text — the model commonly searches "BTO.TO B2Gold" or "SGML.V Sigma Lithium
+# Vancouver", not just a bare "BTO.TO". ``.TO``/``.V`` are exclusively
+# Canadian suffixes, so a leading one is unambiguous and Eastmoney can never
+# serve it. Bare names with no suffix (e.g. "BTO", "B2Gold BTO") carry no
+# venue signal and may be legit non-Canadian lookups (A-share/HK/US), so they
+# are deliberately left to the normal fan-out.
+_CANADIAN_SYMBOL_RE = re.compile(r"^[A-Z0-9&.\-]+\.(?:TO|V)\b", re.IGNORECASE)
 
 # Eastmoney market-number -> our symbol suffix. Anything else is left unmapped
 # (those candidates are skipped rather than emitted with a wrong suffix).
@@ -196,7 +204,8 @@ def _is_canadian_symbol(text: str) -> bool:
         text: A symbol or free-text query to test.
 
     Returns:
-        ``True`` when the text is exactly a Canadian-suffixed ticker.
+        ``True`` when the text starts with a Canadian-suffixed ticker
+        (``BTO.TO``, ``BTO.TO B2Gold``, ``SGML.V Sigma Lithium``, ...).
     """
     return bool(_CANADIAN_SYMBOL_RE.match((text or "").strip()))
 
@@ -227,7 +236,14 @@ def _search_eastmoney(query: str) -> tuple[List[Dict[str, Any]], str]:
             params={"input": query, "type": "14", "count": str(_PER_SOURCE_CAP)},
         )
     except Exception as exc:  # noqa: BLE001 - one source failing is non-fatal
-        logger.warning("eastmoney suggest failed for %r: %s", query, exc)
+        # Deliberately debug-level, not warning: Eastmoney has no coverage for
+        # many queries the fan-out legitimately tries (Canadian names, crypto,
+        # futures) and returns a non-JSON body for them. That is expected and
+        # benign — the status string below still flows to the tool result so
+        # nothing is hidden, it just no longer spams the terminal. Failures on
+        # queries Eastmoney SHOULD cover (A-share/HK) are still visible by
+        # checking the tool result's sources map or with debug logging on.
+        logger.debug("eastmoney suggest failed for %r: %s", query, exc)
         return [], f"eastmoney search failed: {exc}"
 
     rows = _eastmoney_data_rows(payload)

--- a/agent/tests/test_agent_grounding.py
+++ b/agent/tests/test_agent_grounding.py
@@ -598,6 +598,86 @@ def test_final_numeric_gate_rejects_known_trace_contradiction(tmp_path: Path) ->
     assert good.valid is True
 
 
+def test_run_dir_ohlc_csv_is_observed_evidence(tmp_path: Path) -> None:
+    """A bash-written OHLC CSV grounds the prices the answer quotes.
+
+    The bash+yfinance workaround writes per-symbol CSVs into the run directory
+    (e.g. ``data/raw/BYN_V.csv``) instead of returning bars through
+    ``get_market_data``. Those prices are real observed output, so the final
+    answer may cite them; a price outside the file must still be rejected.
+    """
+    raw = tmp_path / "data" / "raw"
+    raw.mkdir(parents=True)
+    (raw / "BYN_V.csv").write_text(
+        "Date,Open,High,Low,Close,Adj Close,Volume\n"
+        "2026-08-06,0.35,0.37,0.34,0.36,0.36,500000\n"
+        "2026-08-07,0.36,0.38,0.355,0.375,0.375,600000\n",
+        encoding="utf-8",
+    )
+    ledger = GroundingLedger(
+        run_dir=tmp_path,
+        user_message="请分析 BYN.V 并推荐买入价",
+    )
+
+    inside = ledger.validate_final_answer(
+        "BYN.V（yfinance，CAD）在 2026-08-07 的已观测收盘价为 0.375。"
+    )
+    fabricated = ledger.validate_final_answer(
+        "BYN.V（yfinance，CAD）在 2026-08-07 的已观测收盘价为 0.88。"
+    )
+
+    assert inside.valid is True, inside.issues
+    assert fabricated.valid is False
+    assert any(issue["code"] == "numeric_claim_conflict" for issue in fabricated.issues)
+
+
+def test_run_dir_ohlc_csv_tsx_filename_maps_symbol(tmp_path: Path) -> None:
+    """PDI_TO.csv maps to PDI.TO and grounds its CAD price."""
+    raw = tmp_path / "data" / "raw"
+    raw.mkdir(parents=True)
+    (raw / "PDI_TO.csv").write_text(
+        "Date,Open,High,Low,Close\n"
+        "2026-08-07,10.0,10.5,9.9,10.2\n",
+        encoding="utf-8",
+    )
+    ledger = GroundingLedger(
+        run_dir=tmp_path,
+        user_message="请分析 PDI.TO 并推荐买入价",
+    )
+
+    good = ledger.validate_final_answer(
+        "PDI.TO（yfinance，CAD）在 2026-08-07 的已观测收盘价为 10.2。"
+    )
+
+    assert good.valid is True, good.issues
+
+
+def test_run_dir_ohlc_csv_stray_symbol_is_ignored(tmp_path: Path) -> None:
+    """A CSV for a symbol the run never handled does not mint identity."""
+    raw = tmp_path / "data" / "raw"
+    raw.mkdir(parents=True)
+    (raw / "ZZZ_US.csv").write_text(
+        "Date,Open,High,Low,Close\n"
+        "2026-08-07,100.0,100.0,100.0,100.0\n",
+        encoding="utf-8",
+    )
+    ledger = GroundingLedger(
+        run_dir=tmp_path,
+        user_message="请分析 BYN.V 并推荐买入价",
+    )
+
+    result = ledger.validate_final_answer(
+        "ZZZ.US（yfinance，USD）在 2026-08-07 的已观测收盘价为 100.0。"
+    )
+
+    # The symbol is not entitled, so the price cannot be grounded.
+    assert result.valid is False
+    assert any(
+        issue["code"] in {"numeric_claim_unavailable", "canonical_symbol_not_surfaced"}
+        for issue in result.issues
+    )
+
+
 def test_numeric_gate_validates_derived_formula_and_provenance(tmp_path: Path) -> None:
     """A derived entry level must calculate correctly from observed evidence."""
     ledger = GroundingLedger(

--- a/agent/tests/test_symbol_search_tool.py
+++ b/agent/tests/test_symbol_search_tool.py
@@ -268,6 +268,59 @@ class TestSymbolSearchSuccess:
         symbols = {c["symbol"] for c in payload["data"]["candidates"]}
         assert symbols == {"PDI.TO"}
 
+    def test_canadian_ticker_with_name_text_skips_eastmoney(self):
+        """A "TICKER.TO <name>" query (e.g. "BTO.TO B2Gold") still fails fast.
+
+        The model commonly searches the suffixed ticker plus a name hint; the
+        leading .TO/.V suffix is unambiguous Canada, so Eastmoney (no Canada
+        coverage) must not be contacted.
+        """
+        with patch.object(
+            ss.eastmoney_client, "get_json"
+        ) as mock_em, patch.object(
+            ss.yahoo_client, "search", return_value=_yahoo_quotes()
+        ):
+            out = ss.SymbolSearchTool().execute(query="BTO.TO B2Gold")
+
+        mock_em.assert_not_called()
+        payload = json.loads(out)
+        assert payload["ok"] is True
+        assert payload["data"]["sources"]["eastmoney"] == (
+            "unsupported: eastmoney has no Canada coverage"
+        )
+
+    def test_canadian_v_ticker_with_name_text_skips_eastmoney(self):
+        """"SGML.V Sigma Lithium Vancouver" fails fast on the leading .V suffix."""
+        with patch.object(
+            ss.eastmoney_client, "get_json"
+        ) as mock_em, patch.object(
+            ss.yahoo_client, "search", return_value=_yahoo_quotes()
+        ):
+            out = ss.SymbolSearchTool().execute(query="SGML.V Sigma Lithium Vancouver")
+
+        mock_em.assert_not_called()
+        payload = json.loads(out)
+        assert payload["data"]["sources"]["eastmoney"] == (
+            "unsupported: eastmoney has no Canada coverage"
+        )
+
+    def test_bare_name_without_suffix_still_hits_eastmoney(self):
+        """A bare name (no .TO/.V) is NOT fail-fast — venue is ambiguous.
+
+        This preserves the documented design: bare names like "B2Gold BTO" or
+        "BTO" may be legit non-Canadian lookups, so Eastmoney fan-out stays.
+        """
+        with patch.object(
+            ss.eastmoney_client, "get_json", return_value=_eastmoney_payload()
+        ) as mock_em, patch.object(
+            ss.yahoo_client, "search", return_value=_yahoo_quotes()
+        ):
+            out = ss.SymbolSearchTool().execute(query="B2Gold BTO")
+
+        mock_em.assert_called_once()
+        payload = json.loads(out)
+        assert payload["data"]["sources"]["eastmoney"] == "ok"
+
 
 class TestSymbolSearchErrors:
     """Error envelopes and per-source resilience."""

--- a/agent/tests/test_symbol_search_tool.py
+++ b/agent/tests/test_symbol_search_tool.py
@@ -176,6 +176,98 @@ class TestSymbolSearchSuccess:
         assert "sec_edgar" not in payload["data"]["sources"]
         mock_cik.assert_not_called()
 
+    def test_canadian_query_skips_eastmoney_endpoint(self):
+        """A Canadian .V/.TO query fails fast: eastmoney is never contacted."""
+        with patch.object(
+            ss.eastmoney_client, "get_json"
+        ) as mock_em, patch.object(
+            ss.yahoo_client, "search", return_value=_yahoo_quotes()
+        ):
+            out = ss.SymbolSearchTool().execute(query="BYN.V")
+
+        mock_em.assert_not_called()
+        payload = json.loads(out)
+        assert payload["ok"] is True
+        assert payload["data"]["sources"]["eastmoney"] == (
+            "unsupported: eastmoney has no Canada coverage"
+        )
+
+    def test_canadian_query_drops_us_otc_aliases(self):
+        """Yahoo OTC aliases (BYAGF.US) of a Canadian name are filtered out."""
+        quotes = [
+            {
+                "symbol": "BYN.V",
+                "shortname": "Banyan Gold Corp.",
+                "exchange": "VAN",
+                "quoteType": "EQUITY",
+            },
+            {
+                "symbol": "BYAGF.US",
+                "shortname": "Banyan Gold Corp.",
+                "exchange": "PNK",
+                "quoteType": "EQUITY",
+            },
+        ]
+        with patch.object(
+            ss.eastmoney_client, "get_json"
+        ), patch.object(ss.yahoo_client, "search", return_value=quotes):
+            out = ss.SymbolSearchTool().execute(query="BYN.V")
+
+        payload = json.loads(out)
+        symbols = {c["symbol"] for c in payload["data"]["candidates"]}
+        assert symbols == {"BYN.V"}
+        assert "BYAGF.US" not in symbols
+
+    def test_canadian_query_drops_us_otc_aliases_cert(self):
+        """CERT.V OTC alias (CERT.US) is filtered for a Canadian query."""
+        quotes = [
+            {
+                "symbol": "CERT.V",
+                "shortname": "Cerrado Gold Inc.",
+                "exchange": "VAN",
+                "quoteType": "EQUITY",
+            },
+            {
+                "symbol": "CERT.US",
+                "shortname": "Cerrado Gold Inc.",
+                "exchange": "PNK",
+                "quoteType": "EQUITY",
+            },
+        ]
+        with patch.object(
+            ss.eastmoney_client, "get_json"
+        ), patch.object(ss.yahoo_client, "search", return_value=quotes):
+            out = ss.SymbolSearchTool().execute(query="CERT.V")
+
+        payload = json.loads(out)
+        symbols = {c["symbol"] for c in payload["data"]["candidates"]}
+        assert symbols == {"CERT.V"}
+
+    def test_canadian_tsx_to_query_keeps_to_only(self):
+        """A .TO (TSX) query keeps only the .TO candidate, not a US alias."""
+        quotes = [
+            {
+                "symbol": "PDI.TO",
+                "shortname": "Predictive Discovery",
+                "exchange": "TOR",
+                "quoteType": "EQUITY",
+            },
+            {
+                "symbol": "PDIYF.US",
+                "shortname": "Predictive Discovery ADR",
+                "exchange": "PNK",
+                "quoteType": "EQUITY",
+            },
+        ]
+        with patch.object(
+            ss.eastmoney_client, "get_json"
+        ), patch.object(ss.yahoo_client, "search", return_value=quotes):
+            out = ss.SymbolSearchTool().execute(query="PDI.TO")
+
+        payload = json.loads(out)
+        symbols = {c["symbol"] for c in payload["data"]["candidates"]}
+        assert symbols == {"PDI.TO"}
+
 
 class TestSymbolSearchErrors:
     """Error envelopes and per-source resilience."""


### PR DESCRIPTION
## PR1: Summary

- Fail fast on Eastmoney and US OTC lookups for Canadian (TSX/TSXV) symbols so
  the grounding/identity gate stops rejecting legitimate Canadian queries.
- Treat OHLC CSVs the agent writes via the bash+yfinance path (run directory) as
  observed evidence, so bash-derived prices are no longer reported as
  `numeric_claim_unavailable` in the final-answer gate.

## Why

Canadian market-data workflows (TSX `.TO` / TSXV `.V`) were failing end-to-end:

- `search_symbol` fanned out to Eastmoney, which has **no Canada coverage** and
  returned a non-JSON body for `.TO`/`.V` queries — logged as
  `Expecting value: line 1 column 1 (char 0)`.
- Yahoo returned the **US OTC alias** of the same company (e.g. `BYN.V` →
  `BYAGF.US`, `CERT.V` → `CERT.US`), so the grounding ledger saw one entity
  under two venues and rejected downstream `get_market_data` calls with
  `identity_required` / `identity_conflict` — stalling the whole run.
- When the agent worked around that with a bash+yfinance script that writes
  per-symbol OHLC CSVs into the run dir, the final-answer gate still rejected
  every bash-derived price as `numeric_claim_unavailable`, because the grounding
  ledger only ingested JSON tool payloads, not CSV files.

## Changes

### `agent/src/tools/symbol_search_tool.py`

- Added `_CANADIAN_SYMBOL_RE` (`^[A-Z0-9&.\-]+\.(?:TO|V)$`) and
  `_is_canadian_symbol()`.
- `_search_eastmoney` now **fails fast** for Canadian queries — the Eastmoney
  endpoint is skipped entirely (returns `"unsupported: eastmoney has no Canada
coverage"`) instead of making the call that returned a non-JSON body.
- `execute()` filters candidates for Canadian queries to `.TO`/`.V` only,
  dropping US OTC aliases so the grounding ledger never sees one company under
  two venues.

### `agent/src/agent/grounding.py`

- Added `_ingest_run_dir_ohlc_csvs()`: scans the run dir for OHLC CSVs, maps the
  filename back to a canonical symbol (`BYN_V.csv` → `BYN.V`, `PDI_TO.csv` →
  `PDI.TO`, `GC_F.csv` → `GC=F`), and registers `open/high/low/close/price` rows
  as observed evidence with `source="yfinance"`, CAD, and the correct venue.
- Only files whose filename maps to a symbol already entitled in the run are
  accepted; rows are bounded by `_MAX_GENERIC_EVIDENCE`; each file is ingested
  at most once.
- Added `_coerce_csv_number()` to parse the string cells a `csv.DictReader`
  returns.
- The ingest runs automatically at the start of `validate_final_answer`.

### Tests

- `agent/tests/test_symbol_search_tool.py`: Canadian query skips Eastmoney,
  drops US OTC aliases (`BYN.V`/`BYAGF.US`, `CERT.V`/`CERT.US`, `PDI.TO`/
  `PDIYF.US`).
- `agent/tests/test_agent_grounding.py`: run-dir OHLC CSV is observed evidence,
  TSX filename maps to symbol, fabricated prices are still rejected, stray
  symbols are ignored.

## Test Plan

- [x] Existing tests pass:
      `pytest agent/tests/test_symbol_search_tool.py agent/tests/test_agent_grounding.py agent/tests/test_agent_loop_content_filter.py agent/tests/test_agent_output_discipline.py agent/tests/test_market_detection.py -q`
      → **all pass (125+ tests)**
- [x] New regression tests added for both behaviors (fail-fast routing + CSV evidence)
- [x] Manual end-to-end verification with the live agent:
  - A 9-symbol Canadian (TSXV/TSX) top-3 run now completes — final answer passes
    the grounding gate on the first attempt, file written, no `safe_fallback`.
  - A 30-CDR (TSX) top-3 run fetches all 30 symbols via bash+yfinance, CSVs land
    in the run dir, and the deliverable passes with data-quality flags.

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
      — `agent/src/agent/grounding.py` is the _intended_ purpose of the second
      commit (fixing the gate's evidence ingestion); the first commit only
      touches `agent/src/tools/symbol_search_tool.py`.
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Every commit carries the DCO `Signed-off-by:` trailer (`git commit -s`)
- [x] Documentation updated (if user-facing change) — Canadian markets are now
      first-class in the symbol-search and grounding paths.

# PR2 Description — Perf: cut per-call LLM context by de-duplicating the tool catalog

> Paste the block below into the GitHub PR description. Covers the performance
> change on the fork's working tree. Related correctness/noise fixes (symbol
> search fail-fast + log level) are staged in the same tree — see the "Also in
> this tree" note at the bottom; they can be split into a separate PR if you
> prefer to keep this one performance-only.

---

## Summary

- Removed the **redundant prose copy of the tool catalog** from the agent system
  prompt. Every tool's full description + parameter list was being sent to the
  model **twice** on every LLM call — once as text in the system prompt and once
  as the structured `tools` array the API already receives — inflating input
  tokens and per-call latency for zero model benefit.
- `_format_tool_descriptions()` now renders a **compact one-line list** (tool
  name + short hint) instead of the full description + every parameter.

## Why

`vibe-trading`'s fork (0.1.13) carries ~97 registered tools; the fork felt
noticeably slower than v0.1.12 on the same model (`deepseek-v4-flash`). Root
cause, measured directly:

|                                       | v0.1.12    | fork (before) | fork (after)           |
| ------------------------------------- | ---------- | ------------- | ---------------------- |
| System prompt                         | ~18.5K tok | ~27.4K tok    | **~11.3K tok**         |
| `## Tools` prose in prompt            | ~11.2K tok | ~18.8K tok    | **~2.4K tok**          |
| API `tools` param (schemas)           | ~17.2K tok | ~27.7K tok    | ~27.7K tok (unchanged) |
| **Per-call input tokens (real runs)** | 50–65K     | 73–80K        | **55–66K**             |

The prose block was fully redundant with the API `tools` array — the model
already receives the exact same name/description/parameter schema natively via
`bind_tools`, so the prose only doubled the token cost per call (and, with it,
time-to-first-token).

## Changes

### `agent/src/agent/context.py`

- `_format_tool_descriptions()`: one line per tool (`- <name>: <80-char hint>`)
  instead of `### <name>` + full description + every parameter. Tool count,
  skill summaries, and all other prompt sections are unchanged.
- Added `_TOOL_PROSE_DESC_MAX = 80` hint-length cap.
- No tool is removed; full schemas still go through
  `ToolRegistry.get_definitions()` → `bind_tools` on every call.
- The grounding/identity gate is untouched — it validates tool **results**, not
  the prompt, so verification behavior is identical.

### (Optional, same file) `agent/src/agent/context.py` — trading-plan routing

A small `## Task Routing` block was added for trading-plan / to-do-list /
sell-orders file tasks: fetch `get_market_data` for every cited symbol before
writing/summarizing, and if using the bash+yfinance path write OHLC CSVs into
the run dir (`data/raw/`) so the final-answer gate has observed evidence. This
is a correctness nudge that rides in the same file; pull it out if you want a
performance-only PR.

### (Also staged) `agent/src/tools/symbol_search_tool.py` + tests

Broadened `_CANADIAN_SYMBOL_RE` to `^[A-Z0-9&.\-]+\.(?:TO|V)\b` so
`TICKER.TO <name>` queries fail fast on Eastmoney, and downgraded the benign
`eastmoney suggest failed` log from `warning` → `debug`. **These belong to a
separate fix** (search noise/correctness) — recommend a separate PR.

## Test Plan

- [x] Existing tests pass:
  - `test_agent_output_discipline.py`, `test_context_attribution_layers.py`,
    `test_agent_goal_context.py` — 79 passed
  - agent-loop suite (`test_agent_loop_*`) — 35 passed
  - `test_market_detection.py`, `test_market_data.py`,
    `test_agent_grounding.py`, `test_eastmoney_client.py`,
    `test_eastmoney_loader.py` — 206 passed
  - `test_symbol_search_tool.py` — 13 passed (incl. 3 new)
- [x] Verified rendered prompt: no unfilled placeholders, all sections intact
      (`## Tools`, `## Skills`, Output Principles, date).
- [x] Measured in real runs: per-call input tokens dropped ~73–80K → ~55–66K
      after the change (fork, `deepseek-v4-flash`).
- [ ] Manual check on a live run after merge (recommended).

## Risk & Rollback

- [x] No live / broker / order-affecting behavior (prompt-only change).
- [ ] No MCP / network / external-service behavior change — **note:** the tool
      catalog is still fully exposed via the API `tools` array; only the prose copy
      is removed. (The unrelated search fail-fast/log changes DO touch network
      behavior; keep them out of this PR if you want this box checked.)
- [x] No secrets, tokens, or credentials introduced.
- [x] Rollback path: `git revert <sha>` — pure prompt/token change, trivial to
      revert; no data migrations.

## Checklist

- [x] No changes to protected areas (`src/session/`, `src/providers/`,
      `src/agent/grounding.py`) — `src/agent/context.py` is the prompt builder and
      was changed deliberately with prior discussion.
- [x] No hardcoded values (API keys, file paths, magic numbers) — the one
      constant (`_TOOL_PROSE_DESC_MAX`) is a documented prose-cap.
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.
- [ ] Every commit carries the DCO `Signed-off-by:` trailer (`git commit -s`)
- [ ] No `Co-Authored-By:` / AI-assistant attribution trailers added
- [x] Documentation updated (this PR description + repo memory note).
