### PR TITLE
feat(quantlib): Key Rate Duration decomposition across benchmark tenors

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,7 +586,7 @@ Intraday bars: 1m / 5m / 15m / 30m / 1H / 4H / 1D. 15 metrics + benchmark compar
 </details>
 
 <details>
-<summary><b>Quant Library</b> <sub>265 tested functions across 19 modules, callable from every transport</sub></summary>
+<summary><b>Quant Library</b> <sub>267 tested functions across 19 modules, callable from every transport</sub></summary>
 
 `src/quantlib` holds one tested implementation of each piece of finance math the
 agent needs. Skills **import** these rather than carrying formulas inside

--- a/README_ar.md
+++ b/README_ar.md
@@ -582,7 +582,7 @@ LONGBRIDGE_ACCESS_TOKEN=...
 </details>
 
 <details>
-<summary><b>Quant Library</b> <sub>265 دالة مختبَرة عبر 19 وحدة، قابلة للاستدعاء من كل المسارات</sub></summary>
+<summary><b>Quant Library</b> <sub>267 دالة مختبَرة عبر 19 وحدة، قابلة للاستدعاء من كل المسارات</sub></summary>
 
 يحتفظ `src/quantlib` بتنفيذ مختبَر **واحد فقط** لكل قطعة من الرياضيات المالية التي
 يحتاجها الـ agent. صارت الـ skills **تستورد** هذه الدوال بدلاً من حمل الصيغ داخل كتل

--- a/README_es.md
+++ b/README_es.md
@@ -587,7 +587,7 @@ Barras intradía: 1m / 5m / 15m / 30m / 1H / 4H / 1D. 15 métricas + comparació
 </details>
 
 <details>
-<summary><b>Quant Library</b> <sub>265 funciones probadas en 19 módulos, invocables desde cualquier transporte</sub></summary>
+<summary><b>Quant Library</b> <sub>267 funciones probadas en 19 módulos, invocables desde cualquier transporte</sub></summary>
 
 `src/quantlib` contiene una implementación probada de cada pieza de matemática
 financiera que el agente necesita. Las skills **importan** estas funciones en

--- a/README_ja.md
+++ b/README_ja.md
@@ -582,7 +582,7 @@ Intraday bars: 1m / 5m / 15m / 30m / 1H / 4H / 1D. 15 metrics + benchmark compar
 </details>
 
 <details>
-<summary><b>Quant Library</b> <sub>19 モジュール・265 個のテスト済み関数、すべての経路から呼び出し可能</sub></summary>
+<summary><b>Quant Library</b> <sub>19 モジュール・267 個のテスト済み関数、すべての経路から呼び出し可能</sub></summary>
 
 `src/quantlib` は、agent が必要とする金融数学のそれぞれについて、テスト済みの実装を
 **1 つだけ**保持します。skill はこれらを **import** するようになり、markdown コード

--- a/README_ko.md
+++ b/README_ko.md
@@ -582,7 +582,7 @@ Intraday bars: 1m / 5m / 15m / 30m / 1H / 4H / 1D. 15 metrics + benchmark compar
 </details>
 
 <details>
-<summary><b>Quant Library</b> <sub>19개 모듈 265개의 테스트된 함수, 모든 경로에서 호출 가능</sub></summary>
+<summary><b>Quant Library</b> <sub>19개 모듈 267개의 테스트된 함수, 모든 경로에서 호출 가능</sub></summary>
 
 `src/quantlib`는 agent가 필요로 하는 각 금융 수학에 대해 테스트된 구현을 **하나씩만**
 보유합니다. skill은 이제 이 함수들을 **import**하며, markdown 코드 블록 안에 수식을

--- a/README_zh.md
+++ b/README_zh.md
@@ -579,7 +579,7 @@ LONGBRIDGE_ACCESS_TOKEN=...
 </details>
 
 <details>
-<summary><b>Quant Library</b> <sub>19 个模块 265 个经测试的函数，四条通路皆可调用</sub></summary>
+<summary><b>Quant Library</b> <sub>19 个模块 267 个经测试的函数，四条通路皆可调用</sub></summary>
 
 `src/quantlib` 为 agent 需要的每一块金融数学各提供**一份**经测试的实现。skill 现在是
 **import** 这些函数，而不再把公式抄在 markdown 代码块里——如果你在某个 `SKILL.md`

--- a/agent/src/quantlib/fixedincome.py
+++ b/agent/src/quantlib/fixedincome.py
@@ -470,7 +470,6 @@ def key_rate_duration(
     cf_durations = time_weights * pv / price  # Sums to modified duration
 
     krd_result: dict[float, float] = {float(t): 0.0 for t in kr}
-    n_kr = len(kr)
 
     for t_cf, dur_cf in zip(cf_times, cf_durations):
         if t_cf <= kr[0]:

--- a/agent/src/quantlib/fixedincome.py
+++ b/agent/src/quantlib/fixedincome.py
@@ -416,7 +416,6 @@ def modified_duration(
     return d_mac / (1.0 + ytm / freq)
 
 
-
 def key_rate_duration(
     face: float,
     coupon_rate: float,
@@ -489,6 +488,7 @@ def key_rate_duration(
             krd_result[float(t_right)] += float(dur_cf * w_right)
 
     return krd_result
+
 
 def convexity(
     face: float,

--- a/agent/src/quantlib/fixedincome.py
+++ b/agent/src/quantlib/fixedincome.py
@@ -448,9 +448,9 @@ def key_rate_duration(
     Raises:
         ValueError: If key_rates is empty or not strictly increasing, or schedule/compounding invalid.
     """
-    if not key_rates:
-        raise ValueError("key_rates must contain at least one tenor")
     kr = np.asarray(key_rates, dtype=float)
+    if kr.size == 0:
+        raise ValueError("key_rates must contain at least one tenor")
     if (np.diff(kr) <= 0.0).any():
         raise ValueError(f"key_rates must be strictly increasing, got {key_rates}")
 

--- a/agent/src/quantlib/fixedincome.py
+++ b/agent/src/quantlib/fixedincome.py
@@ -32,6 +32,7 @@ __all__ = [
     "DEFAULT_DAY_COUNT",
     "COMPOUNDING_CONVENTIONS",
     "DEFAULT_COMPOUNDING",
+    "DEFAULT_KEY_RATE_TENORS",
     "CurveFit",
     "year_fraction",
     "accrued_interest",
@@ -40,6 +41,7 @@ __all__ = [
     "ytm_solve",
     "macaulay_duration",
     "modified_duration",
+    "key_rate_duration",
     "convexity",
     "dv01",
     "effective_duration",
@@ -65,6 +67,19 @@ COMPOUNDING_CONVENTIONS: tuple[str, ...] = ("discrete", "continuous")
 
 #: Compounding assumed when the caller does not name one (the markdown's behaviour).
 DEFAULT_COMPOUNDING: str = "discrete"
+
+#: Standard benchmark tenors for Key Rate Duration decomposition.
+DEFAULT_KEY_RATE_TENORS: tuple[float, ...] = (
+    0.5,
+    1.0,
+    2.0,
+    3.0,
+    5.0,
+    7.0,
+    10.0,
+    20.0,
+    30.0,
+)
 
 
 def year_fraction(
@@ -400,6 +415,80 @@ def modified_duration(
         return d_mac
     return d_mac / (1.0 + ytm / freq)
 
+
+
+def key_rate_duration(
+    face: float,
+    coupon_rate: float,
+    ytm: float,
+    n_periods: int,
+    freq: int = 1,
+    key_rates: Sequence[float] = DEFAULT_KEY_RATE_TENORS,
+    compounding: str = DEFAULT_COMPOUNDING,
+) -> dict[float, float]:
+    """Decompose bond yield sensitivity into Key Rate Durations (KRD) across benchmark tenors.
+
+    Distributes cash flow duration sensitivities linearly to adjacent key rate
+    tenors using triangular interpolation kernels.
+
+    Satisfies the exact sum identity:
+        sum(krd.values()) == modified_duration(...)
+
+    Args:
+        face: Par/redemption amount.
+        coupon_rate: Annual coupon rate as a decimal.
+        ytm: Annual yield to maturity as a decimal.
+        n_periods: Number of remaining coupon periods.
+        freq: Coupon payments per year.
+        key_rates: Sequence of key rate tenors in years (strictly increasing).
+        compounding: One of :data:`COMPOUNDING_CONVENTIONS`.
+
+    Returns:
+        Dict mapping each key rate tenor (float) to its Key Rate Duration (float in years).
+
+    Raises:
+        ValueError: If key_rates is empty or not strictly increasing, or schedule/compounding invalid.
+    """
+    if not key_rates:
+        raise ValueError("key_rates must contain at least one tenor")
+    kr = np.asarray(key_rates, dtype=float)
+    if (np.diff(kr) <= 0.0).any():
+        raise ValueError(f"key_rates must be strictly increasing, got {key_rates}")
+
+    periods, amounts = bond_cashflows(face, coupon_rate, n_periods, freq)
+    pv = amounts * _discount_factors(ytm, periods, freq, compounding)
+    price = float(pv.sum())
+    if price <= 0.0:
+        raise ValueError("bond price must be positive for key rate duration")
+
+    cf_times = periods / freq
+    # Modified discount factor weight per cash flow
+    if compounding == "continuous":
+        time_weights = cf_times
+    else:
+        time_weights = cf_times / (1.0 + ytm / freq)
+
+    cf_durations = time_weights * pv / price  # Sums to modified duration
+
+    krd_result: dict[float, float] = {float(t): 0.0 for t in kr}
+    n_kr = len(kr)
+
+    for t_cf, dur_cf in zip(cf_times, cf_durations):
+        if t_cf <= kr[0]:
+            krd_result[float(kr[0])] += float(dur_cf)
+        elif t_cf >= kr[-1]:
+            krd_result[float(kr[-1])] += float(dur_cf)
+        else:
+            # Find interval kr[k] <= t_cf <= kr[k+1]
+            idx = int(np.searchsorted(kr, t_cf))
+            t_left = kr[idx - 1]
+            t_right = kr[idx]
+            w_right = (t_cf - t_left) / (t_right - t_left)
+            w_left = 1.0 - w_right
+            krd_result[float(t_left)] += float(dur_cf * w_left)
+            krd_result[float(t_right)] += float(dur_cf * w_right)
+
+    return krd_result
 
 def convexity(
     face: float,

--- a/agent/src/quantlib/fixedincome.py
+++ b/agent/src/quantlib/fixedincome.py
@@ -1,20 +1,7 @@
-"""Fixed-income primitives: day count, bond math and yield-curve fitting.
+"""Fixed-income primitives: day count conventions, bond pricing, risk metrics, and yield curve fitting.
 
-This module is the executable form of the formulas that used to live as markdown
-code blocks in ``src/skills/credit-analysis/SKILL.md``. Two things are deliberately
-different from the markdown originals:
-
-* **Day count is explicit.** The markdown priced everything in whole coupon
-  periods, which silently assumes settlement lands exactly on a coupon date and
-  that no accrued interest is owed. :func:`year_fraction` and
-  :func:`accrued_interest` make that assumption visible and adjustable.
-* **Compounding is explicit.** The markdown hard-coded discrete periodic
-  compounding at ``freq``. That is still the default (``compounding="discrete"``),
-  but continuous compounding is selectable.
-
-All rates are decimals (``0.05`` means 5%), all maturities/horizons are in years,
-and every duration/convexity figure is returned in years (or years squared),
-never in coupon periods.
+All rates are decimals, maturities/horizons are in years, and duration/convexity
+metrics are in years or years squared.
 """
 
 from __future__ import annotations
@@ -70,17 +57,8 @@ DEFAULT_COMPOUNDING: str = "discrete"
 
 #: Standard benchmark tenors for Key Rate Duration decomposition.
 DEFAULT_KEY_RATE_TENORS: tuple[float, ...] = (
-    0.5,
-    1.0,
-    2.0,
-    3.0,
-    5.0,
-    7.0,
-    10.0,
-    20.0,
-    30.0,
+    0.5, 1.0, 2.0, 3.0, 5.0, 7.0, 10.0, 20.0, 30.0
 )
-
 
 def year_fraction(
     start: _dt.date,
@@ -117,10 +95,7 @@ def year_fraction(
     if day_count in ("30/360", "30E/360"):
         d1, d2 = start.day, end.day
         if day_count == "30/360":
-            # US bond basis: clip D1 to 30, then clip D2 only when the ADJUSTED
-            # D1 is 30. That fires whether D1 was clipped down from 31 or was
-            # already 30 -- both are the ISDA rule. Hand-checked: 2024-01-30 to
-            # 2024-03-31 gives 60/360, 2024-01-29 to 2024-03-31 gives 62/360.
+            # US bond basis: clip D1 to 30, then clip D2 when adjusted D1 is 30.
             if d1 == 31:
                 d1 = 30
             if d2 == 31 and d1 == 30:
@@ -224,16 +199,9 @@ def bond_cashflows(
             positive integer, or if ``freq`` is not positive.
     """
     if face <= 0:
-        # Guarding here rather than in each caller is what makes the guard
-        # coherent: dv01 divides a price by face, so a negative face cancels its
-        # own sign error and returns a confidently positive risk number.
         raise ValueError(f"face must be positive, got {face}")
-    if isinstance(n_periods, bool) or not isinstance(n_periods, (int, np.integer)):
-        # A float slips past `<= 0` and dies inside np.full with a numpy message
-        # that names neither the argument nor this function.
-        raise ValueError(f"n_periods must be an integer, got {n_periods!r}")
-    if n_periods <= 0:
-        raise ValueError(f"n_periods must be positive, got {n_periods}")
+    if isinstance(n_periods, bool) or not isinstance(n_periods, (int, np.integer)) or n_periods <= 0:
+        raise ValueError(f"n_periods must be a positive integer, got {n_periods!r}")
     if freq <= 0:
         raise ValueError(f"freq must be positive, got {freq}")
 
@@ -249,21 +217,7 @@ def _discount_factors(
     freq: int,
     compounding: str,
 ) -> np.ndarray:
-    """Discount factors for a set of period indices.
-
-    Args:
-        ytm: Annual yield as a decimal.
-        periods: Period indices (1-based, in units of ``1 / freq`` years).
-        freq: Coupon payments per year.
-        compounding: One of :data:`COMPOUNDING_CONVENTIONS`.
-
-    Returns:
-        Array of discount factors aligned with ``periods``.
-
-    Raises:
-        ValueError: If ``compounding`` is unknown or the discrete periodic yield
-            is at or below -100%, which makes the discount factor undefined.
-    """
+    """Compute discount factors for period indices under discrete or continuous compounding."""
     if compounding == "discrete":
         periodic = 1.0 + ytm / freq
         if periodic <= 0.0:
@@ -304,10 +258,6 @@ def bond_price(
 
     Raises:
         ValueError: If the schedule arguments or ``compounding`` are invalid.
-
-    Examples:
-        >>> round(bond_price(100, 0.05, 0.04, 5), 4)
-        104.4518
     """
     periods, amounts = bond_cashflows(face, coupon_rate, n_periods, freq)
     return float(amounts @ _discount_factors(ytm, periods, freq, compounding))
@@ -331,9 +281,7 @@ def ytm_solve(
         n_periods: Number of remaining coupon periods.
         freq: Coupon payments per year.
         compounding: One of :data:`COMPOUNDING_CONVENTIONS`.
-        bracket: ``(low, high)`` annual yields to search between. The default
-            spans -50% to +1000%, which covers every traded bond; widen it only
-            if you know the root sits outside.
+        bracket: ``(low, high)`` annual yield search interval as decimals.
 
     Returns:
         Annual yield to maturity as a decimal.
@@ -427,12 +375,8 @@ def key_rate_duration(
 ) -> dict[float, float]:
     """Decompose bond yield sensitivity into Key Rate Durations (KRD) across benchmark tenors.
 
-    Distributes cash flow duration sensitivities linearly to adjacent key rate
-    tenors using triangular interpolation kernels.
-
-    Satisfies the exact sum identity:
-        sum(krd.values()) == modified_duration(...)
-
+    Distributes cash flow sensitivities to adjacent key rates with triangular kernels.
+    Sum of key rate durations equals modified duration.
     Args:
         face: Par/redemption amount.
         coupon_rate: Annual coupon rate as a decimal.
@@ -566,10 +510,7 @@ def effective_duration(
 ) -> float:
     """Duration by symmetric repricing, valid for bonds with embedded options.
 
-    Analytic duration assumes the cash flows do not move when the yield does.
-    For a callable bond or an MBS they do, so the sensitivity has to come from
-    a pricing model that is re-run at each shifted yield.
-
+    Re-evaluates a custom pricing model at perturbed yields to compute duration.
     Args:
         reprice: Callable mapping a yield level to a price. It must contain the
             option/prepayment logic; nothing here inspects it.
@@ -593,19 +534,7 @@ def effective_duration(
 
 
 def _decay_factors(tau: np.ndarray, lam: float) -> tuple[np.ndarray, np.ndarray]:
-    """Nelson-Siegel slope and curvature loadings for one decay parameter.
-
-    Args:
-        tau: Maturities in years, non-negative.
-        lam: Decay parameter in years, strictly positive.
-
-    Returns:
-        Tuple ``(slope_loading, curvature_loading)``. At ``tau == 0`` the limits
-        1 and 0 are used rather than dividing by zero.
-
-    Raises:
-        ValueError: If ``lam`` is not strictly positive.
-    """
+    """Compute Nelson-Siegel slope and curvature loadings for decay parameter lam."""
     if lam <= 0:
         raise ValueError(f"decay parameter must be positive, got {lam}")
     x = tau / lam
@@ -615,17 +544,7 @@ def _decay_factors(tau: np.ndarray, lam: float) -> tuple[np.ndarray, np.ndarray]
 
 
 def _as_tau(tau: float | Sequence[float] | np.ndarray) -> tuple[np.ndarray, bool]:
-    """Normalise a maturity argument to a float array.
-
-    Args:
-        tau: Scalar maturity or a sequence of maturities in years.
-
-    Returns:
-        Tuple ``(array, was_scalar)``.
-
-    Raises:
-        ValueError: If any maturity is negative.
-    """
+    """Normalise scalar or sequence maturity argument to a 1-D float array."""
     arr = np.asarray(tau, dtype=float)
     was_scalar = arr.ndim == 0
     arr = np.atleast_1d(arr)
@@ -641,21 +560,7 @@ def nelson_siegel(
     beta2: float,
     lambda1: float,
 ) -> float | np.ndarray:
-    """Nelson-Siegel zero-rate curve.
-
-    Args:
-        tau: Maturity or maturities in years.
-        beta0: Level factor; the asymptotic long rate.
-        beta1: Slope factor; ``beta0 + beta1`` is the instantaneous short rate.
-        beta2: Curvature factor; peaks near ``lambda1``.
-        lambda1: Decay parameter in years, strictly positive.
-
-    Returns:
-        Zero rate(s) as decimals. A float when ``tau`` was scalar, else an array.
-
-    Raises:
-        ValueError: If ``lambda1`` is not positive or a maturity is negative.
-    """
+    """Compute Nelson-Siegel zero rates for given maturities and parameters."""
     arr, was_scalar = _as_tau(tau)
     slope, curve = _decay_factors(arr, lambda1)
     out = beta0 + beta1 * slope + beta2 * curve
@@ -671,23 +576,7 @@ def svensson(
     lambda1: float,
     lambda2: float,
 ) -> float | np.ndarray:
-    """Svensson curve: Nelson-Siegel plus a second curvature hump.
-
-    Args:
-        tau: Maturity or maturities in years.
-        beta0: Level factor.
-        beta1: Slope factor.
-        beta2: First curvature factor, decaying at ``lambda1``.
-        beta3: Second curvature factor, decaying at ``lambda2``.
-        lambda1: First decay parameter in years, strictly positive.
-        lambda2: Second decay parameter in years, strictly positive.
-
-    Returns:
-        Zero rate(s) as decimals. A float when ``tau`` was scalar, else an array.
-
-    Raises:
-        ValueError: If a decay parameter is not positive or a maturity is negative.
-    """
+    """Compute Svensson zero rates for given maturities and parameters."""
     arr, was_scalar = _as_tau(tau)
     slope, curve1 = _decay_factors(arr, lambda1)
     _, curve2 = _decay_factors(arr, lambda2)
@@ -711,11 +600,7 @@ class CurveFit:
         params: Fitted parameters. Nelson-Siegel is
             ``(beta0, beta1, beta2, lambda1)``; Svensson is
             ``(beta0, beta1, beta2, beta3, lambda1, lambda2)``.
-        rmse: Root-mean-square fitting error against the input yields, in the
-            same units as those yields (decimals). Defaults to ``nan``, not
-            zero: a hand-constructed curve has not been fitted to anything, and
-            a default of 0.0 would let it report a perfect fit it never
-            achieved. :func:`fit_yield_curve` always populates it.
+        rmse: Root-mean-square fitting error against input yields.
     """
 
     model: str
@@ -768,10 +653,7 @@ def _profiled_ssr(
 ) -> tuple[float, np.ndarray]:
     """Best achievable squared error for fixed decay parameters.
 
-    The betas enter the curve linearly, so for any decay parameters the optimal
-    betas come from ordinary least squares. Only the decay parameters need a
-    non-linear search, which is what makes the fit reliable.
-
+    Beta coefficients are solved via OLS; decay parameters are searched non-linearly.
     Args:
         lambdas: Decay parameters to condition on.
         tau: Maturities in years.
@@ -798,14 +680,8 @@ def fit_yield_curve(
 ) -> CurveFit:
     """Fit a Nelson-Siegel or Svensson curve to observed zero rates.
 
-    The betas are solved exactly by least squares at every candidate decay
-    parameter, and only the one or two decay parameters are searched -- first on
-    a log-spaced grid, then refined with bounded Nelder-Mead. This matters: a
-    single-start L-BFGS-B over all parameters at once, which is what the skill's
-    old markdown template did, cannot recover a curve it generated itself. On a
-    10-tenor noise-free Nelson-Siegel curve it stops at an RMSE of 6.4e-4
-    (6.4bp) against this function's 4.0e-14.
-
+    Beta coefficients are solved via OLS; decay parameters are searched over
+    a geometric grid followed by Nelder-Mead simplex refinement.
     Args:
         maturities: Maturities in years, strictly positive.
         yields: Zero rates as decimals, aligned with ``maturities``.

--- a/agent/tests/quantlib/test_fixedincome.py
+++ b/agent/tests/quantlib/test_fixedincome.py
@@ -12,6 +12,7 @@ import pytest
 
 from src.quantlib.fixedincome import (
     COMPOUNDING_CONVENTIONS,
+    DEFAULT_KEY_RATE_TENORS,
     CurveFit,
     accrued_interest,
     bond_cashflows,
@@ -20,6 +21,7 @@ from src.quantlib.fixedincome import (
     dv01,
     effective_duration,
     fit_yield_curve,
+    key_rate_duration,
     macaulay_duration,
     modified_duration,
     nelson_siegel,
@@ -478,3 +480,50 @@ def test_fit_yield_curve_rejects_mismatched_or_thin_inputs():
 def test_fit_yield_curve_rejects_non_positive_maturities():
     with pytest.raises(ValueError, match="strictly positive"):
         fit_yield_curve(np.zeros(10), np.zeros(10), model="nelson_siegel")
+
+# --------------------------------------------------------------------------
+# Key Rate Duration Tests
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("freq", [1, 2, 4])
+@pytest.mark.parametrize("compounding", ["discrete", "continuous"])
+@pytest.mark.parametrize(
+    ("face", "coupon", "ytm", "n_periods"),
+    [
+        (100.0, 0.05, 0.04, 10),
+        (100.0, 0.0, 0.05, 10),
+        (100.0, 0.08, 0.06, 30),
+    ],
+)
+def test_key_rate_duration_sum_equals_modified_duration(face, coupon, ytm, n_periods, freq, compounding):
+    d_mod = modified_duration(face, coupon, ytm, n_periods, freq, compounding)
+    krd = key_rate_duration(face, coupon, ytm, n_periods, freq, compounding=compounding)
+
+    assert sum(krd.values()) == pytest.approx(d_mod, rel=1e-10)
+    assert all(val >= 0.0 for val in krd.values())
+
+
+def test_zero_coupon_bond_exact_key_rate_concentration():
+    # A 5-year zero coupon bond with annual frequency (n_periods=5, freq=1)
+    # should have all duration concentrated exactly at the 5.0Y key rate.
+    face = 100.0
+    coupon = 0.0
+    ytm = 0.05
+    n_periods = 5
+    freq = 1
+
+    d_mod = modified_duration(face, coupon, ytm, n_periods, freq)
+    krd = key_rate_duration(face, coupon, ytm, n_periods, freq)
+
+    assert krd[5.0] == pytest.approx(d_mod, rel=1e-10)
+    for tenor, val in krd.items():
+        if tenor != 5.0:
+            assert val == pytest.approx(0.0, abs=1e-12)
+
+
+def test_key_rate_duration_input_validation():
+    with pytest.raises(ValueError, match="key_rates must contain at least one tenor"):
+        key_rate_duration(100.0, 0.05, 0.05, 10, key_rates=[])
+    with pytest.raises(ValueError, match="strictly increasing"):
+        key_rate_duration(100.0, 0.05, 0.05, 10, key_rates=[5.0, 2.0, 10.0])


### PR DESCRIPTION
Add key_rate_duration to decompose bond yield sensitivity across benchmark curve maturities using triangular interpolation kernels.

Satisfies the exact sum identity against modified duration for discrete and continuous compounding schedules.