### PR TITLE
fix(swarm): truncate oversized tool results with the shared notice

### DIFF
--- a/agent/src/swarm/worker.py
+++ b/agent/src/swarm/worker.py
@@ -18,7 +18,7 @@ from src.agent.context import ContextBuilder
 from src.agent.progress import HeartbeatTimer
 from src.agent.skills import SkillsLoader
 from src.agent.tools import ToolRegistry
-from src.config.limits import TOOL_RESULT_LIMIT
+from src.config.limits import truncate_tool_result
 from src.config.schema import AgentConfig
 from src.providers.chat import ChatLLM, LLMResponse, ProviderStreamError
 from src.providers.content_filter import (
@@ -791,7 +791,7 @@ def run_worker(
             )
             messages.append(
                 ContextBuilder.format_tool_result(
-                    tc.id, tc.name, result[:TOOL_RESULT_LIMIT]
+                    tc.id, tc.name, truncate_tool_result(result)
                 )
             )
 

--- a/agent/tests/test_swarm_worker_tool_result_truncation.py
+++ b/agent/tests/test_swarm_worker_tool_result_truncation.py
@@ -1,0 +1,152 @@
+"""Tests that run_worker() truncates oversized tool results the same way
+agent/src/agent/loop.py does.
+
+Regression: run_worker() truncated an oversized tool result with a raw
+result[:TOOL_RESULT_LIMIT] slice, no notice, frequently invalid JSON, and no
+correction of any envelope field the cut falsifies. The main agent loop, given
+the identical tool output and the identical limit, uses the shared
+truncate_tool_result() helper, which appends an explicit [TRUNCATED: ...]
+notice. The two call paths must behave identically for the same input.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from src.config.limits import TOOL_RESULT_LIMIT, truncate_tool_result
+from src.providers.chat import LLMResponse, ToolCallRequest
+from src.swarm.models import SwarmAgentSpec, SwarmTask
+import src.swarm.worker as worker_mod
+from src.swarm.worker import run_worker
+
+FINAL_TEXT = (
+    "# BTC-USDT — Short-Term View\n\n"
+    "Spot 81,704.6 (2026-05-05). 7d range 77,750-82,842.\n\n"
+    "**Recommendation: accumulate on dips to 79k; invalidation below 77.5k.**\n"
+    "Position 3% NAV, stop 76,900, target 86,000. Funding 0.035%/8h elevated\n"
+    "but not extreme; exchange reserves declining (bullish)."
+)
+
+
+class _OneToolRegistry:
+    """Minimal ToolRegistry stand-in exposing a single tool whose result the
+    test controls (the existing worker-test stubs hardcode "ok", so they
+    can't exercise the truncation contract this file tests)."""
+
+    def __init__(self, result: str) -> None:
+        self._result = result
+
+    def get_definitions(self) -> list[dict]:
+        return [
+            {"type": "function", "function": {"name": "big_tool", "parameters": {}}}
+        ]
+
+    def get(self, name: str):
+        return None
+
+    def execute(self, name: str, args: dict) -> str:
+        return self._result
+
+
+class _ScriptedChatLLM:
+    """Scripted ChatLLM that returns queued responses in order, capturing
+    every call's messages (same shape as test_swarm_worker_content_filter.py)."""
+
+    def __init__(self, responses: list[LLMResponse]) -> None:
+        self._responses = list(responses)
+        self.received_messages: list[list[dict]] = []
+
+    def __call__(self, *args, **kwargs) -> "_ScriptedChatLLM":
+        return self
+
+    def stream_chat(
+        self, messages, tools=None, on_text_chunk=None, timeout=None
+    ) -> LLMResponse:
+        self.received_messages.append(list(messages))
+        if self._responses:
+            return self._responses.pop(0)
+        return LLMResponse(content=FINAL_TEXT)
+
+
+def _run(monkeypatch, tmp_path: Path, llm: _ScriptedChatLLM, tool_result: str) -> str:
+    """Run a worker that calls one tool returning ``tool_result`` and return
+    the tool-role message content the LLM was sent on its next turn."""
+    agent = SwarmAgentSpec(
+        id="analyst",
+        role="Synthesis analyst",
+        system_prompt="You synthesize upstream findings.",
+        tools=["big_tool"],
+        skills=[],
+        max_iterations=3,
+        timeout_seconds=60,
+    )
+    task = SwarmTask(id="t1", agent_id="analyst", prompt_template="Read the document.")
+    with (
+        patch.object(
+            worker_mod,
+            "build_swarm_registry",
+            lambda *a, **k: _OneToolRegistry(tool_result),
+        ),
+        patch.object(worker_mod, "ChatLLM", llm),
+    ):
+        run_worker(
+            agent_spec=agent,
+            task=task,
+            upstream_summaries={},
+            user_vars={},
+            run_dir=tmp_path,
+        )
+    tool_messages = [m for m in llm.received_messages[-1] if m.get("role") == "tool"]
+    assert len(tool_messages) == 1
+    return tool_messages[0]["content"]
+
+
+def _tool_call_then_final() -> _ScriptedChatLLM:
+    return _ScriptedChatLLM(
+        [
+            LLMResponse(
+                tool_calls=[ToolCallRequest(id="call_1", name="big_tool", arguments={})]
+            ),
+            LLMResponse(content=FINAL_TEXT),
+        ]
+    )
+
+
+def test_oversized_tool_result_gets_truncation_notice(monkeypatch, tmp_path):
+    """An oversized result must carry the same [TRUNCATED: ...] notice the
+    main agent loop produces, not a silent raw slice."""
+    big_result = "x" * (TOOL_RESULT_LIMIT + 5000)
+
+    content = _run(monkeypatch, tmp_path, _tool_call_then_final(), big_result)
+
+    assert "[TRUNCATED:" in content
+    assert content == truncate_tool_result(big_result)
+    assert content != big_result[:TOOL_RESULT_LIMIT]
+
+
+def test_oversized_result_stale_envelope_field_not_left_uncorrected(
+    monkeypatch, tmp_path
+):
+    """A tool's own 'truncated: false' claim must not survive the cut still
+    asserting completeness once the result is actually truncated."""
+    big_result = (
+        '{"status": "ok", "truncated": false, "body": "'
+        + ("y" * TOOL_RESULT_LIMIT)
+        + '"}'
+    )
+
+    content = _run(monkeypatch, tmp_path, _tool_call_then_final(), big_result)
+
+    assert content == truncate_tool_result(big_result)
+    assert "[TRUNCATED:" in content
+
+
+def test_result_under_limit_passes_through_unchanged(monkeypatch, tmp_path):
+    """A result at or under the limit must reach the LLM byte-for-byte
+    unchanged — the fix must not alter ordinary, non-oversized results."""
+    small_result = '{"status": "ok", "body": "normal sized tool output"}'
+
+    content = _run(monkeypatch, tmp_path, _tool_call_then_final(), small_result)
+
+    assert content == small_result


### PR DESCRIPTION
## Summary
`run_worker()` truncated oversized tool results with a raw `result[:TOOL_RESULT_LIMIT]` slice, while the main agent loop uses the shared `truncate_tool_result()` helper. The raw slice could leave the sub-agent LLM with a partial result and no indication that content had been removed.

This change uses the shared helper in the swarm worker as well, keeping both paths consistent.

## Why
The agent loop and swarm worker share the same tool-result limit, but only the agent loop applied the shared truncation behaviour. As a result, an oversized tool result could be silently cut in `run_worker()` without the `[TRUNCATED: ...]` notice provided by the main agent path.

Git history shows that the shared limit was introduced so the agent loop, swarm worker and tools use the same configuration. The swarm worker's tool-result path continued to use a raw slice.

## Changes
- `agent/src/swarm/worker.py`: replace the raw tool-result slice with `truncate_tool_result()`.
- `agent/tests/test_swarm_worker_tool_result_truncation.py`: add regression coverage for oversized results, stale truncation metadata, and unchanged under-limit results through the actual `run_worker()` path.

## Test Plan
- [x] Regression tests fail on unpatched code and pass after the fix; the under-limit control passes before and after
- [x] `pytest agent/tests/test_tool_result_paging.py agent/tests/test_swarm_worker_stream_retry.py agent/tests/test_swarm_worker_report.py agent/tests/test_swarm_worker_tool_result_truncation.py -v` (31 passed)
- [x] `pytest agent/tests/ -k "swarm" -q` (322 passed, 5 skipped)
- [x] `pytest agent --ignore=agent/tests/e2e_backtest --ignore=agent/tests/test_e2e_harness_v2.py --tb=short -q` (10,427 passed, 83 skipped, 1 failed; the single failure is a live `eastmoney.com` request blocked by the sandbox proxy and reproduces identically on unpatched code)
- [x] `black --check` is clean for the new test file; `worker.py` has one pre-existing unrelated formatting finding that reproduces on unpatched `main` and does not involve the changed lines
- [x] `ruff check` on both changed files passes

## Checklist
- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`): this only touches `agent/src/swarm/` and `agent/tests/`
- [x] No hardcoded values
- [x] Code follows `CONTRIBUTING.md` guidelines
- [x] Documentation updated: N/A, no public interface or documented behaviour change
- [x] DCO signed-off

## Risk
No live trading, broker, payment, wallet, MCP, credential, or network behaviour is changed. The fix only changes how an oversized tool result is presented to the LLM inside a swarm worker turn.

## Rollback
The change is contained in one focused commit and can be reverted normally.