### PR TITLE
fix(grounding): ignore identity constants in rate formulas

### DIFF
--- a/agent/src/agent/grounding.py
+++ b/agent/src/agent/grounding.py
@@ -183,6 +183,15 @@ _NUMBER_RE = re.compile(
 # and whitespace, so an in-text decimal like "1.5" (digit after the dot) is
 # never affected.
 _MD_LIST_ITEM_RE = re.compile(r"^\s*\d+[.)]\s+", re.MULTILINE)
+# Unitless identity constants in a symbolic rate formula are not quoted prices.
+# Without this mask, ``1 - 单边成本率`` in a position-sizing formula is read as
+# a one-yuan price merely because the same clause also mentions a close price.
+# Keep the relaxation narrow: only 0/1 directly participating in arithmetic
+# with a token explicitly labelled as a rate is removed.
+_RATE_FORMULA_IDENTITY_RE = re.compile(
+    r"\b[01](?=\s*[-+]\s*(?:[A-Za-z_][A-Za-z0-9_]*_?rate\b|[^\d\s()+*/=-]{0,12}(?:成本率|费率|税率|滑点率)))",
+    re.IGNORECASE,
+)
 _DATE_RE = re.compile(r"\b(?:19|20)\d{2}[-/]\d{1,2}[-/]\d{1,2}\b")
 # A year-less "8/5" is how a trading day is written in running prose, and it
 # contributed 8 and 5 as candidate prices (#983). The month and day ranges are
@@ -2097,6 +2106,7 @@ class GroundingLedger:
             Candidate price values, in order of appearance.
         """
         masked = _MD_LIST_ITEM_RE.sub(" ", text)
+        masked = _RATE_FORMULA_IDENTITY_RE.sub(" ", masked)
         masked = _CANONICAL_SYMBOL_RE.sub(" ", masked)
         masked = _LOCALIZED_DATE_RE.sub(" ", masked)
         masked = _DATE_RE.sub(" ", masked)

--- a/agent/tests/test_agent_grounding.py
+++ b/agent/tests/test_agent_grounding.py
@@ -1813,6 +1813,24 @@ def test_markdown_list_marker_mask_does_not_weaken_contradiction_check(
     assert [issue["value"] for issue in result.issues if issue["code"] == "numeric_claim_conflict"] == [42.0]
 
 
+@pytest.mark.parametrize(
+    "segment",
+    [
+        "买入股数 = 初始资金 × (1 - 单边成本率) / 期初收盘价",
+        "期末市值 = 买入股数 × 期末收盘价 × (1 - fee_rate)",
+        "net proceeds = shares * closing price * (1 - transaction_rate)",
+    ],
+)
+def test_rate_formula_identity_is_not_read_as_a_price(segment: str) -> None:
+    """The identity in ``1 - rate`` is arithmetic, not a one-unit quote."""
+    assert GroundingLedger._numbers_without_dates_or_percent(segment) == []
+
+
+def test_rate_formula_mask_does_not_hide_an_observed_one_unit_quote() -> None:
+    """A genuine price of 1 remains checked outside a rate expression."""
+    assert GroundingLedger._numbers_without_dates_or_percent("closing price = 1 CNY") == [1.0]
+
+
 def test_in_text_decimal_survives_list_marker_mask(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

Prevent unitless identity constants in explicit rate formulas from being classified as ungrounded market prices.

For example, the `1` in `1 - cost_rate` or `1 - 单边成本率` is algebra, not a quoted price. The mask is intentionally narrow: it only applies to `0`/`1` directly participating in arithmetic with a token explicitly labeled as a rate. A genuine statement such as `closing price = 1 CNY` remains subject to grounding checks.

## Validation

- added English and Chinese regression cases
- retained a regression assertion for a genuine 1 CNY price
- `86 passed` in `test_agent_grounding.py`
- Ruff checks passed