### PR TITLE
fix(providers): pass reasoning effort through to the Anthropic adapter

### DIFF
--- a/agent/src/providers/llm.py
+++ b/agent/src/providers/llm.py
@@ -924,17 +924,81 @@ def _make_temperature_safe_anthropic(base_cls: type) -> type:
     return safe_cls
 
 
+# Effort is not universal across the Anthropic line. Fable 5, Opus 5, Opus
+# 4.5-4.8 and Sonnet 5 / 4.6 accept it; Haiku 4.5 and Sonnet 4.5 reject it
+# outright with
+#   400 invalid_request_error: This model does not support the effort parameter.
+#
+# That bites hardest in a swarm, where a per-agent ``model_name`` split
+# deliberately puts cheap models on the data-gathering seats: one global effort
+# setting then kills exactly those workers, and it fails as a hard 400 rather
+# than a warning.
+#
+# A positive allowlist, for the same reason ``top_level_reasoning_effort`` in
+# providers/capabilities.py is one: an unrecognised model gets nothing, because
+# the cost of a wrong entry is that every request to it fails, while the cost of
+# a missing one is only that the effort setting is inert there.
+_EFFORT_CAPABLE_ANTHROPIC: tuple[str, ...] = (
+    "claude-fable-5",
+    "claude-mythos-5",
+    "claude-mythos-preview",
+    "claude-opus-5",
+    "claude-opus-4-8",
+    "claude-opus-4-7",
+    "claude-opus-4-6",
+    "claude-opus-4-5",
+    "claude-sonnet-5",
+    "claude-sonnet-4-6",
+)
+
+
+def _anthropic_supports_effort(model: str) -> bool:
+    """Report whether an Anthropic model accepts the effort parameter.
+
+    Args:
+        model: The configured Anthropic model name.
+
+    Returns:
+        True when the model is on the allowlist above.
+    """
+    name = (model or "").strip().lower()
+    return any(name.startswith(prefix) for prefix in _EFFORT_CAPABLE_ANTHROPIC)
+
+
+def _adapter_accepts_effort(chat_anthropic: type) -> bool:
+    """Report whether the installed langchain-anthropic exposes the field.
+
+    ``ChatAnthropic`` is configured with ``extra="ignore"``, so an unknown
+    keyword is dropped in silence rather than raising. pyproject allows
+    ``langchain-anthropic>=1.3.0``, and ``reasoning_effort`` arrived later --
+    without this check, an older install would swallow the value while the
+    caller still paid the temperature cost below, which is the worst of both.
+
+    Args:
+        chat_anthropic: The resolved ``ChatAnthropic`` class.
+
+    Returns:
+        True when the class declares a ``reasoning_effort`` field.
+    """
+    return "reasoning_effort" in getattr(chat_anthropic, "model_fields", {})
+
+
 def _build_anthropic(
     *,
     model: str,
     temperature: float,
     callbacks: Any = None,
+    effort: str = "",
 ) -> Any:
     """Build the native Anthropic Messages API adapter.
 
     Uses a temperature-safe subclass so models that deprecate the `temperature`
     field (e.g. claude-opus-5 / claude-sonnet-5) work transparently while models
     that still accept it keep the configured deterministic value.
+
+    `effort` is the configured LANGCHAIN_REASONING_EFFORT, forwarded only to
+    models that accept it (see `_anthropic_supports_effort`); an empty string
+    means unset.
     """
     try:
         module = import_module("langchain_anthropic")
@@ -946,13 +1010,30 @@ def _build_anthropic(
         ) from exc
 
     safe_anthropic = _make_temperature_safe_anthropic(chat_anthropic)
+    use_effort = (
+        bool(effort)
+        and _anthropic_supports_effort(model)
+        and _adapter_accepts_effort(chat_anthropic)
+    )
+    # Effort makes langchain-anthropic enable adaptive thinking, and the API
+    # then rejects any temperature other than 1:
+    #   `temperature` may only be set to 1 when thinking is enabled or in
+    #   adaptive mode
+    # The platform's default is 0.0, so temperature is omitted entirely
+    # whenever effort is in play. The temperature-safe wrapper above does not
+    # cover this: it handles models that reject `temperature` outright, not
+    # this thinking-conditional variant.
     return safe_anthropic(
         model=model,
         max_tokens=get_env_config().llm.anthropic_max_tokens,
-        temperature=temperature,
+        temperature=None if use_effort else temperature,
         timeout=get_env_config().llm.timeout_seconds,
         max_retries=get_env_config().llm.max_retries,
         callbacks=callbacks,
+        # Rendered by langchain-anthropic as output_config={'effort': ...}.
+        # Without it, Fable 5 and Opus 5 run at the default effort however
+        # LANGCHAIN_REASONING_EFFORT is set.
+        reasoning_effort=effort if use_effort else None,
         api_key=os.getenv("ANTHROPIC_API_KEY") or None,  # noqa: env-gate — native provider credential
         base_url=(
             os.getenv("ANTHROPIC_BASE_URL")  # noqa: env-gate — native provider endpoint
@@ -1287,6 +1368,7 @@ def build_llm(*, model_name: Optional[str] = None, callbacks: Any = None) -> Any
             model=name,
             temperature=temperature,
             callbacks=callbacks,
+            effort=get_env_config().llm.langchain_reasoning_effort.strip().lower(),
         )
 
     if provider == "deepseek":

--- a/agent/tests/test_llm_reasoning_effort.py
+++ b/agent/tests/test_llm_reasoning_effort.py
@@ -18,9 +18,11 @@ Responses API for endpoints that support it.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
@@ -309,6 +311,170 @@ class TestUnsupportedProviders:
         )
 
         assert kwargs["reasoning_effort"] == "high"
+
+
+class TestAnthropicNativeProvider:
+    """The native Anthropic adapter takes effort as `reasoning_effort`.
+
+    langchain-anthropic renders that kwarg as ``output_config={'effort': ...}``
+    on the wire, which is where the Anthropic API expects it — unlike the
+    OpenAI-compatible providers above, which send a top-level field.
+    """
+
+    def _capture(self, env: dict[str, str]) -> dict[str, Any]:
+        """Run build_llm for the Anthropic provider and return adapter kwargs.
+
+        Patches the temperature-safe subclass factory rather than the module
+        attribute, because ``_build_anthropic`` resolves ChatAnthropic lazily
+        through ``import_module`` at call time.
+
+        Args:
+            env: Full environment for the call; every other variable is cleared.
+
+        Returns:
+            Keyword arguments build_llm passed to the adapter.
+        """
+        if importlib.util.find_spec("langchain_anthropic") is None:
+            pytest.skip("langchain-anthropic is not installed")
+        captured: dict[str, Any] = {}
+
+        class _FakeChatAnthropic:
+            model_fields = {"reasoning_effort": object()}
+
+            def __init__(self, **kwargs: Any) -> None:
+                captured.update(kwargs)
+
+        with patch.dict(os.environ, env, clear=True):
+            with patch.object(
+                llm_mod, "_make_temperature_safe_anthropic", lambda _: _FakeChatAnthropic
+            ):
+                build_llm()
+        return captured
+
+    def _env(self, **overrides: str) -> dict[str, str]:
+        """Return a minimal Anthropic environment with optional overrides."""
+        env = {
+            "LANGCHAIN_PROVIDER": "anthropic",
+            "ANTHROPIC_API_KEY": "sk-ant-test",
+            "LANGCHAIN_MODEL_NAME": "claude-fable-5",
+        }
+        env.update(overrides)
+        return env
+
+    def test_effort_reaches_the_anthropic_adapter(self) -> None:
+        """The gap this closes: the value was read and then dropped."""
+        kwargs = self._capture(self._env(LANGCHAIN_REASONING_EFFORT="high"))
+
+        assert kwargs["reasoning_effort"] == "high"
+
+    def test_unset_effort_stays_absent(self) -> None:
+        kwargs = self._capture(self._env())
+
+        assert kwargs["reasoning_effort"] is None
+
+    def test_temperature_is_omitted_when_effort_is_sent(self) -> None:
+        """Effort enables adaptive thinking, which rejects temperature != 1.
+
+        The platform's default is 0.0, so sending both fails the request with
+        `temperature may only be set to 1 when thinking is enabled or in
+        adaptive mode`. The pre-existing temperature-safe wrapper does not
+        catch this — it handles models that reject temperature outright.
+        """
+        kwargs = self._capture(self._env(LANGCHAIN_REASONING_EFFORT="high"))
+
+        assert kwargs["temperature"] is None
+
+    def test_temperature_is_preserved_without_effort(self) -> None:
+        """No effort means no thinking, so the deterministic default stands."""
+        kwargs = self._capture(self._env(LANGCHAIN_TEMPERATURE="0.0"))
+
+        assert kwargs["temperature"] == 0.0
+
+    def test_a_model_that_rejects_effort_is_not_sent_it(self) -> None:
+        """Haiku 4.5 answers `This model does not support the effort parameter`.
+
+        This is the case that matters in a swarm: a per-agent model split puts
+        cheap models on the data-gathering seats, and a global effort setting
+        would fail those workers with a hard 400 rather than a warning.
+        """
+        kwargs = self._capture(
+            self._env(
+                LANGCHAIN_MODEL_NAME="claude-haiku-4-5",
+                LANGCHAIN_REASONING_EFFORT="high",
+            )
+        )
+
+        assert kwargs["reasoning_effort"] is None
+        assert kwargs["temperature"] == 0.0
+
+    def test_an_unrecognised_model_is_not_sent_it(self) -> None:
+        """The allowlist is positive: unknown means no, not maybe.
+
+        Guessing wrong breaks the request outright, while a missing entry only
+        leaves the effort setting inert — the same asymmetry that keeps
+        `top_level_reasoning_effort` a positive allowlist in capabilities.py.
+        """
+        kwargs = self._capture(
+            self._env(
+                LANGCHAIN_MODEL_NAME="some-future-anthropic-model",
+                LANGCHAIN_REASONING_EFFORT="high",
+            )
+        )
+
+        assert kwargs["reasoning_effort"] is None
+
+    def test_an_adapter_without_the_field_is_not_sent_it(self) -> None:
+        """pyproject allows langchain-anthropic>=1.3.0, which predates the field.
+
+        ChatAnthropic sets `extra="ignore"`, so an older install would swallow
+        the kwarg silently — while the caller still paid the dropped
+        temperature. Sending neither is the honest outcome.
+        """
+        captured: dict[str, Any] = {}
+
+        class _OldChatAnthropic:
+            """Stands in for a langchain-anthropic without the field."""
+
+            model_fields: dict[str, Any] = {}
+
+            def __init__(self, **kwargs: Any) -> None:
+                captured.update(kwargs)
+
+        old_module = SimpleNamespace(ChatAnthropic=_OldChatAnthropic)
+
+        with patch.dict(
+            os.environ, self._env(LANGCHAIN_REASONING_EFFORT="high"), clear=True
+        ):
+            with patch.object(llm_mod, "import_module", lambda _: old_module):
+                with patch.object(
+                    llm_mod,
+                    "_make_temperature_safe_anthropic",
+                    lambda _: _OldChatAnthropic,
+                ):
+                    build_llm()
+
+        assert captured["reasoning_effort"] is None
+        assert captured["temperature"] == 0.0
+
+    def test_the_installed_adapter_renders_effort_as_output_config(self) -> None:
+        """Guards the assumption the whole change rests on.
+
+        `reasoning_effort` is only worth forwarding because langchain-anthropic
+        turns it into the `output_config.effort` field the API reads. If a
+        future release renames or drops that mapping, this fails here rather
+        than silently at request time.
+        """
+        if importlib.util.find_spec("langchain_anthropic") is None:
+            pytest.skip("langchain-anthropic is not installed")
+        from langchain_anthropic import ChatAnthropic
+        from langchain_core.messages import HumanMessage
+
+        instance = ChatAnthropic(
+            model="claude-fable-5", api_key="sk-ant-test", reasoning_effort="high"
+        )
+        payload = instance._get_request_payload([HumanMessage(content="hi")])
+
+        assert payload["output_config"]["effort"] == "high"
 
 
 class TestRelayOptIn:


### PR DESCRIPTION
## Summary

- `LANGCHAIN_REASONING_EFFORT` is read and honoured for the OpenAI-family
  providers but silently dropped on the Anthropic branch, so Fable 5, Opus 5
  and Sonnet 5 always run at the default effort whatever the config says.
- This forwards it as `reasoning_effort`, which langchain-anthropic renders as
  `output_config: {"effort": ...}` on the wire.
- Two non-obvious details make it more than a one-liner: effort is not
  universal across the Anthropic line, and it collides with the platform's
  default temperature.

## Why

`src/providers/llm.py::_build_anthropic` passes `model`, `max_tokens`,
`temperature`, `timeout`, `max_retries`, `callbacks`, `api_key` and `base_url`
— but never reads the configured effort. `LANGCHAIN_REASONING_EFFORT` is
already defined in `src/config/env_schema.py` and surfaced through the settings
API, so the setting appears configurable and does nothing.

On the current Anthropic models effort is the primary cost-and-quality lever,
which makes this the setting most worth having and the one that is inert.

## Changes

**`agent/src/providers/llm.py`**

- `_build_anthropic` takes an `effort` argument; `build_llm` passes the same
  `get_env_config().llm.langchain_reasoning_effort` value the other providers
  already use.
- `_anthropic_supports_effort` — a positive model allowlist. Haiku 4.5 and
  Sonnet 4.5 reject effort with
  `400 invalid_request_error: This model does not support the effort parameter`.
  That bites hardest in a swarm: a per-agent `model_name` split deliberately
  puts cheap models on the data-gathering seats, so one global effort setting
  kills exactly those workers, and it fails as a hard 400 rather than
  degrading. The allowlist mirrors the reasoning already written down on
  `top_level_reasoning_effort` in `providers/capabilities.py` — an unrecognised
  model gets nothing, because a wrong entry fails every request while a missing
  one only leaves the setting inert.
- Temperature is omitted whenever effort is in play. Setting effort makes
  langchain-anthropic enable adaptive thinking, and the API then rejects any
  temperature other than 1:
  `temperature may only be set to 1 when thinking is enabled or in adaptive
  mode`. The platform default is `0.0`. The existing
  `_make_temperature_safe_anthropic` wrapper does not cover this — it handles
  models that reject `temperature` outright, not this thinking-conditional
  variant.
- `_adapter_accepts_effort` — a capability check on the resolved
  `ChatAnthropic`. `pyproject.toml` allows `langchain-anthropic>=1.3.0`,
  `ChatAnthropic` is configured with `extra="ignore"`, and `reasoning_effort`
  arrived later, so on an older install the kwarg would be swallowed in silence
  while the caller still paid the dropped temperature. Sending neither is the
  honest outcome. **Bumping the pin floor to `>=1.5.0` instead would also work
  and is a smaller change — happy to swap if maintainers prefer it.**

**`agent/tests/test_llm_reasoning_effort.py`** — a `TestAnthropicNativeProvider`
class alongside the existing per-provider classes: effort reaches the adapter,
stays absent when unset, temperature drops when effort is sent and survives
when it is not, a rejecting model and an unrecognised model are both sent
nothing, an adapter without the field is sent nothing, and the
`reasoning_effort` → `output_config.effort` mapping is pinned against the
installed langchain-anthropic so a rename fails here rather than at request
time.

## Deliberately out of scope

- **Per-effort-level support.** The allowlist gates the *parameter*, not the
  levels. Opus 4.5 accepts effort but only `low`/`medium`/`high`, so
  `LANGCHAIN_REASONING_EFFORT=max` against it still fails at the API. Modelling
  levels per model needs a table someone maintains; this change deliberately
  does not add one.
- **The OpenAI-family paths**, which already work and are untouched.
- **The outbound alert-bridge gap** (`OutboundMessage` has no producer outside
  `src/channels/`) — a separate concern, offered separately.

## Test Plan

- [x] New tests added — 8 cases in
      `agent/tests/test_llm_reasoning_effort.py::TestAnthropicNativeProvider`;
      8 passed, 0 skipped. The whole file: 42 passed in 5.56s.
- [x] Tested manually — a four-agent swarm preset with a Fable 5 / Haiku 4.5
      per-agent split completes cleanly with this change and fails at iteration
      0 without it (the Haiku seats take the 400). Observed values:

      LANGCHAIN_REASONING_EFFORT=(unset)   output_config=None
      LANGCHAIN_REASONING_EFFORT=high      output_config={'effort': 'high'}   thinking={'type': 'adaptive', ...}
      LANGCHAIN_REASONING_EFFORT=xhigh     output_config={'effort': 'xhigh'}

      claude-fable-5     temperature=(absent)   output_config={'effort': 'high'}
      claude-haiku-4-5   temperature=0.0        output_config=None

- [x] Existing tests pass — to the extent they pass on this platform. Full run
      of `pytest --ignore=agent/tests/e2e_backtest
      --ignore=agent/tests/test_e2e_harness_v2.py`:

      | | main (`9806936`) | this branch |
      |---|---|---|
      | passed | 10368 | 10375 |
      | failed | 40 | 40 |
      | errors | 9 | 9 |

      **The 40 failures and 9 errors are pre-existing and identical.** I ran
      the full suite on unmodified `main` first, then on the branch, and
      diffed the failing node IDs: the sets match exactly, so this change adds
      no failures. They are Windows-platform issues in the harness rather than
      real defects — `signal.SIGALRM` does not exist on Windows (the Telegram
      fence tests), `os.symlink` is unavailable, POSIX `0600` modes are not
      meaningful, and the governance ledger fixtures read back as malformed
      JSON. Nothing in `src/providers/` fails. A Linux CI run should be clean.

- [x] `ruff check` clean on both changed files (the `# noqa` warnings it emits
      are pre-existing `env-gate` directives elsewhere in the file). `black
      --check` reports both files as needing reformatting — but it reports the
      same on unmodified `main`, since there is no `[tool.black]` section and
      black defaults to 88 columns while ruff is configured at 120. I have
      deliberately not reformatted; say the word if you want the whole file
      run through black as a separate commit.

## Risk notes

- **Protected area.** This touches `src/providers/`, which the PR template
  lists as needing prior discussion. Raising it here for exactly that reason —
  happy to move the discussion to an issue first.
- **No live, broker, order, mandate, kill-switch or audit-ledger surface is
  touched.** The change is confined to how one LLM adapter is constructed.
- **No network, secret, MCP or deployment behaviour changes.** No new
  dependency, no new environment variable, no config-file change.
- **Behaviour when the setting is unset is byte-identical to today**: `effort`
  falsy means `reasoning_effort=None` and the configured temperature is passed
  exactly as before. The only behaviour change is for users who had already set
  `LANGCHAIN_REASONING_EFFORT` and were silently getting nothing.
- **Rollback:** `git revert <sha>`. Self-contained to one function, its two new
  helpers, and one test class; nothing else imports them.
