### PR TITLE
[Bug] CLI `connector account` prints "No account summary returned" for Alpaca despite a successful f

### DIFF
--- a/agent/cli/_legacy.py
+++ b/agent/cli/_legacy.py
@@ -4003,9 +4003,15 @@ def cmd_connector_check(
         table.add_row("Connector", profile.connector)
         table.add_row("Environment", profile.environment)
         table.add_row("Transport", profile.transport)
-        table.add_row("Configured", "yes" if report.get("configured") else "[red]no[/red]")
-        table.add_row("OAuth token", "present" if report.get("oauth_token_present") else "[yellow]missing[/yellow]")
-        table.add_row("Capabilities", ", ".join(report.get("capabilities", [])))
+        # Only the remote-MCP status path reports these; a broker_sdk report
+        # carries none of them (and Alpaca authenticates with an API key pair,
+        # not OAuth), so the rows contradicted the readiness line below (#1064).
+        if profile.transport != "broker_sdk":
+            table.add_row("Configured", "yes" if report.get("configured") else "[red]no[/red]")
+            table.add_row(
+                "OAuth token", "present" if report.get("oauth_token_present") else "[yellow]missing[/yellow]"
+            )
+            table.add_row("Capabilities", ", ".join(report.get("capabilities", [])))
         console.print(table)
 
     if report.get("status") not in {"ok"}:

--- a/agent/cli/_legacy.py
+++ b/agent/cli/_legacy.py
@@ -4101,6 +4101,36 @@ def _flatten_account_fields(data: dict[str, Any], prefix: str = "") -> list[tupl
     return rows
 
 
+def _account_summary_rows(account: dict[str, Any], prefix: str = "") -> list[tuple[str, str]]:
+    """Flatten a ``broker_sdk`` account mapping into (field, value) rows.
+
+    Unlike the remote-MCP flattener, zero values are kept: these connectors
+    report a fixed set of account fields, so a 0 cash or margin figure is a
+    real balance rather than an empty asset-class slot.
+    """
+    rows: list[tuple[str, str]] = []
+    for key, value in account.items():
+        if value is None:
+            continue
+        label = f"{prefix}{key}"
+        if isinstance(value, dict):
+            rows.extend(_account_summary_rows(value, prefix=f"{label}."))
+            continue
+        rows.append((label, str(value)))
+    return rows
+
+
+def _print_connector_account_fields(result: dict[str, Any], account: dict[str, Any]) -> int:
+    """Render the single-account field map returned by ``broker_sdk`` connectors."""
+    table = Table(title=f"Account Summary · {result.get('profile_id')}", box=box.SIMPLE_HEAVY, show_lines=False)
+    table.add_column("Field")
+    table.add_column("Value", justify="right")
+    for tag, value in _account_summary_rows(account):
+        table.add_row(tag, value)
+    console.print(table)
+    return EXIT_SUCCESS
+
+
 def _print_connector_account(result: dict[str, Any]) -> int:
     accounts = ", ".join(result.get("accounts", [])) or "(none)"
     rows = result.get("summary", [])
@@ -4110,6 +4140,14 @@ def _print_connector_account(result: dict[str, Any]) -> int:
         label = accounts if accounts != "(none)" else result.get("profile_id", result.get("profile", "unknown"))
         console.print(f"Accounts: [cyan]{rich_escape(str(label))}[/cyan]")
         return _print_connector_balances(result)
+    # Single-account broker_sdk connectors (Alpaca, …) put the fields under an
+    # ``account`` mapping instead of a ``balances`` list (#1064). Tiger reports a
+    # plain account id there, hence the mapping check.
+    account = result.get("account")
+    if not rows and isinstance(account, dict):
+        label = account.get("account_number") or result.get("profile_id", result.get("profile", "unknown"))
+        console.print(f"Account: [cyan]{rich_escape(str(label))}[/cyan]")
+        return _print_connector_account_fields(result, account)
     if not rows:
         # Not the broker_sdk flat shape — try the remote-MCP nested shape.
         # Robinhood's tool result double-wraps: result["data"] unwraps to

--- a/agent/tests/test_cli_connector_renderers.py
+++ b/agent/tests/test_cli_connector_renderers.py
@@ -135,3 +135,43 @@ def test_connector_account_still_handles_ibkr_summary(capsys) -> None:
     out = capsys.readouterr().out
     assert "NetLiquidation" in out
     assert "50000" in out
+
+
+def _profile(transport: str):
+    from src.trading.types import TradingProfile
+
+    return TradingProfile(
+        id=f"probe-{transport}",
+        connector="alpaca",
+        label="Probe",
+        environment="paper",
+        transport=transport,
+        capabilities=("account.read",),
+        readonly=True,
+    )
+
+
+def test_connector_check_hides_remote_mcp_rows_for_broker_sdk(capsys) -> None:
+    """Regression (#1064): a broker_sdk report has no OAuth/capability state."""
+    report = {"status": "ok", "host": "https://paper-api.alpaca.markets"}
+    with patch.object(_legacy, "_selected_profile_or", return_value=_profile("broker_sdk")):
+        with patch("src.trading.service.check_connection", return_value=report):
+            rc = _legacy.cmd_connector_check("probe-broker_sdk")
+
+    assert rc == _legacy.EXIT_SUCCESS
+    out = capsys.readouterr().out
+    assert "Connector profile is ready." in out
+    for label in ("Configured", "OAuth token", "Capabilities"):
+        assert label not in out
+
+
+def test_connector_check_still_reports_remote_mcp_authorization(capsys) -> None:
+    report = {"status": "ok", "configured": True, "oauth_token_present": True, "capabilities": ["account.read"]}
+    with patch.object(_legacy, "_selected_profile_or", return_value=_profile("remote_mcp")):
+        with patch("src.trading.service.check_connection", return_value=report):
+            rc = _legacy.cmd_connector_check("probe-remote_mcp")
+
+    assert rc == _legacy.EXIT_SUCCESS
+    out = capsys.readouterr().out
+    assert "OAuth token" in out and "present" in out
+    assert "account.read" in out

--- a/agent/tests/test_cli_connector_renderers.py
+++ b/agent/tests/test_cli_connector_renderers.py
@@ -77,6 +77,51 @@ def test_connector_account_renders_balances_table(capsys) -> None:
     assert "12" in out and "345" in out  # net_assets 12,345 rendered
 
 
+def test_account_summary_rows_keep_zero_and_skip_none() -> None:
+    rows = _legacy._account_summary_rows({"cash": "0", "pattern_day_trader": None, "pnl": {"equity": 1.5}})
+    # A 0 cash balance is a real figure here, unlike in the remote-MCP flattener.
+    assert rows == [("cash", "0"), ("pnl.equity", "1.5")]
+
+
+def test_connector_account_renders_alpaca_account_mapping(capsys) -> None:
+    """Regression (#1064): Alpaca reports its fields under ``account``."""
+    alpaca_account = {
+        "status": "ok",
+        "profile_id": "alpaca-paper-trade",
+        "profile": "paper",
+        "is_paper": True,
+        "host": "https://paper-api.alpaca.markets",
+        "account": {
+            "account_number": "PA12345678",
+            "status": "AccountStatus.ACTIVE",
+            "currency": "USD",
+            "cash": "100000",
+            "equity": "100000",
+            "buying_power": "400000",
+            "portfolio_value": "100000",
+            "pattern_day_trader": None,
+            "trading_blocked": False,
+        },
+    }
+    rc = _legacy._print_connector_account(alpaca_account)
+
+    assert rc == _legacy.EXIT_SUCCESS
+    out = capsys.readouterr().out
+    assert "No account summary returned." not in out
+    assert "PA12345678" in out
+    assert "buying_power" in out and "400000" in out
+    assert "pattern_day_trader" not in out
+
+
+def test_connector_account_ignores_a_non_mapping_account_field(capsys) -> None:
+    """Tiger reports a plain account id in ``account``, not a field map."""
+    tiger_account = {"status": "ok", "profile_id": "tiger-paper-sdk", "account": "20240101"}
+    rc = _legacy._print_connector_account(tiger_account)
+
+    assert rc == _legacy.EXIT_SUCCESS
+    assert "No account summary returned." in capsys.readouterr().out
+
+
 def test_connector_account_still_handles_ibkr_summary(capsys) -> None:
     ibkr_account = {
         "status": "ok",


### PR DESCRIPTION
`_print_connector_account()` only understood the IBKR `summary`, broker_sdk `balances`, and remote-MCP `data` shapes, so Alpaca's `account` field mapping fell through to "No account summary returned."; a fourth branch renders it as a Field/Value table, guarded against Tiger's plain-string `account` key. Separately, `connector check` no longer prints the `Configured`/`OAuth token`/`Capabilities` rows for `broker_sdk` profiles, where `check_status()` populates none of them and the table therefore contradicted the "Connector profile is ready." line it printed underneath.

Fixes #1064

### Testing
[targeted; 4 commit(s) checked individually] $ /Users/m2/Documents/PW/github-bot/work/HKUDS__Vibe-Trading/1064/.contrib-venv/bin/python -m pytest -q --no-header agent/tests/test_cli_connector_renderers.py

### Notes for reviewers
1) The check-table guard is a denylist (`profile.transport != "broker_sdk"`). Any other non-remote-MCP transport — IBKR's, whatever it is named — still prints "OAuth token missing" against a report that never populates it. Keying on `"configured" in report`, or inverting to `== "remote_mcp"`, would cover the whole class. Also confirm `profile.transport` is a plain str: the test builds the profile with a string literal, so a non-str enum would let the test pass while production never takes the branch (the adjacent `add_row("Transport", profile.transport)` suggests str, but I could not verify it).

