### PR TITLE
fix(shadow): derive shadow PnL from runner metrics, fail closed when unknown

### DIFF
--- a/agent/src/shadow_account/backtester.py
+++ b/agent/src/shadow_account/backtester.py
@@ -270,6 +270,7 @@ def run_shadow_backtest(
         profile=profile,
         journal_path=journal_path,
         combined=combined,
+        initial_capital=initial_capital,
     )
 
     result = ShadowBacktestResult(
@@ -280,7 +281,7 @@ def run_shadow_backtest(
         attribution=attribution,
         shadow_total_pnl=shadow_pnl,
         real_total_pnl=real_pnl,
-        delta_pnl=round(shadow_pnl - real_pnl, 2),
+        delta_pnl=round(shadow_pnl - real_pnl, 2) if shadow_pnl is not None else None,
     )
     _cache_result(base_dir, result)
     return result
@@ -312,9 +313,9 @@ def load_cached_result(shadow_id: str) -> ShadowBacktestResult | None:
             overtrading_pnl=float(attr.get("overtrading_pnl", 0.0)),
             counterfactual_trades=tuple(attr.get("counterfactual_trades") or ()),
         ),
-        shadow_total_pnl=float(data.get("shadow_total_pnl", 0.0)),
+        shadow_total_pnl=(None if data.get("shadow_total_pnl") is None else float(data["shadow_total_pnl"])),
         real_total_pnl=float(data.get("real_total_pnl", 0.0)),
-        delta_pnl=float(data.get("delta_pnl", 0.0)),
+        delta_pnl=None if data.get("delta_pnl") is None else float(data["delta_pnl"]),
     )
 
 
@@ -466,14 +467,38 @@ def _per_market_breakdown(
 
 # ---------------- Attribution ----------------
 
+def _shadow_pnl_from_metrics(combined: dict[str, float], initial_capital: float) -> float | None:
+    """Absolute shadow PnL in the pool's currency, or None when unknown.
+
+    The runner only emits ``final_value`` and ``total_return``; the explicit
+    keys are accepted first for older artifacts. A genuine zero is a valid
+    PnL, so presence is checked with ``is not None`` throughout.
+    """
+    explicit = combined.get("total_return_abs")
+    if explicit is None:
+        explicit = combined.get("total_pnl")
+    if explicit is not None:
+        return float(explicit)
+    final_value = combined.get("final_value")
+    if final_value is not None:
+        return float(final_value) - initial_capital
+    total_return = combined.get("total_return")
+    if total_return is not None:
+        return float(total_return) * initial_capital
+    return None
+
+
 def _attribution_or_zero(
     *,
     profile: ShadowProfile,
     journal_path: str | Path | None,
     combined: dict[str, float],
-) -> tuple[AttributionBreakdown, float, float]:
+    initial_capital: float,
+) -> tuple[AttributionBreakdown, float | None, float]:
     """Compute attribution if the journal is available, else return zeros."""
-    shadow_pnl = float(combined.get("total_return_abs") or combined.get("total_pnl") or 0.0)
+    shadow_pnl = _shadow_pnl_from_metrics(combined, initial_capital)
+    if shadow_pnl is None:
+        return _zero_attribution(), None, 0.0
     if not journal_path:
         return _zero_attribution(), shadow_pnl, 0.0
     path = Path(journal_path)

--- a/agent/src/shadow_account/models.py
+++ b/agent/src/shadow_account/models.py
@@ -98,13 +98,17 @@ class AttributionBreakdown:
 
 @dataclass(frozen=True)
 class ShadowBacktestResult:
-    """Output of multi-market shadow backtest + attribution."""
+    """Output of multi-market shadow backtest + attribution.
+
+    ``shadow_total_pnl``/``delta_pnl`` are None when the runner produced no
+    usable metrics; a failed comparison must never render as 0.0.
+    """
 
     shadow_id: str
     per_market: dict[str, dict[str, float]]
     combined: dict[str, float]
     equity_curves: dict[str, list[tuple[str, float]]]
     attribution: AttributionBreakdown
-    shadow_total_pnl: float
+    shadow_total_pnl: float | None
     real_total_pnl: float
-    delta_pnl: float
+    delta_pnl: float | None

--- a/agent/src/shadow_account/reporter.py
+++ b/agent/src/shadow_account/reporter.py
@@ -230,6 +230,8 @@ def _render_per_market_bar(result: ShadowBacktestResult, path: Path) -> None:
 
 
 def _render_attribution_waterfall(result: ShadowBacktestResult, path: Path) -> None:
+    if result.shadow_total_pnl is None or result.delta_pnl is None:
+        return
     attr = result.attribution
     components = [
         ("Real PnL", result.real_total_pnl),

--- a/agent/src/shadow_account/templates/shadow_report.html
+++ b/agent/src/shadow_account/templates/shadow_report.html
@@ -10,6 +10,7 @@
     <p class="eyebrow">Shadow Account Report</p>
     <h1>You vs Your Shadow</h1>
     <p class="subtitle">{{ profile.shadow_id }} | {{ profile.created_at }}</p>
+    {% if delta_pnl is not none %}
     <div class="cover-delta">
       <div class="delta-label">Delta PnL</div>
       <div class="delta-value {{ 'positive' if delta_pnl > 0 else 'negative' }}">
@@ -17,6 +18,12 @@
       </div>
       <div class="delta-caption">Shadow {{ '%.2f' | format(shadow_pnl) }} | Real {{ '%.2f' | format(real_pnl) }}</div>
     </div>
+    {% else %}
+    <div class="cover-delta">
+      <div class="delta-label">Delta PnL</div>
+      <div class="delta-caption">unavailable - the shadow backtest produced no usable metrics, so no comparison is shown</div>
+    </div>
+    {% endif %}
     <p class="disclaimer">Research use only - not investment advice. Data window: {{ profile.date_range[0] }} -> {{ profile.date_range[1] }}</p>
   </header>
 
@@ -94,7 +101,11 @@
 
   <section class="panel gut-punch">
     <h2>5. You vs Shadow - Delta Attribution</h2>
+    {% if shadow_pnl is not none %}
     <p class="lede">Shadow PnL <strong class="{{ 'pos' if shadow_pnl > 0 else 'neg' if shadow_pnl < 0 else '' }}">{{ '%+.2f' | format(shadow_pnl) }}</strong>, your real PnL <strong class="{{ 'pos' if real_pnl > 0 else 'neg' if real_pnl < 0 else '' }}">{{ '%+.2f' | format(real_pnl) }}</strong>, delta <strong class="{{ 'pos' if delta_pnl > 0 else 'neg' if delta_pnl < 0 else '' }}">{{ '%+.2f' | format(delta_pnl) }}</strong>.</p>
+    {% else %}
+    <p class="lede">The shadow backtest did not produce usable metrics, so Shadow PnL, delta, and the attribution below are not computed for this run.</p>
+    {% endif %}
     {% if charts.attribution_waterfall %}
       <img class="chart" src="{{ charts.attribution_waterfall }}" alt="attribution waterfall"/>
     {% endif %}

--- a/agent/src/tools/shadow_account_tool.py
+++ b/agent/src/tools/shadow_account_tool.py
@@ -302,7 +302,9 @@ class RenderShadowReportTool(BaseTool):
                         missed_signals_pnl=0.0, noise_trades_pnl=0.0, early_exit_pnl=0.0,
                         late_exit_pnl=0.0, overtrading_pnl=0.0, counterfactual_trades=(),
                     ),
-                    shadow_total_pnl=0.0, real_total_pnl=0.0, delta_pnl=0.0,
+                    shadow_total_pnl=None,
+                    real_total_pnl=0.0,
+                    delta_pnl=None,
                 )
 
         today_signals = (

--- a/agent/tests/test_shadow_account.py
+++ b/agent/tests/test_shadow_account.py
@@ -352,8 +352,11 @@ def test_run_shadow_backtest_with_mocked_runner(
         artifacts_dir = run_path / "artifacts"
         artifacts_dir.mkdir(parents=True, exist_ok=True)
         metrics_path = artifacts_dir / "metrics.json"
+        # Same key set the real runner emits (agent/src/core/runner.py
+        # metrics_csv): final_value/total_return, no explicit PnL field.
         metrics_path.write_text(json.dumps({
-            "total_return_abs": 12_345.0,
+            "final_value": 1_012_345.0,
+            "total_return": 0.012345,
             "sharpe": 1.5,
             "max_drawdown": -0.12,
             "win_rate": 0.55,
@@ -382,9 +385,9 @@ def test_run_shadow_backtest_with_mocked_runner(
     assert isinstance(result, ShadowBacktestResult)
     assert result.shadow_id == profile.shadow_id
     assert set(result.per_market.keys()) == {"china_a", "hk", "us", "crypto"}
-    assert result.combined["total_return_abs"] == 12_345.0
+    assert result.combined["final_value"] == 1_012_345.0
     assert result.combined["sharpe"] == 1.5
-    assert result.shadow_total_pnl == 12_345.0
+    assert result.shadow_total_pnl == pytest.approx(12_345.0)
     assert result.real_total_pnl > 0  # all profitable test data
     assert result.delta_pnl == round(result.shadow_total_pnl - result.real_total_pnl, 2)
     assert isinstance(result.attribution, AttributionBreakdown)
@@ -414,8 +417,81 @@ def test_run_shadow_backtest_handles_runner_failure(
         run_backtest_fn=failing_runner,
     )
     assert result.combined.get("error")
-    assert result.shadow_total_pnl == 0.0
+    assert result.shadow_total_pnl is None
+    assert result.delta_pnl is None
     assert result.equity_curves == {}
+
+    from src.shadow_account.backtester import load_cached_result
+
+    cached = load_cached_result(profile.shadow_id)
+    assert cached is not None
+    assert cached.shadow_total_pnl is None
+    assert cached.delta_pnl is None
+
+
+@pytest.mark.unit
+def test_shadow_pnl_derivation_from_runner_metrics() -> None:
+    from src.shadow_account.backtester import _shadow_pnl_from_metrics
+
+    # The exact metrics from the reported bad case: a completed A-share run
+    # whose only PnL signal is final_value/total_return.
+    metrics = {"final_value": 834_141.8041331805, "total_return": -0.1658581958668195, "trade_count": 16.0}
+    assert _shadow_pnl_from_metrics(metrics, 1_000_000.0) == pytest.approx(-165_858.20, abs=0.01)
+    # total_return alone carries the same information.
+    assert _shadow_pnl_from_metrics({"total_return": -0.1658581958668195}, 1_000_000.0) == pytest.approx(
+        -165_858.20, abs=0.01
+    )
+    # Explicit keys win when present, and a genuine zero is kept as zero.
+    assert _shadow_pnl_from_metrics({"total_return_abs": 0.0}, 1_000_000.0) == 0.0
+    assert _shadow_pnl_from_metrics({"total_return_abs": 5.0, "final_value": 1.0}, 1_000_000.0) == 5.0
+    assert _shadow_pnl_from_metrics({"total_pnl": -7.5}, 1_000_000.0) == -7.5
+    # No PnL signal at all means unknown, not zero.
+    assert _shadow_pnl_from_metrics({"sharpe": 1.2}, 1_000_000.0) is None
+    assert _shadow_pnl_from_metrics({}, 1_000_000.0) is None
+
+
+@pytest.mark.unit
+def test_run_shadow_backtest_derives_pnl_from_final_value(
+    profitable_journal: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end form of the reported bad case: runner-schema metrics in,
+    a real negative Shadow PnL out, and the None state survives the cache."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    profile = extract_shadow_profile(profitable_journal)
+
+    def stub_run_backtest(run_dir_str: str) -> str:
+        run_path = Path(run_dir_str)
+        artifacts_dir = run_path / "artifacts"
+        artifacts_dir.mkdir(parents=True, exist_ok=True)
+        metrics_path = artifacts_dir / "metrics.csv"
+        metrics_path.write_text(
+            "final_value,total_return,annual_return,max_drawdown,sharpe,win_rate,trade_count\n"
+            "834141.8041331805,-0.1658581958668195,-0.17,-0.21,-0.9,0.31,16\n",
+            encoding="utf-8",
+        )
+        return json.dumps({
+            "status": "ok",
+            "exit_code": 0,
+            "artifacts": {"metrics.csv": str(metrics_path)},
+        })
+
+    result = run_shadow_backtest(
+        profile,
+        window_start="2026-01-01",
+        window_end="2026-06-30",
+        journal_path=profitable_journal,
+        run_backtest_fn=stub_run_backtest,
+    )
+    assert result.shadow_total_pnl == pytest.approx(-165_858.20, abs=0.01)
+    assert result.delta_pnl == round(result.shadow_total_pnl - result.real_total_pnl, 2)
+
+    from src.shadow_account.backtester import load_cached_result
+
+    cached = load_cached_result(profile.shadow_id)
+    assert cached is not None
+    assert cached.shadow_total_pnl == pytest.approx(-165_858.20, abs=0.01)
+    assert cached.delta_pnl == result.delta_pnl
 
 
 # ---------------- M3b: per-currency multi-market runs ----------------
@@ -675,7 +751,8 @@ def test_all_currency_groups_failure(
     )
     assert len(calls) == 3
     assert result.combined.get("error")
-    assert result.shadow_total_pnl == 0.0
+    assert result.shadow_total_pnl is None
+    assert result.delta_pnl is None
     assert result.equity_curves == {}
     assert all(row == {} for row in result.per_market.values())
 
@@ -753,12 +830,16 @@ def test_render_shadow_report_handles_empty_equity(
             missed_signals_pnl=0.0, noise_trades_pnl=0.0, early_exit_pnl=0.0,
             late_exit_pnl=0.0, overtrading_pnl=0.0, counterfactual_trades=(),
         ),
-        shadow_total_pnl=0.0, real_total_pnl=0.0, delta_pnl=0.0,
+        shadow_total_pnl=None, real_total_pnl=0.0, delta_pnl=None,
     )
     out = render_shadow_report(profile, result, output_dir=tmp_path)
     assert Path(out["html_path"]).exists()
+    content = Path(out["html_path"]).read_text(encoding="utf-8")
+    # An unknown shadow PnL renders as unavailable, never as a fake 0.00.
+    assert "unavailable" in content
+    assert "did not produce usable metrics" in content
     # Section 6 should degrade gracefully when no counterfactuals exist.
-    assert "No material counterfactual" in Path(out["html_path"]).read_text(encoding="utf-8")
+    assert "No material counterfactual" in content
 
 
 @pytest.mark.unit
@@ -949,6 +1030,9 @@ def test_attribution_is_zero_without_journal(
     assert result.attribution.noise_trades_pnl == 0.0
     assert result.real_total_pnl == 0.0
     assert result.attribution.counterfactual_trades == ()
+    # An explicit zero PnL is a real measurement, not a missing value.
+    assert result.shadow_total_pnl == 0.0
+    assert result.delta_pnl == 0.0
 
 
 # ---------------- Price-context features (as-of buy_dt) ----------------


### PR DESCRIPTION
## Summary

- Shadow Account extracted PnL from `total_return_abs`/`total_pnl`, keys the runner never emits, so every successful backtest reported Shadow PnL = 0 and the Delta on the report cover came out inverted.
- PnL is now resolved from what the runner actually writes, and a run without usable metrics propagates an explicit unknown state instead of a fake zero.

## Why

Closes #1216. A user hit this on a real A-share run: final_value 834,141.80 on 1,000,000 initial capital rendered as Shadow PnL 0.00, Delta +9,368.05 instead of -156,490.15. I verified against `agent/src/core/runner.py` that the metrics schema has no PnL field, so the old expression could only return 0.0. The tests never caught it because their fixtures fed `total_return_abs`, a key production never produces.

## Changes

- `backtester._shadow_pnl_from_metrics`: explicit keys via `is not None` (a genuine zero survives), then `final_value - initial_capital`, then `total_return * initial_capital`, otherwise unknown.
- `ShadowBacktestResult.shadow_total_pnl`/`delta_pnl` become optional. Delta is computed only when the shadow side is known, and the cache round trip preserves None.
- The report cover and Section 5 show an explicit unavailable state for unknown runs, the waterfall chart is skipped, and the report tool's error fallback no longer fabricates zeros.

## Test Plan

- [x] New regression tests: the reported run's exact metrics (-165,858.20 derived from `final_value`), the derivation order, genuine-zero preservation, the unknown state, cache round trip, and the unavailable rendering path.
- [x] `pytest agent/tests/test_shadow_account.py -q`: 84 passed. Two failure-mode assertions moved from 0.0 to None, which is the contract change.
- [ ] Full suite and e2e not run; changes are confined to the shadow report path. `ruff check` clean on the touched files.

Risk: report rendering only, no broker, order, or mandate paths touched. Old cached results with float zeros still load. Rollback is a plain revert.

Prepared with AI assistance (Kimi K3); all verification above was run locally.
