### PR TITLE
fix(swarm): stop instructing tool-less agents to call write_file

### DIFF
--- a/agent/src/swarm/worker.py
+++ b/agent/src/swarm/worker.py
@@ -277,23 +277,57 @@ def build_worker_prompt(
         # instruction to prefer these prices over training data.
         prompt_parts.append(grounding_block)
 
-    prompt_parts.append(
-        "## Execution Rules\n\n"
-        "You have a HARD LIMIT of 20 tool calls. After that you will be cut off. Work efficiently.\n\n"
-        "**Phase 1 — Plan (0 tool calls):** Before calling any tool, state your plan in 3-5 bullet points.\n\n"
-        "**Phase 2 — Execute (≤15 tool calls):**\n"
-        "- `load_skill` first to get data access methods and analysis patterns.\n"
-        "- Write ONE focused Python script via `write_file`, then run it with `bash python script.py`.\n"
-        "- Do NOT write long Python code inside bash. Use write_file + bash.\n"
-        "- Do NOT fetch data with curl/requests. Use the patterns from load_skill (yfinance, OKX API via Python).\n"
-        "- If a script fails, read the error, fix with `edit_file`, re-run. Max 2 retries per script.\n\n"
-        "**Phase 3 — Summarize (MUST use write_file):**\n"
-        "- You MUST call `write_file` with path `report.md` to save your final report as a markdown file.\n"
-        "- This is REQUIRED, not optional. Your final response MUST include a write_file call for report.md.\n"
-        "- The report must include specific numbers, dates, and actionable conclusions.\n"
-        "- After writing report.md, output a brief 2-3 sentence summary in your text response.\n"
-        "- Respond in the same language as the task prompt."
-    )
+    # The code-writing/report-file workflow below only makes sense for an
+    # agent whose whitelist (agent_spec.tools, projected by
+    # build_swarm_registry -- see run_worker step 1) actually grants
+    # write_file/bash/edit_file. A preset can and does hand a role a
+    # narrower, MCP-data-only whitelist (e.g. this deployment's
+    # deriv_fx_execution.yaml gives market_analyst/devils_advocate/
+    # optimist/contract_risk_reviewer no write_file at all, reserving it
+    # for desk_lead's final report) -- _classify_deliverable already
+    # relaxes the tool-evidence/report_written requirement for exactly
+    # this case via is_data_agent, but this block used to tell EVERY
+    # agent it "MUST" call write_file regardless, unconditionally
+    # contradicting the framework's own acceptance criteria for that same
+    # agent. In practice this produced a confused response that noticed
+    # the contradiction at runtime (e.g. "write_file is not available in
+    # this environment, so the report is delivered inline below") and
+    # improvised a preamble around it -- which, for agents relying on the
+    # SKIPPED: short-circuit convention, buried the marker several
+    # paragraphs in under markdown decoration instead of leading with it
+    # as their own role instructions require.
+    has_code_tools = bool({"write_file", "bash", "edit_file"} & set(agent_spec.tools or []))
+    if has_code_tools:
+        prompt_parts.append(
+            "## Execution Rules\n\n"
+            "You have a HARD LIMIT of 20 tool calls. After that you will be cut off. Work efficiently.\n\n"
+            "**Phase 1 — Plan (0 tool calls):** Before calling any tool, state your plan in 3-5 bullet points.\n\n"
+            "**Phase 2 — Execute (≤15 tool calls):**\n"
+            "- `load_skill` first to get data access methods and analysis patterns.\n"
+            "- Write ONE focused Python script via `write_file`, then run it with `bash python script.py`.\n"
+            "- Do NOT write long Python code inside bash. Use write_file + bash.\n"
+            "- Do NOT fetch data with curl/requests. Use the patterns from load_skill (yfinance, OKX API via Python).\n"
+            "- If a script fails, read the error, fix with `edit_file`, re-run. Max 2 retries per script.\n\n"
+            "**Phase 3 — Summarize (MUST use write_file):**\n"
+            "- You MUST call `write_file` with path `report.md` to save your final report as a markdown file.\n"
+            "- This is REQUIRED, not optional. Your final response MUST include a write_file call for report.md.\n"
+            "- The report must include specific numbers, dates, and actionable conclusions.\n"
+            "- After writing report.md, output a brief 2-3 sentence summary in your text response.\n"
+            "- Respond in the same language as the task prompt."
+        )
+    else:
+        prompt_parts.append(
+            "## Execution Rules\n\n"
+            "You have a HARD LIMIT of 20 tool calls. After that you will be cut off. Work efficiently.\n\n"
+            "**Plan (0 tool calls):** Before calling any tool, state your plan in 3-5 bullet points.\n\n"
+            "**Execute:** You do not have `write_file`/`bash`/`edit_file` in this role -- call your "
+            "assigned data/analysis tools directly to gather what your role needs. Do not attempt to "
+            "write or run a script; it is not possible with your tool whitelist.\n\n"
+            "**Summarize:** There is no report.md for this role. Output your final analysis directly "
+            "as your plain-text response, in the exact format your role's instructions above require "
+            "(including any short-circuit marker convention they describe).\n\n"
+            "Respond in the same language as the task prompt."
+        )
 
     now = datetime.now(timezone.utc)
     prompt_parts.append(
@@ -533,13 +567,24 @@ def run_worker(
         # Inject wrap-up nudge when approaching iteration limit
         if iteration == wrap_up_at:
             remaining = max_iterations - iteration
-            messages.append({
-                "role": "user",
-                "content": (
+            if "write_file" in (agent_spec.tools or []):
+                wrap_up_content = (
                     f"[SYSTEM] You have {remaining} iterations remaining. "
                     "If report.md is not written yet, make one final write_file call for report.md. "
                     "Otherwise stop calling tools and output your final analysis summary as plain text."
-                ),
+                )
+            else:
+                # This role's whitelist has no write_file -- see
+                # build_worker_prompt's has_code_tools branch for why
+                # telling it to "write report.md" here would be the same
+                # contradiction that block exists to avoid.
+                wrap_up_content = (
+                    f"[SYSTEM] You have {remaining} iterations remaining. "
+                    "Stop calling tools and output your final analysis as your plain-text response now."
+                )
+            messages.append({
+                "role": "user",
+                "content": wrap_up_content,
             })
 
         # On last iteration, call LLM without tool definitions to force text output


### PR DESCRIPTION
## Goal

Stop `build_worker_prompt` from telling every agent it "MUST" call `write_file` for a `report.md` deliverable, even when that agent's own tool whitelist doesn't include `write_file` at all. Found while investigating a related, already-tracked issue: three rounds of fixes (this repo's own history) to a downstream watcher's `SKIPPED:`-marker detection, each chasing a different way `market_analyst` wrapped the marker in markdown decoration several paragraphs into a preamble instead of leading with it as its role instructions require.

## Affected areas

- `agent/src/swarm/worker.py`:
  - `build_worker_prompt`'s "## Execution Rules" block, previously unconditional, now branches on `has_code_tools = bool({"write_file", "bash", "edit_file"} & set(agent_spec.tools or []))`. Agents with none of those three tools get a rewritten block telling them there is no `report.md` for their role and their text response is the deliverable, instead of a "REQUIRED, not optional" instruction to call a tool they structurally cannot call (`build_swarm_registry` projects the shared tool pool onto each agent's own whitelist — see `run_worker` step 1).
  - The iteration-limit wrap-up nudge (`_run_worker_impl`, injected at `wrap_up_at`) had the same unconditional "make one final write_file call for report.md" text; now gated the same way.
- No changes to `_classify_deliverable`/`_is_data_agent`/`_report_written` — those already correctly relax the tool-evidence/`report_written` requirement for non-data agents (see `_classify_deliverable`'s own docstring: "the tool-evidence requirement applies ONLY to data agents"). This PR just brings the *prompt* in line with an acceptance rule the framework already enforces; it doesn't change the rule.

## Evidence this is real, not speculative

A preset in a downstream deployment (`deriv_fx_execution.yaml`) gives `market_analyst`/`devils_advocate`/`optimist`/`contract_risk_reviewer` an MCP-data-only whitelist with no `write_file`/`bash`/`edit_file`, reserving those for `desk_lead`'s final report. Live run output from that preset shows `market_analyst` noticing the contradiction and improvising around it verbatim: *"Note: `write_file` is not available in this environment, so the report is delivered inline below."* — followed by a full preamble before its `SKIPPED:` marker, which is what motivated the three prior watcher-side detection patches referenced above. Fixing the prompt at the source removes the underlying cause those patches were reacting to, rather than adding a fourth marker-formatting variant to detect.

## Out of scope

- Not changing which tools any preset grants which agent — that's preset-authoring policy, not this framework code.
- Not touching `_classify_deliverable`/`_is_data_agent`/`_report_written`, which already handle this distinction correctly on the acceptance side.
- Not a fix to the downstream watcher's `SKIPPED:`-marker detection itself (already iterated three times in this repo's history); this addresses the prompt-level cause rather than adding a fourth detection-side patch.

## Test plan

- [x] `python -m py_compile` on the changed file.
- [x] Checked both existing test files that call `build_worker_prompt` (`agent/tests/test_swarm_grounding.py`, `agent/tests/test_market_data_tool.py`) by static inspection: none assert the literal Phase 2/3 text this PR branches, only the `"## Execution Rules"` heading's presence/ordering (preserved in both branches) and unrelated blocks (Data Citation Discipline, Market Data Tool Policy). `test_worker_prompt_prioritizes_get_market_data_for_ohlcv`'s spec includes `write_file`, so it exercises the unchanged `has_code_tools=True` branch byte-for-byte.
- [ ] Not run: the actual test suite. Same limitation as PR #1142 — no local checkout in this environment; this PR was built via the GitHub API against fetched file content. Flagging for a maintainer/CI run before merge.

## Risk

- **Live/broker/order risk**: none. No order-gate, mandate, kill-switch, or broker-write code touched.
- **MCP/network risk**: none. Prompt-text-only change; no tool registration, routing, or network behavior changes.
- **Secret risk**: none.
- **Deployment risk**: low-to-moderate. This changes what every agent without `write_file`/`bash`/`edit_file` is told to do, which could shift output *shape* for such agents (they were already contradicting the old instruction in practice, per the evidence above, so this is expected to reduce confused preambles, not introduce new ones) — but it's a prompt-content change to every non-code-tool agent across every preset, not scoped to one deployment's config, so it's worth a maintainer's own read before merge given how directly it touches every agent's behavior.

## Rollback / close path

Single revertible change, same shape as #1142: `git revert` this commit restores the previous unconditional instruction with no data migration and nothing else depending on the new branch. If a regression surfaces (e.g. some preset's non-code-tool agent actually relied on the old text for reasons this PR didn't anticipate), reverting is the preferred fix per `AGENT_CONTRIBUTOR_GUIDE.md` rather than a broader change.