### PR TITLE
fix(crossvalidation): align label ends to prior observation

### DIFF
--- a/agent/src/quantlib/crossvalidation.py
+++ b/agent/src/quantlib/crossvalidation.py
@@ -133,9 +133,9 @@ def _as_label_spans(
         starts = label_end_times.index
         ends = label_end_times.to_numpy()
         # searchsorted on the start index converts label end *times* into label
-        # end *positions*; 'left' then clipping keeps a label that ends between
-        # two observations attached to the earlier one.
-        positions = np.searchsorted(starts, ends, side="left")
+        # end *positions*; the right insertion point minus one keeps a label
+        # that ends between two observations attached to the earlier one.
+        positions = np.searchsorted(starts, ends, side="right") - 1
         positions = np.clip(positions, np.arange(len(starts)), len(starts) - 1)
         span_ends = positions.astype(int)
     else:

--- a/agent/tests/quantlib/test_crossvalidation.py
+++ b/agent/tests/quantlib/test_crossvalidation.py
@@ -225,6 +225,37 @@ def test_label_end_times_accepts_a_timestamp_series():
         assert split.purged >= 0
 
 
+def test_label_ending_between_observations_maps_to_the_prior_observation():
+    index = pd.date_range("2024-01-01", periods=10, freq="B")
+    ends = pd.Series(index, index=index)
+    # Observation 3 starts on Thursday and resolves on Saturday. The second
+    # fold begins on Monday, so this label does not overlap that test block.
+    ends.iloc[3] = pd.Timestamp("2024-01-06")
+
+    split = list(
+        purged_kfold_splits(len(index), ends, n_folds=2, embargo_fraction=0.0)
+    )[1]
+
+    assert split.test_bounds == (5, 9)
+    assert 3 in split.train
+    assert split.purged == 0
+
+
+def test_label_ending_on_an_observation_keeps_that_exact_position():
+    index = pd.date_range("2024-01-01", periods=10, freq="B")
+    ends = pd.Series(index, index=index)
+    # Observation 3 resolves exactly when the second fold begins, so closed
+    # intervals overlap at that instant and the observation must be purged.
+    ends.iloc[3] = index[5]
+
+    split = list(
+        purged_kfold_splits(len(index), ends, n_folds=2, embargo_fraction=0.0)
+    )[1]
+
+    assert 3 not in split.train
+    assert split.purged == 1
+
+
 def test_a_label_ending_before_it_starts_is_rejected():
     bad = np.arange(100) - 5
     with pytest.raises(ValueError, match="cannot end before"):


### PR DESCRIPTION
## Summary

- map timestamp label ends between observations to the latest prior observation
- preserve exact-timestamp closed-interval overlap behavior
- add regressions for both between-observation and exact-observation boundaries

## Root cause

`_as_label_spans()` documents each normalized value as the last positional
observation covered by a label. Its timestamp branch used left insertion,
however, so a label ending between two indexed observations was assigned to the
later observation.

For a business-day index, a label ending on Saturday was therefore treated as
covering Monday. When Monday opened a test fold, the splitter unnecessarily
purged a training observation whose outcome had already resolved before that
fold. This does not leak future information, but it reduces and misreports the
usable training sample.

The right insertion point minus one implements the documented last-observation
contract while leaving exact indexed timestamps on their exact position.

## Scope

Changed only:

- `agent/src/quantlib/crossvalidation.py`
- `agent/tests/quantlib/test_crossvalidation.py`

Out of scope:

- split construction, purge and embargo formulas
- index sorting or timezone policy
- strategy, model, order, broker, network or agent-runtime behavior
- unrelated whole-file formatting cleanup

## Validation

- red reproduction: Saturday label end incorrectly purged the Thursday sample
  from a fold beginning Monday
- `33 passed` in `test_crossvalidation.py`
- `1022 passed, 62 skipped` across QuantLib and the public QuantLib tool tests
- Ruff check passed for both changed files
- `git diff --check` passed
- DCO sign-off present

`ruff format --check` reports pre-existing whole-file formatting drift in both
files. The PR keeps the focused existing style rather than mixing unrelated
format churn into the behavioral correction.

## Risk and rollback

Risk is limited to pandas-Series label ends that fall between indexed
observations. Exact timestamps and positional-array inputs retain their existing
behavior. Reverting the single signed commit restores the previous mapping.
