### PR TITLE
fix(cli): explain Docker Codex OAuth EOF

### DIFF
--- a/README.md
+++ b/README.md
@@ -742,6 +742,17 @@ docker compose up --build
 
 Open `http://localhost:8899`. Backend + frontend in one container.
 
+> [!NOTE]
+> **OpenAI Codex OAuth with Docker:** the browser login needs a terminal so you
+> can paste the callback URL. Run it through Compose, which allocates an
+> interactive terminal automatically:
+>
+> ```bash
+> docker compose exec vibe-trading vibe-trading provider login openai-codex
+> ```
+>
+> If you use `docker exec` directly, pass `-it` before the container name.
+
 Docker publishes the backend on `127.0.0.1:8899` by default and runs the app as a non-root container user. If you intentionally expose the API beyond your own machine, set a strong `API_AUTH_KEY` and send `Authorization: Bearer <key>` from clients.
 
 > [!NOTE]

--- a/agent/cli/_legacy.py
+++ b/agent/cli/_legacy.py
@@ -2881,6 +2881,21 @@ def cmd_provider_login(provider: str) -> int:
         account = getattr(token, "account_id", None) or "ChatGPT"
         console.print(f"[green]Authenticated with OpenAI Codex[/green]  [dim]{account}[/dim]")
         return EXIT_SUCCESS
+    except EOFError:
+        # ``docker exec`` does not allocate stdin/TTY unless explicitly asked
+        # to do so. oauth-cli-kit prompts for the browser callback URL after
+        # printing the authorization link, so an unattended stdin otherwise
+        # fails with the opaque ``EOF when reading a line`` error.
+        console.print(
+            "[red]Authentication error:[/red] OpenAI Codex OAuth needs an "
+            "interactive terminal to paste the callback URL."
+        )
+        console.print(
+            "[yellow]Docker:[/yellow] run `docker compose exec vibe-trading "
+            "vibe-trading provider login openai-codex` or add `-it` to "
+            "`docker exec`."
+        )
+        return EXIT_RUN_FAILED
     except Exception as exc:
         console.print(f"[red]Authentication error:[/red] {exc}")
         return EXIT_RUN_FAILED

--- a/agent/tests/test_cli_provider_login.py
+++ b/agent/tests/test_cli_provider_login.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from cli import _legacy
+
+
+def test_provider_login_explains_docker_tty_requirement(capsys) -> None:
+    """An EOF from the OAuth prompt should point Docker users to a TTY command."""
+
+    with patch(
+        "src.providers.openai_codex.login_openai_codex",
+        side_effect=EOFError("EOF when reading a line"),
+    ):
+        result = _legacy.cmd_provider_login("openai-codex")
+
+    assert result == _legacy.EXIT_RUN_FAILED
+    output = capsys.readouterr().out
+    assert "interactive terminal" in output
+    assert "docker compose exec vibe-trading" in output
+    assert "-it" in output


### PR DESCRIPTION
## Summary

- turn the Docker/OpenAI Codex OAuth `EOF when reading a line` failure into an actionable CLI message
- document the TTY-safe `docker compose exec` login command and the equivalent `docker exec -it` form
- add a regression test covering the EOF path

Closes #1050.

## Root cause

`docker exec` without `-i`/`-t` does not provide the interactive stdin needed by `oauth-cli-kit` after it prints the browser authorization URL and prompts for the callback URL. The resulting EOF was surfaced without Docker-specific guidance.

## Validation

- `pytest -q --basetemp <isolated-temp> agent/tests/test_cli_provider_login.py agent/tests/test_cli_interactive.py agent/tests/test_openai_codex.py` (94 passed)
- `ruff check agent/cli/_legacy.py agent/tests/test_cli_provider_login.py`
- `black --check agent/tests/test_cli_provider_login.py`
- `black --check --line-ranges 2883-2900 agent/cli/_legacy.py`
- `git diff --check`
- `python -m compileall -q agent/cli agent/src/providers/openai_codex.py`

The full-file Black check for `agent/cli/_legacy.py` still reports pre-existing formatting outside this focused change; no unrelated formatting was included.