### PR TITLE
fix(eventstudy): anchor events to prior session

### DIFF
--- a/agent/src/quantlib/eventstudy.py
+++ b/agent/src/quantlib/eventstudy.py
@@ -367,8 +367,11 @@ def event_study(
             dropped.append((symbol, event_date, "symbol not in returns frame"))
             continue
 
-        position = index.searchsorted(event_date)
-        if position >= len(index):
+        position = int(index.searchsorted(event_date, side="right")) - 1
+        if position < 0:
+            dropped.append((symbol, event_date, "event date is before the frame starts"))
+            continue
+        if event_date > index[-1]:
             dropped.append((symbol, event_date, "event date is after the frame ends"))
             continue
 

--- a/agent/tests/quantlib/test_eventstudy.py
+++ b/agent/tests/quantlib/test_eventstudy.py
@@ -245,6 +245,76 @@ def test_non_finite_event_window_is_dropped():
     assert [o.symbol for o in result.events] == ["S01"]
 
 
+# --- event-date anchoring ---
+
+
+def test_non_trading_event_date_anchors_to_previous_session():
+    returns, market = _panel(seed=509)
+    friday_pos = next(
+        pos for pos in range(200, len(returns) - 1) if returns.index[pos].weekday() == 4
+    )
+    friday = returns.index[friday_pos]
+    saturday = friday + pd.Timedelta(days=1)
+    assert saturday not in returns.index
+
+    returns = returns.copy()
+    returns.iloc[friday_pos, returns.columns.get_loc("S00")] += 0.10
+    returns.iloc[friday_pos + 1, returns.columns.get_loc("S00")] -= 0.20
+
+    result = event_study(
+        returns,
+        market,
+        [("S00", saturday)],
+        event_window=(0, 0),
+        model="mean_adjusted",
+    )
+
+    outcome = result.events[0]
+    expected = returns.loc[friday, "S00"] - outcome.fit.alpha
+    assert outcome.event_date == friday
+    assert outcome.abnormal_returns.loc[0] == pytest.approx(expected)
+
+
+def test_exact_event_date_remains_on_that_session():
+    returns, market = _panel(seed=510)
+    event_date = returns.index[250]
+
+    result = event_study(
+        returns,
+        market,
+        [("S00", event_date)],
+        event_window=(0, 0),
+    )
+
+    assert result.events[0].event_date == event_date
+
+
+def test_event_before_first_session_is_dropped():
+    returns, market = _panel(seed=511)
+    events = [
+        ("S00", returns.index[250]),
+        ("S01", returns.index[0] - pd.Timedelta(days=1)),
+    ]
+
+    result = event_study(returns, market, events)
+
+    assert [outcome.symbol for outcome in result.events] == ["S00"]
+    assert result.dropped[0][2] == "event date is before the frame starts"
+
+
+def test_event_after_last_session_is_dropped():
+    returns, market = _panel(seed=512)
+    events = [
+        ("S00", returns.index[250]),
+        ("S01", returns.index[-1] + pd.Timedelta(days=1)),
+    ]
+
+    result = event_study(returns, market, events)
+
+    assert [outcome.symbol for outcome in result.events] == ["S00"]
+    assert result.dropped[0][2] == "event date is after the frame ends"
+
+
 # --- clustering disclosure ---
 
 


### PR DESCRIPTION
## Summary

- anchor non-session event dates to the nearest prior row, as documented by `event_study()`
- preserve exact-session anchors and the existing after-frame rejection
- reject pre-frame events explicitly instead of allowing a negative position
- add regressions for weekend, exact-session, pre-frame, and post-frame dates

## Why

`event_study()` documents that an event date absent from the return index uses the nearest earlier row. The implementation called `index.searchsorted(event_date)` with the default left insertion rule, which selects the next row instead.

For a Saturday announcement, the study therefore anchored the event on Monday rather than Friday. A minimal reproduction with `+10%` on Friday and `-20%` on Monday reported Monday and attributed the `-20%` move to the event window.

## Changes

- use the right insertion point minus one to locate the nearest row at or before the event date
- keep dates after the final row rejected, matching the existing contract
- reject dates before the first row before any window arithmetic
- test both the corrected non-session behavior and the two outer boundaries

Deliberately out of scope:

- changing event-window, estimation-window, Patell, BMP, or CAR/CAAR calculations
- introducing a configurable next-session anchoring policy
- changing broker, order, MCP, credential, network, or deployment behavior
- reformatting the two pre-existing files

## Test Plan

- [x] New event-date regressions: `4 passed`
- [x] Full event-study module: `29 passed`
- [x] Full QuantLib suite plus public QuantLib tool tests: `1024 passed, 62 skipped`
- [x] Ruff findings restricted to newly added lines: none
- [x] `git diff --check`: passed
- [x] DCO sign-off present

Repository-wide Ruff currently reports the pre-existing unused `window_len` assignment in `eventstudy.py`, and `ruff format --check` reports pre-existing whole-file formatting drift. Both reproduce unchanged on upstream `main`; this PR does not mix those unrelated cleanups into the event-date correction.

## Risk and rollback

The behavior change is limited to event dates not present in the supplied index. Exact index labels remain exact; dates outside the index range remain rejected. Rollback is the single signed commit.
