### PR TITLE
fix(memory): align fallback tokenizer minimum with FTS5 sanitizer

### DIFF
--- a/agent/src/memory/compression.py
+++ b/agent/src/memory/compression.py
@@ -60,8 +60,11 @@ _SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?。！？])\s+|\n+")
 def _tokenize_for_tfidf(text: str) -> List[str]:
     """Tokenize text for TF-IDF scoring.
 
-    Uses same regex pattern as persistent.py: ASCII words >= 3 chars
-    or individual non-Latin script characters.
+    ASCII words >= 3 chars or individual non-Latin script characters.
+    Deliberately a higher minimum than persistent.py's retrieval tokenizer:
+    this only ranks sentences for summarization, not retrieval, so dropping
+    short tokens from scoring doesn't create the silent-miss failure mode
+    that a stricter retrieval tokenizer would.
     """
     return _TOKEN_RE.findall(text.lower())
 

--- a/agent/src/memory/persistent.py
+++ b/agent/src/memory/persistent.py
@@ -115,7 +115,11 @@ _NON_LATIN_SCRIPT_RANGES = (
     "Ѐ-ӿ"  # Cyrillic
 )
 
-_TOKEN_RE = re.compile(rf"[a-zA-Z0-9]{{3,}}|[{_NON_LATIN_SCRIPT_RANGES}]")
+# Matches search_index.py's FTS5 query sanitizer minimum (2+ ASCII chars) so
+# the token-scan fallback in find_relevant() finds the same content the FTS5
+# path does — short tokens like ticker symbols ("GE") or country codes ("US")
+# must be retrievable regardless of whether VT_MEMORY_FTS_INDEX is enabled.
+_TOKEN_RE = re.compile(rf"[a-zA-Z0-9]{{2,}}|[{_NON_LATIN_SCRIPT_RANGES}]")
 _SLUG_DISALLOWED_RE = re.compile(rf"[^a-z0-9_\-{_NON_LATIN_SCRIPT_RANGES}]")
 
 
@@ -143,7 +147,7 @@ class MemoryEntry:
 
 
 def _tokenize(text: str) -> set[str]:
-    """Split text into searchable tokens (ASCII >=3 chars + non-Latin chars)."""
+    """Split text into searchable tokens (ASCII >=2 chars + non-Latin chars)."""
     return set(_TOKEN_RE.findall(text.lower()))
 
 

--- a/agent/tests/memory/test_tier2_integration.py
+++ b/agent/tests/memory/test_tier2_integration.py
@@ -195,6 +195,52 @@ class TestFtsAddThenSearchFinds:
 
 
 # ---------------------------------------------------------------------------
+# 4a. Fallback token-scan must find the same short-token content the FTS5
+# path does — find_relevant() must not silently miss entries just because
+# VT_MEMORY_FTS_INDEX happens to be off.
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackMatchesFtsForShortTokens:
+    """A 2-character query (e.g. a ticker symbol or country code) must be
+    retrievable through the token-scan fallback exactly as it is through the
+    FTS5 index, regardless of which VT_MEMORY_FTS_INDEX setting is active."""
+
+    def test_fallback_finds_short_token_entry(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VT_MEMORY_FTS_INDEX", "false")
+        reset_env_config()
+
+        mem = PersistentMemory(tmp_path)
+        mem.add(
+            "GE earnings note",
+            "GE reported strong earnings this quarter, beating estimates.",
+            "project",
+        )
+
+        results = mem.find_relevant("GE")
+        assert len(results) == 1
+        assert results[0].title == "GE earnings note"
+
+    def test_fallback_and_fts_agree_on_short_token_query(self, tmp_path, monkeypatch, fts_db):
+        mem = PersistentMemory(tmp_path)
+        mem.add(
+            "GE earnings note",
+            "GE reported strong earnings this quarter, beating estimates.",
+            "project",
+        )
+
+        monkeypatch.setenv("VT_MEMORY_FTS_INDEX", "false")
+        reset_env_config()
+        fallback_titles = {e.title for e in mem.find_relevant("GE")}
+
+        monkeypatch.setenv("VT_MEMORY_FTS_INDEX", "true")
+        reset_env_config()
+        fts_titles = {e.title for e in mem.find_relevant("GE")}
+
+        assert fallback_titles == fts_titles == {"GE earnings note"}
+
+
+# ---------------------------------------------------------------------------
 # 4b. FTS: importance decay must still influence ranking (VT_MEMORY=full
 # enables fts_index_enabled and decay_enabled together)
 # ---------------------------------------------------------------------------

--- a/agent/tests/test_persistent_memory.py
+++ b/agent/tests/test_persistent_memory.py
@@ -63,10 +63,18 @@ class TestTokenize:
         assert "world" in tokens
         assert "testing" in tokens
 
-    def test_short_words_excluded(self) -> None:
-        tokens = _tokenize("I am ok no")
-        # All < 3 chars, should be excluded
+    def test_single_char_words_excluded(self) -> None:
+        tokens = _tokenize("I a")
+        # Single ASCII chars carry no discriminating value, should be excluded
         assert len(tokens) == 0
+
+    def test_two_char_words_included(self) -> None:
+        # Regression: the fallback token-scan used a 3-char minimum while
+        # search_index.py's FTS5 sanitizer used 2 chars, so short tokens like
+        # ticker symbols ("GE") or country codes ("US") were retrievable via
+        # FTS but silently invisible whenever VT_MEMORY_FTS_INDEX was off.
+        tokens = _tokenize("GE US ok no")
+        assert tokens == {"ge", "us", "ok", "no"}
 
     def test_cjk_characters(self) -> None:
         tokens = _tokenize("比特币价格分析")


### PR DESCRIPTION
## Summary
- `find_relevant()`'s token scan fallback in `persistent.py` required tokens of 3 characters or more, while the FTS5 query sanitizer in `search_index.py` accepted tokens of 2 characters or more, so short but meaningful queries (ticker symbols, country codes) silently returned nothing whenever `VT_MEMORY_FTS_INDEX` was disabled, even when the stored entry plainly contained the term.
- Widen the fallback tokenizer's minimum to 2 characters to match the FTS5 sanitizer, so retrieval no longer depends on which search path is active.

## Why
I audited every tokenizer used across the Tier 2 memory modules: `compression.py`, `semantic_links.py`, `persistent.py`, `search_index.py`, and the benchmark runner's own tokenizer. Only the `persistent.py` fallback creates a silent retrieval failure, since it is the only tokenizer whose minimum length diverges from the FTS5 path it stands in for. `compression.py`'s tokenizer only affects which sentences get kept during summarisation, not whether an entry can be found later. `semantic_links.py`'s tokenizer only affects BM25 linking between entries, a separate feature.

I reproduced this directly against real code checked out from upstream main before writing any fix. With an entry containing "GE reported strong earnings...", the fallback path returned zero results for the query "GE" while the FTS5 path found it correctly. Identical content, identical query, different result, based solely on the `VT_MEMORY_FTS_INDEX` flag.

## Changes
- `agent/src/memory/persistent.py`: widen the fallback tokenizer's minimum to 2 ASCII characters, matching the FTS5 sanitizer in `search_index.py`, with a comment explaining why the two need to stay in sync.
- `agent/src/memory/compression.py`: fix a docstring that claimed to use "the same regex pattern as persistent.py," which became inaccurate once `persistent.py`'s minimum changed. Comment only, no behaviour change.
- `agent/tests/memory/test_tier2_integration.py`: two new tests. One confirms the fallback path finds a short token entry on its own. The other confirms the fallback and FTS5 paths agree on the same short token query.
- `agent/tests/test_persistent_memory.py`: split the old `test_short_words_excluded` test, which pinned the previous 3 char minimum as correct behaviour, into a 1 char exclusion test (still correct) and a new 2 char inclusion test (the fixed behaviour).

## Test Plan
- [x] Reproduced the bug against real upstream code before writing any fix, confirming it was a genuine failure and not hypothetical
- [x] New regression tests fail on the pre-fix code with a concrete assertion failure (fallback returned 0 results instead of 1 for a "GE" query against an entry containing "GE"), and pass after the fix
- [x] `pytest agent/tests/memory/ agent/tests/test_persistent_memory.py -q` (150 passed, 1 skipped, no regressions)
- [x] Attempted the broader memory test selection, but collection was blocked by unrelated optional dependencies absent from the minimal environment. Ran the focused suites covering the changed memory paths instead: 150 passed, 1 skipped.
- [x] `black --check` on all four changed files: pre-existing, unrelated formatting issues confirmed via diff-isolation against the unpatched files; no full-file reformat applied, to avoid unrelated diff noise
- [x] `ruff check` on all four changed files: 3 pre-existing issues, all in `test_tier2_integration.py` (two unused imports, one unused variable), none introduced by this change, none in the other three files

## Checklist
- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`): this only touches `agent/src/memory/` and `agent/tests/`
- [x] No hardcoded values
- [x] Code follows CONTRIBUTING.md guidelines
- [x] Documentation updated: corrected the `compression.py` docstring that inaccurately claimed to match `persistent.py`'s tokenizer regex
- [x] DCO signed-off