### PR TITLE
fix(mcp): forward beginTime/endTime through get_research_reports

### DIFF
--- a/agent/mcp_server.py
+++ b/agent/mcp_server.py
@@ -1981,7 +1981,12 @@ def get_sector_info(code: str | None = None, mode: str = "membership", limit: in
 
 
 @mcp.tool
-def get_research_reports(code: str, limit: int = 20) -> str:
+def get_research_reports(
+    code: str,
+    limit: int = 20,
+    beginTime: str | None = None,
+    endTime: str | None = None,
+) -> str:
     """Fetch mainland A-share sell-side research coverage and consensus forecasts.
 
     Returns recent broker research reports (title, brokerage, analyst, publish
@@ -1992,9 +1997,18 @@ def get_research_reports(code: str, limit: int = 20) -> str:
     Args:
         code: A-share symbol in <code>.<exchange> form (SH/SZ/BJ).
         limit: Maximum number of most-recent research reports to return.
+        beginTime: Earliest report publish date (inclusive), 'YYYYMMDD'.
+            Optional; defaults to the start of a trailing two-year window.
+        endTime: Latest report publish date (inclusive), 'YYYYMMDD'.
+            Optional; defaults to today.
     """
+    params: dict[str, Any] = {"code": code, "limit": limit}
+    if beginTime:
+        params["beginTime"] = beginTime
+    if endTime:
+        params["endTime"] = endTime
     registry = _get_registry()
-    return registry.execute("get_research_reports", {"code": code, "limit": limit})
+    return registry.execute("get_research_reports", params)
 
 
 @mcp.tool

--- a/agent/tests/test_mcp_research_reports_date_window.py
+++ b/agent/tests/test_mcp_research_reports_date_window.py
@@ -1,0 +1,51 @@
+"""get_research_reports (MCP) must forward beginTime/endTime.
+
+ResearchReportsTool documents beginTime/endTime as an optional publish-date
+window (defaulting to a trailing two years) and enforces it against the real
+Eastmoney endpoint. The MCP wrapper dropped both parameters on the way in, so
+an MCP client asking for reports in a specific historical window always got
+the default trailing-two-year window instead, the same drift class PR #1131
+and #1138 fixed elsewhere in this file.
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import patch
+
+import mcp_server
+from src.tools import research_reports_tool as rrt
+from src.tools.research_reports_tool import ResearchReportsTool
+
+_get_reports = getattr(mcp_server.get_research_reports, "fn", None) or getattr(
+    mcp_server.get_research_reports, "__wrapped__", mcp_server.get_research_reports
+)
+
+
+def test_get_research_reports_wrapper_matches_tool_contract():
+    spec = ResearchReportsTool.parameters
+    sig = inspect.signature(_get_reports)
+    missing = set(spec["properties"]) - set(sig.parameters)
+    assert not missing, f"MCP wrapper is missing parameters the tool declares: {missing}"
+
+
+def test_mcp_get_research_reports_forwards_the_date_window():
+    captured_params: dict = {}
+
+    def _fake_get_json(url, params=None, **kwargs):
+        captured_params.update(params or {})
+        return {"data": []}
+
+    with (
+        patch.object(rrt, "get_json", side_effect=_fake_get_json),
+        patch.object(rrt, "resolve_secid", return_value="123"),
+        patch.object(rrt, "_fetch_consensus_eps", return_value=[]),
+    ):
+        _get_reports(code="600519.SH", beginTime="20200101", endTime="20201231")
+
+    assert (
+        captured_params.get("beginTime") == "20200101"
+    ), f"beginTime was not forwarded through the MCP wrapper: {captured_params}"
+    assert (
+        captured_params.get("endTime") == "20201231"
+    ), f"endTime was not forwarded through the MCP wrapper: {captured_params}"


### PR DESCRIPTION
## Summary

- Expose the existing `beginTime`/`endTime` publish-date window through MCP `get_research_reports()`.
- Forward both parameters to the registered research-reports tool when supplied.

## Why

`ResearchReportsTool` already supports `beginTime` and `endTime`, but the MCP wrapper only exposed `code` and `limit`.

As a result, MCP clients requesting a specific historical period received the tool's default date window instead. This change restores parity with the underlying tool.

## Changes

- Add optional `beginTime` and `endTime` parameters to `get_research_reports()`.
- Forward them to the registered tool when supplied.
- Update the MCP docstring accordingly.

## Test Plan

- [x] Regression tests fail on unpatched `main` and pass after the fix
- [x] End-to-end coverage confirms the dates reach the outbound request
- [x] Targeted suite: 57 passed
- [x] Broader MCP/research-report selection: 296 passed, 5 skipped
- [x] No new `ruff`, `black`, or `mypy` issues introduced

## Checklist

- [x] No changes to protected areas
- [x] No hardcoded values
- [x] Code follows `CONTRIBUTING.md`
- [x] Documentation: MCP docstring updated for the date-window parameters
- [x] DCO signed-off

## Risk

Low. This exposes an existing filtering capability through MCP without changing report retrieval or consensus EPS logic.

## Rollback

Limited to the two optional MCP parameters and regression coverage; revertible with a normal `git revert`.