### PR TITLE
fix(tools): make technical_indicator RSI use Wilder-EWM smoothing

### DIFF
--- a/agent/src/tools/technical_indicator_tool.py
+++ b/agent/src/tools/technical_indicator_tool.py
@@ -102,14 +102,21 @@ def _compute_ema(close: pd.Series, period: int) -> float | None:
 
 
 def _compute_rsi(close: pd.Series, period: int = _RSI_PERIOD) -> float | None:
-    """Relative Strength Index (Wilder smoothing) over *period* bars."""
+    """Relative Strength Index (Wilder smoothing) over *period* bars.
+
+    Matches the Wilder-EWM convention already used for RSI elsewhere in this
+    codebase (``shadow_account/extractor.py``, ``shadow_account/scanner.py``,
+    ``skills/technical-basic/example_signal_engine.py``): a plain rolling mean
+    of gains/losses is a materially different, non-Wilder technique and used
+    to diverge from those siblings by several RSI points on ordinary data.
+    """
     if len(close) < period + 1:
         return None
     delta = close.diff()
     gain = delta.clip(lower=0)
     loss = (-delta).clip(lower=0)
-    avg_gain = gain.rolling(window=period).mean().iloc[-1]
-    avg_loss = loss.rolling(window=period).mean().iloc[-1]
+    avg_gain = gain.ewm(alpha=1 / period, min_periods=period).mean().iloc[-1]
+    avg_loss = loss.ewm(alpha=1 / period, min_periods=period).mean().iloc[-1]
     if avg_loss == 0:
         return 100.0
     rs = avg_gain / avg_loss

--- a/agent/tests/test_technical_indicator_tool.py
+++ b/agent/tests/test_technical_indicator_tool.py
@@ -66,6 +66,89 @@ class TestRSI:
         close = pd.Series([100.0, 101.0], dtype=float)
         assert _compute_rsi(close, 14) is None
 
+    def test_rsi_uses_wilder_ewm_not_rolling_mean(self):
+        """Regression (sibling divergence): the docstring promises Wilder
+        smoothing, which is Wilder's exponential method, not a plain rolling
+        mean of gains/losses -- a materially different, well-known-distinct
+        technique. Classic 15-bar Wilder worked example: seeded avg_gain/
+        avg_loss over the first 14 deltas gives RSI approx 71.80. A rolling-mean
+        implementation gives approx 70.46 for the same input -- close enough to
+        look plausible, far enough to be wrong.
+        """
+        close = pd.Series(
+            [
+                44.34,
+                44.09,
+                44.15,
+                43.61,
+                44.33,
+                44.83,
+                45.10,
+                45.42,
+                45.84,
+                46.08,
+                45.89,
+                46.03,
+                45.61,
+                46.28,
+                46.28,
+            ]
+        )
+        rsi = _compute_rsi(close, period=14)
+        assert rsi == pytest.approx(71.8024, abs=0.01)
+        assert rsi != pytest.approx(70.4641, abs=0.01)
+
+    def test_rsi_matches_sibling_wilder_implementations(self):
+        """Regression: must agree with the Wilder-EWM RSI already used
+        elsewhere in this codebase (shadow_account/extractor.py,
+        shadow_account/scanner.py, skills/technical-basic/
+        example_signal_engine.py -- all three implement the identical
+        formula below), on a series that crosses both the 30 and 70
+        thresholds a rolling-mean implementation would place differently.
+        """
+        close = pd.Series(
+            [
+                float(x)
+                for x in [
+                    100,
+                    101,
+                    102.5,
+                    104,
+                    103.5,
+                    105,
+                    106.5,
+                    108,
+                    107.5,
+                    109,
+                    110.5,
+                    109.5,
+                    108,
+                    106,
+                    103.5,
+                    101,
+                    98,
+                    95.5,
+                    93,
+                    90.5,
+                    88,
+                ]
+            ]
+        )
+        period = 14
+
+        def sibling_rsi(close: pd.Series, period: int) -> float:
+            delta = close.diff()
+            gain = delta.clip(lower=0)
+            loss = (-delta).clip(lower=0)
+            avg_gain = gain.ewm(alpha=1 / period, min_periods=period).mean()
+            avg_loss = loss.ewm(alpha=1 / period, min_periods=period).mean()
+            rs = avg_gain / avg_loss
+            return float((100 - 100 / (1 + rs)).iloc[-1])
+
+        rsi = _compute_rsi(close, period=period)
+        assert rsi == pytest.approx(sibling_rsi(close, period), abs=1e-9)
+        assert rsi == pytest.approx(18.8237, abs=0.01)
+
 
 class TestMACD:
     def test_macd_normal(self):


### PR DESCRIPTION
## Summary

- `_compute_rsi()` in `technical_indicator_tool.py` claims Wilder smoothing but actually averages gains/losses with a plain rolling mean
- Swaps it for the same ewm(alpha=1/period, min_periods=period) formula already used by three other RSI implementations in this codebase

## Why

The tool's own docstring says "Relative Strength Index (Wilder smoothing)", but the code used a rolling mean instead, which is a materially different technique and not just a rounding difference. On ordinary price data the two methods can produce materially different RSI values, including differences large enough to change standard 30/70 overbought/oversold classifications. This is the technical_indicators tool, reachable from the CLI, Web UI, REST API, and MCP.

## Changes

- `agent/src/tools/technical_indicator_tool.py`: `_compute_rsi()` now uses `ewm(alpha=1/period, min_periods=period)` instead of `rolling(window=period).mean()`, matching the identical formula already used in `shadow_account/extractor.py`, `shadow_account/scanner.py`, and `skills/technical-basic/example_signal_engine.py`. The `avg_loss == 0` guard and all other behavior are unchanged.
- `agent/tests/test_technical_indicator_tool.py`: two new regression tests. One checks against a known Wilder RSI reference calculation, asserting the correct value and explicitly asserting it does not match the old rolling-mean value. The other cross-checks directly against the sibling implementations' formula on a threshold-crossing series.

## Test Plan

- [x] Confirmed the new regression tests fail on the pre-fix implementation with real numeric assertion failures, and pass with the fix
- [x] `pytest tests/test_technical_indicator_tool.py tests/test_shadow_account.py -v` (113 passed)
- [x] `black --check` on both changed files: 2 pre-existing, unrelated formatting issues found (confirmed via `--diff` to be two lines in `_extract_close_series`/`execute()` and two unrelated test methods, none touching `_compute_rsi` or the new tests); nothing new introduced by this change
- [x] `ruff check` on both changed files: all checks passed

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`): this only touches `agent/src/tools/` and `agent/tests/`
- [x] No hardcoded values
- [x] Code follows CONTRIBUTING.md guidelines
- [x] Documentation updated (n/a: internal implementation correction, the docstring already specified Wilder smoothing)
- [x] DCO signed-off