### PR TITLE
[Bug] In the final verification response, the method "numbers_without_dates_or_percent" had a problem in extracting the prices, which resulted in the correct report also being rejected.

### DIFF
--- a/agent/src/agent/grounding.py
+++ b/agent/src/agent/grounding.py
@@ -201,7 +201,17 @@ _RATE_FORMULA_IDENTITY_RE = re.compile(
     r"\b[01](?=\s*[-+]\s*(?:[A-Za-z_][A-Za-z0-9_]*_?rate\b|[^\d\s()+*/=-]{0,12}(?:成本率|费率|税率|滑点率)))",
     re.IGNORECASE,
 )
-_DATE_RE = re.compile(r"\b(?:19|20)\d{2}[-/]\d{1,2}[-/]\d{1,2}\b")
+# "\b" is a word boundary between "\w" and non-"\w", but Python's regex module
+# treats CJK ideographs as "\w" too, so a trailing "\b" never matches where a
+# date directly abuts Chinese prose with no separating space or punctuation:
+# "(2026-07-14最低)" left the date unmasked, and its 2026/7/14 were extracted
+# as candidate prices and rejected against the observed OHLC range. Anchoring
+# on the same ASCII-only lookaround as ``_NUMBER_RE``/``_SHORT_DATE_RE`` keeps
+# the date from merging with an adjacent digit or letter run while still
+# matching when CJK text touches either side.
+_DATE_RE = re.compile(
+    r"(?<![A-Za-z0-9_])(?:19|20)\d{2}[-/]\d{1,2}[-/]\d{1,2}(?![A-Za-z0-9_])"
+)
 # A year-less "8/5" is how a trading day is written in running prose, and it
 # contributed 8 and 5 as candidate prices (#983). The month and day ranges are
 # bounded, and both sides are fenced off from a longer slash run, so the window

--- a/agent/tests/test_agent_grounding.py
+++ b/agent/tests/test_agent_grounding.py
@@ -1134,6 +1134,25 @@ def test_short_date_mask_does_not_swallow_a_plain_ratio(tmp_path: Path) -> None:
     assert [issue["value"] for issue in result.issues] == [42.0]
 
 
+def test_iso_date_mask_matches_when_it_directly_abuts_cjk_text(tmp_path: Path) -> None:
+    """A date with no separating space/punctuation from Chinese prose still masks (#1786964822).
+
+    Python's ``\\b`` treats CJK ideographs as word characters, so the old
+    ``\\b...\\b``-anchored date pattern never matched "2026-07-14最低": there is
+    no boundary between "4" and "最" when both sides count as "\\w". The date's
+    year/month/day survived as three unmasked numbers and were rejected as
+    conflicting with the observed OHLC range even though the report was
+    correct.
+    """
+    ledger = _screened_ledger(tmp_path)
+
+    result = ledger.validate_final_answer(
+        "000543.SZ 现价 8.20 CNY (2026-07-14最低)（source: tencent）"
+    )
+
+    assert result.valid is True, result.issues
+
+
 def test_masked_window_does_not_shield_a_wrong_quote_in_the_same_clause(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## [Bug] In the final verification response, the method "numbers_without_dates_or_percent" had a problem in extracting the prices, which resulted in the correct report also being rejected.

### Description

Method "_numbers_without_dates_or_percent" is used to extract the problematic prices from the report. For example, in the sentence "4. 价格跌破SMA20", the extracted result is [4]. For another example, "4. **技术面风险**: 若跌破观测支撑位0.980 CNY (2026-07-14最低)", the extracted result is [4.0, 2026.0, 7.0, 14.0]. The extracted prices will be verified against the previous evidence. If the verification fails, the issue will be recorded and ultimately lead to the large model refusing to answer.

###

## Changes

Modified 2 file(s): agent/tests/test_agent_grounding.py, agent/src/agent/grounding.py

Closes #1122

## Checklist

- [x] Code follows the project's style guidelines
- [x] Changes have been tested locally
- [x] Documentation updated if needed
