### PR TITLE
fix(fixedincome): keep curve decay within requested bounds

### DIFF
--- a/agent/src/quantlib/fixedincome.py
+++ b/agent/src/quantlib/fixedincome.py
@@ -712,7 +712,7 @@ def fit_yield_curve(
 
     The betas are solved exactly by least squares at every candidate decay
     parameter, and only the one or two decay parameters are searched -- first on
-    a log-spaced grid, then refined with Nelder-Mead. This matters: a
+    a log-spaced grid, then refined with bounded Nelder-Mead. This matters: a
     single-start L-BFGS-B over all parameters at once, which is what the skill's
     old markdown template did, cannot recover a curve it generated itself. On a
     10-tenor noise-free Nelson-Siegel curve it stops at an RMSE of 6.4e-4
@@ -775,6 +775,7 @@ def fit_yield_curve(
         lambda p: _profiled_ssr(np.exp(p), tau, obs)[0],
         np.log(best_lambdas),
         method="Nelder-Mead",
+        bounds=[(math.log(low), math.log(high))] * n_decay,
         options={"xatol": 1e-10, "fatol": 1e-18, "maxiter": 4000},
     )
     refined_lambdas = tuple(float(v) for v in np.exp(refined.x))

--- a/agent/tests/quantlib/test_fixedincome.py
+++ b/agent/tests/quantlib/test_fixedincome.py
@@ -420,6 +420,36 @@ def test_fit_is_robust_to_noise_and_stays_close_to_the_generating_curve():
     assert np.max(np.abs(fit(TENORS) - clean)) < 5e-4
 
 
+def test_fit_keeps_refined_decay_parameter_inside_requested_bounds():
+    bounds = (0.05, 2.0)
+    observed = nelson_siegel(TENORS, 0.03, -0.02, 0.015, 100.0)
+
+    fit = fit_yield_curve(
+        TENORS,
+        observed,
+        model="nelson_siegel",
+        decay_bounds=bounds,
+        grid_points=20,
+    )
+
+    assert bounds[0] <= fit.params[-1] <= bounds[1]
+
+
+def test_svensson_fit_keeps_both_refined_decay_parameters_inside_bounds():
+    bounds = (0.05, 2.0)
+    observed = svensson(TENORS, 0.04, -0.02, 0.02, -0.01, 20.0, 100.0)
+
+    fit = fit_yield_curve(
+        TENORS,
+        observed,
+        model="svensson",
+        decay_bounds=bounds,
+        grid_points=12,
+    )
+
+    assert all(bounds[0] <= decay <= bounds[1] for decay in fit.params[-2:])
+
+
 def test_curve_fit_is_frozen_and_callable():
     fit = fit_yield_curve(TENORS, nelson_siegel(TENORS, 0.04, -0.01, 0.01, 2.0),
                           model="nelson_siegel")


### PR DESCRIPTION
## Summary

- keep Nelson-Siegel and Svensson decay refinement inside the caller-provided `decay_bounds`
- add regression coverage for one- and two-decay-parameter curve fits

## Why

`fit_yield_curve` used `decay_bounds` for its coarse grid, then ran an unconstrained Nelder-Mead refinement in log space. That refinement could escape the requested range and silently return parameters the caller had explicitly excluded.

For example, fitting a Nelson-Siegel curve with `decay_bounds=(0.05, 2.0)` returned a decay parameter near `52.61`. A Svensson reproduction with the same bounds returned both decay parameters above `2.0`.

## Changes

- pass log-transformed bounds to the existing Nelder-Mead refinement
- verify the refined Nelson-Siegel decay remains inside the requested interval
- verify both refined Svensson decays remain inside the requested interval

The profiled least-squares model, coarse grid, public signatures, default bounds, and positive-maturity validation are unchanged.

## Test Plan

- [x] `pytest agent/tests/quantlib/test_fixedincome.py agent/tests/test_quantlib_tool.py -q` (`133 passed, 1 skipped`)
- [x] `pytest agent/tests/quantlib agent/tests/test_quantlib_tool.py -q` (`1022 passed, 62 skipped`)
- [x] `ruff check agent/src/quantlib/fixedincome.py agent/tests/quantlib/test_fixedincome.py`
- [x] `git diff --check`
- [x] regression confirmed red before the fix: Nelson-Siegel returned `52.611842862640756` against an upper bound of `2.0`

The repository-wide non-E2E command was also attempted, but collection stopped before test execution because this local environment lacks the optional `fastmcp`, `yfinance`, and `ccxt` dependencies. The changed QuantLib scope and its public tool adapter are covered by the passing commands above.

`black --check` reports that both touched files would be reformatted on the unchanged upstream commit as well, so this PR intentionally avoids unrelated whole-file formatting churn. Ruff is clean.

## Risk and scope

- deterministic finance-math correction only
- no live trading, order, broker, MCP, credential, network, or deployment behavior
- rollback is the single signed commit
