### PR TITLE
fix(alpha-bench): wire PIT-safe fundamentals into SP500 panel

### DIFF
--- a/agent/backtest/loaders/fundamentals_loader.py
+++ b/agent/backtest/loaders/fundamentals_loader.py
@@ -259,6 +259,23 @@ def load_fundamental_panel(
             columns=symbol_list,
         )
 
+    # Raw fields may declare a fallback derivation (e.g. gross_profit =
+    # revenue - cogs). Fill only cells where the directly-reported concept was
+    # absent; reported values win.
+    for field in raw_fields:
+        spec = _raw_field_spec(schema, field)
+        if spec is None:
+            continue
+        deps = _spec_get(spec, "dependencies") or ()
+        compute = _spec_get(spec, "compute")
+        if not callable(compute) or not deps:
+            continue
+        dep_frames = {str(dep): panels.get(str(dep)) for dep in deps}
+        if any(frame is None for frame in dep_frames.values()):
+            continue
+        fallback = _compute_derived(spec, dep_frames)
+        panels[field] = panels[field].where(panels[field].notna(), fallback)
+
     def panel_for(field: str) -> pd.DataFrame:
         if field in panels:
             return panels[field]
@@ -340,13 +357,17 @@ def _collect_raw_fields(schema: Any, fields: Iterable[str]) -> set[str]:
     def visit(field: str) -> None:
         if field in visiting:
             raise ValueError(f"cyclic derived fundamental field: {field}")
+        visiting.add(field)
         derived = _derived_field(schema, field)
         if derived is None:
             raw.add(field)
-            return
-        visiting.add(field)
-        for dep in _derived_dependencies(derived):
-            visit(_resolve_field_name(schema, dep))
+            spec = _raw_field_spec(schema, field)
+            if spec is not None:
+                for dep in _spec_get(spec, "dependencies") or ():
+                    visit(_resolve_field_name(schema, str(dep)))
+        else:
+            for dep in _derived_dependencies(derived):
+                visit(_resolve_field_name(schema, dep))
         visiting.remove(field)
 
     for field in fields:
@@ -356,6 +377,13 @@ def _collect_raw_fields(schema: Any, fields: Iterable[str]) -> set[str]:
 
 def _derived_field(schema: Any, field: str) -> Any | None:
     return getattr(schema, "DERIVED_FIELDS", {}).get(field)
+
+
+def _raw_field_spec(schema: Any, field: str) -> Any | None:
+    raw_fields = getattr(schema, "RAW_FIELDS", {})
+    if isinstance(raw_fields, dict):
+        return raw_fields.get(field)
+    return getattr(raw_fields, field, None)
 
 
 def _spec_get(derived: Any, key: str) -> Any:

--- a/agent/backtest/loaders/fundamentals_loader.py
+++ b/agent/backtest/loaders/fundamentals_loader.py
@@ -36,6 +36,7 @@ _FLOW_CONCEPTS = {
     "SalesRevenueNet",
     "CostOfGoodsAndServicesSold",
     "CostOfRevenue",
+    "GrossProfit",
     "OperatingIncomeLoss",
     "NetIncomeLoss",
     "ProfitLoss",

--- a/agent/src/tools/alpha_bench_tool.py
+++ b/agent/src/tools/alpha_bench_tool.py
@@ -501,6 +501,34 @@ def _load_sp500_panel(start: str, end: str) -> dict[str, pd.DataFrame]:
     if all(k in panel for k in ("open", "high", "low", "close")):
         panel["vwap"] = (panel["open"] + panel["high"] + panel["low"] + panel["close"]) / 4.0
 
+    # PIT-safe fundamentals for the fundamental zoo (fund:* columns).
+    # Shares the same unified schema the zoo's alphas reference; fetching is
+    # best-effort — missing statements stay NaN and the zoo z-scores exclude
+    # those names per date.
+    try:
+        from backtest.loaders.fundamentals_loader import load_fundamental_panel
+
+        fund_fields = [
+            "roe",
+            "gross_profitability",
+            "asset_growth",
+            "net_income",
+            "shares_diluted",
+        ]
+        fund_panels = load_fundamental_panel(
+            project_codes, fund_fields, start, end, freq="ttm", pit=True
+        )
+        for field, frame in fund_panels.items():
+            if frame is not None and not frame.empty:
+                # registry.compute() looks up the literal column name the alpha
+                # declares; align both axes to the OHLCV panel so the output
+                # shape validation matches (yahoo may drop a few tickers).
+                panel[f"fund:{field}"] = frame.reindex(
+                    index=panel["close"].index, columns=panel["close"].columns
+                )
+    except Exception as exc:  # noqa: BLE001 - best-effort enrichment
+        logger.warning("sp500 panel: fundamentals enrichment failed: %s", exc)
+
     # Attach a non-DataFrame metadata blob. Registry.compute() only iterates
     # required column names, so this extra key is ignored by the compute path.
     panel["_meta"] = {

--- a/agent/tests/test_alpha_bench_fundamental_columns.py
+++ b/agent/tests/test_alpha_bench_fundamental_columns.py
@@ -1,0 +1,115 @@
+"""Tests for fundamental-column enrichment in the SP500 alpha-bench panel.
+
+Pins the wiring added so the ``fundamental`` zoo can run on the US universe:
+``_load_sp500_panel`` must attach PIT-safe ``fund:*`` columns (roe,
+gross_profitability, asset_growth, net_income, shares_diluted) aligned to the
+OHLCV trading-day index, and must degrade to the pre-enrichment panel when the
+fundamentals loader fails.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from src.tools import alpha_bench_tool as abt
+
+FUND_FIELDS = [
+    "fund:roe",
+    "fund:gross_profitability",
+    "fund:asset_growth",
+    "fund:net_income",
+    "fund:shares_diluted",
+]
+
+
+def _ohlcv(code: str, start: str, end: str) -> pd.DataFrame:
+    idx = pd.date_range(start, end, freq="B")
+    return pd.DataFrame(
+        {"open": 10.0, "high": 11.0, "low": 9.0, "close": 10.5, "volume": 1e6},
+        index=idx,
+    )
+
+
+class _FakeLoader:
+    def fetch(self, codes, start, end):
+        return {c: _ohlcv(c, start, end) for c in codes}
+
+
+def _fake_fund_panels(symbols, fields, start, end, freq, pit):
+    """Calendar-day fund frames that deliberately differ from the trading-day
+    index — the enrichment must reindex onto the OHLCV dates."""
+    cal = pd.date_range(start, end, freq="D")
+    out = {}
+    for f in fields:
+        base = 0.2
+        out[f] = pd.DataFrame(
+            {s: base + i for i, s in enumerate(symbols)}, index=cal
+        )
+    return out
+
+
+@pytest.fixture
+def wired_env(monkeypatch):
+    monkeypatch.setattr(abt, "_fetch_sp500_constituents", lambda: ["AAA", "BBB"])
+    import backtest.loaders.registry as reg
+
+    monkeypatch.setattr(reg, "resolve_loader", lambda _market: _FakeLoader())
+    import backtest.loaders.fundamentals_loader as fl
+
+    monkeypatch.setattr(fl, "load_fundamental_panel", _fake_fund_panels)
+
+
+def test_fund_columns_land_aligned_to_trading_index(wired_env):
+    panel = abt._load_sp500_panel("2020-01-01", "2020-01-31")
+
+    for key in FUND_FIELDS:
+        assert key in panel, f"missing {key}"
+        frame = panel[key]
+        # aligned onto the OHLCV trading-day index, not the calendar index
+        pd.testing.assert_index_equal(frame.index, panel["close"].index)
+        # columns match the OHLCV universe
+        assert list(frame.columns) == list(panel["close"].columns)
+        assert frame.notna().all().all(), f"{key} lost values during reindex"
+
+
+def test_fund_frames_drop_symbols_absent_from_ohlcv(wired_env, monkeypatch):
+    """yahoo occasionally drops tickers; fund frames must shrink to the close
+    universe or the registry's shape validation rejects the alpha output."""
+    import backtest.loaders.fundamentals_loader as fl
+
+    def extra_symbol(symbols, fields, start, end, freq, pit):
+        frames = _fake_fund_panels(symbols, fields, start, end, freq, pit)
+        for f in frames:
+            frames[f]["CCC"] = 0.5  # not in the OHLCV universe
+        return frames
+
+    monkeypatch.setattr(fl, "load_fundamental_panel", extra_symbol)
+
+    panel = abt._load_sp500_panel("2020-01-01", "2020-01-31")
+
+    for key in FUND_FIELDS:
+        assert list(panel[key].columns) == list(panel["close"].columns)
+        assert "CCC" not in panel[key].columns
+
+
+def test_fund_enrichment_failure_degrades_gracefully(wired_env, monkeypatch):
+    import backtest.loaders.fundamentals_loader as fl
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("SEC down")
+
+    monkeypatch.setattr(fl, "load_fundamental_panel", boom)
+
+    panel = abt._load_sp500_panel("2020-01-01", "2020-01-31")
+
+    # OHLCV + vwap still present, no fund keys, no exception
+    assert "close" in panel and "vwap" in panel
+    assert not any(k.startswith("fund:") for k in panel)
+
+
+def test_meta_blob_survives_enrichment(wired_env):
+    panel = abt._load_sp500_panel("2020-01-01", "2020-01-31")
+
+    assert "_meta" in panel
+    assert panel["_meta"]["universe"] == "sp500"

--- a/agent/tests/test_fundamentals_gross_profit_fallback.py
+++ b/agent/tests/test_fundamentals_gross_profit_fallback.py
@@ -161,3 +161,79 @@ def test_gross_profit_stays_null_without_either_source(
 
     assert pd.isna(panel["gross_profit"]["AAA"].loc["2024-05-01"])
     assert pd.isna(panel["gross_profitability"]["AAA"].loc["2024-05-01"])
+
+
+def test_gross_profit_direct_concept_is_ttm_summed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_sec(
+        monkeypatch,
+        {
+            "AAA": _facts(
+                {
+                    "GrossProfit": [
+                        _fact_row("2023-06-30", "2023-07-20", 10.0),
+                        _fact_row("2023-09-30", "2023-10-20", 20.0),
+                        _fact_row("2023-12-31", "2024-01-20", 30.0),
+                        _fact_row("2024-03-31", "2024-04-20", 40.0),
+                    ]
+                }
+            )
+        },
+    )
+    index = pd.date_range("2024-04-01", "2024-05-01", freq="D")
+
+    panel = fundamentals_loader.load_fundamental_panel(
+        ["AAA"],
+        ["gross_profit"],
+        "2024-04-01",
+        "2024-05-01",
+        freq="ttm",
+        index=index,
+    )
+
+    gross_profit = panel["gross_profit"]["AAA"]
+    # TTM must be the rolling four-quarter sum, not the latest quarter.
+    assert gross_profit.loc["2024-05-01"] == 100.0
+
+
+def test_gross_profit_direct_concept_excludes_annual_span_from_quarterly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_sec(
+        monkeypatch,
+        {
+            "AAA": _facts(
+                {
+                    "GrossProfit": [
+                        _fact_row("2023-06-30", "2023-07-20", 10.0),
+                        _fact_row("2023-09-30", "2023-10-20", 20.0),
+                        _fact_row("2023-12-31", "2024-01-20", 30.0),
+                        _fact_row(
+                            "2024-03-31",
+                            "2024-02-20",
+                            100.0,
+                            form="10-K",
+                            start="2023-03-31",
+                        ),
+                    ]
+                }
+            )
+        },
+    )
+    index = pd.date_range("2024-02-01", "2024-03-10", freq="D")
+
+    panel = fundamentals_loader.load_fundamental_panel(
+        ["AAA"],
+        ["gross_profit"],
+        "2024-02-01",
+        "2024-03-10",
+        freq="quarterly",
+        index=index,
+    )
+
+    gross_profit = panel["gross_profit"]["AAA"]
+    # The 10-K row is an annual span: quarterly cadence must synthesize fiscal
+    # Q4 (100 - 10 - 20 - 30), never surface the full-year value.
+    assert gross_profit.loc["2024-02-19"] == 30.0
+    assert gross_profit.loc["2024-02-20"] == 40.0

--- a/agent/tests/test_fundamentals_gross_profit_fallback.py
+++ b/agent/tests/test_fundamentals_gross_profit_fallback.py
@@ -1,0 +1,163 @@
+"""Regression tests for the ``gross_profit`` revenue-minus-cogs fallback.
+
+``RAW_FIELDS["gross_profit"]`` declares ``compute = revenue - cogs`` so that
+filers who report revenue and cogs separately (without a literal
+``GrossProfit`` XBRL concept) still get a gross profit and, transitively, a
+``gross_profitability``. These tests pin that fallback at the loader level,
+including PIT anchoring and the preference for the directly reported concept.
+
+No test touches a live endpoint: ``cik_for`` / ``get_company_facts`` are
+monkeypatched on the loader's SEC client module.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from backtest.loaders import fundamentals_loader
+
+
+def _facts(concept_rows: dict[str, list[dict[str, object]]]) -> dict[str, object]:
+    return {
+        "facts": {
+            "us-gaap": {
+                concept: {"units": {"USD": rows}}
+                for concept, rows in concept_rows.items()
+            }
+        }
+    }
+
+
+def _fact_row(
+    end: str,
+    filed: str,
+    value: float,
+    *,
+    form: str = "10-Q",
+    start: str | None = None,
+) -> dict[str, object]:
+    if start is None:
+        start = (pd.Timestamp(end) - pd.Timedelta(days=91)).strftime("%Y-%m-%d")
+    return {"start": start, "end": end, "filed": filed, "val": value, "form": form}
+
+
+def _patch_sec(
+    monkeypatch: pytest.MonkeyPatch,
+    facts_by_symbol: dict[str, dict[str, object]],
+) -> None:
+    def cik_for(symbol: str) -> str | None:
+        return f"CIK-{symbol}" if symbol in facts_by_symbol else None
+
+    def get_company_facts(cik: str) -> dict[str, object]:
+        symbol = cik.removeprefix("CIK-")
+        return facts_by_symbol[symbol]
+
+    monkeypatch.setattr(fundamentals_loader.sec_edgar_client, "cik_for", cik_for)
+    monkeypatch.setattr(
+        fundamentals_loader.sec_edgar_client,
+        "get_company_facts",
+        get_company_facts,
+    )
+
+
+_QUARTER_END = "2024-03-31"
+_FILED = "2024-04-20"
+
+
+def test_gross_profit_falls_back_to_revenue_minus_cogs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_sec(
+        monkeypatch,
+        {
+            "AAA": _facts(
+                {
+                    "Revenues": [_fact_row(_QUARTER_END, _FILED, 100.0)],
+                    "CostOfRevenue": [_fact_row(_QUARTER_END, _FILED, 60.0)],
+                    "Assets": [_fact_row(_QUARTER_END, _FILED, 1000.0)],
+                }
+            )
+        },
+    )
+    index = pd.date_range("2024-04-01", "2024-05-01", freq="D")
+    panel = fundamentals_loader.load_fundamental_panel(
+        ["AAA"],
+        ["gross_profit", "gross_profitability"],
+        "2024-04-01",
+        "2024-05-01",
+        freq="quarterly",
+        index=index,
+    )
+
+    gross_profit = panel["gross_profit"]["AAA"]
+    # PIT: nothing visible before the filing date, fallback value after.
+    assert pd.isna(gross_profit.loc["2024-04-19"])
+    assert gross_profit.loc["2024-04-20"] == 40.0
+    assert gross_profit.loc["2024-05-01"] == 40.0
+
+    profitability = panel["gross_profitability"]["AAA"]
+    assert pd.isna(profitability.loc["2024-04-19"])
+    assert profitability.loc["2024-04-20"] == pytest.approx(0.04)
+
+
+def test_gross_profit_prefers_direct_concept_over_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_sec(
+        monkeypatch,
+        {
+            "AAA": _facts(
+                {
+                    "GrossProfit": [_fact_row(_QUARTER_END, _FILED, 45.0)],
+                    "Revenues": [_fact_row(_QUARTER_END, _FILED, 100.0)],
+                    "CostOfRevenue": [_fact_row(_QUARTER_END, _FILED, 60.0)],
+                    "Assets": [_fact_row(_QUARTER_END, _FILED, 1000.0)],
+                }
+            )
+        },
+    )
+    index = pd.date_range("2024-04-01", "2024-05-01", freq="D")
+
+    panel = fundamentals_loader.load_fundamental_panel(
+        ["AAA"],
+        ["gross_profit", "gross_profitability"],
+        "2024-04-01",
+        "2024-05-01",
+        freq="quarterly",
+        index=index,
+    )
+
+    assert panel["gross_profit"]["AAA"].loc["2024-04-20"] == 45.0
+    assert panel["gross_profitability"]["AAA"].loc["2024-04-20"] == pytest.approx(0.045)
+
+
+def test_gross_profit_stays_null_without_either_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_sec(
+        monkeypatch,
+        {
+            "AAA": _facts(
+                {
+                    # revenue present but cogs absent: fallback cannot fire and
+                    # must not fabricate a gross profit from revenue alone.
+                    "Revenues": [_fact_row(_QUARTER_END, _FILED, 100.0)],
+                    "Assets": [_fact_row(_QUARTER_END, _FILED, 1000.0)],
+                }
+            )
+        },
+    )
+    index = pd.date_range("2024-04-01", "2024-05-01", freq="D")
+
+    panel = fundamentals_loader.load_fundamental_panel(
+        ["AAA"],
+        ["gross_profit", "gross_profitability"],
+        "2024-04-01",
+        "2024-05-01",
+        freq="quarterly",
+        index=index,
+    )
+
+    assert pd.isna(panel["gross_profit"]["AAA"].loc["2024-05-01"])
+    assert pd.isna(panel["gross_profitability"]["AAA"].loc["2024-05-01"])


### PR DESCRIPTION
## Problem

The `fundamental` zoo (fund_roe, fund_gross_profitability, fund_asset_growth, fund_earnings_yield) declares `fund:*` panel columns, but the SP500 alpha-bench panel never provided them — every fundamental alpha skipped with `panel missing required columns` (verified: 0 tested / 4 skipped on sp500 2024).

## Fix

`_load_sp500_panel` now enriches the OHLCV+vwap panel with PIT-safe SEC fundamentals (ttm) via the existing `backtest.loaders.fundamentals_loader` for the same universe:

- `fund:roe`, `fund:gross_profitability`, `fund:asset_growth`, `fund:net_income`, `fund:shares_diluted`
- Both axes reindexed to the OHLCV panel (trading-day index + close column set) — yahoo occasionally drops tickers (e.g. FDXF/HONA), and the registry's output shape validation rejects (252, N+k) vs (252, N)
- Best-effort: enrichment failure degrades to the pre-existing OHLCV+vwap panel with a warning

## Verification

- New regression tests: 4 passed (alignment, symbol-drop, graceful-failure, meta-blob) — `agent/tests/test_alpha_bench_fundamental_columns.py`
- Adjacent bench tests: 9/9 passed; ruff clean
- Live panel probe (full 503-symbol universe): all 5 fund keys present, coverage roe 97.1% / asset_growth 98.0% / net_income 97.1% / shares_diluted 96.5% / gross_profitability 70.2% (70% expected — financials/insurers/utilities don't report GrossProfit; includes the PR #1111 revenue-minus-cogs fallback)
- E2E registry compute on a reduced 8-name universe: all 4 alphas compute, exact shape match, 0 skips

## Notes

- Full-universe bench run (`run_bench('fundamental', 'sp500', '2024-2024')`) needs ~12 min of SEC XBRL fetches on first run; enable `VIBE_TRADING_DATA_CACHE=1` to persist per-symbol parquets
- Stale panel pickles in `~/.vibe-trading/cache/sp500_*.pkl` predate this change — delete to force re-fetch
- Does not touch the separate sector-tag gap (19 alpha101 alphas) — separate change