### PR TITLE
feat(quantlib): factor risk decomposition with Euler marginal contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,7 +586,7 @@ Intraday bars: 1m / 5m / 15m / 30m / 1H / 4H / 1D. 15 metrics + benchmark compar
 </details>
 
 <details>
-<summary><b>Quant Library</b> <sub>265 tested functions across 19 modules, callable from every transport</sub></summary>
+<summary><b>Quant Library</b> <sub>267 tested functions across 19 modules, callable from every transport</sub></summary>
 
 `src/quantlib` holds one tested implementation of each piece of finance math the
 agent needs. Skills **import** these rather than carrying formulas inside

--- a/README_ar.md
+++ b/README_ar.md
@@ -582,7 +582,7 @@ LONGBRIDGE_ACCESS_TOKEN=...
 </details>
 
 <details>
-<summary><b>Quant Library</b> <sub>265 دالة مختبَرة عبر 19 وحدة، قابلة للاستدعاء من كل المسارات</sub></summary>
+<summary><b>Quant Library</b> <sub>267 دالة مختبَرة عبر 19 وحدة، قابلة للاستدعاء من كل المسارات</sub></summary>
 
 يحتفظ `src/quantlib` بتنفيذ مختبَر **واحد فقط** لكل قطعة من الرياضيات المالية التي
 يحتاجها الـ agent. صارت الـ skills **تستورد** هذه الدوال بدلاً من حمل الصيغ داخل كتل

--- a/README_es.md
+++ b/README_es.md
@@ -587,7 +587,7 @@ Barras intradía: 1m / 5m / 15m / 30m / 1H / 4H / 1D. 15 métricas + comparació
 </details>
 
 <details>
-<summary><b>Quant Library</b> <sub>265 funciones probadas en 19 módulos, invocables desde cualquier transporte</sub></summary>
+<summary><b>Quant Library</b> <sub>267 funciones probadas en 19 módulos, invocables desde cualquier transporte</sub></summary>
 
 `src/quantlib` contiene una implementación probada de cada pieza de matemática
 financiera que el agente necesita. Las skills **importan** estas funciones en

--- a/README_ja.md
+++ b/README_ja.md
@@ -582,7 +582,7 @@ Intraday bars: 1m / 5m / 15m / 30m / 1H / 4H / 1D. 15 metrics + benchmark compar
 </details>
 
 <details>
-<summary><b>Quant Library</b> <sub>19 モジュール・265 個のテスト済み関数、すべての経路から呼び出し可能</sub></summary>
+<summary><b>Quant Library</b> <sub>19 モジュール・267 個のテスト済み関数、すべての経路から呼び出し可能</sub></summary>
 
 `src/quantlib` は、agent が必要とする金融数学のそれぞれについて、テスト済みの実装を
 **1 つだけ**保持します。skill はこれらを **import** するようになり、markdown コード

--- a/README_ko.md
+++ b/README_ko.md
@@ -582,7 +582,7 @@ Intraday bars: 1m / 5m / 15m / 30m / 1H / 4H / 1D. 15 metrics + benchmark compar
 </details>
 
 <details>
-<summary><b>Quant Library</b> <sub>19개 모듈 265개의 테스트된 함수, 모든 경로에서 호출 가능</sub></summary>
+<summary><b>Quant Library</b> <sub>19개 모듈 267개의 테스트된 함수, 모든 경로에서 호출 가능</sub></summary>
 
 `src/quantlib`는 agent가 필요로 하는 각 금융 수학에 대해 테스트된 구현을 **하나씩만**
 보유합니다. skill은 이제 이 함수들을 **import**하며, markdown 코드 블록 안에 수식을

--- a/README_zh.md
+++ b/README_zh.md
@@ -579,7 +579,7 @@ LONGBRIDGE_ACCESS_TOKEN=...
 </details>
 
 <details>
-<summary><b>Quant Library</b> <sub>19 个模块 265 个经测试的函数，四条通路皆可调用</sub></summary>
+<summary><b>Quant Library</b> <sub>19 个模块 267 个经测试的函数，四条通路皆可调用</sub></summary>
 
 `src/quantlib` 为 agent 需要的每一块金融数学各提供**一份**经测试的实现。skill 现在是
 **import** 这些函数，而不再把公式抄在 markdown 代码块里——如果你在某个 `SKILL.md`

--- a/agent/src/quantlib/factormodel.py
+++ b/agent/src/quantlib/factormodel.py
@@ -620,7 +620,7 @@ def factor_risk_decomposition(
             f"No matching assets between weights ({sorted(w_series.index)}) and exposures ({sorted(exposures.index)})"
         )
 
-    unmatched_weight = float(w_series.drop(index=assets, errors="ignore").sum())
+    unmatched_weight = float(w_series.drop(index=assets, errors="ignore").abs().sum())
     w = w_series.loc[assets]
     X = exposures.loc[assets]
 

--- a/agent/src/quantlib/factormodel.py
+++ b/agent/src/quantlib/factormodel.py
@@ -62,6 +62,7 @@ __all__ = [
     "MIN_CROSS_SECTION",
     "STYLE_FACTOR_DEFINITIONS",
     "FactorReturnFit",
+    "FactorRiskDecomposition",
     "StyleDrift",
     "standardise_exposures",
     "build_style_exposures",
@@ -69,6 +70,7 @@ __all__ = [
     "portfolio_style_exposure",
     "style_drift",
     "factor_return_attribution",
+    "factor_risk_decomposition",
 ]
 
 #: Fraction trimmed from each tail before standardising.
@@ -157,6 +159,49 @@ class StyleDrift:
     total_change: pd.Series
     max_abs_change: pd.Series
 
+
+
+@dataclass(frozen=True)
+class FactorRiskDecomposition:
+    """Portfolio risk decomposition into factor and asset-specific components.
+
+    Attributes:
+        total_variance: Total portfolio variance.
+        total_volatility: Total portfolio volatility (standard deviation).
+        factor_variance: Portfolio variance explained by common factors.
+        factor_volatility: Portfolio volatility from common factors.
+        specific_variance: Portfolio variance from asset-specific (idiosyncratic) risk.
+        specific_volatility: Portfolio volatility from asset-specific risk.
+        factor_variance_fraction: Fraction of total variance explained by factors.
+        specific_variance_fraction: Fraction of total variance from idiosyncratic risk.
+        portfolio_exposures: Portfolio exposures across factors.
+        factor_marginal_contributions: Marginal contribution to risk (MCR) per factor.
+        factor_risk_contributions: Absolute risk contribution per factor (sums to factor risk).
+        factor_pcr: Percentage contribution to risk (PCR) per factor.
+        asset_marginal_contributions: Marginal contribution to risk (MCR) per asset.
+        asset_risk_contributions: Absolute risk contribution per asset (sums to total volatility).
+        asset_pcr: Percentage contribution to risk (PCR) per asset (sums to 1.0).
+        specific_risk_contributions: Specific risk contribution per asset.
+        specific_pcr: Percentage contribution from specific risk per asset.
+    """
+
+    total_variance: float
+    total_volatility: float
+    factor_variance: float
+    factor_volatility: float
+    specific_variance: float
+    specific_volatility: float
+    factor_variance_fraction: float
+    specific_variance_fraction: float
+    portfolio_exposures: pd.Series
+    factor_marginal_contributions: pd.Series
+    factor_risk_contributions: pd.Series
+    factor_pcr: pd.Series
+    asset_marginal_contributions: pd.Series
+    asset_risk_contributions: pd.Series
+    asset_pcr: pd.Series
+    specific_risk_contributions: pd.Series
+    specific_pcr: pd.Series
 
 def standardise_exposures(
     values: pd.Series,
@@ -513,3 +558,147 @@ def factor_return_attribution(
     contributions["specific"] = portfolio_return - explained
     contributions["total"] = portfolio_return
     return contributions
+
+
+def factor_risk_decomposition(
+    portfolio_weights: pd.Series | Mapping[str, float],
+    exposures: pd.DataFrame,
+    factor_cov: pd.DataFrame,
+    specific_variances: pd.Series | Mapping[str, float] | None = None,
+) -> FactorRiskDecomposition:
+    """Decompose portfolio risk into systematic factor and idiosyncratic components.
+
+    Implements the Euler homogeneous risk decomposition for multi-factor models
+    (Barra/Axioma standard framework):
+
+        Total Variance = w^T X Sigma_F X^T w + w^T D w
+
+    where:
+      * ``w`` is the portfolio weight vector (N x 1)
+      * ``X`` is the asset factor exposure matrix (N x K)
+      * ``Sigma_F`` is the factor covariance matrix (K x K)
+      * ``D`` is the diagonal matrix of specific variances (N x N)
+
+    Args:
+        portfolio_weights: Asset weights in the portfolio.
+        exposures: Asset factor exposures (rows = assets, columns = factors).
+        factor_cov: Covariance matrix of factor returns (K x K).
+        specific_variances: Asset-specific (idiosyncratic) return variances.
+            Defaults to zero if omitted.
+
+    Returns:
+        :class:`FactorRiskDecomposition` containing total/factor/specific
+        variances, volatilities, marginal contributions to risk (MCR), and
+        percentage contributions to risk (PCR) per factor and per asset.
+
+    Raises:
+        ValueError: If weights or matrices are empty, contain non-finite values,
+            or share no common assets or factors.
+    """
+    w_series = pd.Series(portfolio_weights, dtype=float)
+    if w_series.empty:
+        raise ValueError("portfolio_weights cannot be empty")
+    if not np.isfinite(w_series.values).all():
+        raise ValueError("portfolio_weights contains non-finite values")
+
+    if not isinstance(exposures, pd.DataFrame) or exposures.empty:
+        raise ValueError("exposures must be a non-empty DataFrame")
+    if not np.isfinite(exposures.values).all():
+        raise ValueError("exposures contains non-finite values")
+
+    if not isinstance(factor_cov, pd.DataFrame) or factor_cov.empty:
+        raise ValueError("factor_cov must be a non-empty DataFrame")
+    if not np.isfinite(factor_cov.values).all():
+        raise ValueError("factor_cov contains non-finite values")
+
+    # Align assets
+    assets = w_series.index.intersection(exposures.index)
+    if assets.empty:
+        raise ValueError(
+            f"No matching assets between weights ({sorted(w_series.index)}) and exposures ({sorted(exposures.index)})"
+        )
+
+    w = w_series.loc[assets]
+    X = exposures.loc[assets]
+
+    # Align factors
+    factors = X.columns.intersection(factor_cov.index).intersection(factor_cov.columns)
+    if factors.empty:
+        raise ValueError(
+            f"No matching factors between exposures ({sorted(X.columns)}) and factor_cov ({sorted(factor_cov.index)})"
+        )
+
+    X = X[factors]
+    F = factor_cov.loc[factors, factors]
+
+    # Align specific variances
+    if specific_variances is not None:
+        spec_var_s = pd.Series(specific_variances, dtype=float)
+        if not np.isfinite(spec_var_s.values).all():
+            raise ValueError("specific_variances contains non-finite values")
+        d = spec_var_s.reindex(assets, fill_value=0.0).clip(lower=0.0)
+    else:
+        d = pd.Series(0.0, index=assets, dtype=float)
+
+    # Portfolio factor exposure: x_p = X^T w (K x 1)
+    x_p = X.T.dot(w)
+
+    # Factor variance: x_p^T F x_p
+    F_x_p = F.dot(x_p)
+    factor_var = float(np.maximum(0.0, x_p.dot(F_x_p)))
+    factor_vol = float(np.sqrt(factor_var))
+
+    # Specific variance: sum(w_i^2 * d_i)
+    spec_var = float(np.maximum(0.0, (w**2 * d).sum()))
+    spec_vol = float(np.sqrt(spec_var))
+
+    total_var = float(np.maximum(0.0, factor_var + spec_var))
+    total_vol = float(np.sqrt(total_var))
+
+    var_denom = total_var if total_var > 0 else 1.0
+    factor_var_frac = factor_var / var_denom if total_var > 0 else 0.0
+    spec_var_frac = spec_var / var_denom if total_var > 0 else 0.0
+
+    if total_vol > 0:
+        # Factor MCR = (F x_p) / total_vol
+        factor_mcr = F_x_p / total_vol
+        factor_rc = x_p * factor_mcr
+        factor_pcr = factor_rc / total_vol
+
+        # Specific risk contribution per asset = (w_i^2 * d_i) / total_vol
+        spec_rc = (w**2 * d) / total_vol
+        spec_pcr = spec_rc / total_vol
+
+        # Asset MCR = (X (F x_p) + d * w) / total_vol
+        asset_mcr = (X.dot(F_x_p) + d * w) / total_vol
+        asset_rc = w * asset_mcr
+        asset_pcr = asset_rc / total_vol
+    else:
+        factor_mcr = pd.Series(0.0, index=factors, dtype=float)
+        factor_rc = pd.Series(0.0, index=factors, dtype=float)
+        factor_pcr = pd.Series(0.0, index=factors, dtype=float)
+        spec_rc = pd.Series(0.0, index=assets, dtype=float)
+        spec_pcr = pd.Series(0.0, index=assets, dtype=float)
+        asset_mcr = pd.Series(0.0, index=assets, dtype=float)
+        asset_rc = pd.Series(0.0, index=assets, dtype=float)
+        asset_pcr = pd.Series(0.0, index=assets, dtype=float)
+
+    return FactorRiskDecomposition(
+        total_variance=total_var,
+        total_volatility=total_vol,
+        factor_variance=factor_var,
+        factor_volatility=factor_vol,
+        specific_variance=spec_var,
+        specific_volatility=spec_vol,
+        factor_variance_fraction=factor_var_frac,
+        specific_variance_fraction=spec_var_frac,
+        portfolio_exposures=x_p,
+        factor_marginal_contributions=factor_mcr,
+        factor_risk_contributions=factor_rc,
+        factor_pcr=factor_pcr,
+        asset_marginal_contributions=asset_mcr,
+        asset_risk_contributions=asset_rc,
+        asset_pcr=asset_pcr,
+        specific_risk_contributions=spec_rc,
+        specific_pcr=spec_pcr,
+    )

--- a/agent/src/quantlib/factormodel.py
+++ b/agent/src/quantlib/factormodel.py
@@ -180,7 +180,7 @@ class FactorRiskDecomposition:
         factor_pcr: Percentage contribution to risk (PCR) per factor.
         asset_marginal_contributions: Marginal contribution to risk (MCR) per asset.
         asset_risk_contributions: Absolute risk contribution per asset (sums to total volatility).
-        asset_pcr: Percentage contribution to risk (PCR) per asset (sums to 1.0).
+        asset_pcr: Percentage contribution to risk (PCR) per asset (sums to 1.0 when total_volatility > 0, otherwise zero).
         specific_risk_contributions: Specific risk contribution per asset.
         specific_pcr: Percentage contribution from specific risk per asset.
     """
@@ -630,6 +630,12 @@ def factor_risk_decomposition(
 
     X = X[factors]
     F = factor_cov.loc[factors, factors]
+    F_mat = F.to_numpy(dtype=float)
+    if not np.allclose(F_mat, F_mat.T, atol=1e-8):
+        raise ValueError("factor_cov matrix must be symmetric")
+    eigvals = np.linalg.eigvalsh(F_mat)
+    if np.min(eigvals) < -1e-8:
+        raise ValueError("factor_cov matrix must be positive semi-definite")
 
     # Align specific variances
     if specific_variances is not None:

--- a/agent/src/quantlib/factormodel.py
+++ b/agent/src/quantlib/factormodel.py
@@ -183,6 +183,7 @@ class FactorRiskDecomposition:
         asset_pcr: Percentage contribution to risk (PCR) per asset (sums to 1.0 when total_volatility > 0, otherwise zero).
         specific_risk_contributions: Specific risk contribution per asset.
         specific_pcr: Percentage contribution from specific risk per asset.
+        unmatched_weight: Portfolio weight in assets lacking factor exposure data.
     """
 
     total_variance: float
@@ -202,6 +203,7 @@ class FactorRiskDecomposition:
     asset_pcr: pd.Series
     specific_risk_contributions: pd.Series
     specific_pcr: pd.Series
+    unmatched_weight: float = 0.0
 
 def standardise_exposures(
     values: pd.Series,
@@ -618,6 +620,7 @@ def factor_risk_decomposition(
             f"No matching assets between weights ({sorted(w_series.index)}) and exposures ({sorted(exposures.index)})"
         )
 
+    unmatched_weight = float(w_series.drop(index=assets, errors="ignore").sum())
     w = w_series.loc[assets]
     X = exposures.loc[assets]
 
@@ -707,4 +710,5 @@ def factor_risk_decomposition(
         asset_pcr=asset_pcr,
         specific_risk_contributions=spec_rc,
         specific_pcr=spec_pcr,
+        unmatched_weight=unmatched_weight,
     )

--- a/agent/tests/quantlib/test_factormodel.py
+++ b/agent/tests/quantlib/test_factormodel.py
@@ -14,9 +14,12 @@ from src.quantlib.factormodel import (
     MARKET_FACTOR,
     MIN_CROSS_SECTION,
     STYLE_FACTOR_DEFINITIONS,
+    FactorReturnFit,
+    FactorRiskDecomposition,
     build_style_exposures,
     cross_sectional_factor_returns,
     factor_return_attribution,
+    factor_risk_decomposition,
     portfolio_style_exposure,
     standardise_exposures,
     style_drift,
@@ -424,4 +427,124 @@ def test_attribution_rejects_disjoint_factor_sets():
     with pytest.raises(ValueError, match="share no factor"):
         factor_return_attribution(
             pd.Series({"value": 1.0}), pd.Series({"momentum": 0.01}), portfolio_return=0.0
+        )
+
+# --- risk decomposition ---
+
+
+def test_factor_risk_decomposition_euler_sum_identities():
+    assets = _assets(4)
+    factors = ["market", "value", "momentum"]
+    weights = pd.Series([0.4, 0.3, 0.2, 0.1], index=assets)
+    exposures = pd.DataFrame(
+        [
+            [1.0, 0.5, -0.2],
+            [0.9, -0.4, 0.8],
+            [1.1, 0.2, 0.5],
+            [0.8, -0.1, -0.6],
+        ],
+        index=assets,
+        columns=factors,
+    )
+    factor_cov = pd.DataFrame(
+        [
+            [0.04, 0.005, -0.002],
+            [0.005, 0.02, 0.001],
+            [-0.002, 0.001, 0.03],
+        ],
+        index=factors,
+        columns=factors,
+    )
+    specific_vars = pd.Series([0.01, 0.015, 0.02, 0.008], index=assets)
+
+    decomp = factor_risk_decomposition(
+        portfolio_weights=weights,
+        exposures=exposures,
+        factor_cov=factor_cov,
+        specific_variances=specific_vars,
+    )
+
+    assert isinstance(decomp, FactorRiskDecomposition)
+    # 1. Total variance = factor_variance + specific_variance
+    assert decomp.total_variance == pytest.approx(
+        decomp.factor_variance + decomp.specific_variance, abs=1e-12
+    )
+    assert decomp.total_volatility == pytest.approx(np.sqrt(decomp.total_variance), abs=1e-12)
+
+    # 2. Variance fractions sum to 1.0
+    assert decomp.factor_variance_fraction + decomp.specific_variance_fraction == pytest.approx(
+        1.0, abs=1e-12
+    )
+
+    # 3. Euler decomposition across assets: sum(asset_risk_contributions) == total_volatility
+    assert float(decomp.asset_risk_contributions.sum()) == pytest.approx(
+        decomp.total_volatility, abs=1e-12
+    )
+
+    # 4. Asset PCR sum to 1.0 (100%)
+    assert float(decomp.asset_pcr.sum()) == pytest.approx(1.0, abs=1e-12)
+
+    # 5. Factor risk + specific risk = total volatility
+    total_rc_by_factors = (
+        float(decomp.factor_risk_contributions.sum()) + float(decomp.specific_risk_contributions.sum())
+    )
+    assert total_rc_by_factors == pytest.approx(decomp.total_volatility, abs=1e-12)
+
+    # 6. Factor PCR + specific PCR = 1.0
+    assert float(decomp.factor_pcr.sum()) + float(decomp.specific_pcr.sum()) == pytest.approx(
+        1.0, abs=1e-12
+    )
+
+
+def test_factor_risk_decomposition_without_specific_variance():
+    assets = _assets(2)
+    factors = ["market"]
+    weights = pd.Series([0.6, 0.4], index=assets)
+    exposures = pd.DataFrame([[1.0], [1.0]], index=assets, columns=factors)
+    factor_cov = pd.DataFrame([[0.04]], index=factors, columns=factors)
+
+    decomp = factor_risk_decomposition(weights, exposures, factor_cov)
+
+    assert decomp.specific_variance == 0.0
+    assert decomp.specific_volatility == 0.0
+    assert decomp.factor_variance_fraction == 1.0
+    assert decomp.specific_variance_fraction == 0.0
+    # Portfolio beta is 1.0, vol is sqrt(0.04) = 0.20
+    assert decomp.total_volatility == pytest.approx(0.20, abs=1e-12)
+    assert decomp.factor_risk_contributions["market"] == pytest.approx(0.20, abs=1e-12)
+
+
+def test_factor_risk_decomposition_zero_weights_safe():
+    assets = _assets(2)
+    factors = ["market"]
+    weights = pd.Series([0.0, 0.0], index=assets)
+    exposures = pd.DataFrame([[1.0], [1.0]], index=assets, columns=factors)
+    factor_cov = pd.DataFrame([[0.04]], index=factors, columns=factors)
+
+    decomp = factor_risk_decomposition(weights, exposures, factor_cov)
+    assert decomp.total_variance == 0.0
+    assert decomp.total_volatility == 0.0
+    assert (decomp.asset_risk_contributions == 0.0).all()
+    assert (decomp.asset_pcr == 0.0).all()
+
+
+def test_factor_risk_decomposition_input_validation():
+    assets = _assets(2)
+    factors = ["market"]
+    weights = pd.Series([0.5, 0.5], index=assets)
+    exposures = pd.DataFrame([[1.0], [1.0]], index=assets, columns=factors)
+    factor_cov = pd.DataFrame([[0.04]], index=factors, columns=factors)
+
+    with pytest.raises(ValueError, match="weights cannot be empty"):
+        factor_risk_decomposition(pd.Series(dtype=float), exposures, factor_cov)
+
+    with pytest.raises(ValueError, match="non-finite"):
+        factor_risk_decomposition(pd.Series([np.nan, 0.5], index=assets), exposures, factor_cov)
+
+    with pytest.raises(ValueError, match="No matching assets"):
+        factor_risk_decomposition(pd.Series([0.5, 0.5], index=["X1", "X2"]), exposures, factor_cov)
+
+    with pytest.raises(ValueError, match="No matching factors"):
+        factor_risk_decomposition(
+            weights, exposures, pd.DataFrame([[0.04]], index=["other"], columns=["other"])
         )

--- a/agent/tests/quantlib/test_factormodel.py
+++ b/agent/tests/quantlib/test_factormodel.py
@@ -562,3 +562,13 @@ def test_factor_risk_decomposition_input_validation():
             pd.DataFrame([[1.0], [1.0]], index=["A", "B"], columns=["F1"]),
             pd.DataFrame([[-0.04]], index=["F1"], columns=["F1"]),
         )
+
+
+def test_factor_risk_decomposition_reports_unmatched_weight():
+    weights = pd.Series([0.6, 0.4], index=["A", "UNCOVERED"])
+    exposures = pd.DataFrame([[1.0]], index=["A"], columns=["market"])
+    factor_cov = pd.DataFrame([[0.04]], index=["market"], columns=["market"])
+
+    decomp = factor_risk_decomposition(weights, exposures, factor_cov)
+    assert decomp.unmatched_weight == pytest.approx(0.4)
+    assert decomp.total_volatility == pytest.approx(0.6 * 0.20)

--- a/agent/tests/quantlib/test_factormodel.py
+++ b/agent/tests/quantlib/test_factormodel.py
@@ -548,3 +548,17 @@ def test_factor_risk_decomposition_input_validation():
         factor_risk_decomposition(
             weights, exposures, pd.DataFrame([[0.04]], index=["other"], columns=["other"])
         )
+
+    with pytest.raises(ValueError, match="symmetric"):
+        factor_risk_decomposition(
+            pd.Series([0.5, 0.5], index=["A", "B"]),
+            pd.DataFrame([[1.0, 0.5], [0.5, 1.0]], index=["A", "B"], columns=["F1", "F2"]),
+            pd.DataFrame([[0.04, 0.01], [0.03, 0.04]], index=["F1", "F2"], columns=["F1", "F2"]),
+        )
+
+    with pytest.raises(ValueError, match="positive semi-definite"):
+        factor_risk_decomposition(
+            pd.Series([0.5, 0.5], index=["A", "B"]),
+            pd.DataFrame([[1.0], [1.0]], index=["A", "B"], columns=["F1"]),
+            pd.DataFrame([[-0.04]], index=["F1"], columns=["F1"]),
+        )


### PR DESCRIPTION
Add factor_risk_decomposition to compute portfolio factor variance, specific risk, factor variance fractions, and Euler marginal risk contributions under linear multi-factor models.

Validates input covariance symmetry and positive-semidefiniteness, and tracks unmapped holdings in unmatched_weight.