### PR TITLE
fix(scheduled): prevent in-flight research deliveries from being overwritten

### DIFF
--- a/agent/src/scheduled_research/executor.py
+++ b/agent/src/scheduled_research/executor.py
@@ -81,8 +81,15 @@ def is_due(job: ScheduledResearchJob, now_ms: int) -> bool:
     what failed), so excluding it here prevents a re-dispatch loop every tick.
     Already-running jobs are left alone during live polling. Executor startup
     recovers stale persisted ``RUNNING`` jobs separately.
+
+    A firing whose outbox row is still PENDING or SENDING is also left alone:
+    dispatch returns once the run is accepted, not once it is delivered, so a
+    schedule shorter than that gap would otherwise re-dispatch onto the same
+    row and overwrite it, orphaning the briefing a sweep still owes.
     """
     if job.status in {JobStatus.CANCELLED, JobStatus.RUNNING, JobStatus.FAILED}:
+        return False
+    if job.delivery.status in {DeliveryStatus.PENDING, DeliveryStatus.SENDING}:
         return False
     return job.next_run_at <= now_ms
 

--- a/agent/tests/test_scheduled_delivery_clobber.py
+++ b/agent/tests/test_scheduled_delivery_clobber.py
@@ -1,0 +1,97 @@
+"""A schedule shorter than delivery latency must not clobber the outbox row.
+
+Dispatch returns once a run is *accepted*, not once it is delivered
+(#942 / test_scheduled_delivery_outbox.py). is_due() only checked job.status
+and next_run_at, so a job whose schedule interval is shorter than the time
+its briefing actually takes to generate and send could re-fire while the
+previous firing's outbox row was still PENDING or SENDING. _run_job then
+unconditionally overwrote job.delivery with the new firing's DeliveryRecord,
+and the previous session_id was gone from the record for good: sweep_
+deliveries only ever reads the current job.delivery.session_id, so that
+briefing was silently dropped with no error anywhere.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from src.scheduled_research.executor import ScheduledResearchExecutor
+from src.scheduled_research.models import DeliveryStatus, ScheduledResearchJob
+from src.scheduled_research.store import ScheduledResearchJobStore
+
+
+def _store(tmp_path: Path) -> ScheduledResearchJobStore:
+    return ScheduledResearchJobStore(tmp_path / "jobs.json")
+
+
+def _job(**overrides) -> ScheduledResearchJob:
+    base = dict(id="j1", prompt="brief me", schedule="1000", next_run_at=0, delivery_channel="telegram")
+    base.update(overrides)
+    return ScheduledResearchJob(**base)
+
+
+def test_a_re_fire_does_not_clobber_a_still_pending_delivery(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.upsert(_job())
+
+    sessions = iter(["sess-1", "sess-2"])
+
+    async def dispatch(job):
+        return next(sessions)
+
+    # sess-1's run never finishes within this test: the reader always
+    # reports it as still in flight, exactly like a briefing that takes
+    # longer to generate than the job's own re-fire interval.
+    executor = ScheduledResearchExecutor(
+        store,
+        dispatch,
+        now_fn=lambda: 0,
+        enabled=False,
+        briefing_reader=lambda _s: None,
+        channel_sender=None,
+        max_consecutive_failures=3,
+    )
+
+    asyncio.run(executor.tick(now_ms=1_000))
+    first = store.get("j1").delivery
+    assert first.status is DeliveryStatus.PENDING
+    assert first.session_id == "sess-1"
+
+    # The schedule says the job is due again before sess-1's briefing has
+    # been delivered (or even finished running).
+    asyncio.run(executor.tick(now_ms=2_000))
+    second = store.get("j1").delivery
+
+    assert second.session_id == "sess-1", (
+        "a re-fire clobbered the outbox row for a delivery that was still "
+        f"PENDING, replacing it with {second.session_id!r} and orphaning "
+        "sess-1's briefing forever"
+    )
+
+
+def test_a_re_fire_is_allowed_once_the_previous_delivery_is_terminal(tmp_path: Path) -> None:
+    """The gate must not stall a job forever: SENT clears it for the next firing."""
+    store = _store(tmp_path)
+    store.upsert(_job())
+
+    sessions = iter(["sess-1", "sess-2"])
+
+    async def dispatch(job):
+        return next(sessions)
+
+    executor = ScheduledResearchExecutor(
+        store,
+        dispatch,
+        now_fn=lambda: 0,
+        enabled=False,
+        briefing_reader=lambda _s: ("completed", "text"),
+        channel_sender=lambda *_a: asyncio.sleep(0),
+        max_consecutive_failures=3,
+    )
+
+    asyncio.run(executor.tick(now_ms=1_000))
+    assert store.get("j1").delivery.status is DeliveryStatus.SENT
+
+    asyncio.run(executor.tick(now_ms=2_000))
+    assert store.get("j1").delivery.session_id == "sess-2"


### PR DESCRIPTION
## Summary

- Prevent a scheduled research job from firing again while its previous delivery is still `PENDING` or `SENDING`.
- Preserve the existing in-flight delivery instead of allowing a later scheduler tick to replace it.
- Allow the next scheduled run once the previous delivery reaches `SENT` or terminal `FAILED`.

## Why

A scheduled research job could run again while its previous delivery was still pending or actively being sent.

When that happened, the later run could replace the existing delivery record before the previous delivery finished processing. This could orphan a valid research result because the scheduler would retain only the newer delivery reference.

The fix prevents another firing while the current delivery remains `PENDING` or `SENDING`.

Once the delivery reaches a terminal state, either `SENT` or `FAILED`, the next scheduled execution can proceed normally.

## Changes

- Add a guard preventing a scheduled research job from firing while its previous delivery is `PENDING` or `SENDING`.
- Preserve the current delivery until it reaches a terminal state.
- Add regression coverage for the overwrite scenario.
- Add a control confirming a `SENT` delivery does not block the next scheduled run.

## Test Plan

- [x] Regression test reproduces the in-flight delivery overwrite on unpatched `main` and passes after the fix
- [x] Control test confirms a `SENT` delivery allows the next scheduled firing
- [x] `SENT` and terminal `FAILED` both clear the scheduling gate through the same status condition
- [x] Adjacent scheduled-research/delivery suites: 130 passed
- [x] Broader scheduled/research/outbox/delivery selection: 399 passed, 5 skipped
- [x] `ruff check` passes
- [x] No new `black` formatting issues introduced by this change
- [x] No new `mypy` errors introduced by this change

## Checklist

- [x] No changes to protected areas
- [x] No hardcoded values
- [x] Code follows `CONTRIBUTING.md` guidelines
- [x] Documentation: N/A, internal scheduling correctness fix
- [x] DCO signed-off

## Risk

Low. The change only delays a new scheduled research execution while the previous delivery is still `PENDING` or `SENDING`.

Once the existing delivery reaches `SENT` or terminal `FAILED`, the schedule can continue normally.

No broker, credential, order, payment, wallet, or live-trading behaviour is changed.

## Rollback

The change is limited to the scheduled-delivery guard and its regression coverage and can be reverted with a normal `git revert`.