### PR TITLE
perf(swarm): order worker prompts for prompt-cache-friendly prefixes

### DIFF
--- a/agent/src/swarm/worker.py
+++ b/agent/src/swarm/worker.py
@@ -200,31 +200,20 @@ def build_worker_prompt(
     Returns:
         Complete system prompt string for the worker LLM.
     """
-    upstream_block = ""
-    if upstream_summaries:
-        sections = []
-        for key, summary in upstream_summaries.items():
-            sections.append(f"### {key}\n{summary}")
-        upstream_block = (
-            "## Upstream Context (from previous agents)\n\n"
-            + "\n\n".join(sections)
-        )
-
-    prompt_parts = [
-        f"## Role\n\n{agent_spec.role}",
-        agent_spec.system_prompt.replace("{upstream_context}", upstream_block),
-    ]
+    # Static, agent-invariant blocks first: for a given agent_spec these are
+    # byte-identical on every call (skill_descriptions/tools come from the
+    # agent's own YAML spec, not the current task), so they form one stable
+    # prompt-cache-eligible prefix across a swarm's repeated calls to the
+    # same agent. Anything that varies per call (upstream context, grounding
+    # data, the current date) is appended after, in the same relative order
+    # as before -- a cache hit only needs a stable *prefix*, so moving the
+    # variable tail doesn't need to preserve position, only what precedes it.
+    prompt_parts = [f"## Role\n\n{agent_spec.role}"]
 
     if skill_descriptions and skill_descriptions != "(no matching skills)":
         prompt_parts.append(
             f"## Available Skills (use load_skill to access full documentation)\n\n{skill_descriptions}"
         )
-
-    if grounding_block:
-        # Placed before Execution Rules so it's in scope when the worker
-        # plans its first tool call. The block already contains an explicit
-        # instruction to prefer these prices over training data.
-        prompt_parts.append(grounding_block)
 
     if "get_market_data" in (agent_spec.tools or []):
         prompt_parts.append(
@@ -266,6 +255,26 @@ def build_worker_prompt(
         "do NOT introduce one from training data — say the upstream omitted "
         "it and proceed without."
     )
+
+    # From here on, content varies per call (upstream context substitution,
+    # grounding data, the date), so none of it extends the cacheable prefix
+    # above -- relative order matches the original layout exactly.
+    upstream_block = ""
+    if upstream_summaries:
+        sections = []
+        for key, summary in upstream_summaries.items():
+            sections.append(f"### {key}\n{summary}")
+        upstream_block = (
+            "## Upstream Context (from previous agents)\n\n"
+            + "\n\n".join(sections)
+        )
+    prompt_parts.append(agent_spec.system_prompt.replace("{upstream_context}", upstream_block))
+
+    if grounding_block:
+        # Placed before Execution Rules so it's in scope when the worker
+        # plans its first tool call. The block already contains an explicit
+        # instruction to prefer these prices over training data.
+        prompt_parts.append(grounding_block)
 
     prompt_parts.append(
         "## Execution Rules\n\n"


### PR DESCRIPTION
## Goal

Reorder `build_worker_prompt()` (`agent/src/swarm/worker.py`) so the blocks
that are byte-identical across repeated calls to the same agent (Role,
Available Skills, Market Data Tool Policy, Data Citation Discipline —
`skill_descriptions`/`tools` come from the agent's own spec, not the current
task) form one stable prefix, instead of sitting downstream of the
per-call-variable `agent_spec.system_prompt` (which splices in
`{upstream_context}`, different on every call). Prefix-based provider caching
(e.g. DeepSeek's disk-based cache) can only discount a hit against a stable
prefix, and the previous ordering put variable content first, so the shared
static boilerplate never formed one.

## Affected areas

- `agent/src/swarm/worker.py`: `build_worker_prompt()` only.

## Out of scope

- No change to *what* content is included, any conditional, or the relative
  order of the variable-content blocks (upstream context, grounding data,
  current date) among themselves — only where the static/variable boundary
  sits.
- `Execution Rules` deliberately stays after `grounding_block` rather than
  joining the static prefix, preserving the existing "grounding must be in
  scope before the worker plans its first tool call" ordering constraint
  already documented on that block.
- No change to caching behavior itself (that's provider-side and
  best-effort) — this only makes the prompt shape eligible for it.

## Test plan

- `pytest agent/tests/test_swarm_grounding.py agent/tests/test_market_data_tool.py -q` — both exercise `build_worker_prompt()` directly (grounding-block-before-Execution-Rules ordering, Data Citation Discipline presence/ordering, Market Data Tool Policy rendering). 32 passed.
- `pytest agent/tests/ --ignore=agent/tests/e2e_backtest --ignore=agent/tests/test_e2e_harness_v2.py -k "worker or swarm" --tb=short -q` — 225 passed, 5 skipped (pre-existing, unrelated).

## Risk

None expected — pure reassembly order, no content/conditional changes, no
live/broker/MCP/network/secret/deployment surface touched.

## Rollback

`git revert` — single self-contained commit, no schema/state changes.