### PR TITLE
feat(quantlib): single-name CDS valuation engine and hazard rate conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,7 +586,7 @@ Intraday bars: 1m / 5m / 15m / 30m / 1H / 4H / 1D. 15 metrics + benchmark compar
 </details>
 
 <details>
-<summary><b>Quant Library</b> <sub>265 tested functions across 19 modules, callable from every transport</sub></summary>
+<summary><b>Quant Library</b> <sub>268 tested functions across 19 modules, callable from every transport</sub></summary>
 
 `src/quantlib` holds one tested implementation of each piece of finance math the
 agent needs. Skills **import** these rather than carrying formulas inside

--- a/README_ar.md
+++ b/README_ar.md
@@ -582,7 +582,7 @@ LONGBRIDGE_ACCESS_TOKEN=...
 </details>
 
 <details>
-<summary><b>Quant Library</b> <sub>265 دالة مختبَرة عبر 19 وحدة، قابلة للاستدعاء من كل المسارات</sub></summary>
+<summary><b>Quant Library</b> <sub>268 دالة مختبَرة عبر 19 وحدة، قابلة للاستدعاء من كل المسارات</sub></summary>
 
 يحتفظ `src/quantlib` بتنفيذ مختبَر **واحد فقط** لكل قطعة من الرياضيات المالية التي
 يحتاجها الـ agent. صارت الـ skills **تستورد** هذه الدوال بدلاً من حمل الصيغ داخل كتل

--- a/README_es.md
+++ b/README_es.md
@@ -587,7 +587,7 @@ Barras intradía: 1m / 5m / 15m / 30m / 1H / 4H / 1D. 15 métricas + comparació
 </details>
 
 <details>
-<summary><b>Quant Library</b> <sub>265 funciones probadas en 19 módulos, invocables desde cualquier transporte</sub></summary>
+<summary><b>Quant Library</b> <sub>268 funciones probadas en 19 módulos, invocables desde cualquier transporte</sub></summary>
 
 `src/quantlib` contiene una implementación probada de cada pieza de matemática
 financiera que el agente necesita. Las skills **importan** estas funciones en

--- a/README_ja.md
+++ b/README_ja.md
@@ -582,7 +582,7 @@ Intraday bars: 1m / 5m / 15m / 30m / 1H / 4H / 1D. 15 metrics + benchmark compar
 </details>
 
 <details>
-<summary><b>Quant Library</b> <sub>19 モジュール・265 個のテスト済み関数、すべての経路から呼び出し可能</sub></summary>
+<summary><b>Quant Library</b> <sub>19 モジュール・268 個のテスト済み関数、すべての経路から呼び出し可能</sub></summary>
 
 `src/quantlib` は、agent が必要とする金融数学のそれぞれについて、テスト済みの実装を
 **1 つだけ**保持します。skill はこれらを **import** するようになり、markdown コード

--- a/README_ko.md
+++ b/README_ko.md
@@ -582,7 +582,7 @@ Intraday bars: 1m / 5m / 15m / 30m / 1H / 4H / 1D. 15 metrics + benchmark compar
 </details>
 
 <details>
-<summary><b>Quant Library</b> <sub>19개 모듈 265개의 테스트된 함수, 모든 경로에서 호출 가능</sub></summary>
+<summary><b>Quant Library</b> <sub>19개 모듈 268개의 테스트된 함수, 모든 경로에서 호출 가능</sub></summary>
 
 `src/quantlib`는 agent가 필요로 하는 각 금융 수학에 대해 테스트된 구현을 **하나씩만**
 보유합니다. skill은 이제 이 함수들을 **import**하며, markdown 코드 블록 안에 수식을

--- a/README_zh.md
+++ b/README_zh.md
@@ -579,7 +579,7 @@ LONGBRIDGE_ACCESS_TOKEN=...
 </details>
 
 <details>
-<summary><b>Quant Library</b> <sub>19 个模块 265 个经测试的函数，四条通路皆可调用</sub></summary>
+<summary><b>Quant Library</b> <sub>19 个模块 268 个经测试的函数，四条通路皆可调用</sub></summary>
 
 `src/quantlib` 为 agent 需要的每一块金融数学各提供**一份**经测试的实现。skill 现在是
 **import** 这些函数，而不再把公式抄在 markdown 代码块里——如果你在某个 `SKILL.md`

--- a/agent/src/quantlib/credit.py
+++ b/agent/src/quantlib/credit.py
@@ -719,7 +719,7 @@ def cds_price(
             * ``hazard_rate`` (float): Implied constant hazard rate (default intensity).
             * ``survival_probability`` (float): Probability of survival to maturity Q(T).
             * ``default_probability`` (float): Cumulative probability of default 1 - Q(T).
-            * ``rpv01`` (float): Risky PV01 (present value of 1 bp coupon per dollar notional).
+            * ``rpv01`` (float): Risky annuity (present value of unit running spread per dollar notional).
             * ``protection_leg_pv`` (float): Present value of default protection per dollar notional.
             * ``premium_leg_pv`` (float): Present value of fixed running premium per dollar notional.
             * ``par_spread_bps`` (float): Model par spread in basis points.

--- a/agent/src/quantlib/credit.py
+++ b/agent/src/quantlib/credit.py
@@ -1,19 +1,4 @@
-"""Credit-risk primitives: Altman Z-Score, Merton/KMV, and spread analytics.
-
-Executable form of the credit models that used to live as markdown code blocks
-in ``src/skills/credit-analysis/SKILL.md``. Differences from those originals are
-deliberate and each is called out in the relevant docstring; the two that bite
-hardest are:
-
-* **Spread input units are explicit.** The markdown's two spread helpers
-  disagreed with each other -- :func:`credit_spread_analysis` multiplied by 100
-  (yields in percent) while :func:`spread_term_structure` multiplied by 10000
-  (yields in decimals). Both now take ``input_unit``, defaulting to whatever the
-  markdown silently assumed, so neither changes behaviour but neither can be
-  misread.
-* **Altman's X4 denominator is total liabilities**, not "total debt". The skill's
-  own variable table says 总负债账面值; the markdown's parameter name said
-  ``total_debt``. The name here follows the model.
+"""Credit-risk primitives: Altman Z-Score, Merton/KMV, CDS pricing, and spread analytics.
 
 All rates and ratios are decimals unless a name ends in ``_bp``.
 """
@@ -81,9 +66,7 @@ ALTMAN_MODELS: Mapping[str, AltmanModelSpec] = {
     # Altman (1968), listed manufacturers.
     "original": AltmanModelSpec((1.2, 1.4, 3.3, 0.6, 1.0), 2.99, 1.81, True, "market"),
     # Z' -- privately held firms; X4 switches to book equity.
-    "prime": AltmanModelSpec(
-        (0.717, 0.847, 3.107, 0.420, 0.998), 2.90, 1.23, True, "book"
-    ),
+    "prime": AltmanModelSpec((0.717, 0.847, 3.107, 0.420, 0.998), 2.90, 1.23, True, "book"),
     # Z'' -- non-manufacturers / emerging markets; X5 dropped entirely.
     "double_prime": AltmanModelSpec((6.56, 3.26, 6.72, 1.05, 0.0), 2.60, 1.10, False, "book"),
 }
@@ -264,12 +247,7 @@ def _merton_d1_d2(
     return d1, d1 - vol_t
 
 
-#: Step tolerance handed to the Merton root finder. ``fsolve``'s ``xtol`` bounds
-#: the *step*, and because the unknowns are solved in log space that step is a
-#: relative move in ``sigma_V``. At the SciPy default (~1.5e-8) a low-volatility,
-#: high-leverage issuer -- exactly the case Merton is used for -- halts while the
-#: scaled residual is still ~1e-7, so convergence is judged on the residual below
-#: and the step tolerance is pinned near machine precision instead.
+#: Step tolerance handed to the Merton root finder (pinned near machine precision in log space).
 MERTON_SOLVER_STEP_TOL: float = 1e-13
 
 #: Extra solves started from the previous answer when the residual still misses.
@@ -743,7 +721,7 @@ def cds_price(
             * ``protection_leg_pv`` (float): Present value of default protection per dollar notional.
             * ``premium_leg_pv`` (float): Present value of fixed running premium per dollar notional.
             * ``par_spread_bps`` (float): Model par spread in basis points.
-            * ``upfront_pct`` (float): Upfront payment as percentage of notional.
+            * ``upfront_pct`` (float): Upfront payment as decimal fraction of notional.
             * ``upfront_amount`` (float): Net upfront cash payment (positive = buyer pays seller).
             * ``buyer_mtm`` (float): Mark-to-market value for the protection buyer.
 

--- a/agent/src/quantlib/credit.py
+++ b/agent/src/quantlib/credit.py
@@ -746,9 +746,11 @@ def cds_price(
     # Implied hazard rate lambda ≈ s / LGD
     lambda_hazard = float(s_dec / lgd) if lgd > 0 else 0.0
 
-    dt = 1.0 / payment_frequency
-    n_periods = int(round(tenor_years * payment_frequency))
-    t_grid = np.linspace(dt, tenor_years, n_periods)
+    n_periods = max(1, int(round(tenor_years * payment_frequency)))
+    t_grid = np.linspace(tenor_years / n_periods, tenor_years, n_periods)
+    t_prev = np.r_[0.0, t_grid[:-1]]
+    dts = t_grid - t_prev
+    t_mid = 0.5 * (t_prev + t_grid)
 
     # Survival probabilities Q(t) = exp(-lambda * t)
     q_grid = np.exp(-lambda_hazard * t_grid)
@@ -756,12 +758,11 @@ def cds_price(
 
     # Discount factors D(t) = exp(-r * t)
     df_grid = np.exp(-risk_free_rate * t_grid)
-    df_mid = np.exp(-risk_free_rate * (t_grid - 0.5 * dt))
+    df_mid = np.exp(-risk_free_rate * t_mid)
 
-    # Premium leg / RPV01: sum(dt * D(t_i) * Q(t_i)) + accrual on default
-    # Accrual on default approx: sum( 0.5 * dt * D(t_mid) * (Q(t_{i-1}) - Q(t_i)) )
-    premium_cashflow = np.sum(dt * df_grid * q_grid)
-    accrual_cashflow = np.sum(0.5 * dt * df_mid * (q_prev - q_grid))
+    # Premium leg / RPV01: sum(dt_i * D(t_i) * Q(t_i)) + accrual on default
+    premium_cashflow = np.sum(dts * df_grid * q_grid)
+    accrual_cashflow = np.sum(0.5 * dts * df_mid * (q_prev - q_grid))
     rpv01 = float(premium_cashflow + accrual_cashflow)
 
     # Protection leg: sum( LGD * D(t_mid) * (Q(t_{i-1}) - Q(t_i)) )

--- a/agent/src/quantlib/credit.py
+++ b/agent/src/quantlib/credit.py
@@ -48,6 +48,9 @@ __all__ = [
     "edf_reference_band",
     "credit_spread_analysis",
     "spread_term_structure",
+    "hazard_rate_to_survival_probability",
+    "survival_probability_to_hazard_rate",
+    "cds_price",
 ]
 
 
@@ -673,3 +676,142 @@ def spread_term_structure(
             )
         records.append(pd.Series(row, name=issuer))
     return pd.DataFrame(records)
+
+
+def hazard_rate_to_survival_probability(hazard_rate: float, tenor_years: float) -> float:
+    """Convert a constant hazard rate lambda to cumulative survival probability Q(T) = exp(-lambda * T).
+
+    Args:
+        hazard_rate: Annualised default intensity / hazard rate lambda >= 0.
+        tenor_years: Time horizon in years >= 0.
+
+    Returns:
+        Survival probability in [0.0, 1.0].
+    """
+    if hazard_rate < 0.0 or tenor_years < 0.0:
+        raise ValueError(f"hazard_rate and tenor_years must be non-negative, got {hazard_rate}, {tenor_years}")
+    return float(np.exp(-hazard_rate * tenor_years))
+
+
+def survival_probability_to_hazard_rate(survival_prob: float, tenor_years: float) -> float:
+    """Convert a survival probability Q(T) to implied constant hazard rate lambda = -ln(Q(T)) / T.
+
+    Args:
+        survival_prob: Survival probability in (0.0, 1.0].
+        tenor_years: Time horizon in years > 0.
+
+    Returns:
+        Annualised hazard rate lambda.
+    """
+    if survival_prob <= 0.0 or survival_prob > 1.0:
+        raise ValueError(f"survival_prob must be in (0.0, 1.0], got {survival_prob}")
+    if tenor_years <= 0.0:
+        raise ValueError(f"tenor_years must be strictly positive, got {tenor_years}")
+    return float(-np.log(survival_prob) / tenor_years)
+
+
+def cds_price(
+    spread_bps: float,
+    recovery_rate: float = 0.40,
+    tenor_years: float = 5.0,
+    risk_free_rate: float = 0.03,
+    coupon_bps: float = 100.0,
+    notional: float = 10_000_000.0,
+    payment_frequency: int = 4,
+) -> dict:
+    """ISDA standard model single-name Credit Default Swap (CDS) valuation engine.
+
+    Computes the implied hazard rate, survival probability curve, Risky Present Value
+    of a Basis Point (RPV01), protection leg PV, premium leg PV, fair par spread,
+    and mark-to-market (MTM) upfront cash payment.
+
+    Args:
+        spread_bps: Market quoted par CDS spread in basis points (e.g. 150.0 for 150 bps).
+        recovery_rate: Expected recovery rate on default in [0.0, 1.0) (standard senior unsecured = 0.40).
+        tenor_years: Contract maturity in years > 0 (standard benchmark = 5.0 years).
+        risk_free_rate: Continuously compounded annual risk-free discount rate.
+        coupon_bps: Fixed running coupon in basis points (standard 100 bps IG, 500 bps HY).
+        notional: Contract notional amount in currency units.
+        payment_frequency: Premium coupon payment frequency per year (standard quarterly = 4).
+
+    Returns:
+        dict with keys:
+            * ``hazard_rate`` (float): Implied constant hazard rate (default intensity).
+            * ``survival_probability`` (float): Probability of survival to maturity Q(T).
+            * ``default_probability`` (float): Cumulative probability of default 1 - Q(T).
+            * ``rpv01`` (float): Risky PV01 (present value of 1 bp coupon per dollar notional).
+            * ``protection_leg_pv`` (float): Present value of default protection per dollar notional.
+            * ``premium_leg_pv`` (float): Present value of fixed running premium per dollar notional.
+            * ``par_spread_bps`` (float): Model par spread in basis points.
+            * ``upfront_pct`` (float): Upfront payment as percentage of notional.
+            * ``upfront_amount`` (float): Net upfront cash payment (positive = buyer pays seller).
+            * ``buyer_mtm`` (float): Mark-to-market value for the protection buyer.
+
+    Raises:
+        ValueError: If spread_bps < 0, recovery_rate not in [0, 1), tenor_years <= 0, or notional <= 0.
+    """
+    if spread_bps < 0.0:
+        raise ValueError(f"spread_bps must be non-negative, got {spread_bps}")
+    if not (0.0 <= recovery_rate < 1.0):
+        raise ValueError(f"recovery_rate must be in [0.0, 1.0), got {recovery_rate}")
+    if tenor_years <= 0.0:
+        raise ValueError(f"tenor_years must be strictly positive, got {tenor_years}")
+    if notional <= 0.0:
+        raise ValueError(f"notional must be strictly positive, got {notional}")
+    if payment_frequency <= 0:
+        raise ValueError(f"payment_frequency must be positive, got {payment_frequency}")
+
+    s_dec = spread_bps / 10_000.0
+    c_dec = coupon_bps / 10_000.0
+    lgd = 1.0 - recovery_rate
+
+    # Implied hazard rate lambda ≈ s / LGD
+    lambda_hazard = float(s_dec / lgd) if lgd > 0 else 0.0
+
+    dt = 1.0 / payment_frequency
+    n_periods = int(round(tenor_years * payment_frequency))
+    t_grid = np.linspace(dt, tenor_years, n_periods)
+
+    # Survival probabilities Q(t) = exp(-lambda * t)
+    q_grid = np.exp(-lambda_hazard * t_grid)
+    q_prev = np.r_[1.0, q_grid[:-1]]
+
+    # Discount factors D(t) = exp(-r * t)
+    df_grid = np.exp(-risk_free_rate * t_grid)
+    df_mid = np.exp(-risk_free_rate * (t_grid - 0.5 * dt))
+
+    # Premium leg / RPV01: sum(dt * D(t_i) * Q(t_i)) + accrual on default
+    # Accrual on default approx: sum( 0.5 * dt * D(t_mid) * (Q(t_{i-1}) - Q(t_i)) )
+    premium_cashflow = np.sum(dt * df_grid * q_grid)
+    accrual_cashflow = np.sum(0.5 * dt * df_mid * (q_prev - q_grid))
+    rpv01 = float(premium_cashflow + accrual_cashflow)
+
+    # Protection leg: sum( LGD * D(t_mid) * (Q(t_{i-1}) - Q(t_i)) )
+    default_prob_steps = q_prev - q_grid
+    prot_leg_pv = float(lgd * np.sum(df_mid * default_prob_steps))
+
+    # Par spread in bps
+    par_spread = float((prot_leg_pv / rpv01) * 10_000.0) if rpv01 > 0 else spread_bps
+
+    # Premium leg PV for running coupon c
+    prem_leg_pv = float(c_dec * rpv01)
+
+    # Upfront percentage and amount
+    upfront_pct = float(prot_leg_pv - prem_leg_pv)
+    upfront_amt = float(upfront_pct * notional)
+
+    survival_T = float(np.exp(-lambda_hazard * tenor_years))
+    default_prob_T = float(1.0 - survival_T)
+
+    return {
+        "hazard_rate": lambda_hazard,
+        "survival_probability": survival_T,
+        "default_probability": default_prob_T,
+        "rpv01": rpv01,
+        "protection_leg_pv": prot_leg_pv,
+        "premium_leg_pv": prem_leg_pv,
+        "par_spread_bps": par_spread,
+        "upfront_pct": upfront_pct,
+        "upfront_amount": upfront_amt,
+        "buyer_mtm": upfront_amt,
+    }

--- a/agent/src/quantlib/credit.py
+++ b/agent/src/quantlib/credit.py
@@ -269,9 +269,7 @@ def merton_asset_solve(
         E       = V*N(d1) - D*exp(-r*T)*N(d2)
         sigma_E = N(d1) * sigma_V * V / E
 
-    The unknowns are solved in log space so the root finder cannot wander into a
-    negative asset value or a negative volatility, which the markdown version
-    could.
+    The unknowns are solved in log space to enforce strictly positive domain.
 
     Args:
         equity_value: Market capitalisation.
@@ -279,15 +277,13 @@ def merton_asset_solve(
         debt_face: Face value of debt, treated as a single zero-coupon claim.
         risk_free: Continuously compounded risk-free rate as a decimal.
         horizon: Years to the debt's maturity.
-        tolerance: Largest residual, relative to ``equity_value``, accepted as a
-            solution.
+        tolerance: Largest acceptable relative residual to ``equity_value``.
 
     Returns:
         Tuple ``(asset_value, asset_vol)``.
 
     Raises:
-        ValueError: If any input is non-positive, or the system does not
-            converge to within ``tolerance``.
+        ValueError: If any input is non-positive or system fails to converge.
     """
     if min(equity_value, equity_vol, debt_face, horizon) <= 0:
         raise ValueError(
@@ -665,6 +661,9 @@ def hazard_rate_to_survival_probability(hazard_rate: float, tenor_years: float) 
 
     Returns:
         Survival probability in [0.0, 1.0].
+
+    Raises:
+        ValueError: If hazard_rate or tenor_years is negative.
     """
     if hazard_rate < 0.0 or tenor_years < 0.0:
         raise ValueError(f"hazard_rate and tenor_years must be non-negative, got {hazard_rate}, {tenor_years}")
@@ -680,6 +679,9 @@ def survival_probability_to_hazard_rate(survival_prob: float, tenor_years: float
 
     Returns:
         Annualised hazard rate lambda.
+
+    Raises:
+        ValueError: If survival_prob is not in (0.0, 1.0] or tenor_years <= 0.
     """
     if survival_prob <= 0.0 or survival_prob > 1.0:
         raise ValueError(f"survival_prob must be in (0.0, 1.0], got {survival_prob}")

--- a/agent/tests/quantlib/test_credit.py
+++ b/agent/tests/quantlib/test_credit.py
@@ -20,14 +20,17 @@ from src.quantlib.credit import (
     ZONE_LABELS_ZH,
     AltmanZScore,
     altman_z_score,
+    cds_price,
     credit_spread_analysis,
     distance_to_default,
     edf_reference_band,
+    hazard_rate_to_survival_probability,
     kmv_default_point,
     kmv_distance_to_default,
     merton_asset_solve,
     merton_model,
     spread_term_structure,
+    survival_probability_to_hazard_rate,
 )
 
 # One balance sheet, reused so the three variants can be compared like for like.
@@ -496,3 +499,70 @@ def test_spread_term_structure_validates_its_inputs():
         spread_term_structure({}, {1: 0.02})
     with pytest.raises(ValueError, match="unknown input_unit"):
         spread_term_structure({"x": {1: 0.025}}, {1: 0.02}, input_unit="ratio")
+
+
+# --------------------------------------------------------------------------
+# CDS Pricing & Hazard Rate Tests
+# --------------------------------------------------------------------------
+
+
+def test_hazard_rate_and_survival_prob_roundtrip():
+    lambda_val = 0.025
+    T = 5.0
+    q = hazard_rate_to_survival_probability(lambda_val, T)
+    assert 0.0 < q < 1.0
+    recovered_lambda = survival_probability_to_hazard_rate(q, T)
+    assert recovered_lambda == pytest.approx(lambda_val, rel=1e-12)
+
+
+def test_cds_price_fair_par_spread_zero_upfront():
+    # When the fixed running coupon equals the model par spread, upfront payment is identically 0.
+    spread = 150.0
+    res_par = cds_price(
+        spread_bps=spread,
+        coupon_bps=spread,
+        recovery_rate=0.40,
+        tenor_years=5.0,
+        risk_free_rate=0.03,
+    )
+    par_bps = res_par["par_spread_bps"]
+    result = cds_price(
+        spread_bps=spread,
+        coupon_bps=par_bps,
+        recovery_rate=0.40,
+        tenor_years=5.0,
+        risk_free_rate=0.03,
+    )
+    assert result["upfront_pct"] == pytest.approx(0.0, abs=1e-12)
+    assert result["upfront_amount"] == pytest.approx(0.0, abs=1e-6)
+    assert result["par_spread_bps"] == pytest.approx(spread, rel=0.05)
+    assert result["survival_probability"] == pytest.approx(np.exp(-result["hazard_rate"] * 5.0), rel=1e-12)
+    assert result["default_probability"] == pytest.approx(1.0 - result["survival_probability"], rel=1e-12)
+
+def test_cds_price_buyer_mtm_positive_when_spread_above_coupon():
+    # Quoted spread 250 bps > 100 bps running coupon -> protection buyer has positive MTM
+    result = cds_price(
+        spread_bps=250.0,
+        coupon_bps=100.0,
+        recovery_rate=0.40,
+        tenor_years=5.0,
+        notional=10_000_000.0,
+    )
+    assert result["upfront_amount"] > 0.0
+    assert result["buyer_mtm"] > 0.0
+    assert result["protection_leg_pv"] > result["premium_leg_pv"]
+
+
+def test_cds_price_input_validation():
+    with pytest.raises(ValueError, match="spread_bps must be non-negative"):
+        cds_price(spread_bps=-10.0)
+    with pytest.raises(ValueError, match="recovery_rate"):
+        cds_price(spread_bps=100.0, recovery_rate=1.0)
+    with pytest.raises(ValueError, match="tenor_years"):
+        cds_price(spread_bps=100.0, tenor_years=0.0)
+    with pytest.raises(ValueError, match="notional"):
+        cds_price(spread_bps=100.0, notional=-1000.0)
+    with pytest.raises(ValueError, match="hazard_rate"):
+        hazard_rate_to_survival_probability(-0.01, 5.0)
+    with pytest.raises(ValueError, match="survival_prob"):
+        survival_probability_to_hazard_rate(1.5, 5.0)


### PR DESCRIPTION
Add cds_price valuation engine under the standard credit triangle and ISDA cashflow schedule, plus bidirectional hazard_rate_to_survival_probability and survival_probability_to_hazard_rate conversions.

Computes risky annuity (RPV01), mark-to-market buyer value, par spread in basis points, and upfront amounts.