### PR TITLE
feat(swarm): add final report aggregator stage to quant_strategy_desk

### DIFF
--- a/agent/src/swarm/presets/quant_strategy_desk.yaml
+++ b/agent/src/swarm/presets/quant_strategy_desk.yaml
@@ -1,6 +1,6 @@
 name: quant_strategy_desk
 title: "Quant Strategy Desk"
-description: "Stock screening + factor research in parallel → strategy backtest → risk audit."
+description: "Stock screening + factor research in parallel → strategy backtest → risk audit → final report."
 
 agents:
   - id: screener
@@ -117,6 +117,33 @@ agents:
     timeout_seconds: 1800
     max_retries: 1
 
+  - id: report_aggregator
+    role: Report Aggregator
+    system_prompt: |
+      You are a quantitative research editor, skilled in consolidating
+      multi-stage research outputs into one complete, user-facing report.
+
+      ## Task
+      Synthesize the screening, factor research, backtest, and risk audit
+      into a single final quantitative research report.
+
+      {upstream_context}
+
+      ## Required outputs
+      1. **Final strategy** — The strategy and its fully specified trading rules
+      2. **Selected factors** — The factors used and why they were chosen
+      3. **Backtest summary** — Methodology and key performance metrics (return, Sharpe, max drawdown)
+      4. **Risk audit** — The key findings and robustness recommendations
+
+      The report is the single deliverable a user reads after the run; it
+      must stand alone without requiring the reader to open intermediate
+      task outputs.
+    tools: [bash, read_file, write_file, load_skill]
+    skills: [report-generate]
+    max_iterations: 50
+    timeout_seconds: 1800
+    max_retries: 1
+
 tasks:
   - id: task-screen
     agent_id: screener
@@ -142,6 +169,16 @@ tasks:
     depends_on: [task-backtest]
     input_from:
       backtest_result: task-backtest
+
+  - id: task-report
+    agent_id: report_aggregator
+    prompt_template: "Consolidate screening, factor research, backtest, and risk audit into the final research report."
+    depends_on: [task-screen, task-factor, task-backtest, task-risk]
+    input_from:
+      screener_result: task-screen
+      factors: task-factor
+      backtest_result: task-backtest
+      risk_audit: task-risk
 
 variables:
   - name: market

--- a/agent/tests/test_swarm_presets_packaging.py
+++ b/agent/tests/test_swarm_presets_packaging.py
@@ -69,6 +69,55 @@ def test_known_presets_load(preset_name: str) -> None:
     assert data["agents"], f"{preset_name} has no agents"
 
 
+def test_quant_strategy_desk_ends_with_report_aggregator() -> None:
+    """quant_strategy_desk must deliver a final report, not stop at the risk audit.
+
+    Regression for #1029: the preset's last task is task-report run by
+    report_aggregator, consuming all four upstream task summaries.
+    """
+    data = load_preset("quant_strategy_desk")
+
+    agents = {a["id"]: a for a in data["agents"]}
+    assert "report_aggregator" in agents, "report_aggregator agent missing"
+
+    report_task = next(t for t in data["tasks"] if t["id"] == "task-report")
+    assert report_task["agent_id"] == "report_aggregator"
+    assert report_task["depends_on"] == [
+        "task-screen",
+        "task-factor",
+        "task-backtest",
+        "task-risk",
+    ]
+    assert report_task["input_from"] == {
+        "screener_result": "task-screen",
+        "factors": "task-factor",
+        "backtest_result": "task-backtest",
+        "risk_audit": "task-risk",
+    }
+
+
+def test_quant_strategy_desk_report_prompt_covers_four_sections() -> None:
+    """The aggregator prompt must require every deliverable a user expects."""
+    from src.swarm.presets import inspect_preset
+
+    data = load_preset("quant_strategy_desk")
+    prompt = next(
+        a["system_prompt"] for a in data["agents"] if a["id"] == "report_aggregator"
+    )
+    for marker in [
+        "Final strategy",
+        "Selected factors",
+        "Backtest summary",
+        "Risk audit",
+    ]:
+        assert marker in prompt, f"report prompt misses section {marker!r}"
+
+    insp = inspect_preset("quant_strategy_desk")
+    assert insp["valid"] is True, f"preset invalid: {insp['errors']}"
+    assert insp["errors"] == []
+    assert insp["layers"][-1][0]["task_id"] == "task-report"
+
+
 # ── User presets directory (~/.vibe-trading/swarm/presets/) ──────────────────
 
 


### PR DESCRIPTION
## Summary

Adds a final `report_aggregator` agent and a `task-report` task to the `quant_strategy_desk` swarm preset, so a run ends with one consolidated research report instead of stopping at the risk audit.

## Why

The preset currently ends at the `risk_auditor` task. Users get a risk audit rather than a complete quantitative research report (issue #1029). The new final stage consumes all four upstream task outputs and produces a single deliverable with the final strategy + trading rules, selected factors and rationale, backtest methodology and metrics, and risk findings.

## Changes

- `agent/src/swarm/presets/quant_strategy_desk.yaml`: new `report_aggregator` agent, new `task-report` task (`depends_on` all four upstream tasks, `input_from` maps all four summaries), updated `description`
- `agent/tests/test_swarm_presets_packaging.py`: regression tests asserting the aggregator task exists, its `input_from` references all four upstream tasks, the prompt covers all four report sections, and `inspect_preset` stays valid with `task-report` as the last layer

## Test Plan

- [x] ruff check — clean
- [x] pytest (test_swarm_presets_packaging.py) — 19 passed
- [x] pytest (swarm 相关全量) — 212 passed, 5 skipped
- [x] 真实调用: load_preset + inspect_preset + build_run_from_preset — valid=True, errors=[], task-report 为最后一层

## Checklist

- [x] No changes to protected areas without prior discussion
- [x] No hardcoded values
- [x] Code follows CONTRIBUTING.md guidelines
- [x] Documentation updated (if user-facing change)