### PR TITLE
fix(alpha-bench): wire sector tags into SP500 panel

### DIFF
--- a/agent/src/tools/alpha_bench_tool.py
+++ b/agent/src/tools/alpha_bench_tool.py
@@ -501,6 +501,30 @@ def _load_sp500_panel(start: str, end: str) -> dict[str, pd.DataFrame]:
     if all(k in panel for k in ("open", "high", "low", "close")):
         panel["vwap"] = (panel["open"] + panel["high"] + panel["low"] + panel["close"]) / 4.0
 
+    # Per-code sector tags for alpha101 industry-neutralized alphas.
+    # The registry gates 19 alpha101 alphas behind requires_sector=True;
+    # their compute() calls _ind_neutralize() which expects a same-shape
+    # DataFrame of sector labels.  yfinance Ticker.info is free.
+    try:
+        import yfinance as yf
+
+        close_cols = panel["close"].columns
+        sector_map: dict[str, str] = {}
+        for code in close_cols:
+            try:
+                info = yf.Ticker(code.removesuffix(".US")).info
+                sector = info.get("sector")
+                if sector:
+                    sector_map[code] = sector
+            except Exception:  # noqa: BLE001 — per-code best-effort
+                pass
+        if sector_map:
+            panel["sector"] = pd.DataFrame(
+                {c: sector_map.get(c, "") for c in close_cols},
+                index=panel["close"].index,
+            )
+    except Exception as exc:  # noqa: BLE001 — best-effort
+        logger.warning("sp500 panel: sector enrichment failed: %s", exc)
     # Attach a non-DataFrame metadata blob. Registry.compute() only iterates
     # required column names, so this extra key is ignored by the compute path.
     panel["_meta"] = {

--- a/agent/tests/test_alpha_bench_sector_tag.py
+++ b/agent/tests/test_alpha_bench_sector_tag.py
@@ -1,0 +1,87 @@
+"""Tests for sector-tag enrichment in the SP500 alpha-bench panel.
+
+Pins the wiring so the 19 requires_sector=True alpha101 alphas can run on
+the US universe: ``_load_sp500_panel`` must attach a same-shape ``sector``
+DataFrame of per-code sector labels, and must degrade gracefully when the
+sector fetch fails.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from src.tools import alpha_bench_tool as abt
+
+
+def _ohlcv(code: str, start: str, end: str) -> pd.DataFrame:
+    idx = pd.date_range(start, end, freq="B")
+    return pd.DataFrame(
+        {"open": 10.0, "high": 11.0, "low": 9.0, "close": 10.5, "volume": 1e6},
+        index=idx,
+    )
+
+
+class _FakeLoader:
+    def fetch(self, codes, start, end):
+        return {c: _ohlcv(c, start, end) for c in codes}
+
+
+@pytest.fixture
+def wired_env(monkeypatch):
+    monkeypatch.setattr(abt, "_fetch_sp500_constituents", lambda: ["AAA", "BBB"])
+    import backtest.loaders.registry as reg
+
+    monkeypatch.setattr(reg, "resolve_loader", lambda _market: _FakeLoader())
+
+
+def test_sector_dataframe_attached_same_shape(wired_env, monkeypatch):
+    monkeypatch.setattr(
+        abt,
+        "_fetch_sp500_constituents",
+        lambda: ["AAPL", "JPM"],
+    )
+
+    panel = abt._load_sp500_panel("2020-01-01", "2020-01-31")
+
+    assert "sector" in panel, "sector key missing from panel"
+    sec = panel["sector"]
+    assert isinstance(sec, pd.DataFrame)
+    pd.testing.assert_index_equal(sec.index, panel["close"].index)
+    assert list(sec.columns) == list(panel["close"].columns)
+
+
+def test_sector_enrichment_failure_degrades_gracefully(wired_env, monkeypatch):
+    import yfinance as yf
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("yfinance down")
+
+    monkeypatch.setattr(yf, "Ticker", lambda code: type("_T", (), {"info": boom})())
+
+    panel = abt._load_sp500_panel("2020-01-01", "2020-01-31")
+
+    assert "sector" not in panel
+    assert "close" in panel and "vwap" in panel
+
+
+def test_meta_blob_survives_enrichment(wired_env):
+    panel = abt._load_sp500_panel("2020-01-01", "2020-01-31")
+
+    assert "_meta" in panel
+    assert panel["_meta"]["universe"] == "sp500"
+
+
+def test_no_sector_when_yfinance_returns_none(wired_env, monkeypatch):
+    import yfinance as yf
+
+    class _FakeTicker:
+        @property
+        def info(self):
+            return {"sector": None}
+
+    monkeypatch.setattr(yf, "Ticker", lambda code: _FakeTicker())
+
+    panel = abt._load_sp500_panel("2020-01-01", "2020-01-31")
+
+    assert "sector" not in panel

--- a/agent/tests/test_alpha_bench_sector_tag.py
+++ b/agent/tests/test_alpha_bench_sector_tag.py
@@ -30,6 +30,14 @@ class _FakeLoader:
 @pytest.fixture
 def wired_env(monkeypatch):
     monkeypatch.setattr(abt, "_fetch_sp500_constituents", lambda: ["AAA", "BBB"])
+    import yfinance as yf
+
+    class _FakeTicker:
+        @property
+        def info(self):
+            return {"sector": "Technology"}
+
+    monkeypatch.setattr(yf, "Ticker", lambda code: _FakeTicker())
     import backtest.loaders.registry as reg
 
     monkeypatch.setattr(reg, "resolve_loader", lambda _market: _FakeLoader())


### PR DESCRIPTION
## Problem

Nineteen alpha101 alphas are gated behind `requires_sector=True` (industry-neutralized formulas). The SP500 bench panel never attached a `sector` DataFrame, so the registry pre-rejected all 19 — the user sees `n_skipped=19` with no explanation.

The underlying compute functions already have a degraded global-demean fallback (the `_ind_neutralize` helper), but the registry gate blocks them before compute is reached.

## Fix

`_load_sp500_panel` now attaches a same-shape `sector` DataFrame of per-code sector labels after the vwap synthesis. The labels come from `yfinance.Ticker.info['sector']` — free, no API key, and the panel loader already has per-code metadata access.

- Strips `.US` suffix before calling `yfinance.Ticker` (yfinance expects bare symbols)
- Best-effort: per-code fetch failures are silently skipped; a total failure degrades to the pre-existing panel with a warning
- Same shape as `close` (date index × code columns) — exactly what `_ind_neutralize` expects

## Verification

- 4 regression tests pass (same-shape DataFrame, graceful failure when yfinance is down, `_meta` blob survives, no sector key when yfinance returns None)
- E2E on 8-name universe: 3 of 4 sector-gated alphas now compute correctly (alpha101_048 hits >95% NaN — the 4th NaN alpha alongside 019/039/052 on this universe)
- Ruff clean

## Notes

- Combined with the earlier fundamental-zoo PR (#1127), the SP500 bench panel now provides: OHLCV + vwap + fund:* (5 columns) + sector. The only remaining unwired columns are `amount` (gtja191, CN-only) and `advN` (computed internally from volume).
- Stale panel pickles in `~/.vibe-trading/cache/sp500_*.pkl` must be deleted to force re-fetch with the sector DataFrame.
- The alpha101_019/039/048/052 NaN alphas are a separate issue (formula/data-coverage, not panel wiring).