### PR TITLE
fix(factors): stop silently forward-filling gaps in Alpha Zoo returns

### DIFF
--- a/agent/src/factors/zoo/academic/bab.py
+++ b/agent/src/factors/zoo/academic/bab.py
@@ -66,7 +66,7 @@ def compute(panel: dict[str, pd.DataFrame]) -> pd.DataFrame:
     operate per-column) see the same market series against each stock.
     """
     close = panel['close']
-    returns = close.pct_change()
+    returns = close.pct_change(fill_method=None)
 
     market_ret = returns.mean(axis=1, skipna=True)
     market_df = pd.DataFrame(

--- a/agent/src/factors/zoo/alpha101/alpha_001.py
+++ b/agent/src/factors/zoo/alpha101/alpha_001.py
@@ -56,7 +56,7 @@ def compute(panel: dict) -> pd.DataFrame:
     close = panel["close"]
 
 
-    returns = close.pct_change()
+    returns = close.pct_change(fill_method=None)
     # Helper aliases (local closures keep the file standalone & purity-safe).
     cond = (returns < 0).astype(float)
     x = ts_std(returns, 20) * cond + close * (1.0 - cond)

--- a/agent/src/factors/zoo/alpha101/alpha_008.py
+++ b/agent/src/factors/zoo/alpha101/alpha_008.py
@@ -68,7 +68,7 @@ def compute(panel: dict) -> pd.DataFrame:
     close = panel["close"]
     open_ = panel["open"]
 
-    returns = close.pct_change()
+    returns = close.pct_change(fill_method=None)
     # Helper aliases (local closures keep the file standalone & purity-safe).
     rolling_sum = _rolling_sum
     delay = _delay

--- a/agent/src/factors/zoo/alpha101/alpha_014.py
+++ b/agent/src/factors/zoo/alpha101/alpha_014.py
@@ -57,7 +57,7 @@ def compute(panel: dict) -> pd.DataFrame:
     open_ = panel["open"]
     volume = panel["volume"]
 
-    returns = close.pct_change()
+    returns = close.pct_change(fill_method=None)
     # Helper aliases (local closures keep the file standalone & purity-safe).
     out = (-1.0 * rank(delta(returns, 3))) * ts_corr(open_, volume, 10)
     return out

--- a/agent/src/factors/zoo/alpha101/alpha_019.py
+++ b/agent/src/factors/zoo/alpha101/alpha_019.py
@@ -68,7 +68,7 @@ def compute(panel: dict) -> pd.DataFrame:
     close = panel["close"]
 
 
-    returns = close.pct_change()
+    returns = close.pct_change(fill_method=None)
     # Helper aliases (local closures keep the file standalone & purity-safe).
     rolling_sum = _rolling_sum
     delay = _delay

--- a/agent/src/factors/zoo/alpha101/alpha_025.py
+++ b/agent/src/factors/zoo/alpha101/alpha_025.py
@@ -58,7 +58,7 @@ def compute(panel: dict) -> pd.DataFrame:
     volume = panel["volume"]
     vwap = panel["vwap"]
     adv20 = ts_mean(volume, 20)
-    returns = close.pct_change()
+    returns = close.pct_change(fill_method=None)
     # Helper aliases (local closures keep the file standalone & purity-safe).
     out = rank(((-1.0 * returns) * adv20) * vwap * (high - close))
     return out

--- a/agent/src/factors/zoo/alpha101/alpha_029.py
+++ b/agent/src/factors/zoo/alpha101/alpha_029.py
@@ -71,7 +71,7 @@ def _delay(df: pd.DataFrame, n: int) -> pd.DataFrame:
 def compute(panel: dict) -> pd.DataFrame:
     """Compute the alpha on the OHLCV+ panel and return a wide DataFrame."""
     close = panel["close"]
-    returns = close.pct_change()
+    returns = close.pct_change(fill_method=None)
     # Helper aliases (local closures keep the file standalone & purity-safe).
     rolling_sum = _rolling_sum
     rolling_prod = _rolling_prod

--- a/agent/src/factors/zoo/alpha101/alpha_034.py
+++ b/agent/src/factors/zoo/alpha101/alpha_034.py
@@ -56,7 +56,7 @@ def compute(panel: dict) -> pd.DataFrame:
     close = panel["close"]
 
 
-    returns = close.pct_change()
+    returns = close.pct_change(fill_method=None)
     # Helper aliases (local closures keep the file standalone & purity-safe).
     out = rank((1.0 - rank(safe_div(ts_std(returns, 2), ts_std(returns, 5)))) + (1.0 - rank(delta(close, 1))))
     return out

--- a/agent/src/factors/zoo/alpha101/alpha_035.py
+++ b/agent/src/factors/zoo/alpha101/alpha_035.py
@@ -58,7 +58,7 @@ def compute(panel: dict) -> pd.DataFrame:
     low = panel["low"]
     volume = panel["volume"]
 
-    returns = close.pct_change()
+    returns = close.pct_change(fill_method=None)
     # Helper aliases (local closures keep the file standalone & purity-safe).
     out = ts_rank(volume, 32) * (1.0 - ts_rank((close + high - low), 16)) * (1.0 - ts_rank(returns, 32))
     return out

--- a/agent/src/factors/zoo/alpha101/alpha_036.py
+++ b/agent/src/factors/zoo/alpha101/alpha_036.py
@@ -70,7 +70,7 @@ def compute(panel: dict) -> pd.DataFrame:
     volume = panel["volume"]
     vwap = panel["vwap"]
     adv20 = ts_mean(volume, 20)
-    returns = close.pct_change()
+    returns = close.pct_change(fill_method=None)
     # Helper aliases (local closures keep the file standalone & purity-safe).
     rolling_sum = _rolling_sum
     delay = _delay

--- a/agent/src/factors/zoo/alpha101/alpha_039.py
+++ b/agent/src/factors/zoo/alpha101/alpha_039.py
@@ -61,7 +61,7 @@ def compute(panel: dict) -> pd.DataFrame:
     close = panel["close"]
     volume = panel["volume"]
     adv20 = ts_mean(volume, 20)
-    returns = close.pct_change()
+    returns = close.pct_change(fill_method=None)
     # Helper aliases (local closures keep the file standalone & purity-safe).
     rolling_sum = _rolling_sum
     out = (-1.0 * rank(delta(close, 7) * (1.0 - rank(decay_linear(safe_div(volume, adv20), 9))))) * (1.0 + rank(rolling_sum(returns, 250)))

--- a/agent/src/factors/zoo/alpha101/alpha_052.py
+++ b/agent/src/factors/zoo/alpha101/alpha_052.py
@@ -69,7 +69,7 @@ def compute(panel: dict) -> pd.DataFrame:
     low = panel["low"]
     volume = panel["volume"]
 
-    returns = close.pct_change()
+    returns = close.pct_change(fill_method=None)
     # Helper aliases (local closures keep the file standalone & purity-safe).
     rolling_sum = _rolling_sum
     delay = _delay

--- a/agent/src/factors/zoo/alpha101/alpha_056.py
+++ b/agent/src/factors/zoo/alpha101/alpha_056.py
@@ -66,7 +66,7 @@ def compute(panel: dict) -> pd.DataFrame:
     close = panel["close"]
 
 
-    returns = close.pct_change()
+    returns = close.pct_change(fill_method=None)
     # Helper aliases (local closures keep the file standalone & purity-safe).
     rolling_sum = _rolling_sum
     make_one = _make_one

--- a/agent/tests/factors/test_pct_change_gap_preserves_nan.py
+++ b/agent/tests/factors/test_pct_change_gap_preserves_nan.py
@@ -1,0 +1,116 @@
+"""Regression: a factor's internal ``returns`` feature must propagate NaN
+across a genuine missing-close gap, not fabricate a value.
+
+close.pct_change() with no fill_method argument defaults (pandas 2.x,
+deprecated) to fill_method='pad', which forward-fills the missing close
+before differencing — turning a real data gap (a delisting, a market
+holiday not shared across a multi-market panel, a vendor outage) into a
+fabricated "0% return" for that bar and a wrong return for the bar after
+it. base.py's own NaN policy ("every operator propagates NaN; no silent
+fillna(0)") and CONTRIBUTING.md's reviewer checklist ("NaN preserved at
+warmup / missing-data positions") both require the gap to stay NaN.
+Commit 22867b01 already fixed this identical pattern in
+alpha_bench_tool.py's _compute_forward_returns (see
+test_alpha_bench_forward_returns.py); this file extends the same fix to
+the 13 zoo factors that compute an internal returns feature.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.factors.registry import Registry
+
+# The 13 alphas whose formula depends on an interior close.pct_change()
+# gap staying NaN (all fixed by the same one-keyword change).
+_AFFECTED_ALPHA_IDS = [
+    "academic_bab",
+    "alpha101_001",
+    "alpha101_008",
+    "alpha101_014",
+    "alpha101_019",
+    "alpha101_025",
+    "alpha101_029",
+    "alpha101_034",
+    "alpha101_035",
+    "alpha101_036",
+    "alpha101_039",
+    "alpha101_052",
+    "alpha101_056",
+]
+
+N_ROWS = 300
+N_SYMS = 3
+GAP_ROW = 260  # past every affected alpha's min_warmup_bars (max 253, academic_bab)
+
+
+def _panel_with_one_gap() -> dict[str, pd.DataFrame]:
+    """A synthetic OHLCV+vwap panel with one interior missing close on SYM1,
+    the shape every registered alpha's compute(panel) expects."""
+    rng = np.random.default_rng(0)
+    idx = pd.date_range("2024-01-01", periods=N_ROWS, freq="D")
+    cols = [f"SYM{i}" for i in range(N_SYMS)]
+
+    close = (
+        pd.DataFrame(
+            100.0 + np.cumsum(rng.normal(0.0, 1.0, size=(N_ROWS, N_SYMS)), axis=0),
+            index=idx,
+            columns=cols,
+        ).abs()
+        + 1.0
+    )
+    open_ = close.shift(1).fillna(close.iloc[0])
+    high = pd.DataFrame(
+        np.maximum(close.to_numpy(), open_.to_numpy()) + rng.uniform(0.0, 1.0, size=(N_ROWS, N_SYMS)),
+        index=idx,
+        columns=cols,
+    )
+    low = (
+        pd.DataFrame(
+            np.minimum(close.to_numpy(), open_.to_numpy()) - rng.uniform(0.0, 1.0, size=(N_ROWS, N_SYMS)),
+            index=idx,
+            columns=cols,
+        ).abs()
+        + 0.01
+    )
+    volume = pd.DataFrame(
+        rng.integers(1_000, 100_000, size=(N_ROWS, N_SYMS)).astype(float),
+        index=idx,
+        columns=cols,
+    )
+    vwap = (high + low + close + open_) / 4.0
+
+    close.loc[idx[GAP_ROW], "SYM1"] = np.nan
+
+    sectors = ["A", "B", "C"]
+    sector_grid = np.array([sectors[i % len(sectors)] for i in range(N_SYMS)], dtype=object)
+    sector = pd.DataFrame(np.broadcast_to(sector_grid, close.shape).copy(), index=idx, columns=cols)
+
+    return {
+        "open": open_,
+        "high": high,
+        "low": low,
+        "close": close,
+        "volume": volume,
+        "vwap": vwap,
+        "sector": sector,
+    }
+
+
+@pytest.fixture(scope="module")
+def gap_panel() -> dict[str, pd.DataFrame]:
+    return _panel_with_one_gap()
+
+
+@pytest.mark.parametrize("alpha_id", _AFFECTED_ALPHA_IDS)
+def test_returns_gap_stays_nan(alpha_id, gap_panel):
+    out = Registry().compute(alpha_id, gap_panel)
+
+    assert pd.isna(
+        out.iloc[GAP_ROW]["SYM1"]
+    ), f"{alpha_id}: the gap bar itself must be NaN, got {out.iloc[GAP_ROW]['SYM1']!r}"
+    assert pd.isna(out.iloc[GAP_ROW + 1]["SYM1"]), (
+        f"{alpha_id}: the bar right after the gap must be NaN too, " f"got {out.iloc[GAP_ROW + 1]['SYM1']!r}"
+    )


### PR DESCRIPTION
## Summary

- Stop pandas from forward-filling missing close prices before computing returns across the affected Alpha Zoo factors.
- Replace `close.pct_change()` with `close.pct_change(fill_method=None)` in the 13 factor implementations that compute an internal return series.
- Preserve missing-data gaps as `NaN` instead of allowing them to be interpreted as valid price observations.

## Why

`pandas.Series.pct_change()` can forward-fill missing values when `fill_method` is not specified.

For factor calculations, that can turn a genuine missing-price gap into a finite return value that downstream factor ranking treats as real market information.

The repository already uses `pct_change(fill_method=None)` in related return calculations. This change applies the same missing-data policy consistently across the remaining affected Alpha Zoo factors.

The regression matrix covers all 13 changed implementations. Eight reproduce the incorrect finite output directly on unpatched `main`; the remaining five serve as controls because later operators already propagate the gap as `NaN`.

## Changes

- Update 13 files under `agent/src/factors/zoo/academic/` and `agent/src/factors/zoo/alpha101/` to use `pct_change(fill_method=None)`.
- Add parametrized regression coverage for every changed factor.

## Test Plan

- [x] Regression coverage fails on unpatched `main` where the affected factors fabricate finite output and passes after the fix
- [x] Targeted factor regression suite: 13 passed
- [x] Broader factors selection: 1,069 passed, 5 skipped
- [x] No new `ruff` issues introduced by this change
- [x] No new `black` formatting issues introduced by this change
- [x] No new `mypy` errors introduced by this change

## Checklist

- [x] No changes to protected areas
- [x] No hardcoded values
- [x] Code follows `CONTRIBUTING.md` guidelines
- [x] Documentation: N/A, internal factor-computation correction
- [x] DCO signed-off

## Risk

Low. The change only affects return calculations across genuine missing-price gaps. Factor formulas, scoring logic, broker behaviour, credentials, orders, payments, wallets, and live-trading behaviour are unchanged.

## Rollback

The change is limited to the `fill_method` argument in the affected factors and their regression coverage and can be reverted with a normal `git revert`.