### PR TITLE
fix(cli): render direct SDK account diagnostics

### DIFF
--- a/agent/cli/_legacy.py
+++ b/agent/cli/_legacy.py
@@ -4003,9 +4003,25 @@ def cmd_connector_check(
         table.add_row("Connector", profile.connector)
         table.add_row("Environment", profile.environment)
         table.add_row("Transport", profile.transport)
-        table.add_row("Configured", "yes" if report.get("configured") else "[red]no[/red]")
-        table.add_row("OAuth token", "present" if report.get("oauth_token_present") else "[yellow]missing[/yellow]")
-        table.add_row("Capabilities", ", ".join(report.get("capabilities", [])))
+        if profile.transport == "broker_sdk":
+            if "configured" in report:
+                table.add_row("Configured", "yes" if report.get("configured") else "[red]no[/red]")
+            if report.get("connection_state"):
+                table.add_row("Connection", str(report["connection_state"]))
+            sdk = report.get("sdk")
+            if isinstance(sdk, dict) and "installed" in sdk:
+                package = str(sdk.get("package") or "SDK")
+                state = "installed" if sdk.get("installed") else "[yellow]missing[/yellow]"
+                table.add_row(package, state)
+            if "tap" in report:
+                table.add_row("TAP", "enabled" if report.get("tap") else "disabled")
+            capabilities = report.get("capabilities")
+            if capabilities:
+                table.add_row("Capabilities", ", ".join(capabilities))
+        else:
+            table.add_row("Configured", "yes" if report.get("configured") else "[red]no[/red]")
+            table.add_row("OAuth token", "present" if report.get("oauth_token_present") else "[yellow]missing[/yellow]")
+            table.add_row("Capabilities", ", ".join(report.get("capabilities", [])))
         console.print(table)
 
     if report.get("status") not in {"ok"}:
@@ -4073,14 +4089,20 @@ def _normalize_mcp_value(value: Any) -> Any:
     return value
 
 
-def _flatten_account_fields(data: dict[str, Any], prefix: str = "") -> list[tuple[str, str]]:
+def _flatten_account_fields(
+    data: dict[str, Any],
+    prefix: str = "",
+    *,
+    skip_zero: bool = True,
+) -> list[tuple[str, str]]:
     """Flatten a remote-MCP account payload into (tag, value) rows.
 
     Nested one level (e.g. ``buying_power.buying_power``) rather than
     recursing arbitrarily deep, since broker account payloads are shallow.
-    Skips ``None`` and zero-valued numeric-looking fields, matching the
-    guidance the broker's own response typically includes (zero means no
-    holdings in that asset class — noise to omit, not a real 0.00 balance).
+    Skips ``None``. By default it also skips zero-valued numeric-looking fields,
+    matching remote-MCP guidance where zero means an absent asset-class balance.
+    Direct SDK account summaries can disable that behavior because a zero or
+    false risk/status field is meaningful account state.
     """
     rows: list[tuple[str, str]] = []
     for key, value in data.items():
@@ -4089,16 +4111,52 @@ def _flatten_account_fields(data: dict[str, Any], prefix: str = "") -> list[tupl
         label = f"{prefix}{key}"
         normalized = _normalize_mcp_value(value)
         if isinstance(normalized, dict):
-            rows.extend(_flatten_account_fields(normalized, prefix=f"{label}."))
+            rows.extend(
+                _flatten_account_fields(
+                    normalized,
+                    prefix=f"{label}.",
+                    skip_zero=skip_zero,
+                )
+            )
             continue
         text = str(normalized)
-        try:
-            if float(text) == 0.0:
-                continue
-        except (TypeError, ValueError):
-            pass
+        if skip_zero:
+            try:
+                if float(text) == 0.0:
+                    continue
+            except (TypeError, ValueError):
+                pass
         rows.append((label, text))
     return rows
+
+
+def _print_connector_account_mapping(
+    result: dict[str, Any],
+    account_data: dict[str, Any],
+) -> int:
+    """Render the flat/nested ``account`` mapping used by direct SDK brokers."""
+    account_label = (
+        account_data.get("account_number")
+        or result.get("account_number")
+        or result.get("profile_id")
+        or result.get("profile")
+        or "unknown"
+    )
+    table = Table(
+        title=f"Account Summary · {result.get('profile_id') or result.get('profile') or account_label}",
+        box=box.SIMPLE_HEAVY,
+        show_lines=False,
+    )
+    table.add_column("Field")
+    table.add_column("Value", justify="right")
+    currency = account_data.get("currency")
+    if currency is not None:
+        table.add_row("currency", str(currency))
+    for tag, value in _flatten_account_fields(account_data, skip_zero=False):
+        table.add_row(tag, value)
+    console.print(f"Account: [cyan]{rich_escape(str(account_label))}[/cyan]")
+    console.print(table)
+    return EXIT_SUCCESS
 
 
 def _print_connector_account(result: dict[str, Any]) -> int:
@@ -4110,6 +4168,9 @@ def _print_connector_account(result: dict[str, Any]) -> int:
         label = accounts if accounts != "(none)" else result.get("profile_id", result.get("profile", "unknown"))
         console.print(f"Accounts: [cyan]{rich_escape(str(label))}[/cyan]")
         return _print_connector_balances(result)
+    account_data = _normalize_mcp_value(result.get("account"))
+    if not rows and isinstance(account_data, dict) and account_data:
+        return _print_connector_account_mapping(result, account_data)
     if not rows:
         # Not the broker_sdk flat shape — try the remote-MCP nested shape.
         # Robinhood's tool result double-wraps: result["data"] unwraps to

--- a/agent/tests/test_cli_connector_renderers.py
+++ b/agent/tests/test_cli_connector_renderers.py
@@ -8,6 +8,7 @@ Longbridge (and other ``broker_sdk`` connectors) return ``quantity``/``cost_pric
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -90,3 +91,62 @@ def test_connector_account_still_handles_ibkr_summary(capsys) -> None:
     out = capsys.readouterr().out
     assert "NetLiquidation" in out
     assert "50000" in out
+
+
+def test_connector_account_renders_direct_sdk_account_mapping(capsys) -> None:
+    alpaca_account = {
+        "status": "ok",
+        "profile_id": "alpaca-paper-trade",
+        "profile": "paper",
+        "account": {
+            "account_number": "PA123",
+            "status": "AccountStatus.ACTIVE",
+            "currency": "USD",
+            "cash": "100000",
+            "equity": "100000",
+            "buying_power": "400000",
+            "pattern_day_trader": False,
+            "trading_blocked": False,
+        },
+    }
+
+    rc = _legacy._print_connector_account(alpaca_account)
+
+    assert rc == _legacy.EXIT_SUCCESS
+    out = capsys.readouterr().out
+    assert "No account summary returned." not in out
+    assert "PA123" in out
+    assert "USD" in out
+    assert "buying_power" in out
+    assert "400000" in out
+    assert "trading_blocked" in out
+    assert "False" in out
+
+
+def test_connector_check_uses_sdk_diagnostics_without_oauth_rows(capsys) -> None:
+    profile = SimpleNamespace(
+        id="alpaca-paper-trade",
+        connector="alpaca",
+        environment="paper",
+        transport="broker_sdk",
+    )
+    report = {
+        "status": "ok",
+        "sdk": {"package": "alpaca-py", "installed": True},
+        "tap": False,
+    }
+
+    with (
+        patch("cli._legacy._selected_profile_or", return_value=profile),
+        patch("src.trading.service.check_connection", return_value=report),
+    ):
+        rc = _legacy.cmd_connector_check("alpaca-paper-trade")
+
+    assert rc == _legacy.EXIT_SUCCESS
+    out = capsys.readouterr().out
+    assert "Connector profile is ready." in out
+    assert "alpaca-py" in out
+    assert "installed" in out
+    assert "OAuth token" not in out
+    assert "Configured" not in out
+    assert "Capabilities" not in out


### PR DESCRIPTION
## Summary
- Render the `account` mapping returned by Alpaca and other direct-SDK connectors, including meaningful false/zero account-state fields.
- Make `connector check` transport-aware so broker-SDK profiles no longer show inapplicable OAuth rows.
- Add Alpaca-shaped account and SDK diagnostic CLI regressions.

## Test Plan
- Focused CLI renderer suite: 6 passed.
- Expanded connector/IBKR selection: 113 passed; one pre-existing Futu test was deselected because the local OpenD instance is running while that test assumes it is down.
- Ruff and `py_compile`: passed.

Closes #1064
