### PR TITLE
feat(desktop): add dormant update safety boundary

### DIFF
--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -48,6 +48,10 @@ jobs:
         working-directory: desktop/electron
         run: npm ci
 
+      - name: Verify dormant update rejection and recovery policy
+        working-directory: desktop/electron
+        run: npm run test:update-safety
+
       - name: Verify encrypted credential storage
         working-directory: desktop/electron
         run: npm run smoke:credentials

--- a/desktop/electron/README.md
+++ b/desktop/electron/README.md
@@ -8,6 +8,12 @@ credential storage. This layer does not contain an updater, optional IM
 adapters, personal WeChat pairing, or changes to the agent loop and provider
 behavior.
 
+It also contains dormant, fail-closed building blocks for a future signed
+updater: Authenticode/publisher/version verification, an interruption-recovery
+journal, and a strict backend shutdown result. They do not check a feed,
+download an artifact, launch an installer, or enable updates. See
+[UPDATE_SAFETY.md](UPDATE_SAFETY.md).
+
 ## What the shell does
 
 - Enforces a single desktop application instance.
@@ -22,6 +28,8 @@ behavior.
 - Reports startup failures and exposes retry and log-folder actions.
 - Requests authenticated graceful shutdown before asking the watchdog to
   terminate the owned Windows process tree as a fallback.
+- Exposes a strict update-handoff shutdown call that succeeds only after the
+  owned backend PID, watchdog PID, and loopback listener are all gone.
 - Terminates the Python process tree if the Electron main process is killed
   without running JavaScript shutdown handlers.
 - Localizes desktop-owned loading, status, error, dialog, and menu text in
@@ -55,11 +63,15 @@ The Windows lifecycle suite used by CI can be run from the same directory:
 
 ```powershell
 npm run smoke:lifecycle
+npm run test:update-safety
 ```
 
 It verifies localized message parity, graceful shutdown, authentication, and
 the parent-death path by force-terminating only the Electron main PID before
-checking that the Python process and loopback listener are gone.
+checking that the Python process and loopback listener are gone. Both graceful
+and parent-death tests keep a separate Python sentinel alive throughout the
+owned-process cleanup. The update-safety test exercises the rejection matrix
+and every journal recovery phase without enabling an updater.
 
 Backend resolution is intentionally narrow. It checks an explicit
 `VIBE_TRADING_EXECUTABLE` override first, then exact application/resource

--- a/desktop/electron/README.md
+++ b/desktop/electron/README.md
@@ -29,7 +29,9 @@ download an artifact, launch an installer, or enable updates. See
 - Requests authenticated graceful shutdown before asking the watchdog to
   terminate the owned Windows process tree as a fallback.
 - Exposes a strict update-handoff shutdown call that succeeds only after the
-  owned backend PID, watchdog PID, and loopback listener are all gone.
+  owned backend PID, watchdog PID, and loopback listener are all gone. A failed
+  handoff retains those identifiers for retry, and a TCP probe keeps a
+  listening-but-unresponsive port fail-closed.
 - Terminates the Python process tree if the Electron main process is killed
   without running JavaScript shutdown handlers.
 - Localizes desktop-owned loading, status, error, dialog, and menu text in
@@ -71,7 +73,8 @@ the parent-death path by force-terminating only the Electron main PID before
 checking that the Python process and loopback listener are gone. Both graceful
 and parent-death tests keep a separate Python sentinel alive throughout the
 owned-process cleanup. The update-safety test exercises the rejection matrix
-and every journal recovery phase without enabling an updater.
+and every journal recovery phase without enabling an updater, including
+artifact mutation, concurrent journal creation, and failed-shutdown retry.
 
 Backend resolution is intentionally narrow. It checks an explicit
 `VIBE_TRADING_EXECUTABLE` override first, then exact application/resource

--- a/desktop/electron/THREAT_MODEL.md
+++ b/desktop/electron/THREAT_MODEL.md
@@ -9,6 +9,11 @@ injection into that owned Python process. Auto-update, optional messaging
 adapters, personal WeChat pairing, broker configuration, and release ownership
 remain outside this change.
 
+Dormant update-safety primitives are in scope only as a reviewable boundary:
+they inspect a caller-supplied local artifact, apply a fail-closed policy, and
+record/recover a staged attempt. No release feed, downloader, installer launch,
+or default-enabled updater exists.
+
 ## Assets
 
 - The per-launch API authentication secret.
@@ -18,6 +23,10 @@ remain outside this change.
 - LLM, Tushare, and QVeris credentials managed by the desktop host.
 - The integrity of the executable selected as the backend.
 - The ability to invoke authenticated local API routes.
+- Future update publisher policy, release digest metadata, and the integrity of
+  a staged installer.
+- The pending-update journal used to distinguish completed and interrupted
+  attempts.
 
 ## Trust boundaries
 
@@ -111,6 +120,34 @@ therefore security-significant.
 - The automated parent-death smoke test terminates only the Electron main PID,
   then independently verifies that both the Python PID and loopback listener
   are gone.
+- Graceful update handoff returns structured evidence for the exact owned
+  backend PID, watchdog PID, and listener. It fails closed if any remains.
+- Graceful and parent-death tests each start an unrelated Python sentinel and
+  verify that it remains alive; termination commands are always PID-scoped and
+  never use an image name such as `python.exe`.
+
+### Dormant update verification and recovery
+
+- Candidate release and installed versions must be valid semantic versions,
+  and the candidate must be strictly newer.
+- The artifact SHA-256 must match caller-supplied release metadata before its
+  signature is considered.
+- Windows Authenticode status must be `Valid`; unsigned and invalid signatures
+  are rejected with stable codes.
+- Publisher identity uses an explicit allowlist of SHA-256 hashes of signer
+  certificate raw bytes. Subject display names alone are not trusted.
+- No publisher is currently configured. An empty allowlist is itself a policy
+  error, so these primitives cannot silently trust the first certificate seen.
+- A pending-attempt journal is written through a same-directory temporary file
+  and rename. It records only a simple staged `.exe` file name, not an
+  arbitrary deletion path.
+- On the next launch, an attempt that still reports the old version discards
+  the staged candidate and requires a fresh download and verification. A
+  successful target version clears the journal. Any third version or malformed
+  journal is left untouched for explicit operator intervention.
+- The allowed phase order is `verified` -> `backend-stopped` ->
+  `installer-launched`. A future updater must call the strict backend shutdown
+  path before recording `backend-stopped`.
 
 ### Credential storage
 
@@ -155,6 +192,12 @@ therefore security-significant.
   credentials required by the backend.
 - Forceful tree termination can interrupt in-progress local work after the
   graceful shutdown timeout.
+- The verification policy receives its expected digest and certificate
+  allowlist from a future trusted release configuration. Feed ownership and
+  metadata authenticity are unresolved, so no runtime caller is wired today.
+- Recovery proves safe journal and staged-file handling. It does not claim to
+  roll back an installer that has already partially modified application files;
+  the signed end-to-end NSIS test remains required.
 - The review installer is deliberately unsigned and unpublished. This change
   does not provide a signing identity, installer reputation, update
   authenticity, or an official HKUDS release channel.

--- a/desktop/electron/THREAT_MODEL.md
+++ b/desktop/electron/THREAT_MODEL.md
@@ -121,7 +121,9 @@ therefore security-significant.
   then independently verifies that both the Python PID and loopback listener
   are gone.
 - Graceful update handoff returns structured evidence for the exact owned
-  backend PID, watchdog PID, and listener. It fails closed if any remains.
+  backend PID, watchdog PID, and listener. The listener check probes TCP rather
+  than HTTP responsiveness. It fails closed if any remains and retains the
+  ownership state for a later cleanup retry.
 - Graceful and parent-death tests each start an unrelated Python sentinel and
   verify that it remains alive; termination commands are always PID-scoped and
   never use an image name such as `python.exe`.
@@ -132,22 +134,31 @@ therefore security-significant.
   and the candidate must be strictly newer.
 - The artifact SHA-256 must match caller-supplied release metadata before its
   signature is considered.
+- The production Authenticode adapter holds a read-only Windows file lock that
+  denies writers and deletion while it hashes and inspects the same artifact.
+  Its locked digest and a post-inspection digest must both match release
+  metadata.
 - Windows Authenticode status must be `Valid`; unsigned and invalid signatures
   are rejected with stable codes.
 - Publisher identity uses an explicit allowlist of SHA-256 hashes of signer
   certificate raw bytes. Subject display names alone are not trusted.
 - No publisher is currently configured. An empty allowlist is itself a policy
   error, so these primitives cannot silently trust the first certificate seen.
-- A pending-attempt journal is written through a same-directory temporary file
-  and rename. It records only a simple staged `.exe` file name, not an
-  arbitrary deletion path.
+- A pending-attempt journal is fsynced to a same-directory temporary file. Its
+  first publication uses an atomic hard-link create-if-absent operation, so two
+  concurrent begins cannot replace one another; later phase changes use the
+  existing same-directory rename path. It records only a simple staged `.exe`
+  file name, not an arbitrary deletion path.
 - On the next launch, an attempt that still reports the old version discards
   the staged candidate and requires a fresh download and verification. A
   successful target version clears the journal. Any third version or malformed
   journal is left untouched for explicit operator intervention.
 - The allowed phase order is `verified` -> `backend-stopped` ->
   `installer-launched`. A future updater must call the strict backend shutdown
-  path before recording `backend-stopped`.
+  path before recording `backend-stopped`, and must re-hash the verified
+  artifact immediately before installer launch.
+- PowerShell host discovery and Authenticode inspection have hard timeouts; a
+  hung host rejects the candidate rather than blocking Electron indefinitely.
 
 ### Credential storage
 

--- a/desktop/electron/UPDATE_SAFETY.md
+++ b/desktop/electron/UPDATE_SAFETY.md
@@ -1,0 +1,113 @@
+# Dormant signed-update safety boundary
+
+## Status
+
+The desktop application still has **no updater**. There is no release feed,
+download client, update UI, background check, installer launch, or configured
+publisher identity. Updates remain disabled until issue #1016's signed
+`0.3.0 -> 0.3.1` clean-Windows validation is completed.
+
+This code makes two parts of that future review executable now:
+
+1. `update-verification.ts` verifies a local candidate against explicit release
+   and publisher policy.
+2. `update-recovery.ts` records the narrow handoff phases and resolves an
+   interrupted attempt safely on the next launch.
+
+`BackendManager.stopForUpdate()` is the required handoff boundary. It returns
+only after the exact owned backend PID, watchdog PID, and loopback listener are
+gone. It never terminates `python.exe` by image name.
+
+## Verification order
+
+The caller must supply the installed version, candidate version, expected
+SHA-256 digest, and an allowlist containing at least one publisher certificate
+SHA-256 fingerprint. The policy fails closed when the allowlist is empty.
+
+Checks run in this order:
+
+1. policy and release metadata are well formed;
+2. the candidate semantic version is strictly newer;
+3. the local file digest matches the expected SHA-256;
+4. Windows reports a `Valid` Authenticode signature;
+5. the SHA-256 hash of the signer certificate's raw bytes is allowlisted.
+
+The expected digest and publisher allowlist must eventually come from a trusted
+release configuration owned by the maintainers. That source is deliberately
+not invented here.
+
+## Rejection matrix
+
+| Scenario | Verification evidence | Stable result code | Required behavior |
+| --- | --- | --- | --- |
+| Tampered artifact | Local SHA-256 differs from release metadata | `artifact-hash-mismatch` | Do not launch; discard/quarantine the staged file |
+| Unsigned artifact | Authenticode status is `NotSigned` | `artifact-unsigned` | Do not launch, even when the digest matches |
+| Invalid or damaged signature | Authenticode status is not `Valid` or `NotSigned` | `artifact-signature-invalid` | Do not launch; record the Windows status for diagnostics |
+| Wrong publisher | Signature is valid but certificate SHA-256 is not allowlisted | `publisher-not-allowed` | Do not launch; never trust the subject name alone |
+| Equal or downgraded version | Candidate is not strictly newer | `version-not-newer` | Do not download or launch |
+| Missing publisher policy | Certificate allowlist is empty | `invalid-verification-policy` | Keep the updater disabled |
+| Malformed version or digest | Release metadata is not valid | `invalid-release-metadata` | Reject before signature inspection |
+| File or Authenticode inspection failure | Artifact cannot be read or Windows inspection fails | `artifact-inspection-failed` | Reject without launching |
+
+The unsigned automated test uses injected Authenticode observations so every
+branch is deterministic. The later signed end-to-end run must repeat the first
+five rows with real Authenticode artifacts and the agreed publisher identity.
+
+## Recovery journal
+
+The future updater may advance only through these durable phases:
+
+```text
+verified -> backend-stopped -> installer-launched
+```
+
+- `verified`: the staged candidate passed the complete verification policy.
+- `backend-stopped`: `stopForUpdate()` confirmed no owned PID or listener.
+- `installer-launched`: Windows acknowledged the installer process launch.
+
+On the next application start, the journal is reconciled against the running
+application version:
+
+| Installed version | Last phase | Recovery result |
+| --- | --- | --- |
+| Target version | Any | Mark complete; remove journal and staged candidate |
+| Original version | `verified` | Discard staged candidate; no shutdown occurred |
+| Original version | `backend-stopped` | Treat as interrupted before installer; discard and require fresh verification |
+| Original version | `installer-launched` | Treat as failed/interrupted installer; discard and require fresh verification |
+| Any third version | Any | Leave journal and artifact untouched; require manual intervention |
+| Malformed journal | Unknown | Leave it untouched; require manual intervention |
+
+The journal stores a simple `.exe` file name inside its dedicated staging
+directory. Malformed or traversal paths are never followed for deletion. Writes
+use a temporary file and same-directory rename.
+
+This recovery path restores the application to a clean retry state when the
+old or new version can launch. It does **not** claim rollback of a partially
+modified installation. That remains part of the real signed NSIS interruption
+test required by #1016.
+
+## Automated checks
+
+From `desktop/electron`:
+
+```powershell
+npm run test:update-safety
+npm run smoke:lifecycle
+npm run smoke:parent-death
+```
+
+The lifecycle tests start an unrelated Python sentinel before stopping the
+desktop-owned backend. The sentinel must still be alive after graceful and
+forced-parent-death cleanup, while the owned Python PID and listener must be
+gone.
+
+## Remaining enablement gates
+
+- maintainer-owned Authenticode identity and certificate lifecycle;
+- maintainer-owned release feed and authenticated metadata policy;
+- real signed `0.3.0 -> 0.3.1` clean-Windows upgrade;
+- preserved settings and `safeStorage` credential validation;
+- real interrupted NSIS recovery validation;
+- the rejection matrix repeated with real signed and tampered artifacts.
+
+Until every gate passes, no updater call site or release feed should be added.

--- a/desktop/electron/UPDATE_SAFETY.md
+++ b/desktop/electron/UPDATE_SAFETY.md
@@ -16,7 +16,10 @@ This code makes two parts of that future review executable now:
 
 `BackendManager.stopForUpdate()` is the required handoff boundary. It returns
 only after the exact owned backend PID, watchdog PID, and loopback listener are
-gone. It never terminates `python.exe` by image name.
+gone. Listener evidence uses a TCP connection probe rather than HTTP health, so
+a process that accepts connections but stops answering HTTP remains open. A
+failed handoff retains the exact identifiers and log stream for a later cleanup
+retry. It never terminates `python.exe` by image name.
 
 ## Verification order
 
@@ -29,8 +32,18 @@ Checks run in this order:
 1. policy and release metadata are well formed;
 2. the candidate semantic version is strictly newer;
 3. the local file digest matches the expected SHA-256;
-4. Windows reports a `Valid` Authenticode signature;
-5. the SHA-256 hash of the signer certificate's raw bytes is allowlisted.
+4. PowerShell opens the artifact with a lock that permits readers but denies
+   writers and deletion, hashes those locked bytes, and inspects Authenticode;
+5. the locked digest matches the initial and expected digests;
+6. Windows reports a `Valid` Authenticode signature;
+7. the SHA-256 hash of the signer certificate's raw bytes is allowlisted;
+8. the file digest is confirmed again after the locked inspection.
+
+The future launch path must call
+`assertVerifiedUpdateArtifactUnchanged()` immediately before starting the
+installer. Verification and PowerShell discovery are both timeout-bounded. The
+pre-launch assertion is mandatory even though the artifact was already checked:
+no result object makes a mutable path permanently trustworthy.
 
 The expected digest and publisher allowlist must eventually come from a trusted
 release configuration owned by the maintainers. That source is deliberately
@@ -48,6 +61,7 @@ not invented here.
 | Missing publisher policy | Certificate allowlist is empty | `invalid-verification-policy` | Keep the updater disabled |
 | Malformed version or digest | Release metadata is not valid | `invalid-release-metadata` | Reject before signature inspection |
 | File or Authenticode inspection failure | Artifact cannot be read or Windows inspection fails | `artifact-inspection-failed` | Reject without launching |
+| Artifact replaced during inspection | Locked Authenticode digest or post-inspection digest differs | `artifact-changed-during-verification` | Reject and require a fresh staged artifact |
 
 The unsigned automated test uses injected Authenticode observations so every
 branch is deterministic. The later signed end-to-end run must repeat the first
@@ -78,8 +92,11 @@ application version:
 | Malformed journal | Unknown | Leave it untouched; require manual intervention |
 
 The journal stores a simple `.exe` file name inside its dedicated staging
-directory. Malformed or traversal paths are never followed for deletion. Writes
-use a temporary file and same-directory rename.
+directory. Malformed or traversal paths are never followed for deletion. A
+begin operation fsyncs a complete same-directory temporary file and publishes
+it with an atomic hard-link create-if-absent operation. Concurrent begins can
+therefore never overwrite one another. Later phase writes retain the
+same-directory rename path.
 
 This recovery path restores the application to a clean retry state when the
 old or new version can launch. It does **not** claim rollback of a partially
@@ -99,7 +116,11 @@ npm run smoke:parent-death
 The lifecycle tests start an unrelated Python sentinel before stopping the
 desktop-owned backend. The sentinel must still be alive after graceful and
 forced-parent-death cleanup, while the owned Python PID and listener must be
-gone.
+gone. The update-safety test also holds open a TCP listener that never answers
+HTTP, proves shutdown fails closed while retaining the exact identifiers, then
+closes the listener and proves a second cleanup attempt succeeds. It races two
+journal begins and requires exactly one durable winner, and mutates an artifact
+during and after verification to exercise both integrity gates.
 
 ## Remaining enablement gates
 

--- a/desktop/electron/WINDOWS_PACKAGING.md
+++ b/desktop/electron/WINDOWS_PACKAGING.md
@@ -20,6 +20,11 @@ This layer is stacked on the desktop lifecycle shell and adds only:
 Users can install an optional adapter later from a source/developer environment.
 The desktop runtime does not expose a package installer UI in this change.
 
+The source tree contains dormant verification and recovery primitives for the
+future signed-updater review. They remain disconnected from application startup
+and cannot download or launch anything. Their rejection and recovery contract
+is documented in [UPDATE_SAFETY.md](UPDATE_SAFETY.md).
+
 ## Build
 
 From a complete checkout of the current upstream source:

--- a/desktop/electron/package.json
+++ b/desktop/electron/package.json
@@ -11,6 +11,7 @@
     "start": "npm run build && electron .",
     "test:locales": "npm run build && node scripts/test-locales.mjs",
     "test:backend-resolution": "npm run build && node scripts/test-backend-resolution.mjs",
+    "test:update-safety": "npm run build && node scripts/test-update-safety.mjs",
     "smoke:parent-death": "npm run build && node scripts/smoke-parent-death.mjs",
     "prepare:electron": "node scripts/prepare-electron.mjs",
     "runtime:win": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/build-backend.ps1",

--- a/desktop/electron/scripts/process-sentinel.mjs
+++ b/desktop/electron/scripts/process-sentinel.mjs
@@ -1,0 +1,50 @@
+import { spawn } from "node:child_process";
+
+export async function startUnrelatedPythonSentinel() {
+  const executable = process.env.VIBE_TRADING_DESKTOP_TEST_PYTHON || "python.exe";
+  const child = spawn(
+    executable,
+    ["-c", "import time; time.sleep(600)"],
+    { windowsHide: true, stdio: "ignore" },
+  );
+  await new Promise((resolve, reject) => {
+    child.once("spawn", resolve);
+    child.once("error", reject);
+  });
+  if (!child.pid) throw new Error("Unrelated Python sentinel started without a PID");
+  return {
+    pid: child.pid,
+    isAlive: () => isProcessAlive(child.pid),
+    stop: () => terminateExactProcessTree(child.pid),
+  };
+}
+
+function isProcessAlive(pid) {
+  if (!pid) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function terminateExactProcessTree(pid) {
+  if (!pid || !isProcessAlive(pid)) return Promise.resolve();
+  if (process.platform !== "win32") {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // The sentinel already exited.
+    }
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    const killer = spawn("taskkill.exe", ["/PID", String(pid), "/T", "/F"], {
+      windowsHide: true,
+      stdio: "ignore",
+    });
+    killer.once("error", () => resolve());
+    killer.once("exit", () => resolve());
+  });
+}

--- a/desktop/electron/scripts/smoke-lifecycle.mjs
+++ b/desktop/electron/scripts/smoke-lifecycle.mjs
@@ -1,3 +1,4 @@
+import assert from "node:assert/strict";
 import { randomBytes } from "node:crypto";
 import { mkdtemp } from "node:fs/promises";
 import os from "node:os";
@@ -6,12 +7,14 @@ import { fileURLToPath } from "node:url";
 
 import { BackendManager } from "../dist/backend-manager.js";
 import { getDesktopMessages } from "../dist/locales.js";
+import { startUnrelatedPythonSentinel } from "./process-sentinel.mjs";
 
 const electronRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const logDirectory = await mkdtemp(path.join(os.tmpdir(), "vibe-trading-desktop-shell-"));
 const statuses = [];
 let unexpectedExit;
 const apiAuthKey = randomBytes(32).toString("base64url");
+const unrelatedPython = await startUnrelatedPythonSentinel();
 
 const backend = new BackendManager({
   appPath: electronRoot,
@@ -26,6 +29,7 @@ const backend = new BackendManager({
 });
 
 let url;
+let shutdownEvidence;
 try {
   url = await backend.start();
   const parsed = new URL(url);
@@ -48,23 +52,23 @@ try {
   }
   if (unexpectedExit) throw new Error(unexpectedExit);
 } finally {
-  await backend.stop();
-}
-
-let stopped = false;
-if (url) {
   try {
-    await fetch(new URL("health", url), { signal: AbortSignal.timeout(1_000) });
-  } catch {
-    stopped = true;
+    shutdownEvidence = await backend.stopForUpdate();
+    assert.equal(unrelatedPython.isAlive(), true, "Shutdown terminated an unrelated Python process");
+  } finally {
+    await unrelatedPython.stop();
   }
 }
-if (!stopped) throw new Error("Backend still accepted connections after shutdown");
+assert.equal(shutdownEvidence.backendExited, true);
+assert.equal(shutdownEvidence.watchdogExited, true);
+assert.equal(shutdownEvidence.listenerClosed, true);
 
 console.log(JSON.stringify({
   backendOrigin: new URL(url).origin,
   statuses,
   logDirectory,
   authBoundaryVerified: true,
-  shutdownVerified: stopped,
+  shutdownVerified: true,
+  unrelatedPythonPid: unrelatedPython.pid,
+  unrelatedPythonSurvived: true,
 }, null, 2));

--- a/desktop/electron/scripts/smoke-parent-death.mjs
+++ b/desktop/electron/scripts/smoke-parent-death.mjs
@@ -4,6 +4,7 @@ import { mkdtemp, readFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { startUnrelatedPythonSentinel } from "./process-sentinel.mjs";
 
 if (process.platform !== "win32") {
   console.log("Parent-death smoke is Windows-specific; skipped on this platform.");
@@ -18,6 +19,7 @@ const testDirectory = await mkdtemp(path.join(os.tmpdir(), "vibe-desktop-parent-
 const readyFile = path.join(testDirectory, "ready.json");
 const userData = path.join(testDirectory, "user-data");
 const output = [];
+const unrelatedPython = await startUnrelatedPythonSentinel();
 const electronMain = spawn(electronPath, [electronRoot, "--disable-gpu"], {
   cwd: electronRoot,
   windowsHide: true,
@@ -52,6 +54,11 @@ try {
     20_000,
     `Backend listener ${ready.backendOrigin} survived Electron main termination`,
   );
+  assert.equal(
+    unrelatedPython.isAlive(),
+    true,
+    "Parent-death cleanup terminated an unrelated Python process",
+  );
 
   console.log(JSON.stringify({
     killedPid: ready.mainPid,
@@ -60,6 +67,8 @@ try {
     backendOrigin: ready.backendOrigin,
     backendExited: true,
     listenerClosed: true,
+    unrelatedPythonPid: unrelatedPython.pid,
+    unrelatedPythonSurvived: true,
   }, null, 2));
 } finally {
   if (electronMain.pid && isProcessAlive(electronMain.pid)) {
@@ -68,6 +77,7 @@ try {
   if (ready?.backendPid && isProcessAlive(ready.backendPid)) {
     await killProcessTree(ready.backendPid);
   }
+  await unrelatedPython.stop();
 }
 
 async function waitForReadyFile(filePath, timeoutMs, child, capturedOutput) {

--- a/desktop/electron/scripts/test-update-safety.mjs
+++ b/desktop/electron/scripts/test-update-safety.mjs
@@ -1,11 +1,16 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
+import { writeFileSync } from "node:fs";
 import { access, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { createServer } from "node:net";
 import os from "node:os";
 import path from "node:path";
 
+import { BackendManager } from "../dist/backend-manager.js";
+import { getDesktopMessages } from "../dist/locales.js";
 import { UpdateRecoveryJournal } from "../dist/update-recovery.js";
 import {
+  assertVerifiedUpdateArtifactUnchanged,
   compareSemanticVersions,
   inspectAuthenticodeSignature,
   verifyWindowsUpdateCandidate,
@@ -26,12 +31,14 @@ const policy = {
 };
 const validSignature = () => ({
   status: "Valid",
+  artifactSha256: fixtureHash,
   signerSubject: "CN=Vibe-Trading Test Publisher",
   certificateSha256: publisher,
 });
 
 const accepted = await verifyWindowsUpdateCandidate(candidate, policy, validSignature);
 assert.equal(accepted.accepted, true);
+await assertVerifiedUpdateArtifactUnchanged(artifactPath, accepted.sha256);
 
 await expectRejection(
   { ...candidate, expectedSha256: "00".repeat(32) },
@@ -76,6 +83,31 @@ await expectRejection(
   validSignature,
   "artifact-inspection-failed",
 );
+await expectRejection(
+  candidate,
+  policy,
+  () => ({ ...validSignature(), artifactSha256: otherPublisher }),
+  "artifact-changed-during-verification",
+);
+
+const mutationArtifactPath = path.join(testRoot, "mutation.exe");
+await writeFile(mutationArtifactPath, fixture);
+await expectRejection(
+  { ...candidate, artifactPath: mutationArtifactPath },
+  policy,
+  (inspectedPath) => {
+    writeFileSync(inspectedPath, Buffer.from("changed-during-signature-inspection", "utf8"));
+    return validSignature();
+  },
+  "artifact-changed-during-verification",
+);
+
+await writeFile(artifactPath, Buffer.from("changed-after-verification", "utf8"));
+await assert.rejects(
+  () => assertVerifiedUpdateArtifactUnchanged(artifactPath, accepted.sha256),
+  /changed before installer launch/u,
+);
+await writeFile(artifactPath, fixture);
 
 assert.equal(compareSemanticVersions("0.3.1", "0.3.0"), 1);
 assert.equal(compareSemanticVersions("0.3.1-beta.2", "0.3.1-beta.1"), 1);
@@ -140,6 +172,21 @@ assert.equal(
 assert.equal(await exists(mismatchArtifact), true);
 assert.equal(await exists(mismatchJournal.journalPath), true);
 
+const concurrentDirectory = await mkdtemp(path.join(testRoot, "concurrent-"));
+const concurrentJournal = new UpdateRecoveryJournal(concurrentDirectory);
+const concurrentResults = await Promise.allSettled([
+  concurrentJournal.begin(newAttempt("first.exe")),
+  concurrentJournal.begin(newAttempt("second.exe")),
+]);
+const concurrentWinners = concurrentResults.filter((result) => result.status === "fulfilled");
+const concurrentLosers = concurrentResults.filter((result) => result.status === "rejected");
+assert.equal(concurrentWinners.length, 1);
+assert.equal(concurrentLosers.length, 1);
+assert.match(String(concurrentLosers[0].reason), /already exists/u);
+const concurrentRecord = JSON.parse(await readFile(concurrentJournal.journalPath, "utf8"));
+assert.equal(concurrentRecord.attemptId, concurrentWinners[0].value.attemptId);
+assert.equal(concurrentRecord.artifactFileName, concurrentWinners[0].value.artifactFileName);
+
 const traversalDirectory = await mkdtemp(path.join(testRoot, "traversal-"));
 const traversalJournal = new UpdateRecoveryJournal(traversalDirectory);
 const protectedFile = path.join(testRoot, "protected.exe");
@@ -158,9 +205,56 @@ assert.equal(
 );
 assert.equal((await readFile(protectedFile)).equals(fixture), true);
 
+const hungListener = createServer(() => {
+  // Accept TCP and deliberately never speak HTTP. Shutdown evidence must still
+  // classify this port as open.
+});
+await listen(hungListener);
+const hungAddress = hungListener.address();
+if (!hungAddress || typeof hungAddress === "string") throw new Error("Expected a TCP listener address");
+const hungBaseUrl = `http://127.0.0.1:${hungAddress.port}/`;
+const retainedBackendPid = 2_147_483_646;
+const retainedWatchdogPid = 2_147_483_647;
+const retainedManager = new BackendManager({
+  appPath: testRoot,
+  resourcesPath: testRoot,
+  allowSourceDiscovery: false,
+  logDirectory: testRoot,
+  apiAuthKey: "test-auth-key",
+  messages: getDesktopMessages("en"),
+  shutdownEvidenceTimeoutMilliseconds: 25,
+  onStatus: () => {},
+  onUnexpectedExit: () => {},
+});
+// TypeScript `private` fields compile to ordinary properties. This test seam
+// models an already-exited watchdog whose exact identifiers must be retained
+// while a stubborn listener survives.
+retainedManager.watchdog = {
+  pid: retainedWatchdogPid,
+  exitCode: 0,
+  signalCode: null,
+};
+retainedManager.backendPid = retainedBackendPid;
+retainedManager.baseUrl = hungBaseUrl;
+await assert.rejects(() => retainedManager.stopForUpdate(), /could not be verified/u);
+assert.equal(retainedManager.url, hungBaseUrl);
+assert.equal(retainedManager.processId, retainedBackendPid);
+await close(hungListener);
+const retriedEvidence = await retainedManager.stopForUpdate();
+assert.deepEqual(retriedEvidence, {
+  backendPid: retainedBackendPid,
+  watchdogPid: retainedWatchdogPid,
+  backendExited: true,
+  watchdogExited: true,
+  listenerClosed: true,
+});
+assert.equal(retainedManager.url, undefined);
+assert.equal(retainedManager.processId, undefined);
+
 console.log(JSON.stringify({
-  verificationCases: ["accepted", "tampered", "unsigned", "invalid-signature", "wrong-publisher", "downgraded"],
-  recoveryPhases: ["verified", "backend-stopped", "installer-launched", "completed", "version-mismatch", "path-traversal"],
+  verificationCases: ["accepted", "tampered", "unsigned", "invalid-signature", "wrong-publisher", "downgraded", "mutation-during-verification", "mutation-before-launch"],
+  recoveryPhases: ["verified", "backend-stopped", "installer-launched", "completed", "version-mismatch", "path-traversal", "concurrent-begin"],
+  shutdownFailureRetryVerified: true,
   authenticodeAdapterVerified,
   updaterEnabled: false,
 }, null, 2));
@@ -188,4 +282,20 @@ async function exists(file) {
   } catch {
     return false;
   }
+}
+
+function listen(server) {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+  });
 }

--- a/desktop/electron/scripts/test-update-safety.mjs
+++ b/desktop/electron/scripts/test-update-safety.mjs
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { access, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { UpdateRecoveryJournal } from "../dist/update-recovery.js";
+import {
+  compareSemanticVersions,
+  inspectAuthenticodeSignature,
+  verifyWindowsUpdateCandidate,
+} from "../dist/update-verification.js";
+
+const fixture = Buffer.from("vibe-trading-update-safety-fixture", "utf8");
+const fixtureHash = createHash("sha256").update(fixture).digest("hex");
+const publisher = "ab".repeat(32);
+const otherPublisher = "cd".repeat(32);
+const testRoot = await mkdtemp(path.join(os.tmpdir(), "vibe-update-safety-"));
+const artifactPath = path.join(testRoot, "candidate.exe");
+await writeFile(artifactPath, fixture);
+
+const candidate = { artifactPath, version: "0.3.1", expectedSha256: fixtureHash };
+const policy = {
+  currentVersion: "0.3.0",
+  allowedPublisherCertificateSha256: [publisher],
+};
+const validSignature = () => ({
+  status: "Valid",
+  signerSubject: "CN=Vibe-Trading Test Publisher",
+  certificateSha256: publisher,
+});
+
+const accepted = await verifyWindowsUpdateCandidate(candidate, policy, validSignature);
+assert.equal(accepted.accepted, true);
+
+await expectRejection(
+  { ...candidate, expectedSha256: "00".repeat(32) },
+  policy,
+  validSignature,
+  "artifact-hash-mismatch",
+);
+await expectRejection(candidate, policy, () => ({ status: "NotSigned" }), "artifact-unsigned");
+await expectRejection(
+  candidate,
+  policy,
+  () => ({ status: "HashMismatch", certificateSha256: publisher }),
+  "artifact-signature-invalid",
+);
+await expectRejection(
+  candidate,
+  policy,
+  () => ({ status: "Valid", certificateSha256: otherPublisher }),
+  "publisher-not-allowed",
+);
+await expectRejection(
+  { ...candidate, version: "0.2.9" },
+  policy,
+  validSignature,
+  "version-not-newer",
+);
+await expectRejection(
+  candidate,
+  { ...policy, allowedPublisherCertificateSha256: [] },
+  validSignature,
+  "invalid-verification-policy",
+);
+await expectRejection(
+  candidate,
+  { ...policy, allowedPublisherCertificateSha256: [publisher, "malformed"] },
+  validSignature,
+  "invalid-verification-policy",
+);
+await expectRejection(
+  { ...candidate, artifactPath: path.join(testRoot, "missing.exe") },
+  policy,
+  validSignature,
+  "artifact-inspection-failed",
+);
+
+assert.equal(compareSemanticVersions("0.3.1", "0.3.0"), 1);
+assert.equal(compareSemanticVersions("0.3.1-beta.2", "0.3.1-beta.1"), 1);
+assert.equal(compareSemanticVersions("0.3.1-beta.1", "0.3.1"), -1);
+assert.equal(compareSemanticVersions("0.3.0+build.2", "0.3.0+build.1"), 0);
+assert.throws(() => compareSemanticVersions("0.3.1-01", "0.3.0"));
+
+let authenticodeAdapterVerified = false;
+if (process.platform === "win32") {
+  if (!process.env.SystemRoot) throw new Error("SystemRoot is required for the Authenticode adapter test");
+  const signedSystemBinary = path.join(
+    process.env.SystemRoot,
+    "System32",
+    "WindowsPowerShell",
+    "v1.0",
+    "powershell.exe",
+  );
+  const inspection = inspectAuthenticodeSignature(signedSystemBinary);
+  assert.equal(inspection.status, "Valid");
+  assert.match(inspection.certificateSha256 || "", /^[a-f0-9]{64}$/u);
+  authenticodeAdapterVerified = true;
+}
+
+for (const scenario of [
+  { phase: "verified", disposition: "discarded-before-shutdown" },
+  { phase: "backend-stopped", disposition: "interrupted-before-installer" },
+  { phase: "installer-launched", disposition: "installer-failed-or-interrupted" },
+]) {
+  const directory = await mkdtemp(path.join(testRoot, "recovery-"));
+  const journal = new UpdateRecoveryJournal(directory);
+  const stagedArtifact = path.join(directory, "update.exe");
+  await writeFile(stagedArtifact, fixture);
+  let attempt = await journal.begin(newAttempt("update.exe"));
+  if (scenario.phase === "backend-stopped" || scenario.phase === "installer-launched") {
+    attempt = await journal.advance(attempt.attemptId, "backend-stopped");
+  }
+  if (scenario.phase === "installer-launched") {
+    attempt = await journal.advance(attempt.attemptId, "installer-launched");
+  }
+  const recovery = await journal.recover("0.3.0");
+  assert.equal(recovery.disposition, scenario.disposition);
+  assert.equal(await exists(stagedArtifact), false);
+  assert.equal(await exists(journal.journalPath), false);
+}
+
+const completedDirectory = await mkdtemp(path.join(testRoot, "completed-"));
+const completedJournal = new UpdateRecoveryJournal(completedDirectory);
+await writeFile(path.join(completedDirectory, "update.exe"), fixture);
+await completedJournal.begin(newAttempt("update.exe"));
+assert.equal((await completedJournal.recover("0.3.1")).disposition, "completed");
+
+const mismatchDirectory = await mkdtemp(path.join(testRoot, "mismatch-"));
+const mismatchJournal = new UpdateRecoveryJournal(mismatchDirectory);
+const mismatchArtifact = path.join(mismatchDirectory, "update.exe");
+await writeFile(mismatchArtifact, fixture);
+await mismatchJournal.begin(newAttempt("update.exe"));
+await assert.rejects(() => mismatchJournal.begin(newAttempt("other.exe")), /already exists/u);
+assert.equal(
+  (await mismatchJournal.recover("0.4.0")).disposition,
+  "manual-intervention-required",
+);
+assert.equal(await exists(mismatchArtifact), true);
+assert.equal(await exists(mismatchJournal.journalPath), true);
+
+const traversalDirectory = await mkdtemp(path.join(testRoot, "traversal-"));
+const traversalJournal = new UpdateRecoveryJournal(traversalDirectory);
+const protectedFile = path.join(testRoot, "protected.exe");
+await writeFile(protectedFile, fixture);
+await writeFile(traversalJournal.journalPath, JSON.stringify({
+  ...newAttempt("../protected.exe"),
+  schemaVersion: 1,
+  attemptId: "ef".repeat(16),
+  phase: "verified",
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+}));
+assert.equal(
+  (await traversalJournal.recover("0.3.0")).disposition,
+  "manual-intervention-required",
+);
+assert.equal((await readFile(protectedFile)).equals(fixture), true);
+
+console.log(JSON.stringify({
+  verificationCases: ["accepted", "tampered", "unsigned", "invalid-signature", "wrong-publisher", "downgraded"],
+  recoveryPhases: ["verified", "backend-stopped", "installer-launched", "completed", "version-mismatch", "path-traversal"],
+  authenticodeAdapterVerified,
+  updaterEnabled: false,
+}, null, 2));
+
+async function expectRejection(candidateValue, policyValue, inspector, expectedCode) {
+  const result = await verifyWindowsUpdateCandidate(candidateValue, policyValue, inspector);
+  assert.equal(result.accepted, false);
+  assert.equal(result.code, expectedCode);
+}
+
+function newAttempt(artifactFileName) {
+  return {
+    fromVersion: "0.3.0",
+    toVersion: "0.3.1",
+    artifactFileName,
+    artifactSha256: fixtureHash,
+    publisherCertificateSha256: publisher,
+  };
+}
+
+async function exists(file) {
+  try {
+    await access(file);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/desktop/electron/src/backend-manager.ts
+++ b/desktop/electron/src/backend-manager.ts
@@ -31,6 +31,14 @@ export type ResolvedBackend = {
   includeServeCommand: boolean;
 };
 
+export type BackendShutdownEvidence = {
+  backendPid?: number;
+  watchdogPid?: number;
+  backendExited: boolean;
+  watchdogExited: boolean;
+  listenerClosed: boolean;
+};
+
 export type BackendResolutionOptions = {
   appPath: string;
   resourcesPath: string;
@@ -145,9 +153,14 @@ export class BackendManager {
     return this.baseUrl;
   }
 
-  async stop(): Promise<void> {
+  async stop(): Promise<BackendShutdownEvidence> {
     const watchdog = this.watchdog;
-    if (!watchdog) return;
+    const backendPid = this.backendPid;
+    const watchdogPid = watchdog?.pid;
+    const baseUrl = this.baseUrl;
+    if (!watchdog) {
+      return shutdownEvidence(backendPid, watchdogPid, baseUrl);
+    }
     this.stopping = true;
     if (isRunning(watchdog) && this.baseUrl) {
       try {
@@ -178,12 +191,31 @@ export class BackendManager {
       await runTaskkill(watchdog.pid);
     }
 
+    const evidence = await waitForShutdownEvidence(
+      backendPid,
+      watchdogPid,
+      baseUrl,
+      5_000,
+    );
+    if (!evidence.backendExited || !evidence.watchdogExited || !evidence.listenerClosed) {
+      this.writeLog(`[SHUTDOWN] incomplete evidence ${JSON.stringify(evidence)}`);
+    }
+
     this.watchdog = undefined;
     this.watchdogError = undefined;
     this.backendPid = undefined;
     this.baseUrl = undefined;
     await new Promise<void>((resolve) => this.logStream?.end(resolve) ?? resolve());
     this.logStream = undefined;
+    return evidence;
+  }
+
+  async stopForUpdate(): Promise<BackendShutdownEvidence> {
+    const evidence = await this.stop();
+    if (!evidence.backendExited || !evidence.watchdogExited || !evidence.listenerClosed) {
+      throw new Error(`Owned backend shutdown could not be verified: ${JSON.stringify(evidence)}`);
+    }
+    return evidence;
   }
 
   get url(): string | undefined {
@@ -399,6 +431,58 @@ function waitForExit(child: ChildProcess): Promise<void> {
 
 function delay(milliseconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function waitForShutdownEvidence(
+  backendPid: number | undefined,
+  watchdogPid: number | undefined,
+  baseUrl: string | undefined,
+  timeoutMilliseconds: number,
+): Promise<BackendShutdownEvidence> {
+  const deadline = Date.now() + timeoutMilliseconds;
+  let evidence = await shutdownEvidence(backendPid, watchdogPid, baseUrl);
+  while (
+    Date.now() < deadline &&
+    (!evidence.backendExited || !evidence.watchdogExited || !evidence.listenerClosed)
+  ) {
+    await delay(100);
+    evidence = await shutdownEvidence(backendPid, watchdogPid, baseUrl);
+  }
+  return evidence;
+}
+
+async function shutdownEvidence(
+  backendPid: number | undefined,
+  watchdogPid: number | undefined,
+  baseUrl: string | undefined,
+): Promise<BackendShutdownEvidence> {
+  return {
+    backendPid,
+    watchdogPid,
+    backendExited: !backendPid || !isProcessAlive(backendPid),
+    watchdogExited: !watchdogPid || !isProcessAlive(watchdogPid),
+    listenerClosed: !baseUrl || !(await listenerAcceptsConnections(baseUrl)),
+  };
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function listenerAcceptsConnections(baseUrl: string): Promise<boolean> {
+  try {
+    await fetch(new URL("health", baseUrl), {
+      signal: AbortSignal.timeout(500),
+    });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function runTaskkill(pid: number): Promise<void> {

--- a/desktop/electron/src/backend-manager.ts
+++ b/desktop/electron/src/backend-manager.ts
@@ -6,7 +6,7 @@ import {
   readFileSync,
   WriteStream,
 } from "node:fs";
-import { createServer } from "node:net";
+import { connect, createServer } from "node:net";
 import path from "node:path";
 import {
   DesktopMessages,
@@ -21,6 +21,7 @@ type BackendManagerOptions = {
   apiAuthKey: string;
   messages: DesktopMessages;
   credentialEnvironment?: NodeJS.ProcessEnv;
+  shutdownEvidenceTimeoutMilliseconds?: number;
   onStatus: (message: string) => void;
   onUnexpectedExit: (message: string) => void;
 };
@@ -38,6 +39,11 @@ export type BackendShutdownEvidence = {
   watchdogExited: boolean;
   listenerClosed: boolean;
 };
+
+type BackendShutdownTarget = Pick<
+  BackendShutdownEvidence,
+  "backendPid" | "watchdogPid"
+> & { baseUrl?: string };
 
 export type BackendResolutionOptions = {
   appPath: string;
@@ -62,6 +68,7 @@ export class BackendManager {
   private watchdogError: Error | undefined;
   private backendPid: number | undefined;
   private baseUrl: string | undefined;
+  private shutdownTarget: BackendShutdownTarget | undefined;
   private stopping = false;
   private logStream: WriteStream | undefined;
   private readonly recentOutput: string[] = [];
@@ -138,7 +145,6 @@ export class BackendManager {
     });
     watchdog.once("exit", (code, signal) => {
       this.writeLog(`[WATCHDOG] exited code=${String(code)} signal=${String(signal)}`);
-      this.backendPid = undefined;
       if (!this.stopping) {
         this.options.onUnexpectedExit(formatDesktopMessage(
           this.options.messages.backendUnexpectedExit,
@@ -155,16 +161,16 @@ export class BackendManager {
 
   async stop(): Promise<BackendShutdownEvidence> {
     const watchdog = this.watchdog;
-    const backendPid = this.backendPid;
-    const watchdogPid = watchdog?.pid;
-    const baseUrl = this.baseUrl;
-    if (!watchdog) {
-      return shutdownEvidence(backendPid, watchdogPid, baseUrl);
-    }
+    const target = this.shutdownTarget ?? {
+      backendPid: this.backendPid,
+      watchdogPid: watchdog?.pid,
+      baseUrl: this.baseUrl,
+    };
+    this.shutdownTarget = target;
     this.stopping = true;
-    if (isRunning(watchdog) && this.baseUrl) {
+    if (watchdog && isRunning(watchdog) && target.baseUrl) {
       try {
-        await fetch(new URL("system/shutdown", this.baseUrl), {
+        await fetch(new URL("system/shutdown", target.baseUrl), {
           method: "POST",
           headers: { Authorization: `Bearer ${this.options.apiAuthKey}` },
           signal: AbortSignal.timeout(2_000),
@@ -174,11 +180,11 @@ export class BackendManager {
       }
     }
 
-    if (isRunning(watchdog)) {
+    if (watchdog && isRunning(watchdog)) {
       await Promise.race([waitForExit(watchdog), delay(3_000)]);
     }
-    if (isRunning(watchdog)) {
-      this.writeLog(`[SHUTDOWN] asking watchdog to terminate backend pid=${String(this.backendPid)}`);
+    if (watchdog && isRunning(watchdog)) {
+      this.writeLog(`[SHUTDOWN] asking watchdog to terminate backend pid=${String(target.backendPid)}`);
       try {
         watchdog.send({ type: "terminate-backend" });
       } catch (error) {
@@ -186,21 +192,23 @@ export class BackendManager {
       }
       await Promise.race([waitForExit(watchdog), delay(5_000)]);
     }
-    if (isRunning(watchdog) && watchdog.pid) {
-      this.writeLog(`[SHUTDOWN] terminating watchdog tree pid=${watchdog.pid}`);
-      await runTaskkill(watchdog.pid);
+    if (watchdog && isRunning(watchdog) && target.watchdogPid) {
+      this.writeLog(`[SHUTDOWN] terminating watchdog tree pid=${target.watchdogPid}`);
+      await runTaskkill(target.watchdogPid);
     }
 
     const evidence = await waitForShutdownEvidence(
-      backendPid,
-      watchdogPid,
-      baseUrl,
-      5_000,
+      target.backendPid,
+      target.watchdogPid,
+      target.baseUrl,
+      this.options.shutdownEvidenceTimeoutMilliseconds ?? 5_000,
     );
-    if (!evidence.backendExited || !evidence.watchdogExited || !evidence.listenerClosed) {
+    if (!isCompleteShutdownEvidence(evidence)) {
       this.writeLog(`[SHUTDOWN] incomplete evidence ${JSON.stringify(evidence)}`);
+      return evidence;
     }
 
+    this.shutdownTarget = undefined;
     this.watchdog = undefined;
     this.watchdogError = undefined;
     this.backendPid = undefined;
@@ -212,7 +220,7 @@ export class BackendManager {
 
   async stopForUpdate(): Promise<BackendShutdownEvidence> {
     const evidence = await this.stop();
-    if (!evidence.backendExited || !evidence.watchdogExited || !evidence.listenerClosed) {
+    if (!isCompleteShutdownEvidence(evidence)) {
       throw new Error(`Owned backend shutdown could not be verified: ${JSON.stringify(evidence)}`);
     }
     return evidence;
@@ -443,7 +451,7 @@ async function waitForShutdownEvidence(
   let evidence = await shutdownEvidence(backendPid, watchdogPid, baseUrl);
   while (
     Date.now() < deadline &&
-    (!evidence.backendExited || !evidence.watchdogExited || !evidence.listenerClosed)
+    !isCompleteShutdownEvidence(evidence)
   ) {
     await delay(100);
     evidence = await shutdownEvidence(backendPid, watchdogPid, baseUrl);
@@ -461,8 +469,12 @@ async function shutdownEvidence(
     watchdogPid,
     backendExited: !backendPid || !isProcessAlive(backendPid),
     watchdogExited: !watchdogPid || !isProcessAlive(watchdogPid),
-    listenerClosed: !baseUrl || !(await listenerAcceptsConnections(baseUrl)),
+    listenerClosed: !baseUrl || await listenerIsClosed(baseUrl),
   };
+}
+
+function isCompleteShutdownEvidence(evidence: BackendShutdownEvidence): boolean {
+  return evidence.backendExited && evidence.watchdogExited && evidence.listenerClosed;
 }
 
 function isProcessAlive(pid: number): boolean {
@@ -474,15 +486,32 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
-async function listenerAcceptsConnections(baseUrl: string): Promise<boolean> {
+async function listenerIsClosed(baseUrl: string): Promise<boolean> {
+  let endpoint: URL;
   try {
-    await fetch(new URL("health", baseUrl), {
-      signal: AbortSignal.timeout(500),
-    });
-    return true;
+    endpoint = new URL(baseUrl);
   } catch {
     return false;
   }
+  const port = Number(endpoint.port);
+  if (!Number.isSafeInteger(port) || port <= 0 || port > 65_535) return false;
+  return new Promise((resolve) => {
+    const socket = connect({ host: endpoint.hostname, port });
+    let settled = false;
+    const finish = (closed: boolean): void => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(closed);
+    };
+    socket.setTimeout(500, () => finish(false));
+    socket.once("connect", () => finish(false));
+    socket.once("error", (error: NodeJS.ErrnoException) => {
+      // Only an explicit loopback refusal proves that no listener accepted the
+      // connection. Timeouts and other socket failures stay fail-closed.
+      finish(error.code === "ECONNREFUSED");
+    });
+  });
 }
 
 function runTaskkill(pid: number): Promise<void> {

--- a/desktop/electron/src/update-recovery.ts
+++ b/desktop/electron/src/update-recovery.ts
@@ -1,0 +1,215 @@
+import { randomBytes } from "node:crypto";
+import { mkdir, readFile, rename, rm, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { compareSemanticVersions } from "./update-verification";
+
+export type UpdateAttemptPhase = "verified" | "backend-stopped" | "installer-launched";
+
+export type UpdateAttempt = {
+  schemaVersion: 1;
+  attemptId: string;
+  fromVersion: string;
+  toVersion: string;
+  artifactFileName: string;
+  artifactSha256: string;
+  publisherCertificateSha256: string;
+  phase: UpdateAttemptPhase;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type UpdateRecoveryDisposition =
+  | "none"
+  | "completed"
+  | "discarded-before-shutdown"
+  | "interrupted-before-installer"
+  | "installer-failed-or-interrupted"
+  | "manual-intervention-required";
+
+export type UpdateRecoveryResult = {
+  disposition: UpdateRecoveryDisposition;
+  attempt?: UpdateAttempt;
+  detail?: string;
+};
+
+const journalFileName = "pending-update.json";
+
+export class UpdateRecoveryJournal {
+  readonly stagingDirectory: string;
+  readonly journalPath: string;
+
+  constructor(rootDirectory: string) {
+    this.stagingDirectory = path.resolve(rootDirectory);
+    this.journalPath = path.join(this.stagingDirectory, journalFileName);
+  }
+
+  async begin(
+    attempt: Omit<UpdateAttempt, "schemaVersion" | "attemptId" | "phase" | "createdAt" | "updatedAt">,
+  ): Promise<UpdateAttempt> {
+    assertArtifactFileName(attempt.artifactFileName);
+    assertSha256(attempt.artifactSha256, "artifact SHA-256");
+    assertSha256(attempt.publisherCertificateSha256, "publisher certificate SHA-256");
+    if (compareSemanticVersions(attempt.toVersion, attempt.fromVersion) <= 0) {
+      throw new Error("An update attempt must target a newer semantic version");
+    }
+    await mkdir(this.stagingDirectory, { recursive: true });
+    try {
+      await readFile(this.journalPath, "utf8");
+      throw new Error("A pending update attempt already exists");
+    } catch (error) {
+      if (errorCode(error) !== "ENOENT") throw error;
+    }
+    const now = new Date().toISOString();
+    const record: UpdateAttempt = {
+      ...attempt,
+      schemaVersion: 1,
+      attemptId: randomBytes(16).toString("hex"),
+      phase: "verified",
+      createdAt: now,
+      updatedAt: now,
+    };
+    await this.write(record);
+    return record;
+  }
+
+  async advance(attemptId: string, nextPhase: Exclude<UpdateAttemptPhase, "verified">): Promise<UpdateAttempt> {
+    const current = await this.readRequired();
+    if (current.attemptId !== attemptId) throw new Error("Update attempt identifier does not match");
+    const allowed = current.phase === "verified"
+      ? "backend-stopped"
+      : current.phase === "backend-stopped"
+        ? "installer-launched"
+        : undefined;
+    if (nextPhase !== allowed) {
+      throw new Error(`Invalid update phase transition: ${current.phase} -> ${nextPhase}`);
+    }
+    const updated = { ...current, phase: nextPhase, updatedAt: new Date().toISOString() };
+    await this.write(updated);
+    return updated;
+  }
+
+  async recover(currentVersion: string): Promise<UpdateRecoveryResult> {
+    let attempt: UpdateAttempt;
+    try {
+      const raw = await readFile(this.journalPath, "utf8");
+      const parsed: unknown = JSON.parse(raw);
+      if (!isUpdateAttempt(parsed)) {
+        return {
+          disposition: "manual-intervention-required",
+          detail: "The pending update journal is malformed and was left untouched.",
+        };
+      }
+      attempt = parsed;
+    } catch (error) {
+      if (errorCode(error) === "ENOENT") return { disposition: "none" };
+      return {
+        disposition: "manual-intervention-required",
+        detail: `The pending update journal could not be read: ${errorText(error)}`,
+      };
+    }
+
+    if (currentVersion === attempt.toVersion) {
+      await this.clearSafeAttempt(attempt);
+      return { disposition: "completed", attempt };
+    }
+    if (currentVersion !== attempt.fromVersion) {
+      return {
+        disposition: "manual-intervention-required",
+        attempt,
+        detail: `Installed version ${currentVersion} matches neither ${attempt.fromVersion} nor ${attempt.toVersion}.`,
+      };
+    }
+
+    const disposition: UpdateRecoveryDisposition = attempt.phase === "verified"
+      ? "discarded-before-shutdown"
+      : attempt.phase === "backend-stopped"
+        ? "interrupted-before-installer"
+        : "installer-failed-or-interrupted";
+    await this.clearSafeAttempt(attempt);
+    return { disposition, attempt };
+  }
+
+  private async readRequired(): Promise<UpdateAttempt> {
+    const parsed: unknown = JSON.parse(await readFile(this.journalPath, "utf8"));
+    if (!isUpdateAttempt(parsed)) throw new Error("Pending update journal is malformed");
+    return parsed;
+  }
+
+  private async write(attempt: UpdateAttempt): Promise<void> {
+    const temporaryPath = path.join(
+      this.stagingDirectory,
+      `${journalFileName}.${process.pid}.${randomBytes(6).toString("hex")}.tmp`,
+    );
+    try {
+      await writeFile(temporaryPath, `${JSON.stringify(attempt, null, 2)}\n`, {
+        encoding: "utf8",
+        flag: "wx",
+      });
+      await rename(temporaryPath, this.journalPath);
+    } finally {
+      await rm(temporaryPath, { force: true });
+    }
+  }
+
+  private async clearSafeAttempt(attempt: UpdateAttempt): Promise<void> {
+    const artifactPath = resolveSafeArtifactPath(this.stagingDirectory, attempt.artifactFileName);
+    await rm(artifactPath, { force: true });
+    await unlink(this.journalPath);
+  }
+}
+
+function isUpdateAttempt(value: unknown): value is UpdateAttempt {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  try {
+    assertArtifactFileName(candidate.artifactFileName);
+    assertSha256(candidate.artifactSha256, "artifact SHA-256");
+    assertSha256(candidate.publisherCertificateSha256, "publisher certificate SHA-256");
+    if (
+      typeof candidate.fromVersion !== "string"
+      || typeof candidate.toVersion !== "string"
+      || compareSemanticVersions(candidate.toVersion, candidate.fromVersion) <= 0
+    ) {
+      return false;
+    }
+  } catch {
+    return false;
+  }
+  return candidate.schemaVersion === 1
+    && typeof candidate.attemptId === "string"
+    && /^[a-f0-9]{32}$/u.test(candidate.attemptId)
+    && ["verified", "backend-stopped", "installer-launched"].includes(String(candidate.phase))
+    && typeof candidate.createdAt === "string"
+    && typeof candidate.updatedAt === "string";
+}
+
+function resolveSafeArtifactPath(rootDirectory: string, fileName: string): string {
+  assertArtifactFileName(fileName);
+  const resolved = path.resolve(rootDirectory, fileName);
+  if (path.dirname(resolved) !== path.resolve(rootDirectory)) {
+    throw new Error("Update artifact path escaped the staging directory");
+  }
+  return resolved;
+}
+
+function assertArtifactFileName(value: unknown): asserts value is string {
+  if (typeof value !== "string" || value !== path.basename(value) || !/^[A-Za-z0-9._-]+\.exe$/u.test(value)) {
+    throw new Error("Update artifact must be a simple .exe file name");
+  }
+}
+
+function assertSha256(value: unknown, label: string): asserts value is string {
+  if (typeof value !== "string" || !/^[a-f0-9]{64}$/u.test(value)) {
+    throw new Error(`Invalid ${label}`);
+  }
+}
+
+function errorCode(error: unknown): string | undefined {
+  return error && typeof error === "object" && "code" in error
+    ? String((error as { code?: unknown }).code)
+    : undefined;
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/desktop/electron/src/update-recovery.ts
+++ b/desktop/electron/src/update-recovery.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "node:crypto";
-import { mkdir, readFile, rename, rm, unlink, writeFile } from "node:fs/promises";
+import { link, mkdir, open, readFile, rename, rm, unlink } from "node:fs/promises";
 import path from "node:path";
 import { compareSemanticVersions } from "./update-verification";
 
@@ -53,12 +53,6 @@ export class UpdateRecoveryJournal {
       throw new Error("An update attempt must target a newer semantic version");
     }
     await mkdir(this.stagingDirectory, { recursive: true });
-    try {
-      await readFile(this.journalPath, "utf8");
-      throw new Error("A pending update attempt already exists");
-    } catch (error) {
-      if (errorCode(error) !== "ENOENT") throw error;
-    }
     const now = new Date().toISOString();
     const record: UpdateAttempt = {
       ...attempt,
@@ -68,7 +62,7 @@ export class UpdateRecoveryJournal {
       createdAt: now,
       updatedAt: now,
     };
-    await this.write(record);
+    await this.write(record, true);
     return record;
   }
 
@@ -135,17 +129,34 @@ export class UpdateRecoveryJournal {
     return parsed;
   }
 
-  private async write(attempt: UpdateAttempt): Promise<void> {
+  private async write(attempt: UpdateAttempt, exclusive = false): Promise<void> {
     const temporaryPath = path.join(
       this.stagingDirectory,
       `${journalFileName}.${process.pid}.${randomBytes(6).toString("hex")}.tmp`,
     );
     try {
-      await writeFile(temporaryPath, `${JSON.stringify(attempt, null, 2)}\n`, {
-        encoding: "utf8",
-        flag: "wx",
-      });
-      await rename(temporaryPath, this.journalPath);
+      const handle = await open(temporaryPath, "wx");
+      try {
+        await handle.writeFile(`${JSON.stringify(attempt, null, 2)}\n`, "utf8");
+        await handle.sync();
+      } finally {
+        await handle.close();
+      }
+      if (exclusive) {
+        try {
+          // Linking a complete same-directory temp file is an atomic
+          // create-if-absent operation on Windows and POSIX. Unlike rename, it
+          // can never replace a concurrent pending attempt.
+          await link(temporaryPath, this.journalPath);
+        } catch (error) {
+          if (errorCode(error) === "EEXIST") {
+            throw new Error("A pending update attempt already exists");
+          }
+          throw error;
+        }
+      } else {
+        await rename(temporaryPath, this.journalPath);
+      }
     } finally {
       await rm(temporaryPath, { force: true });
     }

--- a/desktop/electron/src/update-verification.ts
+++ b/desktop/electron/src/update-verification.ts
@@ -1,0 +1,253 @@
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { createReadStream } from "node:fs";
+import path from "node:path";
+
+export type AuthenticodeInspection = {
+  status: string;
+  signerSubject?: string;
+  certificateSha256?: string;
+};
+
+export type UpdateCandidate = {
+  artifactPath: string;
+  version: string;
+  expectedSha256: string;
+};
+
+export type UpdateVerificationPolicy = {
+  currentVersion: string;
+  allowedPublisherCertificateSha256: readonly string[];
+};
+
+export type UpdateRejectionCode =
+  | "invalid-verification-policy"
+  | "invalid-release-metadata"
+  | "version-not-newer"
+  | "artifact-inspection-failed"
+  | "artifact-hash-mismatch"
+  | "artifact-unsigned"
+  | "artifact-signature-invalid"
+  | "publisher-not-allowed";
+
+export type UpdateVerificationResult =
+  | {
+      accepted: true;
+      version: string;
+      sha256: string;
+      signerSubject?: string;
+      certificateSha256: string;
+    }
+  | {
+      accepted: false;
+      code: UpdateRejectionCode;
+      detail: string;
+    };
+
+type SignatureInspector = (artifactPath: string) => AuthenticodeInspection;
+
+export async function verifyWindowsUpdateCandidate(
+  candidate: UpdateCandidate,
+  policy: UpdateVerificationPolicy,
+  inspectSignature: SignatureInspector = inspectAuthenticodeSignature,
+): Promise<UpdateVerificationResult> {
+  const expectedHash = normalizeSha256(candidate.expectedSha256);
+  const normalizedPublishers = policy.allowedPublisherCertificateSha256.map(normalizeSha256);
+  if (normalizedPublishers.length === 0 || normalizedPublishers.some((value) => !value)) {
+    return reject(
+      "invalid-verification-policy",
+      "Every publisher entry must be a complete SHA-256 certificate fingerprint.",
+    );
+  }
+  const allowedPublishers = normalizedPublishers as string[];
+  if (!expectedHash || !parseSemanticVersion(candidate.version)) {
+    return reject(
+      "invalid-release-metadata",
+      "The candidate version or SHA-256 digest is malformed.",
+    );
+  }
+  if (!parseSemanticVersion(policy.currentVersion)) {
+    return reject("invalid-verification-policy", "The installed version is malformed.");
+  }
+  if (compareSemanticVersions(candidate.version, policy.currentVersion) <= 0) {
+    return reject(
+      "version-not-newer",
+      `Candidate ${candidate.version} is not newer than ${policy.currentVersion}.`,
+    );
+  }
+
+  let actualHash: string;
+  try {
+    actualHash = await sha256(candidate.artifactPath);
+  } catch (error) {
+    return reject("artifact-inspection-failed", `The artifact could not be read: ${errorText(error)}`);
+  }
+  if (actualHash !== expectedHash) {
+    return reject("artifact-hash-mismatch", "The artifact SHA-256 digest does not match release metadata.");
+  }
+
+  let signature: AuthenticodeInspection;
+  try {
+    signature = inspectSignature(candidate.artifactPath);
+  } catch (error) {
+    return reject(
+      "artifact-inspection-failed",
+      `Authenticode inspection failed: ${errorText(error)}`,
+    );
+  }
+  if (signature.status === "NotSigned") {
+    return reject("artifact-unsigned", "The update artifact has no Authenticode signature.");
+  }
+  if (signature.status !== "Valid") {
+    return reject(
+      "artifact-signature-invalid",
+      `Authenticode reported status '${signature.status || "Unknown"}'.`,
+    );
+  }
+
+  const certificateSha256 = normalizeSha256(signature.certificateSha256);
+  if (!certificateSha256 || !allowedPublishers.includes(certificateSha256)) {
+    return reject(
+      "publisher-not-allowed",
+      "The signer certificate is not in the configured publisher allowlist.",
+    );
+  }
+
+  return {
+    accepted: true,
+    version: candidate.version,
+    sha256: actualHash,
+    signerSubject: signature.signerSubject,
+    certificateSha256,
+  };
+}
+
+export function inspectAuthenticodeSignature(artifactPath: string): AuthenticodeInspection {
+  if (process.platform !== "win32") {
+    return { status: "UnsupportedPlatform" };
+  }
+  const result = spawnSync(
+    resolveSignaturePowerShell(),
+    [
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      [
+        "$signature = Get-AuthenticodeSignature -LiteralPath $env:VIBE_UPDATE_ARTIFACT_PATH",
+        "$fingerprint = $null",
+        "if ($signature.SignerCertificate) {",
+        "  $sha256 = [System.Security.Cryptography.SHA256]::Create()",
+        "  try {",
+        "    $bytes = $sha256.ComputeHash($signature.SignerCertificate.RawData)",
+        "    $fingerprint = ([System.BitConverter]::ToString($bytes)).Replace('-', '').ToLowerInvariant()",
+        "  } finally { $sha256.Dispose() }",
+        "}",
+        "@{ status = $signature.Status.ToString(); signerSubject = $signature.SignerCertificate.Subject; certificateSha256 = $fingerprint } | ConvertTo-Json -Compress",
+      ].join("; "),
+    ],
+    {
+      env: { ...process.env, VIBE_UPDATE_ARTIFACT_PATH: path.resolve(artifactPath) },
+      encoding: "utf8",
+      windowsHide: true,
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || result.stdout.trim() || "Authenticode inspection failed");
+  }
+  const parsed: unknown = JSON.parse(result.stdout.trim());
+  if (!parsed || typeof parsed !== "object" || typeof (parsed as Record<string, unknown>).status !== "string") {
+    throw new Error("Authenticode inspection returned an invalid payload");
+  }
+  const payload = parsed as Record<string, unknown>;
+  return {
+    status: payload.status as string,
+    signerSubject: typeof payload.signerSubject === "string" ? payload.signerSubject : undefined,
+    certificateSha256: typeof payload.certificateSha256 === "string"
+      ? payload.certificateSha256
+      : undefined,
+  };
+}
+
+export function compareSemanticVersions(left: string, right: string): number {
+  const leftVersion = parseSemanticVersion(left);
+  const rightVersion = parseSemanticVersion(right);
+  if (!leftVersion || !rightVersion) throw new Error("Cannot compare malformed semantic versions");
+  for (let index = 0; index < 3; index += 1) {
+    const difference = leftVersion.core[index] - rightVersion.core[index];
+    if (difference !== 0) return Math.sign(difference);
+  }
+  if (!leftVersion.prerelease.length && !rightVersion.prerelease.length) return 0;
+  if (!leftVersion.prerelease.length) return 1;
+  if (!rightVersion.prerelease.length) return -1;
+  const length = Math.max(leftVersion.prerelease.length, rightVersion.prerelease.length);
+  for (let index = 0; index < length; index += 1) {
+    const leftPart = leftVersion.prerelease[index];
+    const rightPart = rightVersion.prerelease[index];
+    if (leftPart === undefined) return -1;
+    if (rightPart === undefined) return 1;
+    if (leftPart === rightPart) continue;
+    const leftNumeric = /^\d+$/u.test(leftPart);
+    const rightNumeric = /^\d+$/u.test(rightPart);
+    if (leftNumeric && rightNumeric) {
+      if (leftPart.length !== rightPart.length) return leftPart.length < rightPart.length ? -1 : 1;
+      return leftPart < rightPart ? -1 : 1;
+    }
+    if (leftNumeric !== rightNumeric) return leftNumeric ? -1 : 1;
+    return leftPart < rightPart ? -1 : 1;
+  }
+  return 0;
+}
+
+function parseSemanticVersion(value: string): { core: [number, number, number]; prerelease: string[] } | undefined {
+  const match = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/u.exec(value);
+  if (!match) return undefined;
+  const core = [Number(match[1]), Number(match[2]), Number(match[3])] as [number, number, number];
+  if (!core.every(Number.isSafeInteger)) return undefined;
+  const prerelease = match[4]?.split(".") ?? [];
+  if (prerelease.some((part) => /^\d+$/u.test(part) && part.length > 1 && part.startsWith("0"))) {
+    return undefined;
+  }
+  return {
+    core,
+    prerelease,
+  };
+}
+
+function normalizeSha256(value: string | undefined): string | undefined {
+  const normalized = value?.replaceAll(":", "").trim().toLowerCase();
+  return normalized && /^[a-f0-9]{64}$/u.test(normalized) ? normalized : undefined;
+}
+
+function resolveSignaturePowerShell(): string {
+  const candidates = [
+    process.env.ProgramFiles
+      ? path.join(process.env.ProgramFiles, "PowerShell", "7", "pwsh.exe")
+      : undefined,
+    "pwsh.exe",
+    "powershell.exe",
+  ].filter((candidate): candidate is string => Boolean(candidate));
+  for (const candidate of new Set(candidates)) {
+    const probe = spawnSync(
+      candidate,
+      ["-NoProfile", "-NonInteractive", "-Command", "Get-Command Get-AuthenticodeSignature -ErrorAction Stop | Out-Null"],
+      { encoding: "utf8", windowsHide: true },
+    );
+    if (!probe.error && probe.status === 0) return candidate;
+  }
+  throw new Error("No PowerShell host can inspect Authenticode signatures");
+}
+
+async function sha256(file: string): Promise<string> {
+  const hash = createHash("sha256");
+  for await (const chunk of createReadStream(file)) hash.update(chunk);
+  return hash.digest("hex");
+}
+
+function reject(code: UpdateRejectionCode, detail: string): UpdateVerificationResult {
+  return { accepted: false, code, detail };
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/desktop/electron/src/update-verification.ts
+++ b/desktop/electron/src/update-verification.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 
 export type AuthenticodeInspection = {
   status: string;
+  artifactSha256?: string;
   signerSubject?: string;
   certificateSha256?: string;
 };
@@ -26,6 +27,7 @@ export type UpdateRejectionCode =
   | "version-not-newer"
   | "artifact-inspection-failed"
   | "artifact-hash-mismatch"
+  | "artifact-changed-during-verification"
   | "artifact-unsigned"
   | "artifact-signature-invalid"
   | "publisher-not-allowed";
@@ -113,13 +115,54 @@ export async function verifyWindowsUpdateCandidate(
     );
   }
 
+  const inspectedArtifactSha256 = normalizeSha256(signature.artifactSha256);
+  if (!inspectedArtifactSha256 || inspectedArtifactSha256 !== actualHash) {
+    return reject(
+      "artifact-changed-during-verification",
+      "Authenticode inspection did not cover the same artifact bytes as the release digest.",
+    );
+  }
+
+  let confirmedHash: string;
+  try {
+    confirmedHash = await sha256(candidate.artifactPath);
+  } catch (error) {
+    return reject(
+      "artifact-inspection-failed",
+      `The artifact could not be confirmed after signature inspection: ${errorText(error)}`,
+    );
+  }
+  if (confirmedHash !== actualHash) {
+    return reject(
+      "artifact-changed-during-verification",
+      "The update artifact changed while its signature was being verified.",
+    );
+  }
+
   return {
     accepted: true,
     version: candidate.version,
-    sha256: actualHash,
+    sha256: confirmedHash,
     signerSubject: signature.signerSubject,
     certificateSha256,
   };
+}
+
+export async function assertVerifiedUpdateArtifactUnchanged(
+  artifactPath: string,
+  expectedSha256: string,
+): Promise<void> {
+  const expectedHash = normalizeSha256(expectedSha256);
+  if (!expectedHash) throw new Error("The verified artifact SHA-256 is malformed");
+  let actualHash: string;
+  try {
+    actualHash = await sha256(artifactPath);
+  } catch (error) {
+    throw new Error(`The verified update artifact could not be read: ${errorText(error)}`);
+  }
+  if (actualHash !== expectedHash) {
+    throw new Error("The verified update artifact changed before installer launch");
+  }
 }
 
 export function inspectAuthenticodeSignature(artifactPath: string): AuthenticodeInspection {
@@ -133,22 +176,33 @@ export function inspectAuthenticodeSignature(artifactPath: string): Authenticode
       "-NonInteractive",
       "-Command",
       [
-        "$signature = Get-AuthenticodeSignature -LiteralPath $env:VIBE_UPDATE_ARTIFACT_PATH",
-        "$fingerprint = $null",
-        "if ($signature.SignerCertificate) {",
-        "  $sha256 = [System.Security.Cryptography.SHA256]::Create()",
+        "$artifactPath = [System.IO.Path]::GetFullPath($env:VIBE_UPDATE_ARTIFACT_PATH)",
+        "$stream = [System.IO.File]::Open($artifactPath, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::Read)",
+        "try {",
+        "  $artifactHasher = [System.Security.Cryptography.SHA256]::Create()",
         "  try {",
-        "    $bytes = $sha256.ComputeHash($signature.SignerCertificate.RawData)",
-        "    $fingerprint = ([System.BitConverter]::ToString($bytes)).Replace('-', '').ToLowerInvariant()",
-        "  } finally { $sha256.Dispose() }",
-        "}",
-        "@{ status = $signature.Status.ToString(); signerSubject = $signature.SignerCertificate.Subject; certificateSha256 = $fingerprint } | ConvertTo-Json -Compress",
-      ].join("; "),
+        "    $artifactBytes = $artifactHasher.ComputeHash($stream)",
+        "    $artifactFingerprint = ([System.BitConverter]::ToString($artifactBytes)).Replace('-', '').ToLowerInvariant()",
+        "  } finally { $artifactHasher.Dispose() }",
+        "  $signature = Get-AuthenticodeSignature -LiteralPath $artifactPath",
+        "  $certificateFingerprint = $null",
+        "  if ($signature.SignerCertificate) {",
+        "    $certificateHasher = [System.Security.Cryptography.SHA256]::Create()",
+        "    try {",
+        "      $certificateBytes = $certificateHasher.ComputeHash($signature.SignerCertificate.RawData)",
+        "      $certificateFingerprint = ([System.BitConverter]::ToString($certificateBytes)).Replace('-', '').ToLowerInvariant()",
+        "    } finally { $certificateHasher.Dispose() }",
+        "  }",
+        "  @{ status = $signature.Status.ToString(); artifactSha256 = $artifactFingerprint; signerSubject = $signature.SignerCertificate.Subject; certificateSha256 = $certificateFingerprint } | ConvertTo-Json -Compress",
+        "} finally { $stream.Dispose() }",
+      ].join("\n"),
     ],
     {
       env: { ...process.env, VIBE_UPDATE_ARTIFACT_PATH: path.resolve(artifactPath) },
       encoding: "utf8",
       windowsHide: true,
+      timeout: 15_000,
+      maxBuffer: 1_048_576,
     },
   );
   if (result.error) throw result.error;
@@ -162,6 +216,9 @@ export function inspectAuthenticodeSignature(artifactPath: string): Authenticode
   const payload = parsed as Record<string, unknown>;
   return {
     status: payload.status as string,
+    artifactSha256: typeof payload.artifactSha256 === "string"
+      ? payload.artifactSha256
+      : undefined,
     signerSubject: typeof payload.signerSubject === "string" ? payload.signerSubject : undefined,
     certificateSha256: typeof payload.certificateSha256 === "string"
       ? payload.certificateSha256
@@ -231,7 +288,12 @@ function resolveSignaturePowerShell(): string {
     const probe = spawnSync(
       candidate,
       ["-NoProfile", "-NonInteractive", "-Command", "Get-Command Get-AuthenticodeSignature -ErrorAction Stop | Out-Null"],
-      { encoding: "utf8", windowsHide: true },
+      {
+        encoding: "utf8",
+        windowsHide: true,
+        timeout: 5_000,
+        maxBuffer: 262_144,
+      },
     );
     if (!probe.error && probe.status === 0) return candidate;
   }


### PR DESCRIPTION
## Summary

- add a strict, PID-scoped backend/watchdog shutdown result for future update handoff;
- add dormant Windows candidate verification and interrupted-attempt recovery primitives;
- document and test the tampered / unsigned / invalid-signature / wrong-publisher / downgraded rejection matrix.

## Why

Refs #1016.

The signed `0.3.0 -> 0.3.1` run is still blocked on maintainer-owned signing
identity and release-feed decisions. The issue identified two useful pieces that
can be completed without those decisions: proving that desktop cleanup never
kills unrelated Python processes, and making the future verification/recovery
contract executable before a real certificate exists.

## Changes

- `BackendManager.stopForUpdate()` succeeds only after the exact owned backend
  PID, watchdog PID, and loopback listener are all gone.
- Graceful-shutdown and parent-death smoke tests each keep an unrelated Python
  sentinel alive while the owned process tree is removed.
- Candidate verification checks semantic-version monotonicity, expected
  SHA-256, Windows Authenticode status, and an explicit allowlist of SHA-256
  signer-certificate fingerprints.
- Rejections use stable codes; an empty or malformed publisher allowlist fails
  closed.
- A same-directory atomic journal records only `verified -> backend-stopped ->
  installer-launched` and reconciles completed/interrupted attempts without
  following arbitrary artifact paths.
- Windows CI runs the deterministic rejection/recovery suite and a real
  Authenticode adapter check against a signed Windows system binary.
- `UPDATE_SAFETY.md` records the rejection matrix, recovery matrix, remaining
  enablement gates, and rollback limitation.

## Deliberately out of scope

- no updater call site, update UI, background check, release feed, or download;
- no installer launch and no change to the signed/unsigned packaging commands;
- no publisher identity, certificate, or release owner is selected;
- no claim that a partially modified NSIS installation can already be rolled back;
- no changes under `agent/src/agent/`, `agent/src/session/`, or
  `agent/src/providers/`.

The updater remains disabled by default. The real signed clean-Windows upgrade
and interruption run tracked in #1016 remains the release gate, so that issue
remains open.

## Test Plan

- [ ] Existing full backend suite (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`) — not run locally because this PR does not change Python/backend code; repository CI remains authoritative.
- [x] New tests added.
- [x] Tested manually on Windows.

Local checks completed:

```text
npm ci
npm run build
npm run test:update-safety
npm run test:locales
npm run test:backend-resolution
npm audit --audit-level=high
node scripts/smoke-lifecycle.mjs
node scripts/smoke-parent-death.mjs
git diff --check upstream/main...HEAD
```

Observed results:

- TypeScript production build passed;
- npm audit reported zero vulnerabilities;
- real Windows Authenticode inspection returned `Valid` with a SHA-256 certificate fingerprint;
- all synthetic acceptance/rejection and journal-recovery cases passed;
- graceful update handoff removed the owned backend/watchdog/listener while an unrelated Python PID survived;
- killing only the Electron main PID removed the owned backend/listener while a second unrelated Python PID survived.

## Risk and rollback

The verifier and journal have no runtime caller, so this PR cannot check,
download, or apply an update. The lifecycle behavior adds bounded post-shutdown
verification; normal application shutdown continues to use the existing path.
Rollback is a single revert of this commit. No user data migration or external
service state is introduced.

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, user file paths, publisher identities)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Documentation updated
- [x] Commit contains the required DCO `Signed-off-by:` trailer
