### PR TITLE
fix(swarm): reject ok/success raw tool-result envelopes

### DIFF
--- a/agent/src/swarm/worker.py
+++ b/agent/src/swarm/worker.py
@@ -908,8 +908,10 @@ def _classify_deliverable(
         return "unparsed tool-call markup (provider did not parse tool calls)"
     if any(m in low for m in _FABRICATION_MARKERS):
         return "explicitly fabricated / mock data"
-    if text.startswith("{") and '"status"' in text[:40] and (
-        '"content"' in text[:300] or '"ok"' in text[:40]
+    if text.startswith("{") and (
+        ('"status"' in text[:40] and ('"content"' in text[:300] or '"ok"' in text[:40]))
+        or '"ok"' in text[:40]
+        or '"success"' in text[:40]
     ):
         return "raw tool-result envelope, not analysis"
     if low.startswith(_PLAN_PREFIXES):

--- a/agent/tests/test_swarm_output_contract.py
+++ b/agent/tests/test_swarm_output_contract.py
@@ -79,6 +79,72 @@ def test_raw_tool_envelope_is_rejected():
     assert _classify_deliverable(txt, is_data_agent=False, report_written=False, data_tool_calls=1)
 
 
+def test_raw_ok_data_envelope_is_rejected():
+    """Real success shape from get_fundamentals_tool.py, no top-level status key."""
+    txt = (
+        '{"ok": true, "source": "yfinance", "freq": "annual", "pit": false, '
+        '"symbols": ["AAPL.US"], "fields": ["revenue"], "data": {"revenue": [1, 2, 3]}}'
+    )
+    assert _classify_deliverable(
+        txt, is_data_agent=True, report_written=False, data_tool_calls=1
+    )
+
+
+def test_raw_ok_non_data_payload_envelope_is_rejected():
+    """Real success shape from research_papers_tool.py: uses "papers" as the
+    payload key, not "data". Proves the fix does not depend on the payload
+    key name, only on the repository's real ok/success discriminator."""
+    txt = (
+        '{"ok": true, "mode": "read", "source": "arxiv", '
+        '"disclaimer": "not investment advice", "requested": 1, "returned": 1, '
+        '"missing_ids": [], "papers": [{"id": "1234.5678", "title": "Example"}], '
+        '"next_actions": ["read_more"]}'
+    )
+    assert _classify_deliverable(
+        txt, is_data_agent=True, report_written=False, data_tool_calls=1
+    )
+
+
+def test_raw_success_envelope_is_rejected():
+    """SYNTHETIC: no current Vibe-Trading tool emits a top-level "success" key
+    (confirmed by repository survey). This branch exists only for consistency
+    with the sibling _is_tool_success / _is_error_result classifiers, which
+    already check both ok and success defensively."""
+    txt = '{"success": true, "data": {"x": 1}}'
+    assert _classify_deliverable(
+        txt, is_data_agent=True, report_written=False, data_tool_calls=1
+    )
+
+
+def test_prose_mentioning_ok_or_success_as_words_is_not_rejected():
+    """Control: legitimate prose that happens to contain the words ok/success
+    must not be misclassified, the check requires the text to start with
+    "{" before any key inspection happens."""
+    txt = "The fundamentals look ok and the outlook is a success story overall."
+    assert (
+        _classify_deliverable(
+            txt, is_data_agent=False, report_written=False, data_tool_calls=0
+        )
+        is None
+    )
+
+
+def test_json_with_late_ok_key_is_a_known_heuristic_limitation():
+    """Documents a known, accepted limitation: the character-window heuristic
+    only looks at the first 40/300 chars, matching the repository's own
+    existing convention for the status/content branch. Every real ok/success
+    tool in this repository puts ok/success first (verified across all 29
+    producers), so this is not expected to occur in practice."""
+    padding = "x" * 60
+    txt = '{"' + padding + '": 1, "ok": true, "data": {}}'
+    assert (
+        _classify_deliverable(
+            txt, is_data_agent=True, report_written=False, data_tool_calls=1
+        )
+        is None
+    )
+
+
 def test_data_agent_without_evidence_is_rejected():
     assert _classify_deliverable(REAL_REPORT, is_data_agent=True, report_written=False, data_tool_calls=0)
 


### PR DESCRIPTION
## Summary

- Extend swarm deliverable validation to reject the ok/success-keyed raw tool-result envelopes used by current Vibe-Trading tools, not just the status/content family already handled.
- Add regression coverage using real envelope shapes from two existing tools, plus a clearly-labeled synthetic case and two control tests.

## Why

`_classify_deliverable()` in `agent/src/swarm/worker.py` only recognized a raw tool-result envelope as `{"status": ..., "content"/"ok": ...}`. Most real tool success envelopes in this repository carry no top-level `"status"` key at all: `get_fundamentals_tool.py` and `research_papers_tool.py` both return `{"ok": true, ...}`, with the payload under varying key names (`"data"`, `"papers"`, and roughly 30 other distinct names across the 29 ok/success-family tool producers surveyed in `agent/src/tools/`).

Confirmed live with a before/after reproduction using the real envelope shapes from both tools: on unpatched `main`, both are accepted by `_classify_deliverable()` as valid deliverables; with the fix, both are rejected. If a worker's final summary is ever a raw envelope like this instead of an analyzed synthesis, it currently passes the output contract unnoticed.

The PR that introduced this output contract (#119) explicitly flagged this exact area as a known follow-up: "follow-up will harden `_classify_deliverable`/`_is_error_result` (substring -> JSON parse); out of scope here." This PR is that hardening. It stays within the existing substring/character-window heuristic convention (`text[:40]`/`text[:300]`) already used by the status/content branch, rather than introducing a full JSON parse, since no repository evidence showed a need to go further, and the fix does not depend on any specific payload key name, since no single key name is common to all 29 producers.

## Changes

- `agent/src/swarm/worker.py`: `_classify_deliverable()`'s raw-envelope guard now also matches an early top-level `"ok"` or `"success"` key, independent of `"status"`.
- `agent/tests/test_swarm_output_contract.py`: 5 new tests — real ok/data envelope (`get_fundamentals_tool.py`), real ok/non-data-payload envelope (`research_papers_tool.py`, proving the fix is not tied to a `"data"` key), a synthetic success-keyed envelope (explicitly labeled — no current tool uses this key), a control proving prose that merely contains the words "ok"/"success" is not misclassified, and a documented known-limitation case for the character-window heuristic.

## Test Plan

- [x] Confirmed 3 of the new tests (ok/data, ok/non-data-payload, synthetic success) fail on unpatched `main`, reproducing the real bug with real envelope shapes; the status/content test and both controls pass regardless
- [x] `pytest agent/tests/test_swarm_output_contract.py -v` (34 passed)
- [x] `pytest agent/tests/ -k "swarm" -q` (222 passed, 5 skipped, 0 failed)
- [x] `black --check` / `ruff check` on both changed files: diffed against the same check on the unpatched files; every pre-existing formatting finding is unchanged, and the formatting issues introduced by my own new lines were found and fixed, then re-verified clean

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`): this only touches `agent/src/swarm/` and `agent/tests/`
- [x] No hardcoded sensitive values
- [x] Code follows CONTRIBUTING.md guidelines
- [x] Documentation updated: docstrings/comments explain the real vs. synthetic envelope shapes and the known heuristic limitation
- [x] DCO signed-off