### PR TITLE
feat(data-loader): add ca certifi with tencent loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,5 @@ desktop/electron/runtime/
 wiki/alpha-library/manifest.json
 wiki/alpha-library/content/
 bench_report.json
+
+.idea/*

--- a/agent/backtest/loaders/tencent_loader.py
+++ b/agent/backtest/loaders/tencent_loader.py
@@ -13,7 +13,10 @@ from __future__ import annotations
 import json
 import logging
 from typing import Dict, List, Optional
+import ssl
+import urllib.request
 
+import certifi
 import pandas as pd
 
 from backtest.loaders.base import cached_loader_fetch, validate_date_range
@@ -23,6 +26,7 @@ logger = logging.getLogger(__name__)
 
 _BASE_URL = "https://web.ifzq.gtimg.cn/appstock/app/fqkline/get"
 
+_SSL_CONTEXT = ssl.create_default_context(cafile=certifi.where())
 
 def _is_a_share(code: str) -> bool:
     return code.upper().endswith((".SZ", ".SH"))
@@ -114,12 +118,11 @@ class DataLoader:
             f"{start_date},{end_date},500,qfq"
         )
 
-        import urllib.request
         req = urllib.request.Request(url, headers={
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
             "Referer": "https://web.ifzq.gtimg.cn/",
         })
-        with urllib.request.urlopen(req, timeout=15) as resp:
+        with urllib.request.urlopen(req, timeout=15, context=_SSL_CONTEXT) as resp:
             raw = resp.read().decode("utf-8")
 
         data = json.loads(raw)

--- a/agent/tests/test_tencent_loader.py
+++ b/agent/tests/test_tencent_loader.py
@@ -41,7 +41,7 @@ def _hk_kline_payload(tencent_code: str) -> str:
 
 
 def _patch_http(monkeypatch, urls: list[str], payload: str) -> None:
-    def fake_urlopen(req, timeout=None):  # noqa: ANN001, ANN002
+    def fake_urlopen(req, timeout=None, **kwargs):  # noqa: ANN001, ANN002
         urls.append(req.full_url)
         return _FakeResponse(payload)
 


### PR DESCRIPTION
## Summary

- 修复 `tencent_loader` 拉取腾讯行情时的 SSL 证书校验失败：改为用 certifi 的 CA bundle 构造 SSL 上下文，解决 `CERTIFICATE_VERIFY_FAILED`（GlobalSign Atlas R3 新根证书在 Python 默认 CA 存储中缺失）。
- 同步更新测试里的 `fake_urlopen` 签名以兼容新增的 `context=` 参数。

## Why

腾讯 `web.ifzq.gtimg.cn` 的证书由新的 GlobalSign Atlas R3 OV CA 签发，Python `urllib` 默认 SSL 上下文不信任该根，导致链路降级失败、HK 行情无法加载（例如 `09660.HK` 多次重试全失败）。

## Changes

- `agent/backtest/loaders/tencent_loader.py`：增加 `ssl.create_default_context(cafile=certifi.where())` 并传入 `urllib.request.urlopen(..., context=...)`。
- `agent/tests/test_tencent_loader.py`：`fake_urlopen` 增加 `**kwargs` 以接收 `context`。

## Test Plan

- [x] Existing tests pass (`pytest tests/test_tencent_loader.py -q`；相关回归 24 passed)
- [ ] 新测试（如适用）——如需要可补一个断言 `context._verify_mode` 的测试
- [x] 手动验证：`09660.HK`、`600519.SH` K 线数据可正常拉取

## Checklist

- [x] 未改动受保护目录（`agent/src/agent/` 等）
- [x] 无硬编码值（certifi 按依赖引入并已在 requirements）
- [x] 代码符合 CONTRIBUTING.md
- [x] 无需更新文档