### PR TITLE
fix(tools): mark unsupported ticker+name symbol queries as skipped

### DIFF
--- a/agent/src/tools/symbol_search_tool.py
+++ b/agent/src/tools/symbol_search_tool.py
@@ -219,6 +219,30 @@ def _is_canadian_symbol(text: str) -> bool:
     return bool(_CANADIAN_SYMBOL_RE.match((text or "").strip()))
 
 
+def _is_ticker_name_query(query: str) -> bool:
+    """Whether *query* is a bare all-caps ticker followed by a name hint.
+
+    Yahoo's search endpoint answers this shape ("XOM ExxonMobil") with zero
+    quotes, so the Yahoo path skips it rather than letting a caller deciding
+    whether an entity exists read the empty result as "not listed". Unlike the
+    Canadian fail-fast, Eastmoney is NOT skipped for this shape — it can serve
+    multi-token queries — so this helper is only consulted on the Yahoo path.
+
+    The first token must be bare all-caps (``[A-Z0-9&]{1,6}``); the absence of
+    a dot/hyphen excludes suffixed tickers (``BTO.TO``, ``BRK.B``) and
+    mixed-case name tokens.
+
+    Args:
+        query: Free-text name or ticker fragment.
+
+    Returns:
+        ``True`` when the query has at least two tokens and starts with a
+        bare all-caps ticker-like token.
+    """
+    tokens = (query or "").strip().split()
+    return len(tokens) >= 2 and bool(re.fullmatch(r"[A-Z0-9&]{1,6}", tokens[0]))
+
+
 def _search_eastmoney(query: str) -> tuple[List[Dict[str, Any]], str]:
     """Query Eastmoney's suggest endpoint and normalize the candidates.
 
@@ -357,6 +381,13 @@ def _search_yahoo(query: str) -> tuple[List[Dict[str, Any]], str]:
     except Exception as exc:  # noqa: BLE001 - one source failing is non-fatal
         logger.warning("yahoo search failed for %r: %s", query, exc)
         return [], f"yahoo search failed: {exc}"
+
+    if not quotes and _is_ticker_name_query(query):
+        # Mirror the non-ASCII guard above: Yahoo answers a multi-token
+        # ticker+name query ("XOM ExxonMobil") with zero quotes, which a
+        # caller deciding whether an entity exists would otherwise read as
+        # "not listed". An unsupported query shape must not read as an outage.
+        return [], f"{_SKIPPED}ticker+name query is not supported by this source"
 
     candidates: List[Dict[str, Any]] = []
     for quote in quotes[:_PER_SOURCE_CAP]:

--- a/agent/tests/test_symbol_search_tool.py
+++ b/agent/tests/test_symbol_search_tool.py
@@ -434,3 +434,156 @@ class TestShanghaiAliasAndUnsupportedQueries:
 
         search.assert_called_once()
         assert data["sources"]["yahoo"] == "ok"
+
+
+class TestTickerNameQueryYahooSkip:
+    """A ticker+name query Yahoo cannot serve must be skipped, not "ok".
+
+    Yahoo's search endpoint answers a multi-token query whose first token is a
+    bare all-caps ticker ("XOM ExxonMobil") with zero quotes. Recording that as
+    "ok" counted a second clean source, so a caller deciding whether an entity
+    exists read "not listed" as two corroborating "not found" answers; the
+    unsupported shape must read as "skipped" instead, mirroring the non-ASCII
+    guard. Eastmoney is NOT skipped for this shape — it can serve multi-token
+    queries — only the Yahoo path relabels.
+    """
+
+    def test_ticker_name_query_skips_yahoo_without_ok_status(self):
+        """Yahoo returns zero quotes for the shape and is relabeled "skipped"."""
+        with patch.object(
+            ss.eastmoney_client,
+            "get_json",
+            return_value={"QuotationCodeTable": {"Data": []}},
+        ), patch.object(
+            ss.yahoo_client, "search", return_value=[]
+        ) as search, patch.object(
+            ss.sec_edgar_client, "cik_for", return_value=None
+        ):
+            data = json.loads(
+                ss.SymbolSearchTool().execute(query="XOM ExxonMobil")
+            )["data"]
+
+        # Post-response relabel, not a pre-call skip: Yahoo is still consulted.
+        search.assert_called_once()
+        assert data["sources"]["yahoo"].startswith("skipped:")
+        assert data["sources"]["eastmoney"] == "ok"
+        assert data["count"] == 0
+
+    def test_ticker_name_query_with_matching_quotes_stays_ok(self):
+        """The relabel must NOT fire when Yahoo can actually serve the shape."""
+        quotes = [
+            {
+                "symbol": "XOM",
+                "shortname": "Exxon Mobil Corp.",
+                "exchange": "NYQ",
+                "quoteType": "EQUITY",
+            }
+        ]
+        with patch.object(
+            ss.eastmoney_client,
+            "get_json",
+            return_value={"QuotationCodeTable": {"Data": []}},
+        ), patch.object(
+            ss.yahoo_client, "search", return_value=quotes
+        ) as search, patch.object(
+            ss.sec_edgar_client, "cik_for", return_value="0000034088"
+        ):
+            data = json.loads(
+                ss.SymbolSearchTool().execute(query="XOM ExxonMobil")
+            )["data"]
+
+        search.assert_called_once()
+        assert data["sources"]["yahoo"] == "ok"
+        assert data["count"] == 1
+
+    def test_multi_word_name_query_still_reaches_yahoo(self):
+        """A multi-word NAME ("Exxon Mobil") is not a ticker+name shape."""
+        with patch.object(
+            ss.eastmoney_client,
+            "get_json",
+            return_value={"QuotationCodeTable": {"Data": []}},
+        ), patch.object(
+            ss.yahoo_client, "search", return_value=_yahoo_quotes()
+        ) as search, patch.object(
+            ss.sec_edgar_client, "cik_for", return_value="0000320193"
+        ):
+            data = json.loads(ss.SymbolSearchTool().execute(query="Exxon Mobil"))["data"]
+
+        search.assert_called_once()
+        assert data["sources"]["yahoo"] == "ok"
+
+    def test_single_token_query_still_reaches_yahoo(self):
+        """A bare single-token ticker ("XOM") is not a ticker+name shape."""
+        with patch.object(
+            ss.eastmoney_client,
+            "get_json",
+            return_value={"QuotationCodeTable": {"Data": []}},
+        ), patch.object(
+            ss.yahoo_client, "search", return_value=_yahoo_quotes()
+        ) as search, patch.object(
+            ss.sec_edgar_client, "cik_for", return_value="0000320193"
+        ):
+            data = json.loads(ss.SymbolSearchTool().execute(query="XOM"))["data"]
+
+        search.assert_called_once()
+        assert data["sources"]["yahoo"] == "ok"
+
+    def test_suffixed_ticker_with_name_still_reaches_yahoo(self):
+        """The bare-ticker clause must not fire on suffixed Canadian tickers."""
+        with patch.object(
+            ss.eastmoney_client,
+            "get_json",
+            return_value={"QuotationCodeTable": {"Data": []}},
+        ), patch.object(
+            ss.yahoo_client, "search", return_value=_yahoo_quotes()
+        ) as search:
+            data = json.loads(
+                ss.SymbolSearchTool().execute(query="BTO.TO B2Gold")
+            )["data"]
+
+        search.assert_called_once()
+        assert data["sources"]["yahoo"] == "ok"
+
+    def test_single_token_ascii_empty_result_stays_ok(self):
+        """A bare single token Yahoo cannot match is "not listed", not "skipped".
+
+        The relabel is shape-specific: only a multi-token ticker+name query is
+        unsupported. A single token (e.g. a bogus ticker) that returns zero
+        quotes is an authoritative "not listed" and must stay "ok", otherwise
+        every genuinely-absent entity would read as an unsupported shape.
+        """
+        with patch.object(
+            ss.eastmoney_client,
+            "get_json",
+            return_value={"QuotationCodeTable": {"Data": []}},
+        ), patch.object(
+            ss.yahoo_client, "search", return_value=[]
+        ) as search:
+            data = json.loads(
+                ss.SymbolSearchTool().execute(query="XOMZZZ")
+            )["data"]
+
+        search.assert_called_once()
+        assert data["sources"]["yahoo"] == "ok"
+
+    def test_multi_word_name_empty_result_stays_ok(self):
+        """A multi-word NAME ("Exxon Mobil") with zero quotes is "not listed".
+
+        The shape classifier keys on a bare all-caps FIRST token ("XOM
+        ExxonMobil"). A name-led query ("Exxon Mobil") is a shape Yahoo can
+        serve, so its empty answer is an authoritative "not listed" and must
+        not be relabeled to "skipped".
+        """
+        with patch.object(
+            ss.eastmoney_client,
+            "get_json",
+            return_value={"QuotationCodeTable": {"Data": []}},
+        ), patch.object(
+            ss.yahoo_client, "search", return_value=[]
+        ) as search:
+            data = json.loads(
+                ss.SymbolSearchTool().execute(query="Exxon Mobil")
+            )["data"]
+
+        search.assert_called_once()
+        assert data["sources"]["yahoo"] == "ok"


### PR DESCRIPTION
## Summary

- `search_symbol` now reports `skipped:` for the Yahoo source when a query
  shape Yahoo cannot serve (a multi-token query whose first token is a bare
  all-caps ticker, e.g. `XOM ExxonMobil`) returns zero quotes, instead of a
  misleading `ok`.
- Adds a module-private `_is_ticker_name_query` predicate and a post-response
  relabel in `_search_yahoo`, mirroring the existing non-ASCII skip.
- Eastmoney is deliberately not skipped for this shape.

Closes #1108.

## Why

For `search_symbol("XOM ExxonMobil")`, Yahoo's search answers with an empty
quote list and the tool mapped that to status `ok`. The grounding ledger then
saw two clean sources and recorded `not_found`, so the model concluded the
entity does not exist and every market-data call was blocked with
`identity_required`. The shape was never servable by Yahoo; recording it as
`ok` hid that from the caller. This is a missing application of the tool's
documented contract that a source which cannot serve a query shape reports
`skipped: ...`, not `ok` or a failure.

## Changes

- `_is_ticker_name_query(query)`: true when the query has at least two
  whitespace-separated tokens and the first is a bare all-caps ticker-like
  token (`[A-Z0-9&]{1,6}` fullmatch). Dots/hyphens are excluded, so suffixed
  tickers (`BTO.TO`, `BRK.B`) are never classified.
- `_search_yahoo`: when Yahoo returns no quotes for such a query, return
  `skipped: ticker+name query is not supported by this source`. The decision
  is made after the source is consulted and only on an empty response, so any
  query Yahoo actually serves keeps `ok`.
- No change to `_search_eastmoney`, `execute()`, or the grounding ledger.

## Test Plan

- [ ] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [ ] New tests added (if applicable)
- [ ] Tested manually (describe below)

Local validation: `pytest agent/tests/test_symbol_search_tool.py -q` — 23
passed (16 existing + 7 new); the core regression test fails on the base
commit with the exact violation (`'ok'.startswith('skipped:')`).
`pytest agent/tests/test_agent_grounding.py -q` — 129 passed (cross-module
`skipped:` contract intact); `test_grounding_recovery.py` — 14 passed;
`test_agent_loop_repeatable_tools.py` — 4 passed; `git diff --check` clean.

Honest scope note: when Eastmoney also returns zero candidates, the recorded
grounding status is `not_found` before and after this change; the ledger
outcome for the both-empty case is unchanged. What changes is the per-source
signal — the model now reads why the shape failed and can retry as a single
token (e.g. `XOM`), which resolves. This satisfies the issue's minimum ask
(empty result distinguishable from "this entity does not exist"); deterministic
in-tool resolution of the combined query is a deliberate out-of-scope follow-up.

## Checklist

- [ ] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [ ] No hardcoded values (API keys, file paths, magic numbers)
- [ ] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] Documentation updated (N/A — tool description and status vocabulary are
  unchanged; the `skipped:` marker is already documented in `_search_yahoo`)