### PR TITLE
feat(quantlib): group-purged k-fold cross-validation for panel data

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,7 +586,7 @@ Intraday bars: 1m / 5m / 15m / 30m / 1H / 4H / 1D. 15 metrics + benchmark compar
 </details>
 
 <details>
-<summary><b>Quant Library</b> <sub>265 tested functions across 19 modules, callable from every transport</sub></summary>
+<summary><b>Quant Library</b> <sub>266 tested functions across 19 modules, callable from every transport</sub></summary>
 
 `src/quantlib` holds one tested implementation of each piece of finance math the
 agent needs. Skills **import** these rather than carrying formulas inside

--- a/README_ar.md
+++ b/README_ar.md
@@ -582,7 +582,7 @@ LONGBRIDGE_ACCESS_TOKEN=...
 </details>
 
 <details>
-<summary><b>Quant Library</b> <sub>265 دالة مختبَرة عبر 19 وحدة، قابلة للاستدعاء من كل المسارات</sub></summary>
+<summary><b>Quant Library</b> <sub>266 دالة مختبَرة عبر 19 وحدة، قابلة للاستدعاء من كل المسارات</sub></summary>
 
 يحتفظ `src/quantlib` بتنفيذ مختبَر **واحد فقط** لكل قطعة من الرياضيات المالية التي
 يحتاجها الـ agent. صارت الـ skills **تستورد** هذه الدوال بدلاً من حمل الصيغ داخل كتل

--- a/README_es.md
+++ b/README_es.md
@@ -587,7 +587,7 @@ Barras intradía: 1m / 5m / 15m / 30m / 1H / 4H / 1D. 15 métricas + comparació
 </details>
 
 <details>
-<summary><b>Quant Library</b> <sub>265 funciones probadas en 19 módulos, invocables desde cualquier transporte</sub></summary>
+<summary><b>Quant Library</b> <sub>266 funciones probadas en 19 módulos, invocables desde cualquier transporte</sub></summary>
 
 `src/quantlib` contiene una implementación probada de cada pieza de matemática
 financiera que el agente necesita. Las skills **importan** estas funciones en

--- a/README_ja.md
+++ b/README_ja.md
@@ -582,7 +582,7 @@ Intraday bars: 1m / 5m / 15m / 30m / 1H / 4H / 1D. 15 metrics + benchmark compar
 </details>
 
 <details>
-<summary><b>Quant Library</b> <sub>19 モジュール・265 個のテスト済み関数、すべての経路から呼び出し可能</sub></summary>
+<summary><b>Quant Library</b> <sub>19 モジュール・266 個のテスト済み関数、すべての経路から呼び出し可能</sub></summary>
 
 `src/quantlib` は、agent が必要とする金融数学のそれぞれについて、テスト済みの実装を
 **1 つだけ**保持します。skill はこれらを **import** するようになり、markdown コード

--- a/README_ko.md
+++ b/README_ko.md
@@ -582,7 +582,7 @@ Intraday bars: 1m / 5m / 15m / 30m / 1H / 4H / 1D. 15 metrics + benchmark compar
 </details>
 
 <details>
-<summary><b>Quant Library</b> <sub>19개 모듈 265개의 테스트된 함수, 모든 경로에서 호출 가능</sub></summary>
+<summary><b>Quant Library</b> <sub>19개 모듈 266개의 테스트된 함수, 모든 경로에서 호출 가능</sub></summary>
 
 `src/quantlib`는 agent가 필요로 하는 각 금융 수학에 대해 테스트된 구현을 **하나씩만**
 보유합니다. skill은 이제 이 함수들을 **import**하며, markdown 코드 블록 안에 수식을

--- a/README_zh.md
+++ b/README_zh.md
@@ -579,7 +579,7 @@ LONGBRIDGE_ACCESS_TOKEN=...
 </details>
 
 <details>
-<summary><b>Quant Library</b> <sub>19 个模块 265 个经测试的函数，四条通路皆可调用</sub></summary>
+<summary><b>Quant Library</b> <sub>19 个模块 266 个经测试的函数，四条通路皆可调用</sub></summary>
 
 `src/quantlib` 为 agent 需要的每一块金融数学各提供**一份**经测试的实现。skill 现在是
 **import** 这些函数，而不再把公式抄在 markdown 代码块里——如果你在某个 `SKILL.md`

--- a/agent/src/quantlib/crossvalidation.py
+++ b/agent/src/quantlib/crossvalidation.py
@@ -335,7 +335,8 @@ def group_purged_kfold_splits(
 
         test_rows_list = [group_to_rows[g] for g in unique_groups[start_g:stop_g]]
         test_rows = np.concatenate(test_rows_list) if test_rows_list else np.array([], dtype=int)
-
+        if test_rows.size == 0:
+            continue
         train_rows_list = []
         for g in unique_groups:
             if g not in test_groups and g not in embargo_groups_set:

--- a/agent/src/quantlib/crossvalidation.py
+++ b/agent/src/quantlib/crossvalidation.py
@@ -270,7 +270,6 @@ def purged_kfold_splits(
         )
 
 
-
 def group_purged_kfold_splits(
     groups: Sequence[object] | pd.Series | np.ndarray,
     n_folds: int = 5,
@@ -355,6 +354,7 @@ def group_purged_kfold_splits(
             embargoed=embargoed_count,
             test_bounds=(int(test_rows.min()), int(test_rows.max())),
         )
+
 
 def purged_walk_forward_splits(
     n_samples: int,

--- a/agent/src/quantlib/crossvalidation.py
+++ b/agent/src/quantlib/crossvalidation.py
@@ -52,6 +52,7 @@ __all__ = [
     "Split",
     "combinatorial_purged_splits",
     "detect_boundary_leakage",
+    "group_purged_kfold_splits",
     "purged_kfold_splits",
     "purged_walk_forward_splits",
 ]
@@ -268,6 +269,91 @@ def purged_kfold_splits(
             test_bounds=(start, stop - 1),
         )
 
+
+
+def group_purged_kfold_splits(
+    groups: Sequence[object] | pd.Series | np.ndarray,
+    n_folds: int = 5,
+    embargo_fraction: float = DEFAULT_EMBARGO_FRACTION,
+) -> Iterator[Split]:
+    """Purged and embargoed K-fold cross-validation for panel and multi-asset datasets.
+
+    Groups all observations sharing a time group identifier (e.g. date or bar timestamp)
+    so that simultaneous observations across different assets are never split across
+    train and test partitions.
+
+    Args:
+        groups: Group identifiers (e.g. dates or bar index) for each sample row in order.
+        n_folds: Number of folds, at least :data:`MIN_FOLDS`.
+        embargo_fraction: Fraction of unique ordered groups embargoed after each test block.
+
+    Yields:
+        One :class:`Split` per fold, with ``train`` and ``test`` containing row indices.
+
+    Raises:
+        ValueError: If ``n_folds`` is invalid, fewer unique groups than folds exist,
+            or ``embargo_fraction`` is out of bounds.
+    """
+    if n_folds < MIN_FOLDS:
+        raise ValueError(f"n_folds must be at least {MIN_FOLDS}, got {n_folds}")
+    if not 0.0 <= embargo_fraction < 1.0:
+        raise ValueError(f"embargo_fraction must be in [0, 1), got {embargo_fraction}")
+
+    grp_array = np.asarray(groups)
+    n_samples = len(grp_array)
+    if n_samples == 0:
+        raise ValueError("groups array cannot be empty")
+
+    # Find unique groups preserving chronological order of appearance
+    unique_groups, first_indices = np.unique(grp_array, return_index=True)
+    # Sort by appearance order
+    order = np.argsort(first_indices)
+    unique_groups = unique_groups[order]
+    n_groups = len(unique_groups)
+
+    if n_groups < n_folds:
+        raise ValueError(f"{n_groups} unique groups cannot make {n_folds} folds")
+
+    # Map each group to its member row indices
+    group_to_rows: dict[object, np.ndarray] = {}
+    for idx, g in enumerate(grp_array):
+        group_to_rows.setdefault(g, []).append(idx)
+    for g in group_to_rows:
+        group_to_rows[g] = np.array(group_to_rows[g], dtype=int)
+
+    embargo_groups = int(round(n_groups * embargo_fraction))
+    boundaries = np.linspace(0, n_groups, n_folds + 1).astype(int)
+
+    for fold in range(n_folds):
+        start_g, stop_g = int(boundaries[fold]), int(boundaries[fold + 1])
+        if stop_g <= start_g:
+            continue
+
+        test_groups = set(unique_groups[start_g:stop_g])
+        embargo_end_g = min(n_groups, stop_g + embargo_groups)
+        embargo_groups_set = set(unique_groups[stop_g:embargo_end_g])
+
+        test_rows_list = [group_to_rows[g] for g in unique_groups[start_g:stop_g]]
+        test_rows = np.concatenate(test_rows_list) if test_rows_list else np.array([], dtype=int)
+
+        train_rows_list = []
+        for g in unique_groups:
+            if g not in test_groups and g not in embargo_groups_set:
+                train_rows_list.append(group_to_rows[g])
+
+        train_rows = np.concatenate(train_rows_list) if train_rows_list else np.array([], dtype=int)
+        train_rows.sort()
+        test_rows.sort()
+
+        embargoed_count = sum(len(group_to_rows[g]) for g in embargo_groups_set)
+
+        yield Split(
+            train=train_rows,
+            test=test_rows,
+            purged=0,
+            embargoed=embargoed_count,
+            test_bounds=(int(test_rows.min()), int(test_rows.max())),
+        )
 
 def purged_walk_forward_splits(
     n_samples: int,

--- a/agent/tests/quantlib/test_crossvalidation.py
+++ b/agent/tests/quantlib/test_crossvalidation.py
@@ -17,6 +17,7 @@ from src.quantlib.crossvalidation import (
     Split,
     combinatorial_purged_splits,
     detect_boundary_leakage,
+    group_purged_kfold_splits,
     purged_kfold_splits,
     purged_walk_forward_splits,
 )
@@ -311,3 +312,44 @@ def test_purge_counts_are_reported_not_hidden():
     for split in purged_kfold_splits(n, labels, n_folds=5):
         removed = n - split.train.size - split.test.size
         assert split.purged + split.embargoed == removed
+
+# --------------------------------------------------------------------------
+# group_purged_kfold_splits
+# --------------------------------------------------------------------------
+
+
+def test_group_purged_kfold_splits_prevents_cross_sectional_leakage():
+    # 10 assets x 100 dates = 1000 observations
+    n_dates = 100
+    n_assets = 10
+    dates = np.repeat(np.arange(n_dates), n_assets)
+
+    splits = list(group_purged_kfold_splits(dates, n_folds=5, embargo_fraction=0.05))
+    assert len(splits) == 5
+
+    for split in splits:
+        # 1. No shared row indices
+        assert len(np.intersect1d(split.train, split.test)) == 0
+
+        # 2. No shared dates between train and test
+        train_dates = set(dates[split.train])
+        test_dates = set(dates[split.test])
+        assert train_dates.intersection(test_dates) == set()
+
+        # 3. Exactly n_assets * number of test dates in test set
+        assert len(split.test) == len(test_dates) * n_assets
+
+        # 4. Embargo is applied to subsequent dates
+        test_max_date = max(test_dates)
+        embargo_expected_end = test_max_date + int(round(n_dates * 0.05))
+        for d in range(test_max_date + 1, min(n_dates, embargo_expected_end)):
+            assert d not in train_dates
+
+
+def test_group_purged_kfold_splits_input_validation():
+    with pytest.raises(ValueError, match="at least 2"):
+        list(group_purged_kfold_splits([1, 1, 2, 2], n_folds=1))
+    with pytest.raises(ValueError, match="cannot make 5 folds"):
+        list(group_purged_kfold_splits([1, 1, 2, 2], n_folds=5))
+    with pytest.raises(ValueError, match="groups array cannot be empty"):
+        list(group_purged_kfold_splits([], n_folds=2))


### PR DESCRIPTION
Add group_purged_kfold_splits for financial cross-validation across discrete time or cluster groups with forward embargo buffers.

Prevents cross-sectional and temporal leakage across training and validation partitions without breaking group integrity.