### PR TITLE
fix(alpaca): sign position quantity by side for the mandate gate

### DIFF
--- a/agent/src/trading/connectors/alpaca/sdk.py
+++ b/agent/src/trading/connectors/alpaca/sdk.py
@@ -847,7 +847,11 @@ def _obj_get(obj: Any, name: str, default: Any = None) -> Any:
 
 
 def _position_to_dict(item: Any) -> dict[str, Any]:
-    side = str(_obj_get(item, "side", ""))
+    # alpaca-py's Position.side is a (str, Enum) member whose str() is
+    # "PositionSide.SHORT", not "short" — read .value so the direct-SDK path
+    # emits the same lowercase token the TAP JSON path does.
+    side_raw = _obj_get(item, "side", "")
+    side = str(getattr(side_raw, "value", side_raw)).strip().lower()
     quantity = _obj_get(item, "qty")
     if side == "short" and quantity is not None:
         # Alpaca reports qty as an absolute magnitude and carries direction in

--- a/agent/src/trading/connectors/alpaca/sdk.py
+++ b/agent/src/trading/connectors/alpaca/sdk.py
@@ -847,10 +847,17 @@ def _obj_get(obj: Any, name: str, default: Any = None) -> Any:
 
 
 def _position_to_dict(item: Any) -> dict[str, Any]:
+    side = str(_obj_get(item, "side", ""))
+    quantity = _obj_get(item, "qty")
+    if side == "short" and quantity is not None:
+        # Alpaca reports qty as an absolute magnitude and carries direction in
+        # side. The mandate gate (like the tiger connector) reads quantity as
+        # signed, so an unsigned short would book as positive exposure.
+        quantity = -float(quantity)
     return {
         "symbol": _obj_get(item, "symbol"),
-        "side": str(_obj_get(item, "side", "")),
-        "quantity": _obj_get(item, "qty"),
+        "side": side,
+        "quantity": quantity,
         "average_cost": _obj_get(item, "avg_entry_price"),
         "market_value": _obj_get(item, "market_value"),
         "current_price": _obj_get(item, "current_price"),

--- a/agent/tests/test_alpaca_position_sign.py
+++ b/agent/tests/test_alpaca_position_sign.py
@@ -1,0 +1,46 @@
+"""Tests for the Alpaca position mapping's quantity sign.
+
+Alpaca reports ``qty`` as an absolute magnitude and carries direction in
+``side`` (``"long"``/``"short"``). The mandate gate reads position quantity as
+signed (its own fixtures use negative quantities for shorts), so an unsigned
+short would book as positive exposure and every sell would move the computed
+exposure toward zero. The connector now negates qty for short positions.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.live.enforcement import _position_signed_market_value
+from src.trading.connectors.alpaca.sdk import _position_to_dict
+
+pytestmark = pytest.mark.unit
+
+
+def test_short_position_gets_negative_quantity() -> None:
+    row = _position_to_dict({"symbol": "AAPL", "side": "short", "qty": "400", "market_value": "-50000"})
+    assert row["quantity"] == -400.0
+    assert row["side"] == "short"
+
+
+def test_long_position_quantity_passes_through() -> None:
+    row = _position_to_dict({"symbol": "AAPL", "side": "long", "qty": "400", "market_value": "50000"})
+    assert row["quantity"] == "400"
+
+
+def test_short_position_without_qty_stays_none() -> None:
+    row = _position_to_dict({"symbol": "AAPL", "side": "short", "qty": None})
+    assert row["quantity"] is None
+
+
+def test_object_positions_get_the_same_sign() -> None:
+    item = SimpleNamespace(symbol="AAPL", side="short", qty="400", market_value="-50000")
+    row = _position_to_dict(item)
+    assert row["quantity"] == -400.0
+
+
+def test_gate_reads_alpaca_short_as_negative_exposure() -> None:
+    row = _position_to_dict({"symbol": "AAPL", "side": "short", "qty": "400", "market_value": "-50000"})
+    assert _position_signed_market_value(row) == -50000.0

--- a/agent/tests/test_alpaca_position_sign.py
+++ b/agent/tests/test_alpaca_position_sign.py
@@ -9,6 +9,7 @@ exposure toward zero. The connector now negates qty for short positions.
 
 from __future__ import annotations
 
+from enum import Enum
 from types import SimpleNamespace
 
 import pytest
@@ -43,4 +44,17 @@ def test_object_positions_get_the_same_sign() -> None:
 
 def test_gate_reads_alpaca_short_as_negative_exposure() -> None:
     row = _position_to_dict({"symbol": "AAPL", "side": "short", "qty": "400", "market_value": "-50000"})
+    assert _position_signed_market_value(row) == -50000.0
+
+
+def test_sdk_enum_side_is_normalized_and_signed() -> None:
+    # The direct-SDK path yields alpaca-py Position objects whose side is a
+    # (str, Enum) member; str() of such a member is "PositionSide.SHORT".
+    class PositionSide(str, Enum):
+        SHORT = "short"
+
+    item = SimpleNamespace(symbol="AAPL", side=PositionSide.SHORT, qty="400", market_value="-50000")
+    row = _position_to_dict(item)
+    assert row["side"] == "short"
+    assert row["quantity"] == -400.0
     assert _position_signed_market_value(row) == -50000.0


### PR DESCRIPTION
## Summary

- Alpaca short positions now carry a signed quantity (`qty` negated when `side` is short), matching what the mandate gate reads.

## Why

Part of #1207 Phase 0. Alpaca reports `qty` as an absolute magnitude with direction in `side`, but `_position_signed_market_value` reads quantity as signed (its own fixtures use negative quantities for shorts). An Alpaca short therefore booked as positive exposure: each additional sell moved the computed exposure toward zero, so `max_total_exposure_usd` and `max_leverage` stopped binding on the short side, and a buy-to-cover read as adding long.

## Changes

- `connectors/alpaca/sdk.py`: negate `qty` when the position side is short; longs pass through untouched.
- New connector tests pinning the sign, plus one proving the gate reads an Alpaca-shaped short row as negative exposure.

## Test Plan

- [x] Existing tests pass (`pytest tests/test_alpaca_position_sign.py tests/test_alpaca_tap_routing.py tests/test_mandate_enforcement.py -q`, 46 passed)
- [x] New tests added (5, mock-only)
- [ ] Tested manually: not run against a live Alpaca account; the mapping is covered by mock tests.

Risk and rollback: the positions payload now shows negative quantity for shorts instead of a bare magnitude; that is the convention the gate and the tiger connector already share. Rollback is reverting the one mapping branch.

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Documentation updated (if user-facing change) — internal mapping fix, nothing user-facing to document
