### PR TITLE
fix(agent): auto-compact no longer silently drops head content past the 80K slice

### DIFF
--- a/agent/src/agent/loop.py
+++ b/agent/src/agent/loop.py
@@ -62,6 +62,11 @@ COLLAPSE_TAIL = 500
 
 TAIL_TOKEN_BUDGET = 20_000
 
+# Per-pass serialization budget for auto-compact summarization. The head is
+# folded through the summarization LLM in chunks whose serialized JSON stays
+# under this limit, so no message is ever silently dropped by a hard slice.
+COMPACT_HEAD_CHAR_BUDGET = 80_000
+
 
 def _override(name: str):
     """Return a monkeypatched module-level override if present."""
@@ -457,6 +462,31 @@ Rules:
 - Keep the same section structure.
 - Do NOT drop any critical context from the previous summary.
 {focus_section}"""
+
+
+def _chunk_messages_for_summary(messages: list, char_budget: int) -> list[list]:
+    """Split messages into chunks whose serialized JSON stays under ``char_budget``.
+
+    Message boundaries are never broken: each message lands in exactly one
+    chunk. A single message larger than the budget forms its own oversized
+    chunk rather than being dropped, so no content is silently lost.
+    """
+    chunks: list[list] = []
+    current: list = []
+    current_len = 2  # "[]"
+    for msg in messages:
+        msg_text = json.dumps(msg, default=str, ensure_ascii=False)
+        added = len(msg_text) + (2 if current else 0)  # ", " separator
+        if current and current_len + added > char_budget:
+            chunks.append(current)
+            current = [msg]
+            current_len = 2 + len(msg_text)
+        else:
+            current.append(msg)
+            current_len += added
+    if current:
+        chunks.append(current)
+    return chunks
 
 
 def _is_tool_success(result: str) -> bool:
@@ -1807,6 +1837,8 @@ class AgentLoop:
           - Token-budget tail: keeps ~20K tokens of recent messages (not a fixed count).
           - Structured summary template: preserves goal, progress, decisions, files, etc.
           - Iterative update: Nth compression updates previous summary, zero info decay.
+          - Chunked head fold: an oversized head is summarized in budget-sized
+            passes, so no message is silently dropped by a serialization slice.
           - Tool pair fix: repairs orphaned tool_call/tool_result after compression.
           - Focus-topic: optionally prioritize specific topic in summary.
 
@@ -1859,20 +1891,25 @@ class AgentLoop:
         # Build focus section
         focus_section = _FOCUS_SECTION.format(topic=focus_topic) if focus_topic else ""
 
-        # Build summary prompt (structured template or iterative update)
-        conv_text = json.dumps(head, default=str, ensure_ascii=False)[:80000]
-
-        if self._previous_summary:
-            prompt = _ITERATIVE_UPDATE_PROMPT.format(
-                previous_summary=self._previous_summary,
-                new_turns=conv_text,
-                focus_section=focus_section,
-            )
-        else:
-            prompt = _STRUCTURED_SUMMARY_PROMPT.format(focus_section=focus_section) + conv_text
-
-        summary_resp = self.llm.chat([{"role": "user", "content": prompt}])
-        summary = summary_resp.content or ""
+        # Fold the head through the summarization LLM in budget-sized chunks.
+        # A single hard slice (the old ``[:80000]``) silently discarded
+        # everything past the cut — neither summarized nor preserved. Here
+        # every message reaches the summarization LLM exactly once: the first
+        # pass starts from the previous summary (or the structured template),
+        # and each later pass folds the next chunk into the running summary.
+        summary = self._previous_summary or ""
+        for chunk in _chunk_messages_for_summary(head, COMPACT_HEAD_CHAR_BUDGET):
+            conv_text = json.dumps(chunk, default=str, ensure_ascii=False)
+            if summary:
+                prompt = _ITERATIVE_UPDATE_PROMPT.format(
+                    previous_summary=summary,
+                    new_turns=conv_text,
+                    focus_section=focus_section,
+                )
+            else:
+                prompt = _STRUCTURED_SUMMARY_PROMPT.format(focus_section=focus_section) + conv_text
+            summary_resp = self.llm.chat([{"role": "user", "content": prompt}])
+            summary = summary_resp.content or ""
         self._previous_summary = summary
 
         tokens_before = estimate_tokens(messages)

--- a/agent/tests/test_auto_compact_no_silent_loss.py
+++ b/agent/tests/test_auto_compact_no_silent_loss.py
@@ -1,0 +1,115 @@
+"""Regression test: auto-compaction must not silently drop head content.
+
+Issue #1055. ``AgentLoop._auto_compact`` used to serialize the head with a
+hard ``json.dumps(head)[:80000]`` slice. Once the head exceeded the slice,
+everything past the cut was neither fed to the summarization LLM nor kept in
+the preserved tail — silent information loss, contradicting the method's own
+"zero info decay" contract.
+
+The fix folds the head through the summarization LLM in budget-sized,
+message-boundary chunks. Every head message must reach the summarization
+prompt exactly once, so no marker may end up in neither the summarization
+prompts nor the reconstructed conversation.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from src.agent.loop import (
+    COMPACT_HEAD_CHAR_BUDGET,
+    AgentLoop,
+    _chunk_messages_for_summary,
+)
+from src.agent.trace import TraceWriter
+
+
+class _RecordingLLM:
+    """Records every summarization prompt _auto_compact sends."""
+
+    model_name = "stub"
+
+    def __init__(self) -> None:
+        self.prompts: list[str] = []
+
+    class _Resp:
+        content = "STUB_SUMMARY"
+        tool_calls: list[Any] = []
+        reasoning_content = None
+        has_tool_calls = False
+
+    def chat(self, messages: list[dict[str, Any]], **_: Any) -> Any:
+        self.prompts.append(messages[0]["content"])
+        return self._Resp()
+
+
+def _build_agent(llm: Any, tmp_run_dir: Path) -> AgentLoop:
+    from src.memory.persistent import PersistentMemory
+    from src.tools import build_registry
+
+    pm = PersistentMemory()
+    agent = AgentLoop(
+        registry=build_registry(persistent_memory=pm, include_shell_tools=False),
+        llm=llm,
+        event_callback=None,
+        max_iterations=1,
+        persistent_memory=pm,
+    )
+    tmp_run_dir.mkdir(parents=True, exist_ok=True)
+    agent.memory.run_dir = str(tmp_run_dir)
+    return agent
+
+
+def test_auto_compact_does_not_drop_head_content_beyond_slice(tmp_path: Path) -> None:
+    """Reproduces issue #1055: an oversized head must not lose any message."""
+    llm = _RecordingLLM()
+    agent = _build_agent(llm, tmp_path / "run")
+    trace = TraceWriter(tmp_path / "trace")
+
+    # 20 tagged messages sized so the head (everything outside the ~20K-token
+    # tail) serializes past the old 80,000-character slice.
+    messages: list[dict[str, str]] = [{"role": "system", "content": "system prompt"}]
+    messages += [
+        {"role": "user", "content": f"MARKER_{i} " + ("alpha " * 2000)}
+        for i in range(20)
+    ]
+
+    try:
+        agent._auto_compact(messages, tmp_path / "run", trace, iteration=1)
+    finally:
+        trace.close()
+
+    all_prompts = "\n".join(llm.prompts)
+    final_transcript = json.dumps(messages, default=str)
+
+    lost = [
+        i
+        for i in range(20)
+        if f"MARKER_{i} " not in all_prompts and f"MARKER_{i} " not in final_transcript
+    ]
+    assert lost == [], f"messages dropped by auto-compaction: {lost}"
+    # The oversized head must have been folded through more than one pass.
+    assert len(llm.prompts) >= 2
+
+
+def test_chunk_messages_for_summary_covers_every_message_exactly_once() -> None:
+    messages = [{"role": "user", "content": f"msg-{i} " + ("x" * 500)} for i in range(30)]
+    chunks = _chunk_messages_for_summary(messages, 8000)
+
+    flattened = [msg for chunk in chunks for msg in chunk]
+    assert flattened == messages
+    for chunk in chunks:
+        assert len(json.dumps(chunk, default=str, ensure_ascii=False)) <= 8000
+
+
+def test_chunk_messages_for_summary_keeps_oversized_single_message() -> None:
+    big = {"role": "user", "content": "y" * (COMPACT_HEAD_CHAR_BUDGET + 1000)}
+    chunks = _chunk_messages_for_summary([big], COMPACT_HEAD_CHAR_BUDGET)
+
+    assert chunks == [[big]]
+
+
+def test_chunk_messages_for_summary_empty_input() -> None:
+    assert _chunk_messages_for_summary([], COMPACT_HEAD_CHAR_BUDGET) == []


### PR DESCRIPTION
## Summary

- Fixes the silent information loss in `AgentLoop._auto_compact()` reported in #1055: the head is now folded through the summarization LLM in budget-sized, message-boundary chunks instead of being hard-sliced at 80,000 serialized characters.
- Every head message now reaches the summarization LLM exactly once, upholding the method's documented "zero info decay" contract.

## Why

`_auto_compact()` built its summarization prompt with:

```python
conv_text = json.dumps(head, default=str, ensure_ascii=False)[:80000]
```

`head` is everything not kept in the ~20K-token tail (`TAIL_TOKEN_BUDGET`). Once `json.dumps(head)` exceeded 80,000 characters, everything past the cut was **neither** seen by the summarization LLM **nor** preserved in the tail — silent information loss with no exception, contradicting the docstring's "zero info decay" guarantee.

Verified against `main` @ c33133f4 with the issue's reproduction script: messages `[7..13]` were present in neither the summarization prompt nor the reconstructed conversation.

Closes #1055

## Changes

- `agent/src/agent/loop.py`
  - New module helper `_chunk_messages_for_summary()`: splits messages into chunks whose serialized JSON stays under the budget; message boundaries are never broken; a single oversized message forms its own chunk rather than being dropped.
  - New constant `COMPACT_HEAD_CHAR_BUDGET = 80_000` (same per-pass budget as the old slice).
  - `_auto_compact()` replaces the single truncated pass with a fold: the first pass starts from the previous summary (or the structured template, keeping prior behavior), and each subsequent pass folds the next chunk into the running summary via the existing `_ITERATIVE_UPDATE_PROMPT`. Single-chunk heads behave exactly as before.
  - Docstring updated to state the chunked no-drop guarantee.
- `agent/tests/test_auto_compact_no_silent_loss.py` — regression tests:
  - the issue's exact scenario (20 tagged messages, oversized head): zero lost markers, multiple summarization passes;
  - chunk helper: exact-once coverage, per-chunk budget invariant, oversized-single-message preservation, empty input.

Note for maintainers: this touches the protected `src/agent/` path. The issue author asked which remediation direction was intended (overflow preservation vs. chunked summarization). This PR implements **chunked summarization**, since it is the only option that keeps the "every message is either summarized or preserved verbatim" contract without growing the retained tail unboundedly; happy to reshape if a different direction is preferred.

## Test Plan

- [x] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`) — **10079 passed, 76 skipped**
- [x] New tests added — 4 regression tests in `agent/tests/test_auto_compact_no_silent_loss.py`
- [x] Tested manually — issue #1055's reproduction script: before the fix, 7-8 markers lost; after the fix, 3 summarization passes and **zero** lost markers

## Checklist

- [ ] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion — *touches `src/agent/loop.py`; flagged above for maintainer direction, per the question raised in #1055*
- [x] No hardcoded values (API keys, file paths, magic numbers) — the 80K budget is a named constant
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines — DCO sign-off on the commit
- [x] Documentation updated (if user-facing change) — `_auto_compact` docstring updated
