### PR TITLE
fix(data): normalize baostock volume to board lots + cross-source consistency guard

### DIFF
--- a/agent/backtest/loaders/akshare_loader.py
+++ b/agent/backtest/loaders/akshare_loader.py
@@ -77,6 +77,11 @@ class DataLoader:
 
     name = "akshare"
     markets = {"a_share", "us_equity", "hk_equity", "futures", "fund", "macro", "forex"}
+    # stock_zh_a_hist empirically returns board lots (HKUDS/Vibe-Trading#1062;
+    # 600519.SH 2026-07-31 ratio 1.00 vs tencent/eastmoney). Note: akshare's
+    # own documentation states shares for this interface — the docs disagree
+    # with the actual behavior. Other markets stay undeclared.
+    volume_units = {"a_share": "lots"}
     requires_auth = False
 
     def is_available(self) -> bool:

--- a/agent/backtest/loaders/baostock_loader.py
+++ b/agent/backtest/loaders/baostock_loader.py
@@ -35,11 +35,10 @@ class DataLoader:
 
     name = "baostock"
     markets = {"a_share"}
-    # BaoStock natively reports volume in single shares, unlike the other
-    # A-share sources which report board lots (HKUDS/Vibe-Trading#1062).
-    # Empirically verified 2026-08-11: 600519.SH 2026-07-31 = 5,512,752
-    # shares vs tencent/eastmoney 55,128 lots (ratio exactly 100.0).
-    volume_units = {"a_share": "shares"}
+    # BaoStock natively reports volume in single shares; fetch() normalizes
+    # to board lots — the A-share canonical unit shared by tencent/eastmoney/
+    # akshare/mootdx/tushare (HKUDS/Vibe-Trading#1062).
+    volume_units = {"a_share": "lots"}
     requires_auth = False
 
     def is_available(self) -> bool:
@@ -159,6 +158,12 @@ class DataLoader:
         df["date"] = pd.to_datetime(df["date"])
         for col in ["open", "high", "low", "close", "volume", "amount"]:
             df[col] = pd.to_numeric(df[col], errors="coerce")
+
+        # BaoStock reports volume in single shares; normalize to board lots
+        # (1 lot = 100 shares) to match every other A-share source
+        # (HKUDS/Vibe-Trading#1062). Fractional lots are valid — odd-lot
+        # trades exist — so no rounding is applied.
+        df["volume"] = df["volume"] / 100.0
 
         df = df.rename(columns={"date": "trade_date"})
         df = df.set_index("trade_date").sort_index()

--- a/agent/backtest/loaders/baostock_loader.py
+++ b/agent/backtest/loaders/baostock_loader.py
@@ -35,6 +35,11 @@ class DataLoader:
 
     name = "baostock"
     markets = {"a_share"}
+    # BaoStock natively reports volume in single shares, unlike the other
+    # A-share sources which report board lots (HKUDS/Vibe-Trading#1062).
+    # Empirically verified 2026-08-11: 600519.SH 2026-07-31 = 5,512,752
+    # shares vs tencent/eastmoney 55,128 lots (ratio exactly 100.0).
+    volume_units = {"a_share": "shares"}
     requires_auth = False
 
     def is_available(self) -> bool:

--- a/agent/backtest/loaders/base.py
+++ b/agent/backtest/loaders/base.py
@@ -245,7 +245,9 @@ LOADER_CACHE_ROOT_ENV = "VIBE_TRADING_DATA_CACHE_ROOT"
 _LOADER_CACHE_TRUE_VALUES = {"1", "true", "yes", "on"}
 # Bump when the key payload or on-disk layout changes so stale entries are
 # simply never matched (old files become unreachable garbage, safe to delete).
-_LOADER_CACHE_VERSION = 3
+# v4: baostock volume normalized from shares to lots (#1062) — entries cached
+# under the pre-normalization unit must never be served again.
+_LOADER_CACHE_VERSION = 4
 
 
 def loader_cache_enabled() -> bool:

--- a/agent/backtest/loaders/base.py
+++ b/agent/backtest/loaders/base.py
@@ -617,7 +617,17 @@ def _duckdb_sql_string(path: Path) -> str:
 
 @runtime_checkable
 class DataLoaderProtocol(Protocol):
-    """Interface that every data source loader must satisfy."""
+    """Interface that every data source loader must satisfy.
+
+    Optional class attribute ``volume_units: dict[str, str]`` (not part of the
+    structural check so existing loaders keep working): declares the unit of
+    the ``volume`` column per market, keyed by market name — e.g.
+    ``{"a_share": "lots", "hk_equity": "shares"}``. ``"lots"`` means board
+    lots (1 A-share lot = 100 shares); ``"shares"`` means single shares.
+    Sources differ natively (see HKUDS/Vibe-Trading#1062), so consumers must
+    read the per-symbol ``volume_unit`` from ``_provenance`` instead of
+    assuming a unit; a missing market entry surfaces as ``null`` (undeclared).
+    """
 
     name: str
     markets: set[str]

--- a/agent/backtest/loaders/eastmoney_loader.py
+++ b/agent/backtest/loaders/eastmoney_loader.py
@@ -54,6 +54,12 @@ class DataLoader:
 
     name = "eastmoney"
     markets = {"a_share", "hk_equity", "us_equity"}
+    # Volume unit is market-dependent (HKUDS/Vibe-Trading#1062): the A-share
+    # push2 endpoint reports board lots, the HK endpoint single shares —
+    # empirically verified 2026-08-11 (600519.SH ratio 1.00 vs tencent;
+    # 00700.HK ratio 1.00 vs tencent/yfinance). us_equity stays undeclared
+    # until empirically verified.
+    volume_units = {"a_share": "lots", "hk_equity": "shares"}
     requires_auth = False
 
     def is_available(self) -> bool:

--- a/agent/backtest/loaders/mootdx_loader.py
+++ b/agent/backtest/loaders/mootdx_loader.py
@@ -69,6 +69,11 @@ class DataLoader:
 
     name = "mootdx"
     markets = {"a_share"}
+    # Tongdaxin K-line convention is board lots (HKUDS/Vibe-Trading#1062).
+    # Tentative declaration: TDX quote servers were unreachable from the
+    # audit environment; the cross-source consistency test pins this at
+    # runtime where TDX access exists.
+    volume_units = {"a_share": "lots"}
     requires_auth = False
 
     def __init__(self) -> None:

--- a/agent/backtest/loaders/stooq_loader.py
+++ b/agent/backtest/loaders/stooq_loader.py
@@ -77,6 +77,9 @@ class DataLoader:
 
     name = "stooq"
     markets = {"us_equity"}
+    # Stooq US EOD volume is single shares (universal US convention,
+    # HKUDS/Vibe-Trading#1062).
+    volume_units = {"us_equity": "shares"}
     requires_auth = False
 
     def __init__(self) -> None:

--- a/agent/backtest/loaders/tencent_loader.py
+++ b/agent/backtest/loaders/tencent_loader.py
@@ -38,6 +38,11 @@ class DataLoader:
 
     name = "tencent"
     markets = {"a_share", "hk_equity"}
+    # Volume unit is market-dependent (HKUDS/Vibe-Trading#1062): the A-share
+    # endpoint reports board lots (1 lot = 100 shares) while the HK endpoint
+    # reports single shares. Empirically verified 2026-08-11 against
+    # 600519.SH (55,128 lots) and 00700.HK (31,100,240 shares).
+    volume_units = {"a_share": "lots", "hk_equity": "shares"}
     requires_auth = False
 
     def is_available(self) -> bool:

--- a/agent/backtest/loaders/tushare.py
+++ b/agent/backtest/loaders/tushare.py
@@ -119,6 +119,9 @@ class DataLoader:
 
     name = "tushare"
     markets = {"a_share", "hk_equity", "futures", "fund"}
+    # Tushare daily() documents vol in board lots (HKUDS/Vibe-Trading#1062).
+    # hk_equity (hk_daily) stays undeclared until empirically verified.
+    volume_units = {"a_share": "lots"}
     requires_auth = True
 
     def is_available(self) -> bool:

--- a/agent/backtest/loaders/yahoo_loader.py
+++ b/agent/backtest/loaders/yahoo_loader.py
@@ -178,6 +178,10 @@ class DataLoader:
     markets = {
         "us_equity", "hk_equity", "india_equity", "kr_equity", "ca_equity",
     }
+    # Yahoo chart volume is single shares for US/HK equities
+    # (HKUDS/Vibe-Trading#1062; HK verified 2026-08-11, 00700.HK ratio 1.00
+    # vs tencent/eastmoney). Other equity markets stay undeclared.
+    volume_units = {"us_equity": "shares", "hk_equity": "shares"}
     requires_auth = False
 
     def is_available(self) -> bool:

--- a/agent/backtest/loaders/yfinance_loader.py
+++ b/agent/backtest/loaders/yfinance_loader.py
@@ -234,6 +234,10 @@ class DataLoader:
     markets = {
         "us_equity", "hk_equity", "india_equity", "kr_equity", "ca_equity", "crypto",
     }
+    # yfinance volume is single shares for US/HK equities
+    # (HKUDS/Vibe-Trading#1062; HK verified 2026-08-11, 00700.HK ratio 1.00
+    # vs tencent/eastmoney). Crypto base-asset units stay undeclared.
+    volume_units = {"us_equity": "shares", "hk_equity": "shares"}
     requires_auth = False
 
     def is_available(self) -> bool:

--- a/agent/mcp_server.py
+++ b/agent/mcp_server.py
@@ -1576,6 +1576,12 @@ def get_market_data(
             even-stride downsample (every step-th bar, last bar pinned)
             plus truncation metadata. Set max_rows=0 for all rows
             (unbounded, legacy behavior).
+
+    Volume units: the ``volume`` column unit is source- and market-dependent
+    (A-share sources report board lots of 100 shares; HK/US sources report
+    single shares). Each symbol's ``_provenance.volume_unit`` states the unit
+    of the returned rows ("lots" / "shares"; null = source undeclared) — read
+    it before interpreting or comparing volume values across symbols/sources.
     """
     return fetch_market_data_json(
         codes=codes,

--- a/agent/src/market_data.py
+++ b/agent/src/market_data.py
@@ -114,6 +114,13 @@ def fetch_market_data(
     the market's :data:`backtest.loaders.registry.FALLBACK_CHAINS` (e.g. crypto
     OKX → Binance → CCXT → Yahoo). At most ``max_fallback_attempts`` retries
     are attempted before the symbol is recorded as ``_unresolved``.
+
+    With ``include_provenance=True`` each symbol carries ``_provenance``
+    metadata including ``volume_unit`` — the unit of the ``volume`` column as
+    declared by the serving loader for that market (``"lots"`` = board lots of
+    100 shares, ``"shares"`` = single shares, ``None`` = undeclared). Volume
+    units are source- and market-dependent (HKUDS/Vibe-Trading#1062), so
+    consumers must read this field instead of assuming a unit.
     """
     from backtest.engines._market_hooks import _detect_market
     from backtest.loaders.base import NoAvailableSourceError
@@ -167,6 +174,7 @@ def fetch_market_data(
 
         data_map: dict[str, Any] = {}
         used_source: str | None = None
+        provider_cls: type | None = None
         for attempt_src in attempts:
             try:
                 loader_cls = loader_resolver(attempt_src)
@@ -180,6 +188,7 @@ def fetch_market_data(
                 loader = loader_cls()
                 data_map = loader.fetch(src_codes, start_date, end_date, interval=interval)
                 used_source = attempt_src
+                provider_cls = loader_cls
                 if data_map:
                     break
             except Exception as exc:  # noqa: BLE001 — contained per-symbol fallback
@@ -202,12 +211,14 @@ def fetch_market_data(
                     row[key] = _json_safe(value)
             results[symbol] = cap_rows(records, max_rows)
             if include_provenance:
+                volume_units = getattr(provider_cls, "volume_units", None) or {}
                 provenance[symbol] = {
                     "source": used_source or src,
                     "requested_source": source,
                     "detected_source": src,
                     "fallback_used": bool(used_source and used_source != src),
                     "currency_conversion": "none",
+                    "volume_unit": volume_units.get(market),
                 }
 
     unresolved = [

--- a/agent/src/tools/market_data_tool.py
+++ b/agent/src/tools/market_data_tool.py
@@ -15,7 +15,10 @@ class MarketDataTool(BaseTool):
     description = (
         "Fetch normalized OHLCV market data through the repository loader layer. "
         "Use this for stock, ETF, index, or crypto price bars before writing raw "
-        "yfinance/OKX/Tushare scripts."
+        "yfinance/OKX/Tushare scripts. Volume units are source- and market-dependent "
+        "(A-share sources report board lots of 100 shares, HK/US sources report single "
+        "shares); read the per-symbol _provenance.volume_unit field ('lots' / 'shares' / "
+        "null=undeclared) before interpreting or comparing volume values."
     )
     parameters = {
         "type": "object",

--- a/agent/tests/test_baostock_loader.py
+++ b/agent/tests/test_baostock_loader.py
@@ -106,3 +106,45 @@ class TestFetchOneCodeHandling:
         loader._fetch_one(bs_mock, "000001.SZ", "2024-01-01", "2024-01-31")
         call_args = bs_mock.query_history_k_data_plus.call_args
         assert call_args[0][0] == "sz.000001"
+
+
+class TestVolumeUnitNormalization:
+    """BaoStock native shares are normalized to board lots (#1062)."""
+
+    def test_volume_shares_normalized_to_lots(self):
+        from unittest.mock import MagicMock
+        from backtest.loaders.baostock_loader import DataLoader
+
+        loader = DataLoader()
+        bs_mock = MagicMock()
+        mock_rs = MagicMock()
+        mock_rs.error_code = "0"
+        mock_rs.error_msg = "success"
+        mock_rs.next.side_effect = [True, False]
+        mock_rs.get_row_data.return_value = [
+            "2024-01-02", "10.0", "10.5", "9.8", "10.2", "5512800", "7400000000",
+        ]
+        bs_mock.query_history_k_data_plus.return_value = mock_rs
+
+        df = loader._fetch_one(bs_mock, "601398.SH", "2024-01-01", "2024-01-31")
+
+        assert df["volume"].iloc[-1] == 55128.0
+
+    def test_odd_lot_volume_keeps_fractional_lots(self):
+        from unittest.mock import MagicMock
+        from backtest.loaders.baostock_loader import DataLoader
+
+        loader = DataLoader()
+        bs_mock = MagicMock()
+        mock_rs = MagicMock()
+        mock_rs.error_code = "0"
+        mock_rs.error_msg = "success"
+        mock_rs.next.side_effect = [True, False]
+        mock_rs.get_row_data.return_value = [
+            "2024-01-02", "10.0", "10.5", "9.8", "10.2", "5512753", "7400000000",
+        ]
+        bs_mock.query_history_k_data_plus.return_value = mock_rs
+
+        df = loader._fetch_one(bs_mock, "601398.SH", "2024-01-01", "2024-01-31")
+
+        assert abs(df["volume"].iloc[-1] - 55127.53) < 1e-9

--- a/agent/tests/test_loader_volume_units.py
+++ b/agent/tests/test_loader_volume_units.py
@@ -1,0 +1,54 @@
+"""Pin the volume-unit declarations of equity loaders (HKUDS/Vibe-Trading#1062).
+
+A-share sources natively report board lots (1 lot = 100 shares) while
+baostock reports single shares; the tencent/eastmoney loaders are
+market-dependent (A-share lots vs HK shares). These pins lock the audit
+matrix from issue #1062 so a declaration cannot drift silently — the
+cross-source 100x discrepancy that motivated the fix was exactly such a
+silent drift.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backtest.loaders.akshare_loader import DataLoader as AkshareLoader
+from backtest.loaders.baostock_loader import DataLoader as BaostockLoader
+from backtest.loaders.eastmoney_loader import DataLoader as EastmoneyLoader
+from backtest.loaders.local_loader import DataLoader as LocalLoader
+from backtest.loaders.mootdx_loader import DataLoader as MootdxLoader
+from backtest.loaders.stooq_loader import DataLoader as StooqLoader
+from backtest.loaders.tencent_loader import DataLoader as TencentLoader
+from backtest.loaders.tushare import DataLoader as TushareLoader
+from backtest.loaders.yahoo_loader import DataLoader as YahooLoader
+from backtest.loaders.yfinance_loader import DataLoader as YfinanceLoader
+
+
+@pytest.mark.parametrize(
+    ("loader_cls", "market", "expected"),
+    [
+        (TencentLoader, "a_share", "lots"),
+        (TencentLoader, "hk_equity", "shares"),
+        (EastmoneyLoader, "a_share", "lots"),
+        (EastmoneyLoader, "hk_equity", "shares"),
+        (BaostockLoader, "a_share", "shares"),
+        (MootdxLoader, "a_share", "lots"),
+        (AkshareLoader, "a_share", "lots"),
+        (TushareLoader, "a_share", "lots"),
+        (YahooLoader, "us_equity", "shares"),
+        (YahooLoader, "hk_equity", "shares"),
+        (YfinanceLoader, "us_equity", "shares"),
+        (YfinanceLoader, "hk_equity", "shares"),
+        (StooqLoader, "us_equity", "shares"),
+    ],
+)
+def test_loader_volume_unit_declaration(loader_cls, market, expected):
+    assert getattr(loader_cls, "volume_units", {})[market] == expected
+
+
+def test_undeclared_markets_surface_as_missing_not_wrong():
+    """Markets without evidence stay undeclared (null), never guessed."""
+    assert "crypto" not in YfinanceLoader.volume_units
+    assert "us_equity" not in EastmoneyLoader.volume_units
+    assert "hk_equity" not in TushareLoader.volume_units
+    assert getattr(LocalLoader, "volume_units", {}) == {}

--- a/agent/tests/test_loader_volume_units.py
+++ b/agent/tests/test_loader_volume_units.py
@@ -1,11 +1,11 @@
 """Pin the volume-unit declarations of equity loaders (HKUDS/Vibe-Trading#1062).
 
-A-share sources natively report board lots (1 lot = 100 shares) while
-baostock reports single shares; the tencent/eastmoney loaders are
-market-dependent (A-share lots vs HK shares). These pins lock the audit
-matrix from issue #1062 so a declaration cannot drift silently — the
-cross-source 100x discrepancy that motivated the fix was exactly such a
-silent drift.
+Every A-share source declares board lots (1 lot = 100 shares) — baostock's
+native single-share volume is normalized at its loader boundary; the
+tencent/eastmoney loaders are market-dependent (A-share lots vs HK shares).
+These pins lock the audit matrix from issue #1062 so a declaration cannot
+drift silently — the cross-source 100x discrepancy that motivated the fix
+was exactly such a silent drift.
 """
 
 from __future__ import annotations
@@ -31,7 +31,7 @@ from backtest.loaders.yfinance_loader import DataLoader as YfinanceLoader
         (TencentLoader, "hk_equity", "shares"),
         (EastmoneyLoader, "a_share", "lots"),
         (EastmoneyLoader, "hk_equity", "shares"),
-        (BaostockLoader, "a_share", "shares"),
+        (BaostockLoader, "a_share", "lots"),
         (MootdxLoader, "a_share", "lots"),
         (AkshareLoader, "a_share", "lots"),
         (TushareLoader, "a_share", "lots"),

--- a/agent/tests/test_market_data_tool.py
+++ b/agent/tests/test_market_data_tool.py
@@ -93,7 +93,92 @@ def test_market_data_json_can_include_actual_source_provenance():
         "detected_source": "yahoo",
         "fallback_used": True,
         "currency_conversion": "none",
+        "volume_unit": None,
     }
+
+
+def test_market_data_provenance_exposes_declared_volume_unit():
+    """Serving loaders declare per-market volume units (#1062)."""
+    idx = pd.date_range("2026-01-01", periods=1, freq="D")
+    idx.name = "trade_date"
+    df = pd.DataFrame(
+        {
+            "open": [1.0],
+            "high": [1.1],
+            "low": [0.9],
+            "close": [1.05],
+            "volume": [100],
+        },
+        index=idx,
+    )
+
+    class _UnitAwareLoader:
+        volume_units = {"a_share": "lots", "hk_equity": "shares"}
+
+        def fetch(self, codes, start, end, interval="1D"):
+            return {code: df for code in codes}
+
+    payload = json.loads(
+        fetch_market_data_json(
+            codes=["600519.SH", "0700.HK"],
+            start_date="2026-01-01",
+            end_date="2026-01-02",
+            source="tencent",
+            loader_resolver=lambda source: _UnitAwareLoader,
+            include_provenance=True,
+        )
+    )
+
+    assert payload["_provenance"]["600519.SH"]["volume_unit"] == "lots"
+    assert payload["_provenance"]["0700.HK"]["volume_unit"] == "shares"
+
+
+def test_market_data_provenance_volume_unit_follows_serving_loader():
+    """After fallback, the unit comes from the loader that actually served."""
+    idx = pd.date_range("2026-01-01", periods=1, freq="D")
+    idx.name = "trade_date"
+    df = pd.DataFrame(
+        {
+            "open": [1.0],
+            "high": [1.1],
+            "low": [0.9],
+            "close": [1.05],
+            "volume": [100],
+        },
+        index=idx,
+    )
+
+    class _PrimaryLoader:
+        volume_units = {"a_share": "lots"}
+
+        def fetch(self, codes, start, end, interval="1D"):
+            raise RuntimeError("primary unavailable")
+
+    class _FallbackLoader:
+        volume_units = {"a_share": "shares"}
+
+        def fetch(self, codes, start, end, interval="1D"):
+            return {codes[0]: df}
+
+    def _resolver(source: str):
+        return _PrimaryLoader if source == "tencent" else _FallbackLoader
+
+    payload = json.loads(
+        fetch_market_data_json(
+            codes=["600519.SH"],
+            start_date="2026-01-01",
+            end_date="2026-01-02",
+            source="tencent",
+            loader_resolver=_resolver,
+            fallback_chain_provider=lambda source: ["tencent", "baostock"],
+            include_provenance=True,
+        )
+    )
+
+    prov = payload["_provenance"]["600519.SH"]
+    assert prov["source"] == "baostock"
+    assert prov["fallback_used"] is True
+    assert prov["volume_unit"] == "shares"
 
 
 def test_market_data_json_is_strict_when_loader_returns_nan():

--- a/agent/tests/test_volume_unit_consistency.py
+++ b/agent/tests/test_volume_unit_consistency.py
@@ -1,0 +1,65 @@
+"""Empirical cross-source volume consistency guard (HKUDS/Vibe-Trading#1062).
+
+Fetches the same settled A-share trading day from every reachable loader and
+asserts the reported volumes agree within tolerance. This is the runtime lock
+the #1062 audit called for: unit drift between fallback sources (the original
+bug: baostock shares vs tencent/eastmoney lots, exactly 100x) fails loudly
+here instead of silently corrupting volume analysis.
+
+Network-guarded by design — sources unreachable from the test environment are
+skipped individually, and the test skips entirely when fewer than two sources
+are reachable, so CI without market access stays green.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+CODE = "600519.SH"
+TRADE_DATE = "2026-07-31"
+TOLERANCE = 0.01
+
+
+def _volume_from(loader_cls) -> float | None:
+    try:
+        data = loader_cls().fetch([CODE], TRADE_DATE, TRADE_DATE)
+    except Exception:  # noqa: BLE001 — unreachable source = not participating
+        return None
+    df = data.get(CODE) if data else None
+    if df is None or df.empty or "volume" not in df.columns:
+        return None
+    value = df["volume"].iloc[-1]
+    if value is None or value != value:  # NaN guard
+        return None
+    return float(value)
+
+
+def test_a_share_volume_consistent_across_sources():
+    from backtest.loaders.baostock_loader import DataLoader as BaostockLoader
+    from backtest.loaders.eastmoney_loader import DataLoader as EastmoneyLoader
+    from backtest.loaders.mootdx_loader import DataLoader as MootdxLoader
+    from backtest.loaders.tencent_loader import DataLoader as TencentLoader
+
+    candidates = [
+        ("tencent", TencentLoader),
+        ("eastmoney", EastmoneyLoader),
+        ("baostock", BaostockLoader),
+        ("mootdx", MootdxLoader),
+    ]
+    volumes: dict[str, float] = {}
+    for name, loader_cls in candidates:
+        value = _volume_from(loader_cls)
+        if value is not None:
+            volumes[name] = value
+
+    if len(volumes) < 2:
+        pytest.skip(f"fewer than two reachable A-share sources: {sorted(volumes)}")
+
+    baseline_name = next(iter(volumes))
+    baseline = volumes[baseline_name]
+    for name, value in volumes.items():
+        ratio = value / baseline
+        assert abs(ratio - 1.0) <= TOLERANCE, (
+            f"{name} volume {value:,.0f} disagrees with {baseline_name} "
+            f"{baseline:,.0f} (ratio {ratio:.2f}) — unit drift? see #1062"
+        )


### PR DESCRIPTION
## Summary

- Phase 2 of the #1062 fix, stacked on #1065 (Phase 1 metadata): normalizes the single outlier — baostock's native single-share volume — to board lots at the loader boundary, so every A-share source now reports one canonical unit
- Adds an empirical cross-source consistency test that locks the unit agreement at runtime, plus cache-version isolation so pre-normalization cached data is never served
- Draft until #1065 lands (the diff then narrows to the Phase 2 commit automatically)

## Why

#1062 identified baostock as the single A-share source reporting volume in shares while tencent/eastmoney/akshare/mootdx/tushare report board lots (1 lot = 100 shares) — empirically 600519.SH 2026-07-31: baostock 5,512,752 shares vs tencent/eastmoney 55,128 lots, ratio exactly 100.0. Phase 1 (#1065) made the discrepancy visible via `_provenance.volume_unit`; Phase 2 removes it. Canonical unit = board lots: the native unit of 4 of the 5 A-share sources and the mainstream A-share quote convention.

## Changes

- `baostock_loader.py`: divide native share volume by 100 at the loader boundary; fractional lots preserved (odd-lot trades are real, so no rounding); `volume_units` declaration flips to `"lots"`, matching every other A-share source
- `base.py`: loader cache version 3 → 4 — entries cached under the pre-normalization unit become unreachable and are never served again
- `tests/test_volume_unit_consistency.py` (new): fetches the same settled trading day from every reachable A-share loader (tencent/eastmoney/baostock/mootdx) and asserts pairwise agreement within 1%; network-guarded — unreachable sources skip individually, and the test skips entirely when fewer than two sources are reachable
- `tests/test_baostock_loader.py`: normalization unit tests (clean lots + odd-lot fractional case)
- `tests/test_loader_volume_units.py`: pins updated to the post-normalization matrix (baostock now declares lots)

## Test Plan

- [x] Existing tests pass: loader/market-data/count-gate sweep — 741 passed, 5 skipped; cache-related suites — 99 passed
- [x] New tests added: consistency guard + 2 normalization unit tests + updated pins (27 passed in the focused run)
- [x] Tested manually: 600519.SH 2026-07-31 — tencent 55,128 lots vs baostock 55,127.52 lots after normalization (ratio 0.999991; the 0.48-lot gap is baostock's exact share count including odd lots, within the 1% tolerance); the consistency test passes with three live sources

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Documentation updated (if user-facing change)

Note for reviewers: this branch stacks on #1065 — it contains the Phase 1 commit until that PR merges, after which this PR's diff narrows to the Phase 2 commit. Behavioral change is bounded: only runs that previously fell back to baostock see different volume values (now consistent with the chain head instead of 100x off).
