### PR TITLE
feat(runs): add a positions tab to run detail

### DIFF
--- a/frontend/src/components/charts/PositionWeightsChart.tsx
+++ b/frontend/src/components/charts/PositionWeightsChart.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useRef } from "react";
+import i18n from "@/i18n";
+import { getChartTheme } from "@/lib/chart-theme";
+import { echarts } from "@/lib/echarts";
+import { useThemeDark } from "@/lib/theme-store";
+import type { WeightPoint } from "@/lib/positions";
+
+interface Props {
+  points: WeightPoint[];
+  symbols: string[];
+  height?: number;
+}
+
+/** Per-rebalance weight evolution as a stacked area, top symbols plus Other. */
+export function PositionWeightsChart({ points, symbols, height = 300 }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  const dark = useThemeDark();
+
+  useEffect(() => {
+    if (!ref.current || points.length === 0) return;
+    const t = getChartTheme();
+    const chart = echarts.init(ref.current);
+    const hasOther = points.some((p) => p.Other !== undefined);
+    const seriesNames = hasOther ? [...symbols, "Other"] : symbols;
+
+    chart.setOption({
+      backgroundColor: "transparent",
+      tooltip: {
+        trigger: "axis",
+        backgroundColor: t.tooltipBg,
+        borderColor: t.tooltipBorder,
+        textStyle: { color: t.tooltipText, fontSize: 11 },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        formatter: (params: any) => {
+          if (!Array.isArray(params) || !params.length) return "";
+          const lines = params
+            .filter((p) => Number(p.value) !== 0)
+            .map((p) => `${p.marker} ${p.seriesName}: <b>${(Number(p.value) * 100).toFixed(1)}%</b>`);
+          return `<b>${params[0].axisValue}</b><br/>${lines.join("<br/>")}`;
+        },
+      },
+      legend: {
+        bottom: 0,
+        textStyle: { color: t.textColor, fontSize: 10 },
+        type: "scroll",
+      },
+      grid: { left: 8, right: 8, top: 16, bottom: 28, containLabel: true },
+      xAxis: {
+        type: "category",
+        data: points.map((p) => p.time),
+        axisLine: { lineStyle: { color: t.axisColor } },
+        axisLabel: { color: t.textColor, fontSize: 10 },
+      },
+      yAxis: {
+        type: "value",
+        splitLine: { lineStyle: { color: t.gridColor } },
+        axisLabel: { color: t.textColor, fontSize: 10, formatter: (v: number) => `${(v * 100).toFixed(0)}%` },
+      },
+      series: seriesNames.map((name) => ({
+        name: name === "Other" ? i18n.t("runDetail.other") : name,
+        type: "line",
+        stack: "weights",
+        areaStyle: { opacity: 0.35 },
+        showSymbol: false,
+        emphasis: { focus: "series" },
+        data: points.map((p) => +(Number(p[name] ?? 0)).toFixed(6)),
+      })),
+    });
+
+    let resizeFrame: number | null = null;
+    const ro = new ResizeObserver(() => {
+      if (resizeFrame !== null) cancelAnimationFrame(resizeFrame);
+      resizeFrame = requestAnimationFrame(() => {
+        resizeFrame = null;
+        chart.resize();
+      });
+    });
+    ro.observe(ref.current!);
+    return () => {
+      ro.disconnect();
+      if (resizeFrame !== null) cancelAnimationFrame(resizeFrame);
+      chart.dispose();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [points, symbols, dark]);
+
+  return <div ref={ref} style={{ height, width: "100%" }} />;
+}

--- a/frontend/src/components/charts/PositionsPieChart.tsx
+++ b/frontend/src/components/charts/PositionsPieChart.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useRef } from "react";
+import i18n from "@/i18n";
+import { getChartTheme } from "@/lib/chart-theme";
+import { echarts } from "@/lib/echarts";
+import { useThemeDark } from "@/lib/theme-store";
+
+interface Props {
+  weights: Record<string, number>;
+  height?: number;
+}
+
+/** Latest basket weights. Long-only books get a donut; any short leg flips to signed bars. */
+export function PositionsPieChart({ weights, height = 280 }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  const dark = useThemeDark();
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const entries = Object.entries(weights)
+      .filter(([, w]) => w !== 0)
+      .sort((a, b) => Math.abs(b[1]) - Math.abs(a[1]));
+    if (entries.length === 0) return;
+    const t = getChartTheme();
+    const chart = echarts.init(ref.current);
+    const hasShort = entries.some(([, w]) => w < 0);
+
+    if (!hasShort) {
+      chart.setOption({
+        backgroundColor: "transparent",
+        tooltip: {
+          trigger: "item",
+          backgroundColor: t.tooltipBg,
+          borderColor: t.tooltipBorder,
+          textStyle: { color: t.tooltipText, fontSize: 11 },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          formatter: (p: any) => `${p.marker} ${p.name}: <b>${(Number(p.value) * 100).toFixed(2)}%</b>`,
+        },
+        legend: {
+          bottom: 0,
+          textStyle: { color: t.textColor, fontSize: 10 },
+          type: "scroll",
+        },
+        series: [
+          {
+            name: i18n.t("runDetail.latestWeights"),
+            type: "pie",
+            radius: ["42%", "68%"],
+            center: ["50%", "46%"],
+            label: { show: false },
+            data: entries.map(([symbol, w]) => ({ name: symbol, value: +w.toFixed(6) })),
+          },
+        ],
+      });
+    } else {
+      chart.setOption({
+        backgroundColor: "transparent",
+        tooltip: {
+          trigger: "axis",
+          axisPointer: { type: "shadow" },
+          backgroundColor: t.tooltipBg,
+          borderColor: t.tooltipBorder,
+          textStyle: { color: t.tooltipText, fontSize: 11 },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          formatter: (params: any) => {
+            if (!Array.isArray(params) || !params.length) return "";
+            const p = params[0];
+            return `${p.marker} ${p.name}: <b>${(Number(p.value) * 100).toFixed(2)}%</b>`;
+          },
+        },
+        grid: { left: 8, right: 16, top: 8, bottom: 8, containLabel: true },
+        xAxis: {
+          type: "value",
+          splitLine: { lineStyle: { color: t.gridColor } },
+          axisLabel: { color: t.textColor, fontSize: 10, formatter: (v: number) => `${(v * 100).toFixed(0)}%` },
+        },
+        yAxis: {
+          type: "category",
+          inverse: true,
+          data: entries.map(([symbol]) => symbol),
+          axisLine: { lineStyle: { color: t.axisColor } },
+          axisLabel: { color: t.textColor, fontSize: 10 },
+        },
+        series: [
+          {
+            name: i18n.t("runDetail.latestWeights"),
+            type: "bar",
+            data: entries.map(([, w]) => ({
+              value: +w.toFixed(6),
+              itemStyle: { color: w >= 0 ? t.upColor : t.downColor },
+            })),
+            barMaxWidth: 18,
+          },
+        ],
+      });
+    }
+
+    let resizeFrame: number | null = null;
+    const ro = new ResizeObserver(() => {
+      if (resizeFrame !== null) cancelAnimationFrame(resizeFrame);
+      resizeFrame = requestAnimationFrame(() => {
+        resizeFrame = null;
+        chart.resize();
+      });
+    });
+    ro.observe(ref.current!);
+    return () => {
+      ro.disconnect();
+      if (resizeFrame !== null) cancelAnimationFrame(resizeFrame);
+      chart.dispose();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [weights, dark]);
+
+  return <div ref={ref} style={{ height, width: "100%" }} />;
+}

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -634,7 +634,18 @@
     "ddTroughToRecovery": "القاع إلى التعافي",
     "ddNotRecovered": "لم يتعافَ",
     "ddDays": "{{count}} يوم",
-    "dashboard": "لوحة البحث"
+    "dashboard": "لوحة البحث",
+    "positions": "المراكز",
+    "latestWeights": "أحدث الأوزان",
+    "weightEvolution": "تطور الأوزان",
+    "targetVsActual": "الهدف مقابل الفعلي",
+    "drift": "الانحراف",
+    "other": "أخرى",
+    "grossExposure": "إجمالي التعرض",
+    "netExposure": "صافي التعرض",
+    "noPositionData": "لا توجد بيانات مراكز لهذا التشغيل.",
+    "target": "الهدف",
+    "actual": "الفعلي"
   },
   "compare": {
     "title": "مقارنة الاستراتيجيات",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -639,7 +639,18 @@
     "ddTroughToRecovery": "Trough→Rec.",
     "ddNotRecovered": "Not recovered",
     "ddDays": "{{count}} d",
-    "dashboard": "Research dashboard"
+    "dashboard": "Research dashboard",
+    "positions": "Positions",
+    "latestWeights": "Latest Weights",
+    "weightEvolution": "Weight Evolution",
+    "targetVsActual": "Target vs Actual",
+    "drift": "Drift",
+    "other": "Other",
+    "grossExposure": "Gross",
+    "netExposure": "Net",
+    "noPositionData": "No position rows in this run.",
+    "target": "Target",
+    "actual": "Actual"
   },
   "compare": {
     "title": "Strategy Comparison",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -639,7 +639,18 @@
     "ddTroughToRecovery": "Valle→Rec.",
     "ddNotRecovered": "No recuperado",
     "ddDays": "{{count}} d",
-    "dashboard": "Panel de investigación"
+    "dashboard": "Panel de investigación",
+    "positions": "Posiciones",
+    "latestWeights": "Pesos más recientes",
+    "weightEvolution": "Evolución de pesos",
+    "targetVsActual": "Objetivo vs real",
+    "drift": "Desviación",
+    "other": "Otros",
+    "grossExposure": "Bruto",
+    "netExposure": "Neto",
+    "noPositionData": "Esta ejecución no tiene datos de posiciones.",
+    "target": "Objetivo",
+    "actual": "Real"
   },
   "compare": {
     "title": "Comparación de estrategias",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -634,7 +634,18 @@
     "ddTroughToRecovery": "安値→回復",
     "ddNotRecovered": "未回復",
     "ddDays": "{{count}}日",
-    "dashboard": "リサーチダッシュボード"
+    "dashboard": "リサーチダッシュボード",
+    "positions": "ポジション",
+    "latestWeights": "最新ウェイト",
+    "weightEvolution": "ウェイト推移",
+    "targetVsActual": "目標 vs 実際",
+    "drift": "乖離",
+    "other": "その他",
+    "grossExposure": "グロス",
+    "netExposure": "ネット",
+    "noPositionData": "このランにはポジションデータがありません。",
+    "target": "目標",
+    "actual": "実際"
   },
   "compare": {
     "title": "戦略比較",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -634,7 +634,18 @@
     "ddTroughToRecovery": "저점→회복",
     "ddNotRecovered": "미회복",
     "ddDays": "{{count}}일",
-    "dashboard": "리서치 대시보드"
+    "dashboard": "리서치 대시보드",
+    "positions": "포지션",
+    "latestWeights": "최신 비중",
+    "weightEvolution": "비중 변화",
+    "targetVsActual": "목표 vs 실제",
+    "drift": "괴리",
+    "other": "기타",
+    "grossExposure": "총 익스포저",
+    "netExposure": "순 익스포저",
+    "noPositionData": "이 실행에는 포지션 데이터가 없습니다.",
+    "target": "목표",
+    "actual": "실제"
   },
   "compare": {
     "title": "전략 비교",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -634,7 +634,18 @@
     "ddTroughToRecovery": "低点→恢复",
     "ddNotRecovered": "未恢复",
     "ddDays": "{{count}} 天",
-    "dashboard": "研究仪表盘"
+    "dashboard": "研究仪表盘",
+    "positions": "持仓",
+    "latestWeights": "最新持仓权重",
+    "weightEvolution": "权重变迁",
+    "targetVsActual": "目标与实际对比",
+    "drift": "偏离",
+    "other": "其他",
+    "grossExposure": "总敞口",
+    "netExposure": "净敞口",
+    "noPositionData": "本 run 无持仓数据。",
+    "target": "目标权重",
+    "actual": "实际权重"
   },
   "compare": {
     "title": "策略对比",

--- a/frontend/src/lib/__tests__/positions.test.ts
+++ b/frontend/src/lib/__tests__/positions.test.ts
@@ -1,0 +1,48 @@
+import { computeDrift, exposureSummary, parsePositionRows, topSymbols, toWeightSeries } from "../positions";
+
+describe("positions helpers", () => {
+  it("parses wide csv rows, coercing strings and skipping zero/NaN cells", () => {
+    const rows = parsePositionRows([
+      { timestamp: "2026-02-01", AAPL: "0.5", MSFT: 0.3, EMPTY: "", ZERO: 0 },
+      { timestamp: "2026-03-01", AAPL: 0.6, MSFT: 0.25 },
+    ]);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toEqual({ time: "2026-02-01", weights: { AAPL: 0.5, MSFT: 0.3 } });
+    expect(rows[1].weights).toEqual({ AAPL: 0.6, MSFT: 0.25 });
+  });
+
+  it("returns no rows for missing payloads", () => {
+    expect(parsePositionRows(undefined)).toEqual([]);
+    expect(parsePositionRows(null)).toEqual([]);
+  });
+
+  it("ranks top symbols by latest-row absolute weight", () => {
+    const rows = parsePositionRows([
+      { timestamp: "2026-02-01", AAPL: 0.9, MSFT: 0.05, TSLA: 0.05 },
+      { timestamp: "2026-03-01", AAPL: 0.2, MSFT: 0.7, TSLA: -0.1 },
+    ]);
+    expect(topSymbols(rows, 2)).toEqual(["MSFT", "AAPL"]);
+  });
+
+  it("aggregates non-top symbols into the Other bucket per row", () => {
+    const rows = parsePositionRows([
+      { timestamp: "2026-02-01", AAPL: 0.5, MSFT: 0.3, TSLA: 0.2 },
+    ]);
+    const series = toWeightSeries(rows, ["AAPL"]);
+    expect(series).toEqual([{ time: "2026-02-01", AAPL: 0.5, Other: 0.5 }]);
+  });
+
+  it("computes target-vs-actual drift over the union of symbols", () => {
+    const target = parsePositionRows([{ timestamp: "2026-03-01", AAPL: 0.65, TSLA: 0.1 }]);
+    const actual = parsePositionRows([{ timestamp: "2026-03-01", AAPL: 0.6, MSFT: 0.25 }]);
+    const drift = computeDrift(target, actual);
+    expect(drift[0]).toEqual({ symbol: "MSFT", target: 0, actual: 0.25, drift: 0.25 });
+    expect(drift.find((r) => r.symbol === "AAPL")?.drift).toBeCloseTo(-0.05);
+  });
+
+  it("sums gross and net exposure", () => {
+    const { gross, net } = exposureSummary({ AAPL: 0.6, TSLA: -0.2 });
+    expect(gross).toBeCloseTo(0.8);
+    expect(net).toBeCloseTo(0.4);
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -669,6 +669,8 @@ export interface RunData {
   /** Full equity.csv rows (timestamp/equity/drawdown as strings); not capped like equity_curve. */
   artifacts_equity_csv?: Array<Record<string, string>>;
   artifacts_metrics_csv?: Array<Record<string, string>>;
+  artifacts_positions_csv?: Array<Record<string, string>>;
+  artifacts_target_positions_csv?: Array<Record<string, string>>;
   artifacts_trades_csv?: Array<Record<string, string>>;
   run_logs?: Array<{ source?: string; line_number?: number; message?: string }>;
 }

--- a/frontend/src/lib/positions.ts
+++ b/frontend/src/lib/positions.ts
@@ -1,0 +1,91 @@
+// Parsing and aggregation helpers for the positions artifacts
+// (artifacts/positions.csv and artifacts/target_positions.csv). Both are wide
+// frames: one `timestamp` column plus one numeric column per symbol.
+
+export interface PositionRow {
+  time: string;
+  weights: Record<string, number>;
+}
+
+export function parsePositionRows(rows?: Array<Record<string, unknown>> | null): PositionRow[] {
+  if (!rows) return [];
+  const out: PositionRow[] = [];
+  for (const row of rows) {
+    const time = String(row.timestamp ?? "");
+    if (!time) continue;
+    const weights: Record<string, number> = {};
+    for (const [key, value] of Object.entries(row)) {
+      if (key === "timestamp") continue;
+      const n = typeof value === "number" ? value : Number(value);
+      if (Number.isFinite(n) && n !== 0) weights[key] = n;
+    }
+    out.push({ time, weights });
+  }
+  return out;
+}
+
+/** Symbols to show as named series, ranked by latest-row absolute weight. */
+export function topSymbols(rows: PositionRow[], limit = 8): string[] {
+  const latest = rows[rows.length - 1]?.weights ?? {};
+  return Object.entries(latest)
+    .sort((a, b) => Math.abs(b[1]) - Math.abs(a[1]))
+    .slice(0, limit)
+    .map(([symbol]) => symbol);
+}
+
+export interface WeightPoint {
+  time: string;
+  [symbol: string]: number | string;
+}
+
+/** Rows reshaped for a stacked area chart: top symbols plus an Other bucket. */
+export function toWeightSeries(rows: PositionRow[], symbols: string[]): WeightPoint[] {
+  return rows.map((row) => {
+    const point: WeightPoint = { time: row.time };
+    let other = 0;
+    for (const [symbol, weight] of Object.entries(row.weights)) {
+      if (symbols.includes(symbol)) {
+        point[symbol] = weight;
+      } else {
+        other += weight;
+      }
+    }
+    for (const symbol of symbols) {
+      if (point[symbol] === undefined) point[symbol] = 0;
+    }
+    if (other !== 0) point.Other = other;
+    return point;
+  });
+}
+
+export interface DriftRow {
+  symbol: string;
+  target: number;
+  actual: number;
+  drift: number;
+}
+
+/** Latest target weights vs latest actual weights, largest absolute drift first. */
+export function computeDrift(targetRows: PositionRow[], actualRows: PositionRow[]): DriftRow[] {
+  const target = targetRows[targetRows.length - 1]?.weights;
+  const actual = actualRows[actualRows.length - 1]?.weights;
+  if (!target || !actual) return [];
+  const symbols = new Set([...Object.keys(target), ...Object.keys(actual)]);
+  return [...symbols]
+    .map((symbol) => {
+      const t = target[symbol] ?? 0;
+      const a = actual[symbol] ?? 0;
+      return { symbol, target: t, actual: a, drift: a - t };
+    })
+    .sort((a, b) => Math.abs(b.drift) - Math.abs(a.drift));
+}
+
+export function exposureSummary(weights: Record<string, number>): { gross: number; net: number } {
+  let gross = 0;
+  let net = 0;
+  for (const w of Object.values(weights)) {
+    gross += Math.abs(w);
+    net += w;
+  }
+  return { gross, net };
+}

--- a/frontend/src/pages/RunDetail.tsx
+++ b/frontend/src/pages/RunDetail.tsx
@@ -19,6 +19,7 @@ import {
   List,
   LayoutDashboard,
   Loader2,
+  PieChart,
   ShieldCheck,
   Sigma,
   XCircle,
@@ -47,10 +48,13 @@ import { Skeleton, SkeletonMetrics, SkeletonChart } from "@/components/common/Sk
 import { ErrorBoundary } from "@/components/common/ErrorBoundary";
 import { getStrategyReportIdentity, StrategyResearchDashboard } from "@/components/charts/StrategyResearchDashboard";
 import { FactorResearchPanel } from "@/components/charts/FactorResearchPanel";
+import { PositionsPieChart } from "@/components/charts/PositionsPieChart";
+import { PositionWeightsChart } from "@/components/charts/PositionWeightsChart";
+import { computeDrift, exposureSummary, parsePositionRows, topSymbols, toWeightSeries } from "@/lib/positions";
 
 const rehypePlugins = [rehypeHighlight];
 
-type Tab = "dashboard" | "chart" | "tearsheet" | "trades" | "runCard" | "code" | "validation" | "studio" | "factor";
+type Tab = "dashboard" | "chart" | "tearsheet" | "trades" | "runCard" | "code" | "validation" | "studio" | "factor" | "positions";
 type ChartPayload = Pick<RunData, "price_series" | "indicator_series" | "trade_markers">;
 type ChartCache = Record<string, ChartPayload>;
 type ChartLoadProgress = { done: number; total: number };
@@ -134,6 +138,7 @@ export function RunDetail() {
   const hasValidation = !!run?.validation;
   const hasRunCard = !!run?.run_card;
   const hasStudio = !!run?.risk_xray || !!run?.rebalance_notes;
+  const hasPositions = !!run?.artifacts_positions_csv?.length;
   const hasTearsheet = (run?.artifacts_equity_csv?.length ?? 0) > 0 || (run?.equity_curve?.length ?? 0) > 0;
   const hasFactor = !!run?.has_factor_artifacts;
   const TABS: { id: Tab; label: string; icon: typeof BarChart3; hidden?: boolean }[] = [
@@ -143,6 +148,7 @@ export function RunDetail() {
     { id: "trades", label: i18n.t("runDetail.trades"), icon: List },
     { id: "factor", label: i18n.t("runDetail.factor"), icon: Sigma, hidden: !hasFactor },
     { id: "studio", label: i18n.t("runDetail.studio"), icon: Gauge, hidden: !hasStudio },
+    { id: "positions", label: i18n.t("runDetail.positions"), icon: PieChart, hidden: !hasPositions },
     { id: "validation", label: i18n.t("runDetail.validation"), icon: ShieldCheck, hidden: !hasValidation },
     { id: "runCard", label: i18n.t("runDetail.runCard"), icon: FileCheck2, hidden: !hasRunCard },
     { id: "code", label: i18n.t("runDetail.code"), icon: Code2 },
@@ -417,6 +423,7 @@ export function RunDetail() {
           {tab === "studio" && hasStudio && (
             <StudioTab xray={run.risk_xray} notes={run.rebalance_notes} />
           )}
+          {tab === "positions" && hasPositions && <PositionsTab run={run} />}
           {tab === "runCard" && run.run_card && <RunCardTab card={run.run_card} />}
           {tab === "code" && <CodeTab code={code} />}
         </ErrorBoundary>
@@ -594,6 +601,88 @@ function StudioTab({ xray, notes }: { xray?: RiskXRayPayload; notes?: RebalanceN
               </table>
             </div>
           )}
+        </RunCardPanel>
+      )}
+    </div>
+  );
+}
+
+function PositionsTab({ run }: { run: RunData }) {
+  const rows = useMemo(() => parsePositionRows(run.artifacts_positions_csv), [run.artifacts_positions_csv]);
+  const targetRows = useMemo(() => parsePositionRows(run.artifacts_target_positions_csv), [run.artifacts_target_positions_csv]);
+  const latest = rows[rows.length - 1]?.weights ?? {};
+  const latestEntries = Object.entries(latest).sort((a, b) => Math.abs(b[1]) - Math.abs(a[1]));
+  const { gross, net } = exposureSummary(latest);
+  const symbols = useMemo(() => topSymbols(rows), [rows]);
+  const series = useMemo(() => toWeightSeries(rows, symbols), [rows, symbols]);
+  const drift = useMemo(() => computeDrift(targetRows, rows), [targetRows, rows]);
+
+  if (rows.length === 0) {
+    return <div className="p-4 text-sm text-muted-foreground">{i18n.t("runDetail.noPositionData")}</div>;
+  }
+
+  return (
+    <div className="space-y-4">
+      <RunCardPanel title={i18n.t("runDetail.latestWeights")} icon={PieChart}>
+        <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+          <RunCardStat label={i18n.t("runDetail.grossExposure")} value={fmtPct(gross)} />
+          <RunCardStat label={i18n.t("runDetail.netExposure")} value={fmtPct(net)} />
+          <RunCardStat label={i18n.t("runDetail.rebalanceCount")} value={String(rows.length)} />
+          <RunCardStat label={i18n.t("runDetail.date")} value={rows[rows.length - 1]?.time || "-"} />
+        </div>
+        <div className="mt-3 grid gap-4 xl:grid-cols-2">
+          <PositionsPieChart weights={latest} />
+          <div className="max-h-72 overflow-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b bg-muted/40 text-left text-[11px] uppercase tracking-wide text-muted-foreground [&_th]:font-medium">
+                  <th className="py-2 ps-4 pr-4">{i18n.t("runDetail.symbol")}</th>
+                  <th className="py-2 pr-4">{i18n.t("runDetail.weight")}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {latestEntries.map(([sym, w]) => (
+                  <tr key={sym} className="border-b last:border-0 hover:bg-muted/40">
+                    <td className="py-1.5 ps-4 pr-4 font-mono text-xs">{sym}</td>
+                    <td className="py-1.5 pr-4 font-mono tabular-nums">{fmtPct(w, 2)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </RunCardPanel>
+
+      {rows.length > 1 && (
+        <RunCardPanel title={i18n.t("runDetail.weightEvolution")} icon={PieChart}>
+          <PositionWeightsChart points={series} symbols={symbols} />
+        </RunCardPanel>
+      )}
+
+      {drift.length > 0 && (
+        <RunCardPanel title={i18n.t("runDetail.targetVsActual")} icon={Gauge}>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b bg-muted/40 text-left text-[11px] uppercase tracking-wide text-muted-foreground [&_th]:font-medium">
+                  <th className="py-2 ps-4 pr-4">{i18n.t("runDetail.symbol")}</th>
+                  <th className="py-2 pr-4">{i18n.t("runDetail.target")}</th>
+                  <th className="py-2 pr-4">{i18n.t("runDetail.actual")}</th>
+                  <th className="py-2">{i18n.t("runDetail.drift")}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {drift.map((r) => (
+                  <tr key={r.symbol} className="border-b last:border-0 hover:bg-muted/40">
+                    <td className="py-1.5 ps-4 pr-4 font-mono text-xs">{r.symbol}</td>
+                    <td className="py-1.5 pr-4 font-mono tabular-nums">{fmtPct(r.target, 2)}</td>
+                    <td className="py-1.5 pr-4 font-mono tabular-nums">{fmtPct(r.actual, 2)}</td>
+                    <td className="py-1.5 font-mono tabular-nums">{`${r.drift >= 0 ? "+" : ""}${fmtPct(r.drift, 2)}`}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </RunCardPanel>
       )}
     </div>

--- a/frontend/src/pages/__tests__/RunDetail.test.tsx
+++ b/frontend/src/pages/__tests__/RunDetail.test.tsx
@@ -19,6 +19,12 @@ vi.mock("@/components/charts/CandlestickChart", () => ({
 vi.mock("@/components/charts/EquityChart", () => ({
   EquityChart: () => <div data-testid="equity-chart" />,
 }));
+vi.mock("@/components/charts/PositionsPieChart", () => ({
+  PositionsPieChart: () => <div data-testid="positions-pie-chart" />,
+}));
+vi.mock("@/components/charts/PositionWeightsChart", () => ({
+  PositionWeightsChart: () => <div data-testid="position-weights-chart" />,
+}));
 vi.mock("@/components/charts/StrategyResearchDashboard", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/components/charts/StrategyResearchDashboard")>();
   return {
@@ -343,4 +349,53 @@ describe("RunDetail page", () => {
 
     await screen.findByText("Plain run");
     expect(screen.queryByRole("tab", { name: "Portfolio Studio" })).not.toBeInTheDocument();
+  });
+
+  it("renders the Positions tab from positions artifacts, including target-vs-actual drift", async () => {
+    apiMock.getRun.mockResolvedValue({
+      status: "success",
+      run_id: "positions-run",
+      prompt: "Positions run",
+      artifacts_positions_csv: [
+        { timestamp: "2026-02-01", AAPL: 0.5, MSFT: 0.3, TSLA: 0.2 },
+        { timestamp: "2026-03-01", AAPL: 0.6, MSFT: 0.25, TSLA: 0.15 },
+      ],
+      artifacts_target_positions_csv: [
+        { timestamp: "2026-03-01", AAPL: 0.65, MSFT: 0.25, TSLA: 0.1 },
+      ],
+    });
+    apiMock.getRunCode.mockResolvedValue({});
+
+    renderRunDetail("/runs/positions-run");
+
+    await screen.findByText("Positions run");
+    fireEvent.click(screen.getByRole("tab", { name: "Positions" }));
+
+    expect(await screen.findByText("Latest Weights")).toBeInTheDocument();
+    // gross and net both sum to 100% for this long-only fully invested book
+    expect(screen.getAllByText("100.0%")).toHaveLength(2);
+    // latest actual weights: weights table row plus drift table's actual column
+    expect(screen.getAllByText("60.00%")).toHaveLength(2);
+    expect(screen.getByText("65.00%")).toBeInTheDocument();
+    expect(screen.getByText("-5.00%")).toBeInTheDocument();
+    expect(screen.getByText("+5.00%")).toBeInTheDocument();
+    expect(screen.getByText("Target vs Actual")).toBeInTheDocument();
+    // two snapshots -> the evolution chart renders
+    expect(screen.getByTestId("position-weights-chart")).toBeInTheDocument();
+    expect(screen.getByTestId("positions-pie-chart")).toBeInTheDocument();
+  });
+
+  it("hides the Positions tab when the run has no positions artifact", async () => {
+    apiMock.getRun.mockResolvedValue({
+      status: "success",
+      run_id: "plain-run",
+      prompt: "Plain run",
+      trade_log: [],
+    });
+    apiMock.getRunCode.mockResolvedValue({});
+
+    renderRunDetail("/runs/plain-run");
+
+    await screen.findByText("Plain run");
+    expect(screen.queryByRole("tab", { name: "Positions" })).not.toBeInTheDocument();
   });


### PR DESCRIPTION
Closes the chartable slice of #1098.

Run Detail gains a Positions tab, fed entirely by artifacts the run response already carries (`positions.csv` / `target_positions.csv`), so there is no backend change:

- Latest Weights: gross/net exposure cards, a donut for long-only books (it flips to signed bars as soon as any short leg shows up), plus the full weight table
- Weight Evolution: stacked area across rebalances, top 8 symbols by latest weight plus an Other bucket
- Target vs Actual: latest optimizer targets against post-fill weights, sorted by absolute drift, so blocked or rounded fills stay auditable

Out of scope, deliberately: the sector/asset-class tilt from #1098 (the product has no industry mapping source today, and deriving one from symbol prefixes would be wrong), and a treemap (the donut and bars answer the same concentration question without another render path).

Test plan: new unit tests for the parsing/drift helpers plus two RunDetail tests (tab render with drift math, and hidden-when-absent gating): 19 passed. `tsc -b` clean, `npm run build` clean. The full frontend suite shows 32 failures in apiAuth/useDarkMode/useSSE/SettingsQVeris/Layout that reproduce identically on clean main in this environment (verified with a stash), untouched by this change.

Frontend-only, no broker/MCP/network surface. Rollback is reverting the single commit.
