### PR TITLE
fix(providers): normalize Ollama runtime URL at source

### DIFF
--- a/agent/src/providers/capabilities.py
+++ b/agent/src/providers/capabilities.py
@@ -312,7 +312,10 @@ def get_llm_credentials(
         Reads dynamic env vars via ``os.getenv`` — not part of ``EnvConfig``.
         When no base URL is set in the environment, falls back to the provider
         catalog's ``default_base_url`` so a provider set without an explicit
-        ``*_BASE_URL`` still hits its canonical endpoint.
+        ``*_BASE_URL`` still hits its canonical endpoint. Ollama URLs are
+        normalized here to its OpenAI-compatible ``/v1`` root so diagnostics,
+        preflight, environment synchronization, and runtime construction all
+        consume the same endpoint.
     """
     caps = get_provider_capabilities(provider, model)
     key_env, base_env = caps.api_key_env, caps.base_url_env
@@ -343,6 +346,10 @@ def get_llm_credentials(
         )
         or _provider_default_base_url(caps.name)
     )
+    if caps.name == "ollama":
+        base_url = base_url.strip().rstrip("/")
+        if base_url and not base_url.endswith("/v1"):
+            base_url = f"{base_url}/v1"
 
     return {
         "provider": (provider or "").strip().lower(),

--- a/agent/src/providers/llm.py
+++ b/agent/src/providers/llm.py
@@ -996,16 +996,6 @@ def _ensure_dotenv() -> None:
     )
 
 
-def _normalize_ollama_base_url(base_url: str) -> str:
-    """Append ``/v1`` when missing so ChatOpenAI hits Ollama's OpenAI-compatible API."""
-    url = base_url.strip().rstrip("/")
-    if not url:
-        return url
-    if url.endswith("/v1"):
-        return url
-    return f"{url}/v1"
-
-
 def _sync_provider_env() -> None:
     """Map provider-specific env vars to OPENAI_* for ChatOpenAI.
 
@@ -1029,9 +1019,6 @@ def _sync_provider_env() -> None:
     creds = get_llm_credentials(provider, get_env_config().llm.langchain_model_name)
     api_key = creds["api_key"]
     base_url = creds["base_url"]
-
-    if provider == "ollama" and base_url:
-        base_url = _normalize_ollama_base_url(base_url)
 
     # SDK-side env setup, not Vibe-Trading config reads
     if api_key:

--- a/agent/tests/test_llm.py
+++ b/agent/tests/test_llm.py
@@ -798,6 +798,50 @@ class TestGetLlmCredentials:
             creds = get_llm_credentials("ollama", "llama3")
             assert creds["api_key"] == "ollama"
 
+    @pytest.mark.parametrize(
+        "configured_url",
+        [
+            "http://localhost:11434",
+            "http://localhost:11434/",
+            "http://localhost:11434/v1",
+            "http://localhost:11434/v1/",
+        ],
+    )
+    def test_ollama_base_url_is_normalized_at_credentials_boundary(
+        self,
+        configured_url: str,
+    ) -> None:
+        with patch.dict(
+            os.environ,
+            {"OLLAMA_BASE_URL": configured_url},
+            clear=True,
+        ):
+            creds = get_llm_credentials("ollama", "llama3")
+
+        assert creds["base_url"] == "http://localhost:11434/v1"
+
+    def test_build_llm_receives_normalized_ollama_base_url(self) -> None:
+        """The runtime constructor must not reintroduce Ollama's raw root (#1069)."""
+        import src.providers.llm as llm_mod
+
+        llm_mod._dotenv_loaded = True
+        captured: dict[str, object] = {}
+
+        class _FakeChatOpenAI:
+            def __init__(self, **kwargs: object) -> None:
+                captured.update(kwargs)
+
+        env = {
+            "LANGCHAIN_PROVIDER": "ollama",
+            "LANGCHAIN_MODEL_NAME": "qwen2.5:3b",
+            "OLLAMA_BASE_URL": "http://localhost:11434",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with patch.object(llm_mod, "ChatOpenAIWithReasoning", _FakeChatOpenAI):
+                build_llm()
+
+        assert captured["base_url"] == "http://localhost:11434/v1"
+
     def test_base_url_uses_provider_specific_env(self) -> None:
         with patch.dict(
             os.environ,


### PR DESCRIPTION
## Summary
- Normalize Ollama base URLs to `/v1` at the centralized credential boundary.
- Remove the duplicated environment-only normalization so preflight, diagnostics, synchronized environment variables, and runtime construction share one resolved endpoint.
- Add URL-variant coverage and an actual `build_llm()` constructor regression.

## Root cause
`_sync_provider_env()` normalized the configured root, but `build_llm()` called `get_llm_credentials()` again and passed the original unnormalized URL to `ChatOpenAIWithReasoning`, producing requests against the wrong path.

## Test Plan
- Provider-focused pytest selection: 90 passed.
- Ruff and `py_compile`: passed.

Closes #1069
