### PR TITLE
fix(cli): render broker_sdk order rows and strip stringified SDK enums

### DIFF
--- a/agent/cli/_legacy.py
+++ b/agent/cli/_legacy.py
@@ -4235,6 +4235,21 @@ def _print_connector_account_mapping(
     return EXIT_SUCCESS
 
 
+def _enum_text(value: Any) -> str:
+    """Render ``OrderSide.BUY``-style enum reprs as ``BUY``.
+
+    broker_sdk connectors stringify SDK enums, so the raw repr reaches the
+    table. Only strips when the prefix looks like a CamelCase class name (it
+    must contain a lowercase letter), so ticker symbols such as ``BRK.B`` and
+    decimal values are left alone.
+    """
+    text = str(value or "")
+    match = re.fullmatch(r"([A-Z][A-Za-z0-9_]*)\.([A-Z][A-Z0-9_]*)", text)
+    if match and any(ch.islower() for ch in match.group(1)):
+        return match.group(2)
+    return text
+
+
 def _print_connector_account(result: dict[str, Any]) -> int:
     accounts = ", ".join(result.get("accounts", [])) or "(none)"
     rows = result.get("summary", [])
@@ -4439,15 +4454,18 @@ def cmd_connector_orders(
     for row in orders:
         contract = row.get("contract") or {}
         order = row.get("order") or row
-        order_status = row.get("status") or {}
+        # IBKR nests status as ``{"status": {"status": ...}}``; broker_sdk
+        # connectors (Alpaca, …) return it as a plain string on the flat row.
+        raw_status = row.get("status")
+        status_text = raw_status.get("status") if isinstance(raw_status, dict) else raw_status
         table.add_row(
             str(order.get("account") or ""),
-            str(contract.get("local_symbol") or contract.get("symbol") or ""),
-            str(order.get("action") or ""),
-            str(order.get("order_type") or ""),
-            str(order.get("total_quantity") or ""),
+            str(contract.get("local_symbol") or contract.get("symbol") or order.get("symbol") or ""),
+            _enum_text(order.get("action") or order.get("side") or ""),
+            _enum_text(order.get("order_type") or ""),
+            str(order.get("total_quantity") or order.get("quantity") or ""),
             str(order.get("limit_price") or ""),
-            str(order_status.get("status") or ""),
+            _enum_text(status_text or ""),
         )
     console.print(table)
     return EXIT_SUCCESS

--- a/agent/tests/test_cli_connector_renderers.py
+++ b/agent/tests/test_cli_connector_renderers.py
@@ -150,3 +150,112 @@ def test_connector_check_uses_sdk_diagnostics_without_oauth_rows(capsys) -> None
     assert "OAuth token" not in out
     assert "Configured" not in out
     assert "Capabilities" not in out
+
+
+# --- #1150: `connector orders` had no coverage at all -------------------------
+#
+# `cmd_connector_orders` was written against the IBKR row shape
+# (``{"contract": ..., "order": ..., "status": {"status": ...}}``). broker_sdk
+# connectors return a flat row with ``symbol``/``side``/``quantity`` and a
+# plain-string ``status``, so every column but Account rendered empty. The
+# renderer had no test, which is why the whole column set could go blank
+# unnoticed.
+
+
+def test_enum_text_strips_sdk_enum_reprs_but_keeps_symbols_and_numbers() -> None:
+    # SDK enums arrive already stringified by the broker_sdk layer.
+    assert _legacy._enum_text("OrderSide.BUY") == "BUY"
+    assert _legacy._enum_text("OrderStatus.PARTIALLY_FILLED") == "PARTIALLY_FILLED"
+    # A class-name prefix must look like CamelCase, so class-B tickers survive.
+    assert _legacy._enum_text("BRK.B") == "BRK.B"
+    assert _legacy._enum_text("BRK.A") == "BRK.A"
+    # Decimals and already-plain values are returned untouched.
+    assert _legacy._enum_text("716.64") == "716.64"
+    assert _legacy._enum_text("BUY") == "BUY"
+    assert _legacy._enum_text(None) == ""
+
+
+def test_connector_orders_renders_flat_broker_sdk_row(capsys) -> None:
+    alpaca_result = {
+        "status": "ok",
+        "profile_id": "alpaca-paper-trade",
+        "open_orders": [
+            {
+                "account": "PA3ABCD",
+                "symbol": "AAPL",
+                "side": "OrderSide.BUY",
+                "order_type": "OrderType.LIMIT",
+                "quantity": 10,
+                "limit_price": 187.5,
+                "status": "OrderStatus.NEW",
+            }
+        ],
+    }
+    with patch("src.trading.service.get_open_orders", return_value=alpaca_result):
+        rc = _legacy.cmd_connector_orders("alpaca-paper-trade")
+
+    assert rc == _legacy.EXIT_SUCCESS
+    out = capsys.readouterr().out
+    assert "AAPL" in out       # symbol on the flat row, not under contract
+    assert "BUY" in out        # side → Action, enum prefix stripped
+    assert "LIMIT" in out      # order_type enum prefix stripped
+    assert "10" in out         # quantity → Qty
+    assert "187.5" in out      # limit_price
+    assert "NEW" in out        # plain-string status, enum prefix stripped
+    assert "OrderSide" not in out
+    assert "OrderStatus" not in out
+
+
+def test_connector_orders_keeps_class_b_ticker_intact(capsys) -> None:
+    result = {
+        "status": "ok",
+        "profile_id": "alpaca-paper-trade",
+        "open_orders": [
+            {
+                "account": "PA3ABCD",
+                "symbol": "BRK.B",
+                "side": "OrderSide.SELL",
+                "order_type": "OrderType.MARKET",
+                "quantity": 1,
+                "status": "OrderStatus.NEW",
+            }
+        ],
+    }
+    with patch("src.trading.service.get_open_orders", return_value=result):
+        rc = _legacy.cmd_connector_orders("alpaca-paper-trade")
+
+    assert rc == _legacy.EXIT_SUCCESS
+    out = capsys.readouterr().out
+    assert "BRK.B" in out  # must not be stripped to "B"
+    assert "SELL" in out
+
+
+def test_connector_orders_still_renders_the_nested_ibkr_row(capsys) -> None:
+    ibkr_result = {
+        "status": "ok",
+        "profile_id": "ibkr-local",
+        "open_orders": [
+            {
+                "contract": {"local_symbol": "MSFT", "symbol": "MSFT"},
+                "order": {
+                    "account": "DU123",
+                    "action": "BUY",
+                    "order_type": "LMT",
+                    "total_quantity": 100,
+                    "limit_price": 401.25,
+                },
+                "status": {"status": "PreSubmitted"},
+            }
+        ],
+    }
+    with patch("src.trading.service.get_open_orders", return_value=ibkr_result):
+        rc = _legacy.cmd_connector_orders("ibkr-local")
+
+    assert rc == _legacy.EXIT_SUCCESS
+    out = capsys.readouterr().out
+    assert "MSFT" in out
+    assert "DU123" in out
+    assert "LMT" in out
+    assert "100" in out
+    assert "401.25" in out
+    assert "PreSubmitted" in out  # the dict branch must survive the flat-row fix


### PR DESCRIPTION
## What

`connector orders` still assumes IBKR's nested payload shape. broker_sdk connectors (Alpaca, binance, tiger, dhan, shoonya, mt5) return **flat** rows, which breaks the command two ways:

- **Crash:** `status` is a plain string on a flat row, not a nested `{"status": {...}}` dict, so the renderer raised `AttributeError` as soon as an order existed.
- **Blank table:** the symbol / side / quantity columns read only the IBKR keys (`contract.symbol`, `order.action`, `order.total_quantity`), so those columns rendered empty for flat rows.

This maps the flat fields alongside the existing nested ones and accepts a string `status`, so the table is *populated* rather than merely non-crashing.

It also adds `_enum_text()`. Real broker_sdk payloads carry stringified SDK enums — `OrderSide.BUY`, `OrderStatus.ACCEPTED` — and the raw repr was reaching the table.

## Why the guard in `_enum_text` matters

It only strips when the CamelCase prefix contains a lowercase letter, so legitimate dotted values survive:

| input | output |
|---|---|
| `OrderSide.BUY` | `BUY` |
| `OrderStatus.ACCEPTED` | `ACCEPTED` |
| `BRK.B` | `BRK.B` (ticker preserved) |
| `716.64` | `716.64` (decimal preserved) |

## Scope note for reviewers

An earlier version of this change also fixed `connector account` printing `(none)` for flat payloads. **That half is dropped** — #735 landed `_print_connector_account_mapping()`, which covers the flat `account` mapping and additionally normalizes nested MCP values. That implementation supersedes mine; only the orders path was still broken. This PR is rebased onto current `main` and is now 24 insertions / 6 deletions in one file.

## Testing

Verified against a live Alpaca **paper** account: place → list → cancel. IBKR's nested shape re-checked for regressions, since both paths share the renderer.