### PR TITLE
fix(grounding): mask ISO dates that run into CJK text

### DIFF
--- a/agent/src/agent/grounding.py
+++ b/agent/src/agent/grounding.py
@@ -201,7 +201,12 @@ _RATE_FORMULA_IDENTITY_RE = re.compile(
     r"\b[01](?=\s*[-+]\s*(?:[A-Za-z_][A-Za-z0-9_]*_?rate\b|[^\d\s()+*/=-]{0,12}(?:成本率|费率|税率|滑点率)))",
     re.IGNORECASE,
 )
-_DATE_RE = re.compile(r"\b(?:19|20)\d{2}[-/]\d{1,2}[-/]\d{1,2}\b")
+# re.ASCII keeps ``\b`` a *byte* word boundary. Without it, ``\w`` is
+# Unicode-aware and CJK letters count as word characters, so a date that runs
+# straight into Chinese text -- "(2026-07-14最低)" -- has no boundary after
+# "14" and is left unmasked, contributing 2026/7/14 as candidate prices that
+# reject a correct report (#1122).
+_DATE_RE = re.compile(r"\b(?:19|20)\d{2}[-/]\d{1,2}[-/]\d{1,2}\b", re.ASCII)
 # A year-less "8/5" is how a trading day is written in running prose, and it
 # contributed 8 and 5 as candidate prices (#983). The month and day ranges are
 # bounded, and both sides are fenced off from a longer slash run, so the window

--- a/agent/tests/test_agent_grounding.py
+++ b/agent/tests/test_agent_grounding.py
@@ -1119,6 +1119,36 @@ def test_price_validation_ignores_short_dates_and_percent_ranges(
         assert result.valid is True, (draft, result.issues)
 
 
+def test_numbers_without_dates_or_percent_masks_cjk_glued_iso_dates() -> None:
+    """An ISO date running into CJK text is one date, not three prices (#1122).
+
+    ``\b`` is Unicode-aware, so CJK letters count as word characters and
+    ``(2026-07-14最低)`` had no boundary after ``14`` -- the date survived and
+    contributed 2026/7/14 as candidate prices. ``re.ASCII`` restores the byte
+    boundary so the whole date masks while a genuine quote beside it stays.
+    """
+    assert (
+        GroundingLedger._numbers_without_dates_or_percent("若跌破观测支撑位0.980 CNY (2026-07-14最低)")
+        == []
+    )
+    assert (
+        GroundingLedger._numbers_without_dates_or_percent("收盘价 8.20 CNY 自2026-07-14以来最低")
+        == [8.2]
+    )
+
+
+def test_iso_date_running_into_cjk_text_is_still_masked(tmp_path: Path) -> None:
+    """The end-to-end gate no longer rejects a correct report over a glued date (#1122)."""
+    ledger = _screened_ledger(tmp_path)
+
+    for draft in (
+        "000543.SZ 收盘价 8.20 CNY（2026-07-14最低）（source: tencent）",
+        "000543.SZ 收盘价 8.20 CNY 自2026-07-14以来最低（source: tencent）",
+    ):
+        result = ledger.validate_final_answer(draft)
+        assert result.valid is True, (draft, result.issues)
+
+
 def test_short_date_mask_does_not_swallow_a_plain_ratio(tmp_path: Path) -> None:
     """The month/day mask is bounded, so an ordinary ratio still reads (#983).
 


### PR DESCRIPTION
## Summary

The grounding gate's price extractor now masks ISO dates that run straight into CJK text, instead of reading their digits as three candidate prices.

## Why

`_DATE_RE` used `\b` as a word boundary, but `\b` is Unicode-aware so CJK letters count as word characters. A date glued to Chinese text — e.g. `(2026-07-14最低)` — has no boundary after `14`, so the date survived the mask and contributed `2026`, `7`, `14` as candidate prices that rejected a correct report (reported in #1122 and again in #1125).

## Changes

- `agent/src/agent/grounding.py`: compile `_DATE_RE` with `re.ASCII` so `\b` is a byte boundary (CJK is no longer a word character). ASCII-token boundaries such as `x2026-07-14` keep their old behavior.
- `agent/tests/test_agent_grounding.py`: two regressions — a unit test on `_numbers_without_dates_or_percent` and an end-to-end `validate_final_answer` test.

## Test Plan

- [x] ruff clean on both files
- [x] `pytest tests/test_agent_grounding.py -q` → 131 passed (2 new)
- [x] related grounding suites (`test_agent_output_discipline`, `test_grounding_recovery`, `test_swarm_grounding`) → 101 passed

## Checklist

- [x] No changes to protected areas without prior discussion
- [x] No hardcoded values
- [x] Code follows CONTRIBUTING.md guidelines
- [x] Documentation updated (comment explains the re.ASCII rationale)
