### PR TITLE
fix(tools): reject non-finite prediction-market fields, keep envelope strict JSON

### DIFF
--- a/agent/src/tools/prediction_market_tool.py
+++ b/agent/src/tools/prediction_market_tool.py
@@ -108,6 +108,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 from datetime import datetime, timezone
 from typing import Any
 
@@ -234,7 +235,7 @@ def _error(message: str) -> str:
     Returns:
         A ``{"ok": false, "error": ...}`` JSON string.
     """
-    return json.dumps({"ok": False, "error": message}, ensure_ascii=False)
+    return json.dumps({"ok": False, "error": message}, ensure_ascii=False, allow_nan=False)
 
 
 def _get_json(url: str, *, host_key: str, params: dict[str, Any] | None = None) -> Any:
@@ -287,14 +288,17 @@ def _to_float(value: Any) -> float | None:
         value: Raw value from a payload.
 
     Returns:
-        The float, or ``None`` when the value is missing or non-numeric.
+        The float, or ``None`` when the value is missing, non-numeric, or
+        non-finite (``float()`` parses "nan"/"inf"/"Infinity" as valid
+        floats; those are not usable numeric data here).
     """
     if value is None or isinstance(value, bool):
         return None
     try:
-        return float(value)
+        result = float(value)
     except (ValueError, TypeError):
         return None
+    return result if math.isfinite(result) else None
 
 
 def _probability(value: Any) -> dict[str, float] | None:
@@ -1233,4 +1237,5 @@ class PredictionMarketTool(BaseTool):
                 "data": data,
             },
             ensure_ascii=False,
+            allow_nan=False,
         )

--- a/agent/tests/test_prediction_market_tool.py
+++ b/agent/tests/test_prediction_market_tool.py
@@ -674,6 +674,21 @@ class TestMarket:
         assert market["spread"] == 0.01
         assert market["volume_usd"] == pytest.approx(6306835.903025)
 
+    def test_non_finite_field_does_not_break_strict_json(self, monkeypatch):
+        """A market with a non-finite upstream field (e.g. an undefined
+        day-over-day change on a newly listed outcome) must not leak a bare
+        NaN/Infinity token into the envelope: the field normalizes to null
+        and the whole envelope stays valid strict (RFC 8259) JSON."""
+        market = _open_market()
+        market["oneDayPriceChange"] = "Infinity"
+        _install(monkeypatch, {"/markets/": market})
+        raw = PredictionMarketTool().execute(mode="market", ids=["2774056"])
+
+        assert "NaN" not in raw and "Infinity" not in raw
+        payload = json.loads(raw)
+        json.dumps(payload, allow_nan=False)  # raises if a non-finite value slipped through
+        assert payload["data"]["markets"][0]["one_day_probability_change"] is None
+
     def test_units_are_declared_on_every_envelope(self, monkeypatch):
         _install(monkeypatch, {"/markets/": _open_market()})
         units = _run(mode="market", ids=["2774056"])["units"]
@@ -992,7 +1007,25 @@ class TestHelpers:
         assert prediction_market_tool._json_list(raw) == expected
 
     @pytest.mark.parametrize(
-        "raw, expected", [("0.5", 0.5), (0.5, 0.5), (None, None), (True, None), ("x", None)]
+        "raw, expected",
+        [
+            ("0.5", 0.5),
+            (0.5, 0.5),
+            (None, None),
+            (True, None),
+            ("x", None),
+            # float() parses these as valid non-finite floats; _coerce_int
+            # already rejects the same tokens (see test_coerce_int below),
+            # so _to_float must reject them too rather than propagate
+            # inf/nan into a probability or JSON envelope.
+            ("nan", None),
+            ("NaN", None),
+            ("inf", None),
+            ("-inf", None),
+            ("Infinity", None),
+            (float("nan"), None),
+            (float("inf"), None),
+        ],
     )
     def test_to_float(self, raw, expected):
         assert prediction_market_tool._to_float(raw) == expected


### PR DESCRIPTION
## Summary

- `prediction_market_tool._to_float()` now rejects non-finite floats such as `nan`, `inf`, and `Infinity`, matching the existing guard in `_coerce_int()`.
- Both JSON envelopes now use `allow_nan=False`, keeping prediction-market responses valid strict JSON.

## Why

Python's `float()` accepts values such as `nan`, `inf`, and `Infinity`.

`_to_float()` previously had no finiteness check, so non-finite upstream values could reach the prediction-market response as invalid JSON tokens or propagate into derived fields such as implied probability, spread, or volume.

`_coerce_int()` in the same file already rejects this class of non-finite input. This change brings `_to_float()` into the same validation contract.

## Changes

- Add a `math.isfinite()` check to `_to_float()`.
- Add `allow_nan=False` to both JSON envelopes.
- Extend `_to_float()` regression coverage for non-finite values.
- Add an envelope-level test confirming non-finite fields normalize safely while the response remains strict JSON.

## Test Plan

- [x] Regression tests fail on unpatched `main` and pass after the fix
- [x] `test_prediction_market_tool.py`: 147 passed
- [x] `ruff check` passes on both changed files
- [x] No errors introduced by this change in `mypy`

## Checklist

- [x] No changes to protected areas
- [x] No hardcoded values
- [x] Code follows `CONTRIBUTING.md` guidelines
- [x] Documentation: N/A
- [x] DCO signed-off

## Risk

Low. Only non-finite values are affected. They now normalize safely instead of propagating as `nan` or `inf`. No broker, credential, order, payment, wallet, or live-trading behaviour is changed.

## Rollback

The change is small and self-contained and can be reverted with a normal `git revert`.