### PR TITLE
fix(web): mark inferred strategy labels in run dashboard (part 1 of #1094)

### DIFF
--- a/frontend/src/components/charts/StrategyResearchDashboard.tsx
+++ b/frontend/src/components/charts/StrategyResearchDashboard.tsx
@@ -35,6 +35,7 @@ function timestamp(row: Record<string, string>): string {
 type ReportIdentity = {
   title: string;
   strategy: string;
+  strategyInferred: boolean;
   symbols: string[];
   startDate: string;
   endDate: string;
@@ -82,6 +83,7 @@ export function getStrategyReportIdentity(run: RunData): ReportIdentity {
   return {
     title: `${symbolLabel} · ${strategy}`,
     strategy,
+    strategyInferred: true,
     symbols,
     startDate,
     endDate,
@@ -224,8 +226,15 @@ export function StrategyResearchDashboard({ run }: { run: RunData }) {
             <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-[#3676df]">{t("runDashboard.eyebrow")}</p>
             <span className="rounded-full border border-[#3676df]/20 bg-background/70 px-2.5 py-1 font-mono text-[10px] text-muted-foreground">RUN {run.run_id.slice(-8).toUpperCase()}</span>
           </div>
-          <h2 className="mt-4 max-w-4xl text-2xl font-semibold leading-tight tracking-[-0.025em] text-foreground md:text-[30px]">{identity.title}</h2>
-          {run.prompt && run.prompt !== identity.strategy && (
+          <div className="mt-4 flex max-w-4xl flex-wrap items-center gap-2">
+            <h2 className="text-2xl font-semibold leading-tight tracking-[-0.025em] text-foreground md:text-[30px]">{identity.title}</h2>
+            {identity.strategyInferred && (
+              <span className="inline-flex items-center gap-1 rounded-full border border-[#ff8a3d]/30 bg-[#ff8a3d]/10 px-2 py-0.5 text-[11px] text-[#c25a14]">
+                {t("runDashboard.strategyInferred")}
+              </span>
+            )}
+          </div>
+          {run.prompt && (
             <p className="mt-2 max-w-4xl text-sm leading-6 text-muted-foreground">{compactPrompt(run.prompt)}</p>
           )}
           <div className="mt-5 flex flex-wrap gap-2 text-xs text-muted-foreground">

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -1346,6 +1346,7 @@
     "engine": "محرك",
     "portfolio": "محفظة",
     "systematicStrategy": "استراتيجية منهجية",
+    "strategyInferred": "مُستنتَج",
     "strategyMacd": "استراتيجية اتجاه MACD",
     "strategyRsi": "استراتيجية توقيت RSI",
     "strategyMomentum": "استراتيجية الزخم",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1346,6 +1346,7 @@
     "engine": "Engine",
     "portfolio": "Portfolio",
     "systematicStrategy": "Systematische Strategie",
+    "strategyInferred": "Inferiert",
     "strategyMacd": "MACD-Trend-Strategie",
     "strategyRsi": "RSI-Timing-Strategie",
     "strategyMomentum": "Momentum-Strategie",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1346,6 +1346,7 @@
     "engine": "engine",
     "portfolio": "Portfolio",
     "systematicStrategy": "Systematic strategy",
+    "strategyInferred": "Inferred",
     "strategyMacd": "MACD trend strategy",
     "strategyRsi": "RSI timing strategy",
     "strategyMomentum": "Momentum strategy",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1346,6 +1346,7 @@
     "engine": "motor",
     "portfolio": "Cartera",
     "systematicStrategy": "Estrategia sistemática",
+    "strategyInferred": "Inferido",
     "strategyMacd": "Estrategia de tendencia MACD",
     "strategyRsi": "Estrategia de timing RSI",
     "strategyMomentum": "Estrategia de momentum",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1346,6 +1346,7 @@
     "engine": "エンジン",
     "portfolio": "ポートフォリオ",
     "systematicStrategy": "システマティック戦略",
+    "strategyInferred": "推定",
     "strategyMacd": "MACD トレンド戦略",
     "strategyRsi": "RSI タイミング戦略",
     "strategyMomentum": "モメンタム戦略",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1346,6 +1346,7 @@
     "engine": "엔진",
     "portfolio": "포트폴리오",
     "systematicStrategy": "시스테매틱 전략",
+    "strategyInferred": "추정",
     "strategyMacd": "MACD 추세 전략",
     "strategyRsi": "RSI 타이밍 전략",
     "strategyMomentum": "모멘텀 전략",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1346,6 +1346,7 @@
     "engine": "回测引擎",
     "portfolio": "投资组合",
     "systematicStrategy": "系统化交易策略",
+    "strategyInferred": "推断",
     "strategyMacd": "MACD 趋势策略",
     "strategyRsi": "RSI 择时策略",
     "strategyMomentum": "动量策略",

--- a/frontend/src/pages/RunDetail.tsx
+++ b/frontend/src/pages/RunDetail.tsx
@@ -352,7 +352,14 @@ export function RunDetail() {
             </>
           )}
           <div className="min-w-0">
-            <h1 className="truncate text-xl font-semibold tracking-tight">{reportIdentity.title}</h1>
+            <div className="flex flex-wrap items-center gap-2">
+              <h1 className="truncate text-xl font-semibold tracking-tight">{reportIdentity.title}</h1>
+              {reportIdentity.strategyInferred && (
+                <span className="inline-flex items-center gap-1 rounded-full border border-[#ff8a3d]/30 bg-[#ff8a3d]/10 px-2 py-0.5 text-[11px] text-[#c25a14]">
+                  {t("runDashboard.strategyInferred")}
+                </span>
+              )}
+            </div>
             <p className="mt-0.5 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">RUN {runId}</p>
           </div>
           {run.elapsed_seconds && <span className="text-xs text-muted-foreground">{run.elapsed_seconds.toFixed(1)}s</span>}


### PR DESCRIPTION
Part 1 of #1094. The maintainer landed the archive-merge fix separately (with `_ARCHIVE_MANIFEST`), so this PR contains only the strategy-label work.

## Summary

`StrategyResearchDashboard.tsx` regex-infers the strategy from the prompt with first-match-wins — `"compare MACD against RSI"` is labelled `MACD trend strategy` — and rendered that guess as a factual report title (`<h2>`) and run-detail header with no qualifier.

- The inferred label is now explicitly marked with a visible `Inferred` chip next to the title in both the report `<h2>` and the run-detail `<h1>`.
- The raw prompt excerpt now always shows below the title (previously hidden when it happened to equal the localized label).
- New `runDashboard.strategyInferred` key added to all seven locales (en, zh-CN, ja, ko, es, ar, de).

## Validation

- `tsc -b` clean.
- `vitest` RunDetail suite: 11 passed (run with `--pool=threads`).
- All 7 locale JSON files parse.

Note: an authoritative strategy name is not available on the frontend today (`run_card.backtest` carries only codes/start_date/end_date/interval/engine/initial_cash/source). A future backend change plumbing a name through `run_card.py` could replace the inferred chip with the real label; this PR only stops presenting the guess as fact.
