### PR TITLE
fix(quantlib): survive long-horizon discount underflow in xirr and money-weighted return

### DIFF
--- a/agent/src/quantlib/performance.py
+++ b/agent/src/quantlib/performance.py
@@ -147,6 +147,13 @@ _IRR_TOLERANCE = 1e-12
 #: Hard iteration cap for the bisection, so a pathological input cannot spin.
 _IRR_MAX_ITERATIONS = 400
 
+#: Magnitude returned in place of a diverging NPV term. At ``base`` just above
+#: zero and a horizon beyond ~51 years the discount factor underflows to 0.0 and
+#: the true term diverges to +/-inf. The bisection compares signs only, so a
+#: sign-preserving finite stand-in keeps the bracketing exact without letting
+#: :func:`math.fsum` overflow.
+_NPV_DIVERGED_MAGNITUDE = 1e300
+
 
 class UnsolvableRateError(ValueError):
     """Raised when a cash-flow stream admits no single internal rate of return."""
@@ -715,15 +722,44 @@ def _npv(rate: float, years: Sequence[float], amounts: Sequence[float]) -> float
     Returns:
         The discounted sum. A term whose discount factor overflows to beyond
         the float range contributes ``0.0``, which is its limit, rather than
-        raising and aborting the search.
+        raising and aborting the search. A term whose discount factor
+        *underflows* to ``0.0`` -- or stays subnormal long enough that the
+        term itself leaves the float range -- diverges to +/-inf in truth;
+        such terms are represented by a sign-preserving stand-in of magnitude
+        :data:`_NPV_DIVERGED_MAGNITUDE`, which dominates every finite term
+        exactly as the limit does while keeping ``fsum`` finite.
     """
     base = 1.0 + rate
     terms: list[float] = []
+    diverged: dict[float, float] = {}
     for exponent, amount in zip(years, amounts, strict=True):
         try:
-            terms.append(amount / (base**exponent))
+            factor = base**exponent
         except OverflowError:
             terms.append(0.0)
+            continue
+        if factor == 0.0:
+            # Underflow: the true term is infinite, so only its sign and its
+            # exponent rank matter. Group by exponent first, so several terms
+            # that share the largest exponent can still cancel before the sign
+            # of the limit is decided.
+            diverged[exponent] = diverged.get(exponent, 0.0) + amount
+            continue
+        term = amount / factor
+        if not math.isfinite(term):
+            # A subnormal factor (a horizon just short of the underflow point)
+            # can still push the term past the float range. It diverges in
+            # exactly the same sense and is grouped the same way; leaving it in
+            # ``terms`` would hand ``fsum`` an infinity and, with two opposite
+            # signs, raise ``-inf + inf in fsum``.
+            diverged[exponent] = diverged.get(exponent, 0.0) + amount
+            continue
+        terms.append(term)
+
+    for exponent in sorted(diverged, reverse=True):
+        grouped = diverged[exponent]
+        if grouped != 0.0:
+            return math.copysign(_NPV_DIVERGED_MAGNITUDE, grouped)
     return math.fsum(terms)
 
 

--- a/agent/tests/quantlib/test_performance.py
+++ b/agent/tests/quantlib/test_performance.py
@@ -352,6 +352,73 @@ def test_xirr_discounts_by_actual_days() -> None:
     assert (1.0 + half_year) ** (182 / 365) == pytest.approx(1.10, rel=1e-6)
 
 
+def test_xirr_survives_a_horizon_that_underflows_the_discount_factor() -> None:
+    """Sixty years underflows the factor at the solver's lower bracket.
+
+    The bisection starts just above -100%, where a 60-year discount factor
+    (``1e-6 ** 60 ~ 1e-360``) underflows to zero and the term diverges. The
+    search must still return the exact flat rate the dates imply,
+    ``3 ** (365 / 21915) - 1``, instead of crashing with a division by zero.
+    """
+    start, end = date(1965, 1, 1), date(2025, 1, 1)
+    days = (end - start).days  # 21915 calendar days, 15 leap days included
+    rate = xirr([(start, -1000.0), (end, 3000.0)])
+    assert rate == pytest.approx(3.0 ** (365.0 / days) - 1.0, rel=1e-9)
+
+
+def test_a_long_horizon_loss_still_solves_to_a_negative_rate() -> None:
+    """The underflow stand-in must not flip the sign of a losing stream."""
+    start, end = date(1965, 1, 1), date(2025, 1, 1)
+    days = (end - start).days
+    rate = xirr([(start, -1000.0), (end, 500.0)])
+    assert rate == pytest.approx(0.5 ** (365.0 / days) - 1.0, rel=1e-9)
+
+
+def test_money_weighted_return_survives_the_same_long_horizon() -> None:
+    """The money-weighted path shares the NPV kernel and must not crash either."""
+    start, end = date(1965, 1, 1), date(2025, 1, 1)
+    result = money_weighted_return([(start, 1000.0), (end, 3000.0)])
+    assert result.period_return == pytest.approx(2.0, abs=1e-9)
+    assert result.annualized_return == pytest.approx(
+        3.0 ** (365.0 / (end - start).days) - 1.0, rel=1e-9
+    )
+
+
+def test_xirr_survives_a_horizon_in_the_subnormal_discount_window() -> None:
+    """~52 years leaves the discount factor subnormal rather than zero.
+
+    At the lower bracket ``1e-6 ** 52 ~ 6e-313`` is a denormal, so the closing
+    term overflows to infinity before the factor underflows. The result must
+    still be the exact flat rate, and must not depend on ``fsum`` tolerating
+    infinity on any given platform.
+    """
+    start, end = date(1965, 1, 1), date(2017, 1, 1)
+    days = (end - start).days
+    rate = xirr([(start, -1000.0), (end, 3000.0)])
+    assert rate == pytest.approx(3.0 ** (365.0 / days) - 1.0, rel=1e-9)
+
+
+def test_long_horizon_opposite_signed_terms_do_not_cancel_to_nan() -> None:
+    """Two subnormal-window terms must resolve to the latest-dated flow.
+
+    With both the 2016 and 2017 terms overflowing, the old kernel sums
+    ``-inf + inf = nan`` and the bisection silently walks to its upper bracket.
+    Grouping diverging terms by exponent keeps the latest-dated flow dominant,
+    exactly as the limit requires, and the solver must return the rate that
+    zeroes the stream.
+    """
+    start, mid, end = date(1965, 1, 1), date(2016, 1, 1), date(2017, 1, 1)
+    rate = xirr([(start, -1000.0), (mid, -500.0), (end, 2000.0)])
+    years = [(day - start).days / 365.0 for day in (start, mid, end)]
+    residual = (
+        -1000.0
+        - 500.0 / (1.0 + rate) ** years[1]
+        + 2000.0 / (1.0 + rate) ** years[2]
+    )
+    assert abs(residual) < 1e-6
+    assert 0.0 < rate < 1.0
+
+
 def test_a_one_directional_stream_has_no_irr() -> None:
     """Refusing is correct; there is no rate that zeroes an all-negative NPV."""
     with pytest.raises(UnsolvableRateError, match="one-directional"):


### PR DESCRIPTION
# Draft PR Body — Vibe-Trading `xirr` discount-underflow fix

Branch: `fix/quantlib-xirr-underflow`
Title: `fix(quantlib): survive long-horizon discount underflow in xirr and money-weighted return`

---

## Summary

- `xirr()` and `money_weighted_return()` crash with `ZeroDivisionError: float division by zero` on cash-flow streams spanning more than ~51 years.
- The NPV kernel now treats a discount factor that *underflows* to zero as a diverging term and keeps the bisection bracketing sign-exact.
- No behavior change for any existing input; three focused regressions added.

## Why

The IRR bisection always evaluates the NPV at its lower bracket (`rate = -0.999999`, `base = 1e-6`). For horizons beyond `308 / log10(1e6) ≈ 51.34` years, `base**exponent` leaves the normal float range: it either underflows to `0.0` and the term `amount / 0.0` raises, or it stays subnormal so the term overflows to `inf` and two opposite-signed flows make `math.fsum` raise `ValueError: -inf + inf in fsum`. XIRR exists precisely for long, irregular streams (long-dated instruments, historical series, pension-style cash flows), so the crash is a real input class, not a theoretical edge:

```text
xirr([(date(1965,1,1), -1000.0), (date(2025,1,1), 3000.0)])
# before: ZeroDivisionError: float division by zero
# after:  0.0184661...  == 3**(365/21915) - 1
```

## Changes

- `agent/src/quantlib/performance.py`: in `_npv`, two classes of diverging term are now grouped by exponent (largest first) and represented by a sign-preserving finite stand-in (`_NPV_DIVERGED_MAGNITUDE = 1e300`): a discount factor that underflows to zero, and a subnormal factor whose term leaves the float range (the latter previously handed `fsum` infinities and raised `ValueError: -inf + inf in fsum` for opposite signs). The solver compares signs only, so bracketing stays exact, `math.fsum` cannot overflow, and the behavior is platform-independent. The existing `OverflowError -> 0.0` policy and every finite-term computation are untouched.
- `agent/tests/quantlib/test_performance.py`: five red-before regressions — 60-year gain, 60-year loss, `money_weighted_return` path, 52-year subnormal window, and a three-flow stream with opposite-signed long-horizon terms — asserted against closed-form rates.

## Test Plan

- [x] Existing tests pass: `py -3 -m pytest agent/tests/quantlib -q` → `1007 passed, 61 skipped` (baseline before change: `1002 passed, 61 skipped`).
- [x] New tests added (5), including one that fails on the pre-fix kernel with `ValueError: -inf + inf in fsum`.
- [x] Tested manually: 60-year and 52-year `xirr` probes match `3**(365/days)-1` to 1e-9 relative; opposite-sign stream zeroes its NPV residual to < 1e-6.
- Not run (unchanged code): `agent/tests/e2e_backtest`, frontend build.

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`).
- [x] No hardcoded values (the stand-in magnitude is a documented module constant).
- [x] Code follows CONTRIBUTING.md guidelines (ruff clean, diff whitespace clean, no unrelated reformatting).
- [x] Documentation updated: module docstrings for `_npv` and the new constant; no user-facing surface change.

## Risk and rollback

- Risk: none. Pure quantlib math, no broker/MCP/network/live-order surface.
- Out of scope (deliberately): `fundmath.py` keeps its own log-space NPV kernel and its documented non-finite contract; this PR does not touch it.
- Rollback: `git revert <sha>` restores the previous behavior; no data migration.
