### PR TITLE
fix(store): guard _json_loads against corrupted JSON in database columns

### DIFF
--- a/agent/src/goal/store.py
+++ b/agent/src/goal/store.py
@@ -67,7 +67,10 @@ def _json_dumps(value: object) -> str:
 def _json_loads(value: str | None, default: object) -> object:
     if not value:
         return default
-    return json.loads(value)
+    try:
+        return json.loads(value)
+    except (json.JSONDecodeError, TypeError):
+        return default
 
 
 def _default_db_path() -> Path:

--- a/agent/src/strategy_store/sqlite_store.py
+++ b/agent/src/strategy_store/sqlite_store.py
@@ -81,10 +81,13 @@ def _json_dumps(value: object) -> str:
 
 
 def _json_loads(value: str | None, default: object) -> object:
-    """Deserialize a JSON string, returning *default* when empty."""
+    """Deserialize a JSON string, returning *default* when empty or corrupt."""
     if not value:
         return default
-    return json.loads(value)
+    try:
+        return json.loads(value)
+    except (json.JSONDecodeError, TypeError):
+        return default
 
 
 def _default_db_path() -> Path:

--- a/agent/tests/test_json_loads_guard.py
+++ b/agent/tests/test_json_loads_guard.py
@@ -1,0 +1,52 @@
+"""Regression: _json_loads must not crash on corrupted JSON in database columns.
+
+Both goal/store.py and strategy_store/sqlite_store.py define _json_loads
+to deserialize JSON columns (theme, benchmark, assumptions, etc.). The
+original code called json.loads(value) without a try/except — a
+corrupted JSON string in the database (manual edit, partial write,
+encoding issue) crashes the caller with json.JSONDecodeError, taking
+down the entire goal/strategy read path.
+"""
+
+from __future__ import annotations
+
+from src.goal.store import _json_loads as goal_json_loads
+from src.strategy_store.sqlite_store import _json_loads as strategy_json_loads
+
+
+def test_goal_json_loads_valid_json() -> None:
+    assert goal_json_loads('["a", "b"]', []) == ["a", "b"]
+    assert goal_json_loads('{"key": "val"}', {}) == {"key": "val"}
+
+
+def test_goal_json_loads_empty_returns_default() -> None:
+    assert goal_json_loads(None, []) == []
+    assert goal_json_loads("", {}) == {}
+    assert goal_json_loads("", "default") == "default"
+
+
+def test_goal_json_loads_corrupted_returns_default() -> None:
+    assert goal_json_loads("not json", []) == []
+    assert goal_json_loads("{broken", {}) == {}
+    assert goal_json_loads('["unclosed', []) == []
+
+
+def test_strategy_json_loads_valid_json() -> None:
+    assert strategy_json_loads('["momentum", "reversal"]', []) == ["momentum", "reversal"]
+
+
+def test_strategy_json_loads_empty_returns_default() -> None:
+    assert strategy_json_loads(None, []) == []
+    assert strategy_json_loads("", []) == []
+
+
+def test_strategy_json_loads_corrupted_returns_default() -> None:
+    assert strategy_json_loads("not json", []) == []
+    assert strategy_json_loads("{broken", []) == []
+    assert strategy_json_loads('["unclosed', []) == []
+
+
+def test_json_loads_non_string_input_returns_default() -> None:
+    """Non-string input (e.g. int from a misconfigured column) must not crash."""
+    assert goal_json_loads(123, []) == []  # type: ignore[arg-type]
+    assert strategy_json_loads(123, []) == []  # type: ignore[arg-type]


### PR DESCRIPTION
## Bug

`_json_loads` in both `agent/src/goal/store.py` and `agent/src/strategy_store/sqlite_store.py` called `json.loads(value)` without a try/except. If a database row contains corrupted or truncated JSON (e.g. from a partial write, disk error, or manual edit), the entire store query crashes with `JSONDecodeError` instead of returning a default value.

## Fix

Wrap `json.loads(value)` in try/except for `json.JSONDecodeError` and `TypeError`, returning the default value on failure. This matches the fail-open pattern already used by `read_daily_count` in the same codebase.

## Tests

4 tests covering: valid JSON, corrupted JSON returns default, None input returns default, and both goal store and strategy store are guarded.