### PR TITLE
fix(mcp): attach market-data provenance to get_market_data responses

### DIFF
--- a/agent/mcp_server.py
+++ b/agent/mcp_server.py
@@ -1591,6 +1591,7 @@ def get_market_data(
         interval=interval,
         max_rows=max_rows,
         loader_resolver=_get_loader,
+        include_provenance=True,
     )
 
 

--- a/agent/tests/test_get_market_data_provenance.py
+++ b/agent/tests/test_get_market_data_provenance.py
@@ -1,0 +1,73 @@
+"""Regression test — get_market_data (MCP) must attach the _provenance
+block its own docstring promises.
+
+Pre-fix: fetch_market_data_json() was called without include_provenance=True,
+so _provenance (including volume_unit) was silently omitted from every MCP
+response, while the internal MarketDataTool.execute() call site (used by the
+agent/swarm loop for the same request) always passed include_provenance=True
+and got the block. An MCP client reading the tool's own docstring, which
+tells it to check `_provenance.volume_unit` before comparing volume values,
+got a response with no such field. Post-fix: the MCP path passes
+include_provenance=True too, matching MarketDataTool.execute() exactly.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+
+import mcp_server
+
+# fastmcp wraps the tool; reach the raw callable.
+_gmd = getattr(mcp_server.get_market_data, "fn", None) or getattr(
+    mcp_server.get_market_data, "__wrapped__", mcp_server.get_market_data
+)
+
+
+def _df():
+    df = pd.DataFrame(
+        {"open": [1.0], "high": [1.0], "low": [1.0], "close": [1.0], "volume": [100.0]},
+        index=pd.to_datetime(["2026-05-01"]),
+    )
+    df.index.name = "trade_date"
+    return df
+
+
+class _ALotsLoader:
+    """Declares its A-share volume unit, like the real tencent/eastmoney loaders."""
+
+    volume_units = {"a_share": "lots"}
+
+    def fetch(self, codes, start, end, interval="1D"):
+        return {"600519.SH": _df()}
+
+
+def _call(codes, source="tencent"):
+    return json.loads(
+        _gmd(codes=codes, start_date="2026-05-01", end_date="2026-05-02", source=source)
+    )
+
+
+def test_mcp_get_market_data_carries_provenance(monkeypatch):
+    monkeypatch.setattr(mcp_server, "_get_loader", lambda src: _ALotsLoader)
+    out = _call(["600519.SH"])
+    assert "_provenance" in out
+    assert out["_provenance"]["600519.SH"]["volume_unit"] == "lots"
+
+
+def test_mcp_get_market_data_row_shape_unchanged(monkeypatch):
+    """The fix must not alter the per-symbol row payload itself, only add
+    the additive _provenance key alongside it."""
+    monkeypatch.setattr(mcp_server, "_get_loader", lambda src: _ALotsLoader)
+    out = _call(["600519.SH"])
+    assert out["600519.SH"] == [
+        {
+            "trade_date": "2026-05-01T00:00:00",
+            "open": 1.0,
+            "high": 1.0,
+            "low": 1.0,
+            "close": 1.0,
+            "volume": 100.0,
+        }
+    ]


### PR DESCRIPTION
## Summary

- `get_market_data()` now passes `include_provenance=True` to `fetch_market_data_json()`, so `_provenance`, including `volume_unit`, is present in the MCP response.
- This aligns the MCP path with `MarketDataTool.execute()` and the existing MCP docstring, which already instructs clients to inspect `_provenance.volume_unit`.

## Why

`get_market_data()` documents `_provenance.volume_unit` as the source of volume-unit information, but its call to `fetch_market_data_json()` omitted `include_provenance=True`.

As a result, the `_provenance` block was absent from MCP responses even though `MarketDataTool.execute()` already enables it for the same market-data path.

Without `_provenance.volume_unit`, MCP consumers cannot reliably distinguish volume units across sources and markets.

Out of scope: market-data normalization, loaders, source selection, and provenance generation itself.

## Changes

- Pass `include_provenance=True` from `get_market_data()` to `fetch_market_data_json()`.
- Add regression coverage confirming `_provenance.volume_unit` is included.
- Add a control confirming the existing per-symbol row payload remains unchanged.

## Test Plan

- [x] Regression test fails on unpatched `main` and passes after the fix
- [x] Row-shape control passes before and after the fix
- [x] Adjacent MCP/market-data suites: 86 passed
- [x] Broader MCP/market-data selection: 353 passed, 5 skipped
- [x] Full suite: 10,455 passed, 90 skipped, 2 unrelated failures reproduced on unpatched `main`
- [x] `ruff check` passes on both changed files
- [x] No errors introduced by this change in `mypy`

## Checklist

- [x] No changes to protected areas
- [x] No hardcoded values
- [x] Code follows `CONTRIBUTING.md` guidelines
- [x] Documentation: N/A, the existing docstring already describes the provenance contract
- [x] DCO signed-off

## Risk

Low. The response change is additive only. Existing market-data rows remain unchanged; the MCP response now also includes the provenance block already supported by the underlying market-data path. No broker, credential, order, payment, wallet, or live-trading behaviour is changed.

## Rollback

Single call-site option plus its regression test; revertible with a normal `git revert`.