### PR TITLE
fix(ibkr): point official read-only MCP seed at /mcp-public endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1495,7 +1495,7 @@ endpoint in read-only mode. Add this to `~/.vibe-trading/agent.json`:
   "mcpServers": {
     "ibkr": {
       "type": "streamableHttp",
-      "url": "https://api.ibkr.com/v1/api/mcp",
+      "url": "https://api.ibkr.com/v1/api/mcp-public",
       "auth": {
         "type": "oauth",
         "scopes": ["mcp.read"],

--- a/agent/SKILL.md
+++ b/agent/SKILL.md
@@ -256,7 +256,7 @@ Add Interactive Brokers' official MCP endpoint as a read-only external server:
   "mcpServers": {
     "ibkr": {
       "type": "streamableHttp",
-      "url": "https://api.ibkr.com/v1/api/mcp",
+      "url": "https://api.ibkr.com/v1/api/mcp-public",
       "auth": {
         "type": "oauth",
         "scopes": ["mcp.read"],

--- a/agent/src/config/schema.py
+++ b/agent/src/config/schema.py
@@ -226,7 +226,7 @@ ROBINHOOD_MCP_SERVER_SEED: dict[str, object] = {
 # config must pin an explicit tool allowlist plus pass the live order gate.
 IBKR_MCP_SERVER_SEED: dict[str, object] = {
     "type": "streamableHttp",
-    "url": "https://api.ibkr.com/v1/api/mcp",
+    "url": "https://api.ibkr.com/v1/api/mcp-public",
     "auth": {
         "type": "oauth",
         "scopes": ["mcp.read"],

--- a/agent/tests/test_ibkr_mcp_seed.py
+++ b/agent/tests/test_ibkr_mcp_seed.py
@@ -65,7 +65,7 @@ def test_ibkr_seed_validates_as_readonly_probe() -> None:
     cfg = AgentConfig.model_validate({"mcpServers": {"ibkr": IBKR_MCP_SERVER_SEED}})
     server = cfg.mcp_servers["ibkr"]
 
-    assert server.url == "https://api.ibkr.com/v1/api/mcp"
+    assert server.url == "https://api.ibkr.com/v1/api/mcp-public"
     assert server.auth is not None
     assert server.auth.scopes == ["mcp.read"]
     assert server.enabled_tools == ["*"]

--- a/agent/tests/test_mcp_oauth_schema.py
+++ b/agent/tests/test_mcp_oauth_schema.py
@@ -127,7 +127,7 @@ def test_ibkr_seed_is_official_readonly_oauth_probe() -> None:
     cfg = AgentConfig.model_validate({"mcpServers": {"ibkr": IBKR_MCP_SERVER_SEED}})
     ibkr = cfg.mcp_servers["ibkr"]
     assert ibkr.resolved_transport() == "streamableHttp"
-    assert ibkr.url == "https://api.ibkr.com/v1/api/mcp"
+    assert ibkr.url == "https://api.ibkr.com/v1/api/mcp-public"
     assert ibkr.auth is not None and ibkr.auth.type == "oauth"
     assert ibkr.auth.scopes == ["mcp.read"]
     assert ibkr.auth.cache_dir == "~/.vibe-trading/live/ibkr/oauth"
@@ -185,7 +185,7 @@ def test_ibkr_rejects_wildcard_when_write_scope_is_requested() -> None:
                 "mcpServers": {
                     "ibkr": {
                         "type": "streamableHttp",
-                        "url": "https://api.ibkr.com/v1/api/mcp",
+                        "url": "https://api.ibkr.com/v1/api/mcp-public",
                         "auth": {"type": "oauth", "scopes": ["mcp.read", "mcp.write"]},
                         "enabledTools": ["*"],
                     }
@@ -201,7 +201,7 @@ def test_ibkr_rejects_wildcard_without_read_scope() -> None:
                 "mcpServers": {
                     "ibkr": {
                         "type": "streamableHttp",
-                        "url": "https://api.ibkr.com/v1/api/mcp",
+                        "url": "https://api.ibkr.com/v1/api/mcp-public",
                         "auth": {"type": "oauth", "scopes": ["openid"]},
                         "enabledTools": ["*"],
                     }


### PR DESCRIPTION
# fix(ibkr): point official read-only MCP seed at /mcp-public endpoint

## Problem

The official IBKR MCP read-only profile (`ibkr-live-official-mcp-readonly`) is seeded and
documented with `https://api.ibkr.com/v1/api/mcp`. After completing OAuth, connector/tool
discovery fails because that endpoint returns HTTP 400:

```
httpx.HTTPStatusError: Client error 400 Bad Request for url https://api.ibkr.com/v1/api/mcp
```

This blocks the documented read-only probe from discovering or calling IBKR tools.
(Reported in #1126.)

## Solution

IBKR publishes the public MCP endpoint at `https://api.ibkr.com/v1/api/mcp-public`. This PR:

- Updates the seeded default `IBKR_MCP_SERVER_SEED["url"]` in `agent/src/config/schema.py`
  — the actual config value used at runtime.
- Updates the two matching docs: `README.md` ("Official IBKR MCP read-only probe") and
  `agent/SKILL.md`.
- Aligns the two seed assertions in `agent/tests/test_ibkr_mcp_seed.py` and
  `agent/tests/test_mcp_oauth_schema.py` (these assert the seed URL).

## Affected areas

- `agent/src/config/schema.py` — `IBKR_MCP_SERVER_SEED`
- `README.md`, `agent/SKILL.md` — documentation
- `agent/tests/test_ibkr_mcp_seed.py`, `agent/tests/test_mcp_oauth_schema.py` — tests

## Out of scope

- No OAuth compatibility code, no new tools, no order-path changes. The read-only `mcp.read`
  wildcard discovery probe, its scopes, and the live order gate are unchanged.
- Translation files (`README_*.md`) are intentionally left for a follow-up sync.
- This is a config/doc correction only; it does not add the broader IBKR OAuth client-approval
  flow described in the issue (that is a larger enhancement and out of scope for this minimal fix).

## Test plan

- `python -m py_compile agent/src/config/schema.py` and the two test modules — pass.
- Targeted validation (local, pydantic only):
  `AgentConfig.model_validate({"mcpServers": {"ibkr": IBKR_MCP_SERVER_SEED}})` yields
  `server.url == "https://api.ibkr.com/v1/api/mcp-public"` with `scopes == ["mcp.read"]` and
  `enabled_tools == ["*"]` — verified.
- The two updated assertions now match the corrected seed URL.
- The full suite (`pytest agent/tests/test_ibkr_mcp_seed.py agent/tests/test_mcp_oauth_schema.py`)
  was not executed here because it requires the heavy `fastmcp`/`mcp` dev environment; the changed
  lines are pure string literals matching the seed, so they pass once that environment is installed.

## Risk

- No live/broker/MCP write, no network call, no secret, no deployment, no CI-secret change.
- The change only repoints a read-only profile's URL to IBKR's public MCP endpoint. The profile
  stays read-only (`mcp.read`, wildcard discovery probe); the live order gate is untouched.
- Existing users who already wrote the old URL into `~/.vibe-trading/agent.json` must re-run
  `vibe-trading connector configure ibkr-live-official-mcp-readonly --yes` (or re-seed) to pick up
  the corrected endpoint.

## Rollback

- Documentation/config-only change; revert with `git revert <sha>`.

## DCO

- Every commit is signed off (`Signed-off-by:`).

---

Refs #1126 (the OAuth client-registration failure reported there stays open)

