### PR TITLE
fix(grounding): handle NaN/inf volume and close in format_grounding_block

### DIFF
--- a/agent/src/swarm/grounding.py
+++ b/agent/src/swarm/grounding.py
@@ -51,6 +51,7 @@ are told to cite only symbols they analyze.
 from __future__ import annotations
 
 import logging
+import math
 import os
 import re
 from datetime import date, timedelta
@@ -59,6 +60,11 @@ from typing import Iterable
 from src.config.accessor import get_env_config
 
 logger = logging.getLogger(__name__)
+
+
+def _is_finite(value: float) -> bool:
+    """Return True when *value* is a finite number (not NaN, not inf)."""
+    return isinstance(value, (int, float)) and math.isfinite(value)
 
 
 # Window of OHLCV bars to fetch per symbol. 30 calendar days yields
@@ -238,10 +244,19 @@ def format_grounding_block(grounding: dict[str, list[dict]]) -> str:
             continue
         first_date = rows[0]["trade_date"][:10]
         last_date = rows[-1]["trade_date"][:10]
-        closes = [row["close"] for row in rows]
+        closes = [row["close"] for row in rows if _is_finite(row["close"])]
+        if not closes:
+            continue
         window_low = min(closes)
         window_high = max(closes)
         last_close = closes[-1]
+        # Find the last row with a finite close so the "Latest close" label
+        # pairs the price with its correct date, not the final bar's date
+        # (which may have a NaN close in the halted-stock case).
+        last_finite_row = next(
+            (r for r in reversed(rows) if _is_finite(r["close"])), rows[-1]
+        )
+        last_close_date = last_finite_row["trade_date"][:10]
 
         lines = [
             f"### {code}  (window {first_date} → {last_date})",
@@ -250,13 +265,13 @@ def format_grounding_block(grounding: dict[str, list[dict]]) -> str:
             "| --- | ---: | ---: |",
         ]
         for row in rows[-PROMPT_TABLE_TAIL:]:
-            lines.append(
-                f"| {row['trade_date'][:10]} | {row['close']:.2f} "
-                f"| {int(row['volume']):,} |"
-            )
+            vol = row["volume"]
+            vol_str = f"{int(vol):,}" if _is_finite(vol) else "—"
+            close_str = f"{row['close']:.2f}" if _is_finite(row["close"]) else "—"
+            lines.append(f"| {row['trade_date'][:10]} | {close_str} | {vol_str} |")
         lines.append("")
         lines.append(
-            f"**Latest close:** {last_close:.2f} ({last_date})  "
+            f"**Latest close:** {last_close:.2f} ({last_close_date})  "
             f"**Window range:** {window_low:.2f} – {window_high:.2f}"
         )
         sections.append("\n".join(lines))

--- a/agent/tests/test_grounding_nan_volume.py
+++ b/agent/tests/test_grounding_nan_volume.py
@@ -1,0 +1,125 @@
+"""Regression: format_grounding_block must not crash on NaN/inf volume or close.
+
+Loaders can return NaN for missing OHLCV fields (e.g. volume on a
+non-trading day, close on a halted stock). The original code called
+``int(row['volume'])`` unconditionally — ``int(float('nan'))`` raises
+``ValueError: cannot convert float NaN to integer``. NaN closes also
+produced ``nan`` in the formatted output via ``:.2f``.
+"""
+
+from __future__ import annotations
+
+import math
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_spec = importlib.util.spec_from_file_location(
+    "grounding_test_mod",
+    Path(__file__).resolve().parent.parent / "src" / "swarm" / "grounding.py",
+)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["grounding_test_mod"] = _mod
+_spec.loader.exec_module(_mod)
+format_grounding_block = _mod.format_grounding_block
+
+
+def test_format_with_normal_data() -> None:
+    """Normal data renders without error."""
+    grounding = {
+        "AAPL.US": [
+            {"trade_date": "2026-01-01", "open": 150.0, "high": 155.0,
+             "low": 149.0, "close": 152.0, "volume": 1_000_000.0},
+            {"trade_date": "2026-01-02", "open": 152.0, "high": 158.0,
+             "low": 151.0, "close": 157.0, "volume": 1_200_000.0},
+        ],
+    }
+    result = format_grounding_block(grounding)
+    assert "AAPL.US" in result
+    assert "152.00" in result
+    assert "1,000,000" in result
+
+
+def test_format_with_nan_volume_does_not_crash() -> None:
+    """NaN volume must render as a dash, not crash with ValueError."""
+    grounding = {
+        "AAPL.US": [
+            {"trade_date": "2026-01-01", "open": 150.0, "high": 155.0,
+             "low": 149.0, "close": 152.0, "volume": float("nan")},
+            {"trade_date": "2026-01-02", "open": 152.0, "high": 158.0,
+             "low": 151.0, "close": 157.0, "volume": 1_200_000.0},
+        ],
+    }
+    result = format_grounding_block(grounding)
+    assert "AAPL.US" in result
+    assert "—" in result  # NaN volume rendered as dash
+
+
+def test_format_with_nan_close_does_not_crash() -> None:
+    """NaN close must render as a dash, not produce 'nan' in the table."""
+    grounding = {
+        "AAPL.US": [
+            {"trade_date": "2026-01-01", "open": 150.0, "high": 155.0,
+             "low": 149.0, "close": float("nan"), "volume": 1_000_000.0},
+            {"trade_date": "2026-01-02", "open": 152.0, "high": 158.0,
+             "low": 151.0, "close": 157.0, "volume": 1_200_000.0},
+        ],
+    }
+    result = format_grounding_block(grounding)
+    assert "AAPL.US" in result
+    # The NaN close row should have a dash, not 'nan'.
+    assert "nan" not in result.lower()
+
+
+def test_format_with_all_nan_closes_skips_symbol() -> None:
+    """When all closes are NaN, the symbol is skipped entirely."""
+    grounding = {
+        "AAPL.US": [
+            {"trade_date": "2026-01-01", "open": 150.0, "high": 155.0,
+             "low": 149.0, "close": float("nan"), "volume": 1_000_000.0},
+        ],
+    }
+    result = format_grounding_block(grounding)
+    # No data to render → empty string.
+    assert result == ""
+
+
+def test_format_with_inf_volume_does_not_crash() -> None:
+    """inf volume must render as a dash, not crash."""
+    grounding = {
+        "AAPL.US": [
+            {"trade_date": "2026-01-01", "open": 150.0, "high": 155.0,
+             "low": 149.0, "close": 152.0, "volume": float("inf")},
+            {"trade_date": "2026-01-02", "open": 152.0, "high": 158.0,
+             "low": 151.0, "close": 157.0, "volume": 1_200_000.0},
+        ],
+    }
+    result = format_grounding_block(grounding)
+    assert "AAPL.US" in result
+    assert "—" in result
+
+
+def test_format_with_empty_grounding() -> None:
+    assert format_grounding_block({}) == ""
+
+
+def test_format_with_empty_rows() -> None:
+    result = format_grounding_block({"AAPL.US": []})
+    assert result == ""
+
+
+def test_latest_close_date_matches_finite_close_row() -> None:
+    """When the final bar has NaN close, the 'Latest close' date must match
+    the last row with a finite close, not the final bar's date."""
+    grounding = {
+        "AAPL.US": [
+            {"trade_date": "2026-08-05", "close": 195.0, "volume": 1000000},
+            {"trade_date": "2026-08-06", "close": 200.0, "volume": 1100000},
+            {"trade_date": "2026-08-07", "close": float("nan"), "volume": 0},
+        ]
+    }
+    result = format_grounding_block(grounding)
+    # Latest close should be 200.00 with date 2026-08-06, not 2026-08-07
+    assert "200.00 (2026-08-06)" in result
+    assert "200.00 (2026-08-07)" not in result


### PR DESCRIPTION
## Bug

`format_grounding_block` called `int(row['volume'])` which raises `ValueError` on NaN volume and `OverflowError` on inf volume. Data loaders return NaN for missing data (e.g. halted stocks, newly listed symbols). Additionally, NaN closes produced `nan` in the formatted output, and the "Latest close" label paired a price from an earlier bar with the final bar's date when the final bar had a NaN close.

## Fix

Add `_is_finite()` helper. Render NaN/inf volume and close as `—` (em dash) in the table. Filter NaN closes when computing window range. Track the last row with a finite close and use its `trade_date` for the "Latest close" label so the price and date are always from the same bar.

## Tests

8 tests covering: normal data, NaN volume, NaN close, all-NaN closes skip symbol, inf volume, empty grounding, empty rows, and price/date mismatch on NaN final close.