### PR TITLE
fix(live): fail closed when broker position reads return an API error

### DIFF
--- a/agent/src/trading/connectors/futu/sdk.py
+++ b/agent/src/trading/connectors/futu/sdk.py
@@ -279,7 +279,16 @@ def get_account_snapshot(config: FutuConfig | None = None) -> dict[str, Any]:
     try:
         acc_id = _resolve_acc_id(cfg, trade_ctx)
         trd_env = _trd_env_enum(cfg)
-        rows = _records(_unwrap(trade_ctx.accinfo_query(trd_env=trd_env, acc_id=acc_id)))
+        result = trade_ctx.accinfo_query(trd_env=trd_env, acc_id=acc_id)
+        ret = result[0] if isinstance(result, (list, tuple)) and len(result) >= 2 else None
+        futu = _require_futu()
+        if ret is not None and ret != getattr(futu, "RET_OK", 0):
+            return {
+                "status": "error",
+                "error": f"futu accinfo_query failed: ret={ret} data={result[1]}",
+                "assets": [],
+            }
+        rows = _records(_unwrap(result))
         return {
             "status": "ok",
             "profile": cfg.profile,
@@ -298,7 +307,19 @@ def get_positions(config: FutuConfig | None = None) -> dict[str, Any]:
     try:
         acc_id = _resolve_acc_id(cfg, trade_ctx)
         trd_env = _trd_env_enum(cfg)
-        rows = _records(_unwrap(trade_ctx.position_list_query(trd_env=trd_env, acc_id=acc_id)))
+        result = trade_ctx.position_list_query(trd_env=trd_env, acc_id=acc_id)
+        ret = result[0] if isinstance(result, (list, tuple)) and len(result) >= 2 else None
+        futu = _require_futu()
+        if ret is not None and ret != getattr(futu, "RET_OK", 0):
+            # The mandate gate fails closed only on an explicit error, so a
+            # rejected query must not flatten into an empty position list
+            # (#1207 Phase 0).
+            return {
+                "status": "error",
+                "error": f"futu position_list_query failed: ret={ret} data={result[1]}",
+                "positions": [],
+            }
+        rows = _records(_unwrap(result))
         return {
             "status": "ok",
             "profile": cfg.profile,

--- a/agent/src/trading/connectors/okx/sdk.py
+++ b/agent/src/trading/connectors/okx/sdk.py
@@ -250,6 +250,13 @@ def get_account_snapshot(config: OKXConfig | None = None) -> dict[str, Any]:
     cfg = config or load_config()
     account = _account_client(cfg)
     resp = _safe_call(account, "get_account_balance")
+    error = _business_error(resp)
+    if error is not None:
+        return {
+            "status": "error",
+            "error": f"okx get_account_balance failed: {error}",
+            "account": {},
+        }
     rows = _extract_data(resp)
     summary = rows[0] if rows else {}
     return {
@@ -269,6 +276,13 @@ def get_positions(config: OKXConfig | None = None) -> dict[str, Any]:
     cfg = config or load_config()
     account = _account_client(cfg)
     resp = _safe_call(account, "get_positions")
+    error = _business_error(resp)
+    if error is not None:
+        return {
+            "status": "error",
+            "error": f"okx get_positions failed: {error}",
+            "positions": [],
+        }
     rows = [_position_to_dict(item) for item in _extract_data(resp)]
     return {
         "status": "ok",
@@ -653,6 +667,18 @@ def _first(obj: Any, names: tuple[str, ...], default: Any = None) -> Any:
         if value is not None:
             return value
     return default
+
+
+def _business_error(resp: Any) -> str | None:
+    """Return the OKX business error string, or None when the call succeeded.
+
+    The mandate gate fails closed only on an explicit error, so a non-zero
+    business code must never be flattened into an empty data list on the
+    position/balance reads (#1207 Phase 0).
+    """
+    if isinstance(resp, Mapping) and str(resp.get("code")) != "0":
+        return f"code={resp.get('code')} msg={resp.get('msg')}"
+    return None
 
 
 def _extract_data(resp: Any) -> list[Any]:

--- a/agent/tests/test_position_read_error_envelope.py
+++ b/agent/tests/test_position_read_error_envelope.py
@@ -1,0 +1,113 @@
+"""Tests for the error envelopes of the position and balance reads.
+
+A broker API failure must surface as ``status: error`` so the mandate gate
+fails closed; flattening a rejected call into an empty list would let the gate
+evaluate mandates against an empty book (#1207 Phase 0). All SDK boundaries
+are mocked; no network, no credentials.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.trading.connectors.futu import sdk as futu_sdk
+from src.trading.connectors.okx import sdk as okx_sdk
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeFutu:
+    RET_OK = 0
+
+    class TrdEnv:
+        SIMULATE = "SIMULATE"
+
+
+class _FakeTradeCtx:
+    def __init__(self, *, position_result, accinfo_result):
+        self._position_result = position_result
+        self._accinfo_result = accinfo_result
+
+    def get_acc_list(self):
+        return (0, [{"trd_env": "SIMULATE", "acc_id": 123}])
+
+    def position_list_query(self, **_):
+        return self._position_result
+
+    def accinfo_query(self, **_):
+        return self._accinfo_result
+
+    def close(self):
+        pass
+
+
+def _futu_config():
+    return futu_sdk.FutuConfig(acc_id=123)
+
+
+def test_futu_positions_error_code_returns_error_envelope(monkeypatch) -> None:
+    ctx = _FakeTradeCtx(position_result=(1, "permission denied"), accinfo_result=(0, []))
+    monkeypatch.setattr(futu_sdk, "_trade_ctx", lambda cfg: ctx)
+    monkeypatch.setattr(futu_sdk, "_require_futu", lambda: _FakeFutu)
+
+    result = futu_sdk.get_positions(_futu_config())
+    assert result["status"] == "error"
+    assert "permission denied" in result["error"]
+
+
+def test_futu_positions_success_stays_ok(monkeypatch) -> None:
+    ctx = _FakeTradeCtx(position_result=(0, []), accinfo_result=(0, []))
+    monkeypatch.setattr(futu_sdk, "_trade_ctx", lambda cfg: ctx)
+    monkeypatch.setattr(futu_sdk, "_require_futu", lambda: _FakeFutu)
+
+    result = futu_sdk.get_positions(_futu_config())
+    assert result["status"] == "ok"
+    assert result["positions"] == []
+
+
+def test_futu_snapshot_error_code_returns_error_envelope(monkeypatch) -> None:
+    ctx = _FakeTradeCtx(position_result=(0, []), accinfo_result=(1003, "system busy"))
+    monkeypatch.setattr(futu_sdk, "_trade_ctx", lambda cfg: ctx)
+    monkeypatch.setattr(futu_sdk, "_require_futu", lambda: _FakeFutu)
+
+    result = futu_sdk.get_account_snapshot(_futu_config())
+    assert result["status"] == "error"
+    assert "system busy" in result["error"]
+
+
+class _FakeOKXAccount:
+    def __init__(self, resp):
+        self._resp = resp
+
+    def get_positions(self):
+        return self._resp
+
+    def get_account_balance(self):
+        return self._resp
+
+
+def test_okx_positions_business_error_returns_error_envelope(monkeypatch) -> None:
+    resp = {"code": "50011", "msg": "Request too frequent", "data": []}
+    monkeypatch.setattr(okx_sdk, "_account_client", lambda cfg: _FakeOKXAccount(resp))
+
+    result = okx_sdk.get_positions(okx_sdk.OKXConfig())
+    assert result["status"] == "error"
+    assert "50011" in result["error"]
+
+
+def test_okx_positions_success_stays_ok(monkeypatch) -> None:
+    resp = {"code": "0", "data": []}
+    monkeypatch.setattr(okx_sdk, "_account_client", lambda cfg: _FakeOKXAccount(resp))
+
+    result = okx_sdk.get_positions(okx_sdk.OKXConfig())
+    assert result["status"] == "ok"
+    assert result["positions"] == []
+
+
+def test_okx_snapshot_business_error_returns_error_envelope(monkeypatch) -> None:
+    resp = {"code": "50113", "msg": "Invalid sign", "data": []}
+    monkeypatch.setattr(okx_sdk, "_account_client", lambda cfg: _FakeOKXAccount(resp))
+
+    result = okx_sdk.get_account_snapshot(okx_sdk.OKXConfig())
+    assert result["status"] == "error"
+    assert "50113" in result["error"]


### PR DESCRIPTION
## Summary

- OKX and Futu position/balance reads now return an explicit `status: error` envelope when the broker API rejects the call, instead of flattening the failure into an empty list with `status: ok`.

## Why

Part of #1207 Phase 0. The mandate gate fails closed only on an explicit error. Today, an OKX non-zero business code or a Futu non-`RET_OK` return unwraps to an empty list, so a transient API error (rate limit, permission blip) makes the gate evaluate `max_total_exposure_usd` and friends against an empty book and let orders through.

## Changes

- `connectors/okx/sdk.py`: new `_business_error` check; `get_positions` and `get_account_snapshot` return the error envelope on a non-zero code.
- `connectors/futu/sdk.py`: same check on the `(ret, data)` tuple for `position_list_query` and `accinfo_query`.
- New mock-only tests pin both the error and the success envelopes for all four reads.

## Test Plan

- [x] Existing tests pass (`pytest tests/test_position_read_error_envelope.py tests/test_futu_extended_reads.py tests/test_alpaca_position_sign.py -q`, 25 passed)
- [x] New tests added (6, mock-only)
- [ ] Tested manually: not run against live broker accounts; the envelope mapping is covered by mock tests.

Risk and rollback: read endpoints now report `error` where they previously reported `ok` with empty data; the mandate gate already treats `error` as fail-closed, and other consumers see the same envelope shape other connectors return on failure. Rollback is reverting this commit.

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Documentation updated (if user-facing change) — internal error-handling fix, nothing user-facing to document
