### PR TITLE
fix(http-throttle): sweep stale bucket entries to prevent unbounded memory growth

### DIFF
--- a/agent/backtest/loaders/_http.py
+++ b/agent/backtest/loaders/_http.py
@@ -54,8 +54,21 @@ class HostThrottle:
     """
 
     def __init__(self) -> None:
-        self._last: dict[str, float] = {}
+        self._last: dict[str, tuple[float, float]] = {}
         self._lock = threading.Lock()
+        self._last_sweep: float = 0.0
+
+    def _sweep_stale_locked(self, cutoff: float) -> None:
+        """Drop buckets whose spacing window has fully elapsed. Caller holds the lock.
+
+        A bucket is only stale once ``fire_at + min_interval`` has passed —
+        before that, the next request to that bucket must still wait for its
+        spacing interval. Sweeping earlier would let the next request fire
+        immediately, defeating the rate limiter.
+        """
+        stale = [k for k, (t, interval) in self._last.items() if t + interval < cutoff]
+        for k in stale:
+            del self._last[k]
 
     def wait(self, bucket: str, min_interval: float) -> None:
         """Block until ``bucket`` is allowed to fire again, then record the slot.
@@ -71,7 +84,15 @@ class HostThrottle:
             return
         with self._lock:
             now = time.monotonic()
-            last = self._last.get(bucket)
+            # Periodic sweep: drop stale buckets so a process that queries
+            # many distinct hosts (e.g. a batch job hitting N tickers) does
+            # not accumulate dead entries without bound. Throttled to once
+            # per minute to avoid sweeping on every call.
+            if now - self._last_sweep >= 60.0:
+                self._sweep_stale_locked(now)
+                self._last_sweep = now
+            entry = self._last.get(bucket)
+            last = entry[0] if entry is not None else None
             if last is None or now >= last + min_interval:
                 # Slot is free right now — fire immediately, no jitter needed.
                 fire_at = now
@@ -79,7 +100,7 @@ class HostThrottle:
                 # Chain off the previous reservation and add jitter to desync
                 # concurrent callers, baking the jitter into the stored slot.
                 fire_at = last + min_interval + random.uniform(0.0, _JITTER_MAX_S)
-            self._last[bucket] = fire_at
+            self._last[bucket] = (fire_at, min_interval)
         sleep_for = fire_at - time.monotonic()
         if sleep_for > 0:
             time.sleep(sleep_for)

--- a/agent/tests/test_host_throttle_memory.py
+++ b/agent/tests/test_host_throttle_memory.py
@@ -1,0 +1,117 @@
+"""Regression: HostThrottle must not leak memory from stale bucket entries.
+
+The ``_last`` dict grows one entry per unique host bucket and never
+evicts stale entries. A batch job that queries many distinct hosts
+(e.g. N tickers across N providers) accumulates dead entries without
+bound. The fix adds a periodic sweep that drops buckets whose spacing
+window (fire_at + min_interval) has fully elapsed.
+
+The sweep must be interval-aware: a bucket that fired 0.1s ago with a
+1.5s interval is still within its spacing window and must NOT be swept.
+Sweeping it early would let the next request fire immediately with no
+spacing, defeating the rate limiter.
+"""
+
+from __future__ import annotations
+
+import time
+
+from backtest.loaders._http import HostThrottle
+
+
+def test_wait_records_bucket() -> None:
+    throttle = HostThrottle()
+    throttle.wait("eastmoney", min_interval=1.0)
+    assert "eastmoney" in throttle._last
+
+
+def test_wait_zero_interval_no_op() -> None:
+    throttle = HostThrottle()
+    throttle.wait("x", min_interval=0.0)
+    # min_interval <= 0 returns early without recording.
+    assert "x" not in throttle._last
+
+
+def test_sweep_removes_stale_buckets() -> None:
+    """Buckets whose spacing window has fully elapsed must be swept."""
+    throttle = HostThrottle()
+    # Use a tiny interval so the spacing window elapses quickly.
+    throttle.wait("a", min_interval=0.01)
+    throttle.wait("b", min_interval=0.01)
+    assert len(throttle._last) == 2
+
+    # Wait for the spacing window (fire_at + 0.01) to pass.
+    time.sleep(0.02)
+
+    now = time.monotonic()
+    with throttle._lock:
+        throttle._sweep_stale_locked(now)
+
+    assert "a" not in throttle._last
+    assert "b" not in throttle._last
+
+
+def test_sweep_keeps_active_buckets() -> None:
+    """Buckets with a future fire time must survive the sweep."""
+    throttle = HostThrottle()
+    # Manually set a future fire time to avoid the real sleep.
+    with throttle._lock:
+        throttle._last["a"] = (time.monotonic() + 100.0, 1.0)
+
+    now = time.monotonic()
+    with throttle._lock:
+        throttle._sweep_stale_locked(now)
+    assert "a" in throttle._last
+
+
+def test_sweep_keeps_buckets_within_spacing_window() -> None:
+    """A bucket that fired recently but is still within its spacing window
+    must NOT be swept — sweeping it early would skip rate-limit spacing."""
+    throttle = HostThrottle()
+    # Bucket fired 0.01s ago with a 10s interval — still within spacing window.
+    with throttle._lock:
+        throttle._last["iwencai"] = (time.monotonic() - 0.01, 10.0)
+
+    now = time.monotonic()
+    with throttle._lock:
+        throttle._sweep_stale_locked(now)
+
+    assert "iwencai" in throttle._last
+
+
+def test_periodic_sweep_on_wait() -> None:
+    """wait() should trigger a sweep after the sweep interval."""
+    throttle = HostThrottle()
+    # Use a tiny interval so the bucket becomes stale quickly.
+    throttle.wait("a", min_interval=0.01)
+
+    # Simulate that the last sweep was long ago.
+    throttle._last_sweep = time.monotonic() - 61.0
+
+    time.sleep(0.02)
+
+    # This wait should trigger a sweep, removing "a" (stale) and adding "b".
+    throttle.wait("b", min_interval=1.0)
+
+    assert "a" not in throttle._last
+    assert "b" in throttle._last
+
+
+def test_many_unique_buckets_do_not_grow_unboundedly() -> None:
+    """After a sweep, stale buckets from earlier calls must be gone."""
+    throttle = HostThrottle()
+    # Simulate old last_sweep so the next wait triggers a sweep.
+    throttle._last_sweep = time.monotonic() - 61.0
+
+    # Add 100 buckets with past fire times and tiny intervals (stale).
+    now = time.monotonic()
+    for i in range(100):
+        throttle._last[f"host-{i}"] = (now - 10.0, 0.01)
+
+    assert len(throttle._last) == 100
+
+    # This wait triggers a sweep that should remove all stale entries.
+    throttle.wait("new-host", min_interval=1.0)
+
+    assert len(throttle._last) == 1
+    assert "new-host" in throttle._last


### PR DESCRIPTION
## Bug

`HostThrottle._last` grows one entry per unique host bucket and never evicts stale entries. A batch job that queries many distinct hosts (e.g. N tickers across N providers) accumulates dead entries without bound.

## Fix

Add a periodic sweep (throttled to once per 60 seconds) that drops buckets whose full spacing window (`fire_at + min_interval`) has elapsed. The sweep is interval-aware: a bucket that fired recently but is still within its spacing window is NOT swept, because sweeping it early would let the next request fire immediately with no spacing — defeating the rate limiter and risking provider bans.

Each bucket stores a `(fire_at, min_interval)` tuple so the sweep can check the spacing window without needing the caller's interval.

## Tests

7 tests covering: bucket recording, zero-interval no-op, stale bucket removal, active bucket preservation, spacing-window preservation, periodic sweep on wait, and 100 unique buckets swept to 1.