### PR TITLE
feat(scheduled): render each monitor's latest verdict on the list

### DIFF
--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -173,7 +173,12 @@
     "delivery_pending": "الملخص بانتظار الإرسال إلى {{channel}}",
     "delivery_sending": "جارٍ الإرسال إلى {{channel}}",
     "delivery_sent": "تم الإرسال إلى {{channel}}",
-    "delivery_failed": "تعذّر الإرسال إلى {{channel}}"
+    "delivery_failed": "تعذّر الإرسال إلى {{channel}}",
+    "verdictEmpty": "لا يوجد تقييم بعد",
+    "verdictUnreadable": "تعذر قراءة أحدث تقييم",
+    "verdictNoCalls": "لا إشارات",
+    "verdictDelta": "{{was}} ← {{now}}",
+    "verdictRecorded": "اعتبارًا من {{when}}"
   },
   "reports": {
     "badge": "التقارير",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -178,7 +178,12 @@
     "delivery_pending": "Briefing wartet auf Versand an {{channel}}",
     "delivery_sending": "Briefing wird an {{channel}} gesendet",
     "delivery_sent": "Briefing an {{channel}} gesendet",
-    "delivery_failed": "Versand an {{channel}} fehlgeschlagen"
+    "delivery_failed": "Versand an {{channel}} fehlgeschlagen",
+    "verdictEmpty": "Noch kein Urteil",
+    "verdictUnreadable": "Letztes Urteil nicht lesbar",
+    "verdictNoCalls": "Keine Calls",
+    "verdictDelta": "{{was}} → {{now}}",
+    "verdictRecorded": "Stand {{when}}"
   },
   "reports": {
     "badge": "Berichte",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -178,7 +178,12 @@
     "delivery_pending": "Briefing owed to {{channel}}",
     "delivery_sending": "Sending the briefing to {{channel}}",
     "delivery_sent": "Briefing delivered to {{channel}}",
-    "delivery_failed": "Could not deliver to {{channel}}"
+    "delivery_failed": "Could not deliver to {{channel}}",
+    "verdictEmpty": "No verdict yet",
+    "verdictUnreadable": "Latest verdict unreadable",
+    "verdictNoCalls": "No calls",
+    "verdictDelta": "{{was}} → {{now}}",
+    "verdictRecorded": "as of {{when}}"
   },
   "reports": {
     "badge": "Reports",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -178,7 +178,12 @@
     "delivery_pending": "Informe pendiente de envío a {{channel}}",
     "delivery_sending": "Enviando el informe a {{channel}}",
     "delivery_sent": "Informe enviado a {{channel}}",
-    "delivery_failed": "No se pudo enviar a {{channel}}"
+    "delivery_failed": "No se pudo enviar a {{channel}}",
+    "verdictEmpty": "Sin veredicto aún",
+    "verdictUnreadable": "No se pudo leer el último veredicto",
+    "verdictNoCalls": "Sin señales",
+    "verdictDelta": "{{was}} → {{now}}",
+    "verdictRecorded": "a fecha de {{when}}"
   },
   "reports": {
     "badge": "Informes",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -173,7 +173,12 @@
     "delivery_pending": "{{channel}} への配信待ちです",
     "delivery_sending": "{{channel}} へ配信中です",
     "delivery_sent": "{{channel}} へ配信しました",
-    "delivery_failed": "{{channel}} へ配信できませんでした"
+    "delivery_failed": "{{channel}} へ配信できませんでした",
+    "verdictEmpty": "判定はまだありません",
+    "verdictUnreadable": "最新の判定を読み取れません",
+    "verdictNoCalls": "コールなし",
+    "verdictDelta": "{{was}} → {{now}}",
+    "verdictRecorded": "{{when}} 時点"
   },
   "reports": {
     "badge": "レポート",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -173,7 +173,12 @@
     "delivery_pending": "{{channel}}(으)로 전달 대기 중",
     "delivery_sending": "{{channel}}(으)로 전달하는 중",
     "delivery_sent": "{{channel}}(으)로 전달했습니다",
-    "delivery_failed": "{{channel}}(으)로 전달하지 못했습니다"
+    "delivery_failed": "{{channel}}(으)로 전달하지 못했습니다",
+    "verdictEmpty": "아직 판정 없음",
+    "verdictUnreadable": "최신 판정을 읽을 수 없음",
+    "verdictNoCalls": "호출 없음",
+    "verdictDelta": "{{was}} → {{now}}",
+    "verdictRecorded": "{{when}} 기준"
   },
   "reports": {
     "badge": "리포트",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -173,7 +173,12 @@
     "delivery_pending": "待推送到 {{channel}}",
     "delivery_sending": "正在推送到 {{channel}}",
     "delivery_sent": "已推送到 {{channel}}",
-    "delivery_failed": "推送到 {{channel}} 失败"
+    "delivery_failed": "推送到 {{channel}} 失败",
+    "verdictEmpty": "尚无判定",
+    "verdictUnreadable": "最新判定无法解析",
+    "verdictNoCalls": "无调用",
+    "verdictDelta": "{{was}} → {{now}}",
+    "verdictRecorded": "记于 {{when}}"
   },
   "reports": {
     "badge": "报告",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -319,6 +319,21 @@ export const api = {
 
 // --- Scheduled research types ---
 
+export interface VerdictItem {
+  symbol: string;
+  state: string;
+  reason: string;
+}
+
+export interface VerdictRecord {
+  session_id: string;
+  recorded_at: number;
+  parse: string;
+  outcome: string;
+  items: VerdictItem[];
+  previous: VerdictRecord | null;
+}
+
 export interface ScheduledRun {
   id: string;
   prompt: string;
@@ -339,6 +354,9 @@ export interface ScheduledRun {
   delivery_status: string;
   delivery_error: string | null;
   delivery_updated_at: number | null;
+  // The latest run's parsed verdict, embedded with its predecessor so the list
+  // renders a delta in one query. Null until a completed run records one.
+  last_verdict: VerdictRecord | null;
 }
 
 export interface CreateScheduledRunRequest {

--- a/frontend/src/pages/Scheduled.tsx
+++ b/frontend/src/pages/Scheduled.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { CalendarClock, Loader2, Plus, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -210,6 +210,53 @@ export function Scheduled() {
       default:
         return cadence.expression;
     }
+  }
+
+  function verdictCell(run: ScheduledRun): ReactNode {
+    const verdict = run.last_verdict;
+    if (verdict === null) {
+      return (
+        <p className={hintClass} data-testid={`verdict-empty-${run.id}`}>
+          {t("scheduled.verdictEmpty")}
+        </p>
+      );
+    }
+    // A monitor built from an ad-hoc prompt never produces a verdict section,
+    // and that is its correct permanent state: render nothing, not a warning.
+    if (verdict.parse === "no_verdict_section") {
+      return null;
+    }
+    if (verdict.parse === "contract_violation") {
+      // Never show a wrong verdict: the malformed run reads as unreadable, and
+      // the prior good one is still visible through `previous` next release.
+      return (
+        <p className={hintClass} data-testid={`verdict-unreadable-${run.id}`}>
+          {t("scheduled.verdictUnreadable")}
+        </p>
+      );
+    }
+    const when = formatInZone(verdict.recorded_at, displayZone(run), locale);
+    if (verdict.items.length === 0) {
+      return (
+        <p className={hintClass} data-testid={`verdict-nocalls-${run.id}`}>
+          {t("scheduled.verdictNoCalls")} · {t("scheduled.verdictRecorded", { when })}
+        </p>
+      );
+    }
+    const delta =
+      verdict.previous && verdict.previous.outcome !== verdict.outcome
+        ? t("scheduled.verdictDelta", { was: verdict.previous.outcome, now: verdict.outcome })
+        : null;
+    return (
+      <p className="break-words text-xs text-muted-foreground" data-testid={`verdict-line-${run.id}`}>
+        <span className="font-medium text-foreground">
+          {verdict.items.map((item) => `${item.symbol} ${item.state}`).join(" · ")}
+        </span>
+        {" · "}
+        {delta ? <span>{delta} · </span> : null}
+        {t("scheduled.verdictRecorded", { when })}
+      </p>
+    );
   }
 
   function statusLabel(run: ScheduledRun): { label: string; tone: "success" | "danger" | "warning" | "neutral" } {
@@ -450,6 +497,7 @@ export function Scheduled() {
                           : ""}
                       </p>
                     )}
+                    {verdictCell(run)}
                   </div>
                   {pendingDelete === run.id ? (
                     <div className="flex items-center gap-1.5">

--- a/frontend/src/pages/__tests__/Scheduled.test.tsx
+++ b/frontend/src/pages/__tests__/Scheduled.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Scheduled } from "@/pages/Scheduled";
-import { ApiError, api, type ScheduledRun } from "@/lib/api";
+import { ApiError, api, type ScheduledRun, type VerdictRecord } from "@/lib/api";
 
 vi.mock("@/lib/api", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/api")>();
@@ -41,6 +41,7 @@ function run(overrides: Partial<ScheduledRun> = {}): ScheduledRun {
     delivery_status: "none",
     delivery_error: null,
     delivery_updated_at: null,
+    last_verdict: null,
     ...overrides,
   };
 }
@@ -213,5 +214,71 @@ describe("briefing delivery", () => {
     render(<Scheduled />);
 
     expect(await screen.findByText(/channel unreachable/i)).toBeInTheDocument();
+  });
+});
+
+function verdict(overrides: Partial<VerdictRecord> = {}): VerdictRecord {
+  return {
+    session_id: "sess-1",
+    recorded_at: 1_789_000_000_000,
+    parse: "ok",
+    outcome: "FLAT",
+    items: [{ symbol: "600519.SH", state: "FLAT", reason: "band held" }],
+    previous: null,
+    ...overrides,
+  };
+}
+
+describe("Scheduled page verdict cell", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocked.listScheduledRuns.mockResolvedValue([]);
+  });
+
+  it("renders the latest verdict with its delta and the recorded time", async () => {
+    mocked.listScheduledRuns.mockResolvedValue([
+      run({
+        last_verdict: verdict({
+          outcome: "DRIFT",
+          items: [{ symbol: "600519.SH", state: "DRIFT", reason: "band crossed" }],
+          previous: verdict({ session_id: "sess-0", outcome: "FLAT", recorded_at: 1_788_000_000_000 }),
+        }),
+      }),
+    ]);
+    render(<Scheduled />);
+
+    expect(await screen.findByText(/600519.SH DRIFT/)).toBeInTheDocument();
+    expect(screen.getByText(/FLAT → DRIFT/)).toBeInTheDocument();
+    expect(screen.getByText(/as of/)).toBeInTheDocument();
+  });
+
+  it("shows an explicit empty state when no run has recorded one", async () => {
+    mocked.listScheduledRuns.mockResolvedValue([run({ last_verdict: null })]);
+    render(<Scheduled />);
+
+    expect(await screen.findByText("No verdict yet")).toBeInTheDocument();
+  });
+
+  it("renders nothing for ad-hoc monitors permanently at no_verdict_section", async () => {
+    mocked.listScheduledRuns.mockResolvedValue([run({ last_verdict: verdict({ parse: "no_verdict_section", items: [] }) })]);
+    render(<Scheduled />);
+
+    await screen.findByRole("listitem");
+    expect(screen.queryByText(/No verdict yet/)).not.toBeInTheDocument();
+    expect(screen.queryByTestId("verdict-line-auckland-scan")).toBeNull();
+  });
+
+  it("never shows a wrong verdict: a malformed section reads as unreadable", async () => {
+    mocked.listScheduledRuns.mockResolvedValue([run({ last_verdict: verdict({ parse: "contract_violation", items: [] }) })]);
+    render(<Scheduled />);
+
+    expect(await screen.findByText("Latest verdict unreadable")).toBeInTheDocument();
+  });
+
+  it("reads an empty item list as a real 'no calls' answer", async () => {
+    mocked.listScheduledRuns.mockResolvedValue([run({ last_verdict: verdict({ items: [] }) })]);
+    render(<Scheduled />);
+
+    expect(await screen.findByText(/No calls/)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- The Market Watch list now renders each monitor's latest verdict inline: the tracked symbols' states, the delta against the previous run when it changed, and the time it was recorded, so a verdict that stopped updating reads as stale.

Refs #943. This is the list half; the record side landed in #1152.

## Why

The issue's acceptance criteria, wired to the record shape from #1152:

- A monitor with no completed run gets an explicit empty state ("No verdict yet"), not a blank cell.
- A monitor built from an ad-hoc prompt sits at `no_verdict_section` permanently and correctly; its row renders nothing in that spot, never a warning or an error.
- A run whose verdict section was missing or malformed never shows a wrong verdict: malformed reads as "Latest verdict unreadable", and an empty-but-well-formed section reads as the real answer it is ("No calls").
- The delta and the recorded time come from the embedded `previous` and `recorded_at`, so the list keeps its single query.

## Changes

- `api.ts`: the `VerdictRecord`/`VerdictItem` wire types and `last_verdict` on `ScheduledRun`.
- `Scheduled.tsx`: the verdict cell. Ad-hoc monitors (`no_verdict_section`) return null; the other three states render the empty state, the unreadable marker, or the line with symbols, delta, and recorded time.
- The seven locale catalogs: the five new `scheduled.verdict*` strings.

## Test Plan

- [x] Existing tests pass (`pnpm vitest run src/pages/__tests__/Scheduled.test.tsx`: 16/16, five of them new)
- [x] New tests added: delta shown when the outcome moved, empty state, ad-hoc renders nothing, contract violation never shows a verdict, empty items read as "No calls"
- [x] Tested manually (describe below)

`tsc -b` is clean. Note on the wider local suite: five unrelated files (apiAuth, useDarkMode, storage) fail on main too under node 26's localStorage gate, so this branch's signal is the Scheduled suite plus CI.

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Documentation updated (the verdict cell's user-facing strings ship in all locale catalogs)
