### PR TITLE
fix(grounding): mask line-leading ordered-list markers from number ex…

### DIFF
--- a/agent/src/agent/grounding.py
+++ b/agent/src/agent/grounding.py
@@ -176,6 +176,13 @@ _NUMBER_RE = re.compile(
     r"(?<![A-Za-z0-9_])[-+]?(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?"
     r"(?![A-Za-z0-9_])"
 )
+# A line-leading ordered-list marker ("1. **标题**") is prose structure, not a
+# number. Without masking it, "1." is parsed as a float and rejected downstream
+# as a numeric_claim_conflict against an observed OHLC range (#BUGS-1). The
+# pattern only matches a digit run at the start of a line followed by "." or ")"
+# and whitespace, so an in-text decimal like "1.5" (digit after the dot) is
+# never affected.
+_MD_LIST_ITEM_RE = re.compile(r"^\s*\d+[.)]\s+", re.MULTILINE)
 _DATE_RE = re.compile(r"\b(?:19|20)\d{2}[-/]\d{1,2}[-/]\d{1,2}\b")
 # A year-less "8/5" is how a trading day is written in running prose, and it
 # contributed 8 and 5 as candidate prices (#983). The month and day ranges are
@@ -2089,7 +2096,8 @@ class GroundingLedger:
         Returns:
             Candidate price values, in order of appearance.
         """
-        masked = _CANONICAL_SYMBOL_RE.sub(" ", text)
+        masked = _MD_LIST_ITEM_RE.sub(" ", text)
+        masked = _CANONICAL_SYMBOL_RE.sub(" ", masked)
         masked = _LOCALIZED_DATE_RE.sub(" ", masked)
         masked = _DATE_RE.sub(" ", masked)
         masked = _SHORT_DATE_RE.sub(" ", masked)

--- a/agent/tests/test_agent_grounding.py
+++ b/agent/tests/test_agent_grounding.py
@@ -1769,3 +1769,64 @@ def test_a_currency_symbol_counts_as_naming_the_currency(
     )
 
     assert result.valid is True, result.issues
+
+
+def test_price_validation_ignores_markdown_ordered_list_markers(
+    tmp_path: Path,
+) -> None:
+    """Line-leading ordered-list numbers are prose, not prices (#BUGS-1).
+
+    A verdict written as a numbered Markdown list ("1. **原料药价格持续低迷**")
+    must not let the marker "1." be parsed as a float and rejected against the
+    observed OHLC range as a numeric_claim_conflict.
+    """
+    ledger = _screened_ledger(tmp_path)
+    symbol = "000543.SZ"  # populated by _screened_ledger
+
+    for draft in (
+        f"1. **原料药价格持续低迷**，{symbol} 现价 8.20 CNY（source: tencent）",
+        f"1. 原料药价格持续低迷\n2. 板块持续走强\n3. 建议关注 {symbol} 收盘价 8.20 CNY（source: tencent）",
+        f"  1. 第一项描述\n  2. 第二项描述，{symbol} 收盘价 8.20 CNY（source: tencent）",
+        f"结论如下：\n1) 原料药承压，{symbol} 8.20 CNY 可建仓（source: tencent）",
+    ):
+        result = ledger.validate_final_answer(draft)
+        assert result.valid is True, (draft, result.issues)
+
+
+def test_markdown_list_marker_mask_does_not_weaken_contradiction_check(
+    tmp_path: Path,
+) -> None:
+    """Masking list markers must not shield a genuinely out-of-range quote (#BUGS-1).
+
+    A wrong quote sitting in a numbered list item is still caught, so the mask is
+    span-local: it removes only the marker, not a contradicted price that follows.
+    """
+    ledger = _screened_ledger(tmp_path)
+    symbol = "000543.SZ"
+
+    result = ledger.validate_final_answer(
+        f"1. 原料药价格持续低迷，{symbol} 收盘价 42.00 CNY（source: tencent）"
+    )
+
+    codes = [issue["code"] for issue in result.issues]
+    assert "numeric_claim_conflict" in codes
+    assert [issue["value"] for issue in result.issues if issue["code"] == "numeric_claim_conflict"] == [42.0]
+
+
+def test_in_text_decimal_survives_list_marker_mask(
+    tmp_path: Path,
+) -> None:
+    """An ordinary decimal like 1.5 (digit after the dot) is never a list marker (#BUGS-1).
+
+    The mask only matches a digit run at line start followed by "." or ")" and
+    whitespace, so a genuine in-text decimal must remain a candidate price.
+    """
+    ledger = _screened_ledger(tmp_path)
+    symbol = "000543.SZ"
+
+    for draft in (
+        f"{symbol} 目标价 1.5 CNY，收盘价 8.20 CNY（source: tencent）",
+        f"{symbol} 变动 0.03 CNY，收盘价 8.20 CNY（source: tencent）",
+    ):
+        result = ledger.validate_final_answer(draft)
+        assert result.valid is True, (draft, result.issues)


### PR DESCRIPTION
…traction

Markdown ordered-list markers (e.g. "1. **标题**") were parsed as floats by _NUMBER_RE and rejected downstream as numeric_claim_conflict against the observed OHLC range.

Add _MD_LIST_ITEM_RE and strip "^\s*\d+[.)]\s+" at the head of _numbers_without_dates_or_percent's mask chain, so list markers are removed at the number-extraction entry point across all numeric paths, not just price comparison. In-text decimals like 1.5 are unaffected (digit after the dot).

Add tests in test_agent_grounding.py covering marker masking, conflict check not weakened, and in-text decimal survival.

## Summary

<!-- What does this PR do? 1-3 bullet points. -->

-

## Why

<!-- What problem does it solve? Link related issues with "Closes #123". -->

## Changes

<!-- List key changes. For new skills/presets, describe what they cover. -->

-

## Test Plan

- [ ] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [ ] New tests added (if applicable)
- [ ] Tested manually (describe below)

## Checklist

- [ ] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [ ] No hardcoded values (API keys, file paths, magic numbers)
- [ ] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] Documentation updated (if user-facing change)
