### PR TITLE
fix(cli): dispatch show subcommand's run_id, not the --show flag

### DIFF
--- a/agent/cli/_legacy.py
+++ b/agent/cli/_legacy.py
@@ -5901,7 +5901,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "list":
         return _coerce_exit_code(cmd_list(args.list_limit))
     if args.command == "show":
-        return _coerce_exit_code(cmd_show(args.show))
+        return _coerce_exit_code(cmd_show(args.run_id))
     if args.command == "chat":
         return _coerce_exit_code(cmd_interactive(args.chat_max_iter))
     if args.command == "update":

--- a/agent/tests/test_cli_show_subcommand.py
+++ b/agent/tests/test_cli_show_subcommand.py
@@ -1,0 +1,41 @@
+"""Regression tests for the ``show`` subcommand dispatch.
+
+The subcommand parser defines a positional ``run_id``, but the dispatch
+previously read the ``--show`` flag instead — so ``vibe-trading show <id>``
+always crashed with ``TypeError: unsupported operand type(s) for /:
+'PosixPath' and 'NoneType'``. The flag form kept working, hiding the bug.
+"""
+
+from __future__ import annotations
+
+from cli import _legacy
+
+
+def test_show_subcommand_passes_run_id_to_cmd_show(monkeypatch) -> None:
+    """``show <run_id>`` must dispatch the positional run_id, not the flag."""
+    captured: list[str | None] = []
+    monkeypatch.setattr(
+        _legacy, "cmd_show", lambda run_id: captured.append(run_id)
+    )
+    assert _legacy.main(["show", "some_run_123"]) == 0
+    assert captured == ["some_run_123"], f"cmd_show got {captured!r}"
+
+
+def test_show_flag_still_passes_run_id(monkeypatch) -> None:
+    """``--show <run_id>`` (legacy flag form) must keep working."""
+    captured: list[str | None] = []
+    monkeypatch.setattr(
+        _legacy, "cmd_show", lambda run_id: captured.append(run_id)
+    )
+    assert _legacy.main(["--show", "flag_run_456"]) == 0
+    assert captured == ["flag_run_456"], f"cmd_show got {captured!r}"
+
+
+def test_show_missing_run_id_is_usage_error(monkeypatch) -> None:
+    """``show`` without a run_id is a parse error, not a crash."""
+    captured: list[str | None] = []
+    monkeypatch.setattr(
+        _legacy, "cmd_show", lambda run_id: captured.append(run_id)
+    )
+    assert _legacy.main(["show"]) != 0
+    assert captured == []


### PR DESCRIPTION
Closes #1146

`vibe-trading show <run_id>` crashes 100% of the time with `TypeError: unsupported operand type(s) for /: PosixPath and NoneType` — the dispatch reads `args.show` (the `--show` flag, None for the subcommand) instead of the subcommand positional `run_id`. The flag form works, hiding the break.

## Change

- `agent/cli/_legacy.py`: subcommand path dispatches `cmd_show(args.run_id)`; flag path unchanged (`args.show`).
- `agent/tests/test_cli_show_subcommand.py`: 3 regression tests — subcommand dispatch passes run_id, flag dispatch passes run_id, missing run_id is a usage error not a crash. Tests fail on the buggy line (verified RED).

## Verification

- 3 new tests GREEN, RED on buggy dispatch
- 108 adjacent CLI tests pass (continue/runtime/interactive)
- Both real forms verified live: `show <id>` and `--show <id>` render the run table