### PR TITLE
fix(mcp): route load_skill through the registry so oversized skills page

### DIFF
--- a/agent/mcp_server.py
+++ b/agent/mcp_server.py
@@ -507,21 +507,26 @@ def list_skills() -> str:
 
 
 @mcp.tool
-def load_skill(name: str) -> str:
-    """Load full documentation for a named finance skill.
+def load_skill(name: str, section: str | None = None, offset: int | None = None) -> str:
+    """Load documentation for a named finance skill.
 
-    Each skill is a comprehensive knowledge document covering methodology,
-    code templates, parameters, and examples. Use list_skills() first to
-    discover available skills.
+    A skill over the tool-result cap is returned as a skeleton (outline plus
+    per-section summaries) instead of being silently cut off. Request a
+    specific section by name, or page through one with offset, to read the
+    rest. Use list_skills() first to discover available skills.
 
     Args:
         name: Skill name (e.g. 'strategy-generate', 'risk-analysis', 'technical-basic').
+        section: Optional section title to expand (see the skeleton's outline).
+        offset: Optional character offset to resume a long section/document from.
     """
-    loader = _get_skills_loader()
-    content = loader.get_content(name)
-    if content.startswith("Error:"):
-        return json.dumps({"status": "error", "error": content}, ensure_ascii=False)
-    return json.dumps({"status": "ok", "skill": name, "content": content}, ensure_ascii=False)
+    registry = _get_registry()
+    params: dict[str, Any] = {"name": name}
+    if section is not None:
+        params["section"] = section
+    if offset is not None:
+        params["offset"] = offset
+    return registry.execute("load_skill", params)
 
 
 # ---------------------------------------------------------------------------

--- a/agent/tests/test_mcp_load_skill_paging.py
+++ b/agent/tests/test_mcp_load_skill_paging.py
@@ -1,0 +1,56 @@
+"""Regression test — load_skill (MCP) must page an oversized skill the same
+way the internal LoadSkillTool does.
+
+Pre-fix: the MCP wrapper called SkillsLoader.get_content() directly and
+returned the complete, uncapped document, bypassing the skeleton/section/
+offset paging agent/src/tools/load_skill_tool.py already implements for the
+identical "tushare" skill (a 102,890-character document, 10.3x the shared
+TOOL_RESULT_LIMIT). The internal agent path, which calls the same tool
+through the registry, already gets the capped, paged envelope. Post-fix, the
+MCP wrapper delegates to the registry too, matching it exactly.
+"""
+
+from __future__ import annotations
+
+import json
+
+import mcp_server
+from src.config.limits import TOOL_RESULT_LIMIT
+
+# fastmcp wraps the tool; reach the raw callable.
+_load_skill = getattr(mcp_server.load_skill, "fn", None) or getattr(
+    mcp_server.load_skill, "__wrapped__", mcp_server.load_skill
+)
+
+
+def test_mcp_load_skill_stays_within_tool_result_limit():
+    """An oversized skill must be capped and pageable through MCP too, not
+    returned whole."""
+    raw = _load_skill(name="tushare")
+    assert len(raw) <= TOOL_RESULT_LIMIT, f"{len(raw)} chars, over the {TOOL_RESULT_LIMIT} cap"
+    payload = json.loads(raw)
+    assert payload["status"] == "ok"
+    assert payload["mode"] == "outline"
+    assert "next_offset" in payload
+    assert payload["complete"] is False
+
+
+def test_mcp_load_skill_short_skill_still_whole_and_uncorrupted():
+    """A skill under the cap must still return complete, byte-identical
+    content — the registry envelope adds paging metadata (mode, offset,
+    next_offset, complete) even for a whole document, but must not alter it."""
+    from src.agent.skills import SkillsLoader
+
+    raw = _load_skill(name="candlestick")
+    payload = json.loads(raw)
+    assert payload["status"] == "ok"
+    assert payload["mode"] == "document"
+    assert payload["complete"] is True
+    assert payload["content"] == SkillsLoader().get_content("candlestick")
+
+
+def test_mcp_load_skill_error_shape_preserved():
+    """An unknown skill must still surface as a clean error, not an exception."""
+    raw = _load_skill(name="does-not-exist")
+    payload = json.loads(raw)
+    assert payload["status"] == "error"


### PR DESCRIPTION
## Summary

- `load_skill()` now delegates to the shared tool registry instead of calling `SkillsLoader` directly, so oversized skills use the same paging behaviour as the internal agent path.
- Adds `section` and `offset` parameters so MCP clients can request additional skill content using the existing `LoadSkillTool` contract.

## Why

`load_skill()` previously called `SkillsLoader.get_content()` directly and returned the full skill document.

That bypassed the paging behaviour already implemented by `LoadSkillTool`, so large skill documents could exceed the normal tool-result limit without the structured paging metadata available on the internal agent path.

Routing the MCP wrapper through the shared registry keeps both paths consistent and lets clients retrieve large skills progressively.

Out of scope: no changes to `LoadSkillTool` or `SkillsLoader`; both already implement the intended paging behaviour.

## Changes

- Route `load_skill()` through `registry.execute("load_skill", ...)`.
- Add `section` and `offset` parameters to the MCP tool.
- Add regression coverage for oversized skills, short skills, and unknown skills.

## Test Plan

- [x] Regression test fails on unpatched `main` and passes after the fix
- [x] Adjacent suites: 21 passed
- [x] Broader MCP/skill selection: 1,089 passed, 5 skipped
- [x] `ruff check` passes on both changed files
- [x] No errors introduced by this change in `mypy`

## Checklist

- [x] No changes to protected areas
- [x] No hardcoded values
- [x] Code follows `CONTRIBUTING.md` guidelines
- [x] Documentation updated in the existing docstring for the new parameters
- [x] DCO signed-off

## Risk

Low to medium. The MCP response now follows the existing `LoadSkillTool` paging contract, so the response shape changes for skill loading. Existing skill content is unchanged; oversized skills are returned progressively instead of as one large payload.

No broker, credential, order, payment, wallet, or live-trading behaviour is changed.

## Rollback

The change is isolated to the MCP `load_skill()` wrapper and its regression tests and can be reverted with a normal `git revert`.