### PR TITLE
fix(backtest): keep excess_return consistent with corrected benchmark_return

### DIFF
--- a/agent/backtest/engines/base.py
+++ b/agent/backtest/engines/base.py
@@ -764,6 +764,17 @@ class BaseEngine(ABC):
             turnover_series=realized_turnover,
         )
         m.update(benchmark_metadata)
+        if "benchmark_return" in benchmark_metadata:
+            # calc_metrics()'s own excess_return is derived from bench_ret
+            # compounded as (1 + bench_ret).prod() - 1, the same pattern #872
+            # found unsafe once a benchmark price series contains a
+            # non-positive-prior-price bar. benchmark_return above is already
+            # corrected to the #872-safe price relative; excess_return has to
+            # be re-derived from that same corrected value or the two fields
+            # go inconsistent with each other in the same metrics dict.
+            m["excess_return"] = (
+                m["total_return"] - benchmark_metadata["benchmark_return"]
+            )
         m["by_symbol"] = by_symbol_stats(self.trades)
         m["by_exit_reason"] = by_exit_reason_stats(self.trades)
 

--- a/agent/tests/test_benchmark_excess_return_consistency.py
+++ b/agent/tests/test_benchmark_excess_return_consistency.py
@@ -1,0 +1,124 @@
+"""Regression: excess_return must stay consistent with the corrected
+benchmark_return once an external benchmark's price series crosses a
+non-positive-prior-price bar.
+
+BaseEngine.run_backtest() overwrites the internally-computed benchmark_return
+with the #872-safe price relative (BenchmarkResult.total_ret), but never
+re-derived excess_return from that same corrected value, so the two fields
+went inconsistent with each other in the same metrics dict.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from backtest.benchmark import BenchmarkResult
+from backtest.engines.china_a import ChinaAEngine
+from backtest.metrics import bar_returns, buy_and_hold_return
+
+
+class _FakeLoader:
+    def __init__(self, bars: pd.DataFrame) -> None:
+        self._bars = bars
+
+    def fetch(self, *args, **kwargs):
+        return {"000001.SZ": self._bars.copy()}
+
+
+class _FlatSignal:
+    """Zero position throughout: equity stays exactly at initial_cash, so
+    total_return is 0.0."""
+
+    def generate(self, data_map):
+        return {code: pd.Series(0.0, index=df.index) for code, df in data_map.items()}
+
+
+def _config(tmp_path, dates: pd.DatetimeIndex) -> dict:
+    return {
+        "codes": ["000001.SZ"],
+        "start_date": str(dates[0].date()),
+        "end_date": str(dates[-1].date()),
+        "source": "tushare",
+        "initial_cash": 1_000_000.0,
+        "benchmark": "BENCH",
+    }
+
+
+def test_excess_return_matches_corrected_benchmark_return(monkeypatch, tmp_path):
+    dates = pd.bdate_range("2026-01-05", periods=4)
+    bars = pd.DataFrame(
+        {
+            "open": [10.0, 10.0, 10.0, 10.0],
+            "high": [10.0, 10.0, 10.0, 10.0],
+            "low": [10.0, 10.0, 10.0, 10.0],
+            "close": [10.0, 10.0, 10.0, 10.0],
+            "volume": [1_000, 1_000, 1_000, 1_000],
+        },
+        index=dates,
+    )
+
+    # Benchmark price series with a non-positive-prior-price bar: a
+    # suspended/zero-printed bar mid-series, the exact hazard class #872
+    # already treats as real (China A-share suspended constituents, vendor
+    # glitches). True buy-and-hold return over this series is -50%.
+    bench_close = pd.Series([100.0, 100.0, 0.0, 50.0], index=dates)
+    fake_result = BenchmarkResult(
+        ticker="BENCH",
+        ret_series=bar_returns(bench_close, label="test-benchmark"),
+        total_ret=buy_and_hold_return(bench_close),
+    )
+    assert fake_result.total_ret == pytest.approx(-0.5)
+
+    monkeypatch.setattr(
+        "backtest.benchmark.resolve_benchmark", lambda **kwargs: fake_result
+    )
+
+    engine = ChinaAEngine({"initial_cash": 1_000_000.0})
+    metrics = engine.run_backtest(
+        _config(tmp_path, dates), _FakeLoader(bars), _FlatSignal(), tmp_path
+    )
+
+    # No trades executed, so the strategy's own total_return is exactly 0.0,
+    # independent of anything benchmark-related.
+    assert metrics["total_return"] == pytest.approx(0.0)
+
+    # benchmark_return is already corrected to the true price relative.
+    assert metrics["benchmark_return"] == pytest.approx(-0.5)
+
+    # excess_return must be derived from that same corrected value
+    # (0.0 - (-0.5) == 0.5), not from the stale (1 + bench_ret).prod() - 1
+    # compounded product, which would silently read 1.0 here instead.
+    assert metrics["excess_return"] == pytest.approx(0.5)
+    assert metrics["total_return"] - metrics["excess_return"] == pytest.approx(
+        metrics["benchmark_return"]
+    )
+
+
+def test_excess_return_unaffected_when_no_external_benchmark(tmp_path):
+    """No config["benchmark"] set: benchmark_metadata stays empty, so the fix
+    must not touch excess_return at all on the ordinary, unconfigured path."""
+    dates = pd.bdate_range("2026-01-05", periods=3)
+    bars = pd.DataFrame(
+        {
+            "open": [10.0, 10.0, 10.0],
+            "high": [10.0, 10.0, 10.0],
+            "low": [10.0, 10.0, 10.0],
+            "close": [10.0, 10.0, 10.0],
+            "volume": [1_000, 1_000, 1_000],
+        },
+        index=dates,
+    )
+    config = {
+        "codes": ["000001.SZ"],
+        "start_date": str(dates[0].date()),
+        "end_date": str(dates[-1].date()),
+        "source": "tushare",
+        "initial_cash": 1_000_000.0,
+    }
+
+    engine = ChinaAEngine({"initial_cash": 1_000_000.0})
+    metrics = engine.run_backtest(config, _FakeLoader(bars), _FlatSignal(), tmp_path)
+
+    assert "benchmark_return" not in metrics or metrics.get("benchmark_ticker") is None
+    assert metrics["excess_return"] == pytest.approx(0.0)


### PR DESCRIPTION
## Summary

- BaseEngine.run_backtest() corrects the displayed benchmark_return once an external benchmark's price series contains a non-positive-prior-price bar, but never recomputes excess_return from that same corrected value
- Recomputes excess_return right where benchmark_return is already corrected, so the two fields remain consistent for this corrected benchmark path

## Why

Issue #872 replaced the fragile pct_change-based return calculation with a safe price relative (buy_and_hold_return) for the displayed benchmark_return, after finding it could report numbers like +39,560% where the true return was -42.7%. calc_metrics() has its own internal re-derivation of the same total, still using the exact (1 + bench_ret).prod() - 1 pattern #872 found unsafe. base.py corrects the displayed field but never re-derives excess_return from the corrected value, so the metrics dict can become self-contradictory: benchmark_return reads correctly while excess_return implies a different number, both in the same JSON output the backtest tool returns to the LLM.

I audited every benchmark-derived metric in calc_metrics() (benchmark_return, excess_return, information_ratio, tracking_error, benchmark_beta). Only excess_return is affected. The other three are computed from the per-bar bench_ret series directly, which is already the corrected, #872-safe series by the time it reaches calc_metrics().

## Changes

- agent/backtest/engines/base.py: after the existing benchmark_metadata override, excess_return is recomputed as total_return minus the corrected benchmark_return, but only when an external benchmark was actually resolved. The internal-basket-benchmark path (no config["benchmark"]) is untouched.
- agent/tests/test_benchmark_excess_return_consistency.py: two new regression tests. One runs the real production path (ChinaAEngine.run_backtest, real calc_metrics(), only the network-dependent resolve_benchmark() fetch is stubbed) with a benchmark price series crossing a non-positive-prior-price bar, and asserts total_return minus excess_return equals benchmark_return. The other is a control confirming the fix does not touch excess_return when no external benchmark is configured.

## Test Plan

- [x] Confirmed the load-bearing regression test fails on the pre-fix implementation with a real numeric assertion failure (excess_return read 1.0 instead of 0.5), and passes with the fix
- [x] pytest tests/ -k "engine or backtest or benchmark or metrics" -q --ignore=tests/e2e_backtest (813 passed, 6 skipped, pre-existing)
- [x] black --check on both changed files: pre-existing, unrelated formatting issues in base.py confirmed via diff-isolation against the unpatched file (identical content at shifted line numbers); the new test file is clean
- [x] ruff check on both changed files: all checks passed

## Checklist

- [x] No changes to protected areas (src/agent/, src/session/, src/providers/): this only touches agent/backtest/
- [x] No hardcoded values
- [x] Code follows CONTRIBUTING.md guidelines
- [x] Documentation updated (n/a: internal correctness fix, no public interface change)
- [x] DCO signed-off