### PR TITLE
fix(ibkr): select market-data tier; report starved quotes as no_data

### DIFF
--- a/agent/src/trading/connectors/ibkr/local.py
+++ b/agent/src/trading/connectors/ibkr/local.py
@@ -32,6 +32,19 @@ PROFILE_DEFAULT_PORTS = {
     "live-readonly": 7496,
 }
 
+# TWS market-data tiers. Type 1 (live) requires a paid market-data subscription
+# for the instrument; without one TWS answers error 354 and never sends a tick.
+# Types 3/4 fall back to the free 15-minute delayed feed, so they are the safe
+# default for a research/backtest connector.
+MARKET_DATA_TYPES = {
+    1: "live",
+    2: "frozen",
+    3: "delayed",
+    4: "delayed-frozen",
+}
+
+DEFAULT_MARKET_DATA_TYPE = 3
+
 
 class IBKRDependencyError(RuntimeError):
     """Raised when the optional ``ib_async`` package is not installed."""
@@ -57,6 +70,9 @@ class IBKRLocalConfig:
         account: Optional account code to filter requests.
         timeout: Connection timeout in seconds.
         readonly: Always passed as true when the SDK supports it.
+        market_data_type: TWS market-data tier (1 live, 2 frozen, 3 delayed,
+            4 delayed-frozen). Defaults to delayed so quotes work without a
+            paid market-data subscription.
     """
 
     host: str = "127.0.0.1"
@@ -66,6 +82,7 @@ class IBKRLocalConfig:
     account: str | None = None
     timeout: float = 8.0
     readonly: bool = True
+    market_data_type: int = DEFAULT_MARKET_DATA_TYPE
 
     @classmethod
     def from_mapping(cls, data: Mapping[str, Any] | None = None) -> "IBKRLocalConfig":
@@ -90,6 +107,9 @@ class IBKRLocalConfig:
             account=_clean_optional_str(payload.get("account")),
             timeout=float(payload.get("timeout") or 8.0),
             readonly=bool(payload.get("readonly", True)),
+            market_data_type=_clean_market_data_type(
+                payload.get("market_data_type", payload.get("marketDataType"))
+            ),
         )
 
     def with_overrides(
@@ -100,9 +120,12 @@ class IBKRLocalConfig:
         client_id: int | None = None,
         profile: str | None = None,
         account: str | None = None,
+        market_data_type: int | None = None,
     ) -> "IBKRLocalConfig":
         """Return a copy with CLI/tool overrides applied."""
         payload = asdict(self)
+        if market_data_type is not None:
+            payload["market_data_type"] = market_data_type
         if profile is not None:
             payload["profile"] = profile
             if port is None:
@@ -326,7 +349,27 @@ def _tick_has_data(ticker: Any) -> bool:
     return False
 
 
-def _wait_for_tick(ib: Any, ticker: Any, *, timeout: float = 5.0, poll_interval: float = 0.1) -> None:
+def _apply_market_data_type(ib: Any, config: IBKRLocalConfig) -> None:
+    """Select the TWS market-data tier before requesting prices.
+
+    TWS defaults to live data (type 1). An account without a market-data
+    subscription for the instrument then gets error 354 and the ticker never
+    fills, so the caller silently receives null prices after the full poll
+    timeout. Setting type 3/4 falls back to the free delayed feed instead.
+
+    The call is best-effort: it is a no-op against SDK stubs that do not expose
+    ``reqMarketDataType``.
+    """
+    fn = getattr(ib, "reqMarketDataType", None)
+    if fn is None:
+        return
+    try:
+        fn(int(config.market_data_type))
+    except Exception:  # noqa: BLE001 - never fail a read over a tier hint
+        pass
+
+
+def _wait_for_tick(ib: Any, ticker: Any, *, timeout: float = 5.0, poll_interval: float = 0.1) -> bool:
     """Pump the ib_async event loop until the snapshot ticker fills.
 
     ``reqMktData(..., snapshot=True)`` returns immediately but the ticker
@@ -339,14 +382,18 @@ def _wait_for_tick(ib: Any, ticker: Any, *, timeout: float = 5.0, poll_interval:
     reliably processes all pending socket messages on each call, while
     ``waitOnUpdate`` can return True for unrelated messages, causing
     premature exit with NaN fields.
+
+    Returns:
+        True if real market data arrived before the deadline, False on timeout.
     """
     import time as _time
 
     deadline = _time.monotonic() + timeout
     while _time.monotonic() < deadline:
         if _tick_has_data(ticker):
-            return
+            return True
         _sleep(ib, poll_interval)
+    return _tick_has_data(ticker)
 
 
 def get_quote(
@@ -365,13 +412,16 @@ def get_quote(
         _assert_profile(cfg, accounts)
         contract = _make_contract(symbol, exchange=exchange, currency=currency, sec_type=sec_type)
         _qualify_contract(ib, contract)
+        _apply_market_data_type(ib, cfg)
         ticker = ib.reqMktData(contract, "", True, False)
-        _wait_for_tick(ib, ticker)
-        return {
-            "status": "ok",
+        received = _wait_for_tick(ib, ticker)
+        tier = MARKET_DATA_TYPES.get(cfg.market_data_type, str(cfg.market_data_type))
+        result = {
+            "status": "ok" if received else "no_data",
             "symbol": symbol.upper(),
             "exchange": exchange,
             "currency": currency,
+            "market_data_type": tier,
             "quote": {
                 "bid": _obj_get(ticker, "bid"),
                 "ask": _obj_get(ticker, "ask"),
@@ -381,6 +431,14 @@ def get_quote(
                 "time": str(_obj_get(ticker, "time", "")),
             },
         }
+        if not received:
+            result["error"] = (
+                f"No market data arrived for {symbol.upper()} on the '{tier}' tier. "
+                "Common causes: the instrument needs a market-data subscription, "
+                "the market is closed (try market_data_type 2 or 4 for frozen "
+                "last-known prices), or the symbol/exchange pair is wrong."
+            )
+        return result
     finally:
         _pool.release()
 
@@ -405,6 +463,7 @@ def get_historical_bars(
         _assert_profile(cfg, accounts)
         contract = _make_contract(symbol, exchange=exchange, currency=currency, sec_type=sec_type)
         _qualify_contract(ib, contract)
+        _apply_market_data_type(ib, cfg)
         bars = ib.reqHistoricalData(
             contract,
             endDateTime="",
@@ -598,6 +657,28 @@ def _obj_get(obj: Any, name: str, default: Any = None) -> Any:
     if isinstance(obj, Mapping):
         return obj.get(name, default)
     return getattr(obj, name, default)
+
+
+def _clean_market_data_type(value: Any) -> int:
+    """Normalize a market-data tier, accepting either the code or its name."""
+    if value is None or value == "":
+        return DEFAULT_MARKET_DATA_TYPE
+    if isinstance(value, str):
+        text = value.strip().lower()
+        for code, name in MARKET_DATA_TYPES.items():
+            if text == name:
+                return code
+        try:
+            value = int(text)
+        except ValueError as exc:
+            raise ValueError(
+                f"market_data_type must be one of {sorted(MARKET_DATA_TYPES)} "
+                f"or {sorted(MARKET_DATA_TYPES.values())}"
+            ) from exc
+    code = int(value)
+    if code not in MARKET_DATA_TYPES:
+        raise ValueError(f"market_data_type must be one of {sorted(MARKET_DATA_TYPES)}")
+    return code
 
 
 def _clean_optional_str(value: Any) -> str | None:

--- a/agent/tests/test_ibkr_local.py
+++ b/agent/tests/test_ibkr_local.py
@@ -345,3 +345,120 @@ def test_pool_release_idempotent_no_connection(fake_ib_async) -> None:
     local._pool._local.ib = None
     # Must not raise.
     local._pool.release()
+
+
+# -- market-data tier regression tests -----------------------------------
+# TWS defaults to live data (tier 1), which needs a paid per-exchange
+# subscription. Without one IBKR answers error 354, no tick ever arrives, and
+# get_quote used to return status "ok" with null prices — a silent failure the
+# tool layer passed straight to the LLM agent.
+
+
+def _install_fake_ib(monkeypatch: pytest.MonkeyPatch, ib_cls) -> None:
+    module = types.ModuleType("ib_async")
+    module.IB = ib_cls
+    module.Stock = _FakeStock
+    module.Contract = _FakeContract
+    monkeypatch.setitem(sys.modules, "ib_async", module)
+    monkeypatch.setattr(local, "tcp_port_open", lambda *_, **__: True)
+    monkeypatch.setattr(local._pool._local, "refcount", 0)
+    monkeypatch.setattr(local._pool._local, "ib", None)
+
+
+def test_default_market_data_type_is_free_delayed() -> None:
+    """Default tier must not be 1 (live), which requires a paid subscription."""
+    assert local.DEFAULT_MARKET_DATA_TYPE == 3
+    assert local.IBKRLocalConfig().market_data_type == 3
+    assert local.MARKET_DATA_TYPES[3] == "delayed"
+
+
+def test_quote_selects_tier_before_requesting_data(monkeypatch: pytest.MonkeyPatch) -> None:
+    """reqMarketDataType is called with the configured tier before reqMktData."""
+    calls: list[tuple[str, object]] = []
+
+    class _TierIB(_FakeIB):
+        def reqMarketDataType(self, tier):
+            calls.append(("tier", tier))
+
+        def reqMktData(self, contract, genericTickList, snapshot, regulatorySnapshot):
+            calls.append(("mktdata", contract.symbol))
+            return SimpleNamespace(bid=1.0, ask=1.1, last=1.05, close=1.0, volume=1, time="")
+
+    _install_fake_ib(monkeypatch, _TierIB)
+
+    result = local.get_quote("AAPL", config=local.IBKRLocalConfig(profile="paper", market_data_type=4))
+
+    assert calls == [("tier", 4), ("mktdata", "AAPL")], calls
+    assert result["market_data_type"] == "delayed-frozen"
+
+
+def test_historical_bars_select_tier_too(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The tier hint is applied ahead of reqHistoricalData as well."""
+    calls: list[str] = []
+
+    class _TierIB(_FakeIB):
+        def reqMarketDataType(self, tier):
+            calls.append(f"tier:{tier}")
+
+        def reqHistoricalData(self, contract, **kwargs):
+            calls.append("history")
+            return [SimpleNamespace(date="2026-05-29", open=1, high=2, low=0.5, close=1.5, volume=100)]
+
+    _install_fake_ib(monkeypatch, _TierIB)
+
+    local.get_historical_bars("AAPL", config=local.IBKRLocalConfig(profile="paper"))
+
+    assert calls == ["tier:3", "history"], calls
+
+
+def test_starved_ticker_reports_no_data_not_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A ticker that never fills must not be reported as a successful quote."""
+
+    class _StarvedIB(_FakeIB):
+        def reqMarketDataType(self, tier):
+            return None
+
+        def reqMktData(self, contract, genericTickList, snapshot, regulatorySnapshot):
+            return SimpleNamespace(bid=None, ask=None, last=None, close=None, volume=None, time="")
+
+    _install_fake_ib(monkeypatch, _StarvedIB)
+    # Keep the poll short — the real default is a 5s wall-clock timeout.
+    monkeypatch.setattr(local, "_wait_for_tick", lambda *_, **__: False)
+
+    result = local.get_quote("AAPL", config=local.IBKRLocalConfig(profile="paper"))
+
+    assert result["status"] == "no_data"
+    assert result["quote"]["last"] is None
+    assert "market-data subscription" in result["error"]
+
+
+def test_tier_hint_is_best_effort_against_old_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A stub without reqMarketDataType, or one that raises, must not break reads."""
+
+    class _RaisingIB(_FakeIB):
+        def reqMarketDataType(self, tier):
+            raise RuntimeError("not supported by this SDK build")
+
+    _install_fake_ib(monkeypatch, _RaisingIB)
+    assert local.get_quote("AAPL", config=local.IBKRLocalConfig(profile="paper"))["status"] == "ok"
+
+    # _FakeIB itself has no reqMarketDataType at all — the getattr path.
+    _install_fake_ib(monkeypatch, _FakeIB)
+    assert local.get_quote("AAPL", config=local.IBKRLocalConfig(profile="paper"))["status"] == "ok"
+
+
+@pytest.mark.parametrize("bad", [0, 5, -1, "banana", "0"])
+def test_invalid_market_data_type_is_rejected(bad) -> None:
+    """Config validation refuses tiers TWS does not define."""
+    with pytest.raises(ValueError, match="market_data_type"):
+        local.IBKRLocalConfig.from_mapping({"profile": "paper", "market_data_type": bad})
+
+
+@pytest.mark.parametrize(
+    ("given", "expected"),
+    [("live", 1), ("frozen", 2), ("delayed", 3), ("delayed-frozen", 4), ("3", 3), (None, 3), ("", 3)],
+)
+def test_market_data_type_accepts_names_codes_and_blanks(given, expected) -> None:
+    """Tier may be given as its TWS name or code; blank falls back to the free tier."""
+    cfg = local.IBKRLocalConfig.from_mapping({"profile": "paper", "market_data_type": given})
+    assert cfg.market_data_type == expected


### PR DESCRIPTION
## Summary

- `reqMarketDataType` is never called anywhere in the codebase, so TWS serves every request on tier 1 (live), which requires a paid per-instrument market-data subscription.
- Without that subscription IBKR answers error 354, no tick ever arrives, and `get_quote` returns `status: "ok"` with every price field `null` — a silent failure passed through the tool layer to the agent as if it had succeeded.
- Adds a validated `market_data_type` connector config field (default `3`, the free 15-minute delayed feed), applies it ahead of `reqMktData` and `reqHistoricalData`, and returns `status: "no_data"` with a diagnostic when the ticker never fills.

## Why

A read-only research connector that reports success while handing back null prices is worse than one that errors: nothing downstream can distinguish "this instrument is quiet" from "you are not entitled to this data." Anyone running the IBKR connector without a market-data subscription hits this on their first quote, and the response gives no indication why.

TWS defaults to live data. Tier 3 (delayed) is free and needs no subscription, which makes it the appropriate default for a research connector; users who hold subscriptions can set `market_data_type: 1`.

No existing issue covers this — happy to open one first if you prefer that order.

## Changes

**`agent/src/trading/connectors/ibkr/local.py`**

- `MARKET_DATA_TYPES` / `DEFAULT_MARKET_DATA_TYPE` constants documenting the four TWS tiers.
- `IBKRLocalConfig.market_data_type` — accepts either the numeric code or the tier name, reads both `market_data_type` and `marketDataType` keys, and rejects codes TWS does not define.
- `_apply_market_data_type()` — best-effort by design: no-ops when the SDK lacks `reqMarketDataType`, and swallows errors so a tier hint can never fail a read that would otherwise succeed.
- `_wait_for_tick()` now returns whether data actually arrived. Private helper, so no API change.
- `get_quote()` returns `status: "no_data"` plus an `error` naming the likely causes when the ticker never fills; the response also reports which tier served it.
- `get_historical_bars()` applies the same tier hint.

**`agent/tests/test_ibkr_local.py`** — 7 new tests (17 cases with parametrization) covering tier ordering before both request calls, the starved-ticker path, best-effort degradation against old SDK builds, and config validation.

## Decision worth your review

**This changes effective default behavior.** Previously TWS's own default (live) applied; now delayed does. Users with paid subscriptions get delayed data until they set `market_data_type: 1`.

I chose that because the silent-null failure is the worse outcome and it affects everyone without a subscription, whereas the new default degrades data freshness for users who can trivially opt back in. If you would rather keep live as the default and rely on the new `no_data` signal to surface the problem, that is a one-line change to `DEFAULT_MARKET_DATA_TYPE` and I will push it.

## Deliberately out of scope

- `get_historical_bars` gets the tier hint but still returns `status: "ok"` with an empty `bars` list when IBKR sends nothing. Same class of problem, but empty-vs-starved is murkier for historical data and I did not want to widen a bug fix.
- No changes to order placement, mandate enforcement, kill-switch, or audit-ledger paths.
- No README or wiki updates. Say the word if the new config field should be documented there and I will add it.

## Test Plan

- [x] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [x] New tests added
- [ ] Tested manually against a live TWS session — **not done, see risk notes**

Verification run on this branch:

- `agent/tests/test_ibkr_local.py` goes from 14 to 31 tests; all 17 new cases pass.
- One pre-existing test, `test_cli_connector_routes_to_handler`, fails in my sandbox for lack of optional deps (`scipy`/`pandas` via the factor stack). It fails **identically on unmodified `main` in the same environment**, so it is environmental and not a regression from this change.
- `ruff check` on both changed files reports the same 4 findings before and after this change — no new lint errors introduced.
- `bash tools/ci_grep_gates.sh` passes.
- `python -m compileall` on the changed module is clean.

## Risk notes

Per `AGENT_CONTRIBUTOR_GUIDE.md`:

- **Live/broker risk:** none to order flow. This touches only the read path (`get_quote`, `get_historical_bars`). No order placement, mandate, kill-switch, or audit-ledger code is modified. `reqMarketDataType` is a session-scoped hint to TWS about which data tier to serve and cannot place, modify, or cancel anything.
- **Network:** unchanged — the existing loopback socket to TWS/IB Gateway. No new endpoints, no outbound calls.
- **Secrets/credentials:** none touched. The connector still holds no IBKR credentials.
- **MCP/deployment:** no changes.
- **Not validated against real Interactive Brokers infrastructure.** Every test runs against the repo's fake IB. No TWS or IB Gateway session was available, so the delayed-data path is correct-by-construction and reviewed, not empirically proven. That is the main thing I would want a maintainer with a live session to sanity-check.

## Rollback

Single commit touching two files. `git revert` restores prior behavior exactly; there are no migrations, no persisted state, and no config file rewrites. A narrower rollback is available by setting `DEFAULT_MARKET_DATA_TYPE = 1`, which restores the old effective default while keeping the `no_data` diagnostic.

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers) — tier codes are named constants
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines; commit carries the DCO `Signed-off-by:` trailer
- [x] Documentation updated (if user-facing change) — config field is documented in the `IBKRLocalConfig` docstring; happy to extend to README on request

## Disclosure

This change was AI-assisted, prepared and reviewed per `AGENT_CONTRIBUTOR_GUIDE.md`. The bug was found by reading the connector against the IBKR API docs rather than by hitting it at runtime; the reasoning and the tests are in the diff for review on their merits.

---
_Generated by [Claude Code](https://claude.ai/code)_