### PR TITLE
fix(onboard): create .env.partial with owner only permissions

### DIFF
--- a/agent/cli/onboard.py
+++ b/agent/cli/onboard.py
@@ -14,6 +14,7 @@ directly so Esc / Left-arrow can be bound to a back-step sentinel.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import tempfile
 from dataclasses import dataclass
@@ -129,14 +130,20 @@ def _render_env(values: dict[str, str]) -> str:
 
 
 def _save_partial(values: dict[str, str]) -> None:
-    """Best-effort write to ``.env.partial`` (crash-resilience nicety)."""
+    """Best-effort write to ``.env.partial`` (crash-resilience nicety).
+
+    The mode is applied at creation, as ``_finalize`` already does via
+    ``mkstemp``.
+    """
     try:
         _env_dir().mkdir(parents=True, exist_ok=True)
-        _partial_path().write_text(_render_env(values), encoding="utf-8")
-        try:
-            _partial_path().chmod(0o600)
-        except OSError:
-            pass
+        path = _partial_path()
+        with contextlib.suppress(FileNotFoundError):
+            path.unlink()
+        # O_CREAT does not apply the mode to an existing file.
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(_render_env(values))
     except OSError:
         pass
 


### PR DESCRIPTION
## Summary

- `_save_partial` in `agent/cli/onboard.py` wrote the in-progress onboarding config (API keys included) with `Path.write_text` and narrowed permissions afterward with `chmod(0o600)`
- Under the default umask this leaves the file world/group readable at 0644 for the brief window between creation and the chmod call, and permanently if the chmod raises (the exception is swallowed)

## Why

`_finalize` already writes the final `.env` via `mkstemp` (0600 from creation), and `tools/alpha_bench_tool.py`'s `_cache_hmac_key` already uses `os.open` with `O_EXCL` and mode `0o600` for the same reason: a concurrent writer must not be able to race it into a world readable key. `_save_partial`, the crash-resilience path invoked after every onboarding step, was the one place in the file that still had a create-then-chmod window.

Measured locally on Linux under the default umask: 0644 held the collected values before being narrowed to 0600, and permanently 0644 whenever the chmod raised.

## Changes

- `_save_partial` now creates the file directly at `0o600` via `os.open(..., os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)`, so the mode applies at creation rather than after
- A leftover `.env.partial` from an interrupted run is unlinked first rather than truncated in place, since `O_CREAT` does not apply the requested mode to a file that already exists — the old permissions would otherwise be inherited silently

## Test Plan

- [x] `python -m py_compile agent/cli/onboard.py`
- [x] Verified the permission-bit behavior standalone (old: created at `0o644`, narrowed to `0o600` after; new: created directly at `0o600`, including on a simulated leftover-file rerun)
- [ ] Full `pytest` suite not run (no project venv available in this environment); this is a stdlib-only change isolated to `_save_partial`, with no existing test coverage for that function to run narrower against

Signed-off-by: lukiod <mohakgupta0981@gmail.com>