### PR TITLE
fix(api): return empty Response for scheduled-runs DELETE 204

### DIFF
--- a/agent/src/api/scheduled_routes.py
+++ b/agent/src/api/scheduled_routes.py
@@ -14,6 +14,7 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 from fastapi import Depends, FastAPI, HTTPException, Query, status
 from pydantic import BaseModel, Field
+from starlette.responses import Response
 
 from src.config.accessor import get_env_config
 
@@ -353,7 +354,7 @@ def register_scheduled_routes(
         status_code=status.HTTP_204_NO_CONTENT,
         dependencies=[Depends(require_auth)],
     )
-    async def delete_scheduled_run(job_id: str) -> None:
+    async def delete_scheduled_run(job_id: str) -> Response:
         """Cancel (delete) a scheduled research job by id."""
         _host_validate_path_param(job_id, "job_id")
         removed = _get_scheduled_research_store().delete(job_id)
@@ -361,6 +362,7 @@ def register_scheduled_routes(
             raise HTTPException(
                 status_code=404, detail=f"scheduled run {job_id} not found"
             )
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
 
     # --- Playbook templates ---
     #

--- a/agent/tests/test_scheduled_routes.py
+++ b/agent/tests/test_scheduled_routes.py
@@ -174,6 +174,7 @@ def test_delete_removes_job_and_returns_204(
 
     assert response.status_code == 204
     assert not response.content
+    assert "content-type" not in response.headers
     assert store.get("cancel-me") is None
 
 


### PR DESCRIPTION
## Summary

- Return an explicit empty `Response` from `DELETE /scheduled-runs/{job_id}` so FastAPI accepts the 204 route on current releases and the response omits `Content-Type: application/json`.

## Why

The handler already returned no body, but annotating `-> None` on a 204 route fails FastAPI route registration in some versions, and the implicit response could carry a JSON content type. This is unrelated to the eToro runtime UI work (#1051).

## Changes

- `agent/src/api/scheduled_routes.py` — return `Response(status_code=204)` on successful delete
- `agent/tests/test_scheduled_routes.py` — assert delete responses have no `content-type` header

## Test Plan

- [x] `pytest agent/tests/test_scheduled_routes.py -q`
- [x] Full CI suite on upstream

## Risk / rollback

- Low risk: success path only; 404 behavior unchanged. Rollback: revert single commit.
