### PR TITLE
fix(tools): add entry-order and market-data arbitration hints to trading_* tools

### DIFF
--- a/agent/mcp_server.py
+++ b/agent/mcp_server.py
@@ -1356,8 +1356,9 @@ def _trading_common_args(
 def trading_connections() -> str:
     """List selectable trading connector profiles.
 
-    The connector is the first-level choice. Paper/live is an attribute of each
-    profile under that connector.
+    Start here before any other ``trading_*`` call. The connector is the
+    first-level choice. Paper/live is an attribute of each profile under that
+    connector.
     """
     registry = _get_registry()
     return registry.execute("trading_connections", {})
@@ -1366,6 +1367,8 @@ def trading_connections() -> str:
 @mcp.tool
 def trading_select_connection(connection: str) -> str:
     """Select the default trading connector profile for later trading_* calls.
+
+    Run ``trading_connections`` first to list valid profile ids.
 
     Args:
         connection: Profile id, e.g. ``ibkr-paper-local`` or ``robinhood-live-mcp``.
@@ -1384,9 +1387,10 @@ def trading_check(
 ) -> str:
     """Check whether a trading connector profile is configured and reachable.
 
-    This never places orders. For local profiles, it checks the user's local
-    app/socket. For remote MCP profiles, it reports config and OAuth-token
-    presence without returning secrets.
+    Run ``trading_connections`` first to list profiles. This never places
+    orders. For local profiles, it checks the user's local app/socket. For
+    remote MCP profiles, it reports config and OAuth-token presence without
+    returning secrets.
 
     Args:
         connection: Optional profile id. Defaults to the selected profile.
@@ -1412,6 +1416,9 @@ def trading_account(
 ) -> str:
     """Read account data from the selected trading connector profile.
 
+    Requires a configured connector profile; run ``trading_connections`` to
+    list profiles.
+
     Args:
         connection: Optional profile id. Defaults to the selected profile.
         host: Optional local host override.
@@ -1435,6 +1442,9 @@ def trading_positions(
     account: str | None = None,
 ) -> str:
     """Read positions from the selected trading connector profile.
+
+    Requires a configured connector profile; run ``trading_connections`` to
+    list profiles.
 
     Args:
         connection: Optional profile id. Defaults to the selected profile.
@@ -1461,7 +1471,9 @@ def trading_orders(
 ) -> str:
     """Read open orders from the selected trading connector profile.
 
-    Read-only: this tool does not place, cancel, modify, or replace orders.
+    Requires a configured connector profile; run ``trading_connections`` to
+    list profiles. Read-only: this tool does not place, cancel, modify, or
+    replace orders.
 
     Args:
         connection: Optional profile id. Defaults to the selected profile.
@@ -1490,6 +1502,9 @@ def trading_quote(
     sec_type: str = "STK",
 ) -> str:
     """Read a quote snapshot from the selected trading connector profile.
+
+    This is the broker-account view. For market quotes without a broker
+    connection, use ``get_market_data`` instead.
 
     Args:
         symbol: Symbol such as AAPL.
@@ -1527,6 +1542,9 @@ def trading_history(
     limit: int = 90,
 ) -> str:
     """Read historical bars from the selected trading connector profile.
+
+    This is the broker-account view. For market OHLCV without a broker
+    connection, use ``get_market_data`` instead.
 
     Args:
         symbol: Symbol such as AAPL.

--- a/agent/src/tools/trading_connector_tool.py
+++ b/agent/src/tools/trading_connector_tool.py
@@ -217,7 +217,8 @@ class TradingConnectionsTool(BaseTool):
 
     name = "trading_connections"
     description = (
-        "List selectable trading connector profiles. Connectors come first; paper/live is a profile attribute."
+        "List selectable trading connector profiles. Start here before any other trading_* call. "
+        "Connectors come first; paper/live is a profile attribute."
     )
     parameters = {"type": "object", "properties": {}, "required": []}
     repeatable = True
@@ -242,7 +243,10 @@ class TradingSelectConnectionTool(BaseTool):
     """Select the default trading connector profile."""
 
     name = "trading_select_connection"
-    description = "Select the default trading connector profile for subsequent trading_* tool calls."
+    description = (
+        "Select the default trading connector profile for subsequent trading_* tool calls. "
+        "Run trading_connections first to list valid profile ids."
+    )
     parameters = {
         "type": "object",
         "properties": {
@@ -270,7 +274,10 @@ class TradingCheckTool(BaseTool):
     """Check a trading connector profile."""
 
     name = "trading_check"
-    description = "Check whether a trading connector profile is configured and reachable. This never places orders."
+    description = (
+        "Check whether a trading connector profile is configured and reachable. "
+        "Run trading_connections first to list profiles. This never places orders."
+    )
     parameters = {
         "type": "object",
         "properties": TRADING_COMMON_PARAMETERS,
@@ -291,7 +298,10 @@ class TradingAccountTool(BaseTool):
     """Read account summary from a trading connector profile."""
 
     name = "trading_account"
-    description = "Read account summary from the selected trading connector profile. Read-only."
+    description = (
+        "Read account summary from the selected trading connector profile. "
+        "Requires a configured connector profile; run trading_connections to list profiles. Read-only."
+    )
     parameters = TradingCheckTool.parameters
     repeatable = True
     is_readonly = True
@@ -308,7 +318,10 @@ class TradingPositionsTool(BaseTool):
     """Read positions from a trading connector profile."""
 
     name = "trading_positions"
-    description = "Read positions from the selected trading connector profile. Read-only."
+    description = (
+        "Read positions from the selected trading connector profile. "
+        "Requires a configured connector profile; run trading_connections to list profiles. Read-only."
+    )
     parameters = TradingCheckTool.parameters
     repeatable = True
     is_readonly = True
@@ -325,7 +338,10 @@ class TradingOrdersTool(BaseTool):
     """Read open orders from a trading connector profile."""
 
     name = "trading_orders"
-    description = "Read open orders from the selected trading connector profile. Read-only."
+    description = (
+        "Read open orders from the selected trading connector profile. "
+        "Requires a configured connector profile; run trading_connections to list profiles. Read-only."
+    )
     parameters = {
         "type": "object",
         "properties": {
@@ -355,7 +371,10 @@ class TradingQuoteTool(BaseTool):
     """Read a quote from a trading connector profile."""
 
     name = "trading_quote"
-    description = "Read a quote snapshot from the selected trading connector profile. Read-only."
+    description = (
+        "Read a quote snapshot from the selected trading connector profile. "
+        "For market quotes without a broker connection, use get_market_data instead. Read-only."
+    )
     parameters = {
         "type": "object",
         "properties": {
@@ -391,7 +410,10 @@ class TradingHistoryTool(BaseTool):
     """Read historical bars from a trading connector profile."""
 
     name = "trading_history"
-    description = "Read historical bars from the selected trading connector profile. Read-only."
+    description = (
+        "Read historical bars from the selected trading connector profile. "
+        "For market OHLCV without a broker connection, use get_market_data instead. Read-only."
+    )
     parameters = {
         "type": "object",
         "properties": {


### PR DESCRIPTION
## Summary

- The eight MCP-surface `trading_*` tools get entry-order hints: `trading_connections` is marked as the start point, and `trading_select_connection` / `trading_check` / `trading_account` / `trading_positions` / `trading_orders` point back to it.
- `trading_quote` and `trading_history` get explicit arbitration against `get_market_data`: they are the broker-account view; for market quotes/OHLCV without a broker connection, use `get_market_data` instead.
- Mirrored on both routing surfaces: agent tool-class descriptions (`trading_connector_tool.py`) and MCP wrapper docstrings (`mcp_server.py`).

## Why

Part of #1218 (Stage A). Today nothing tells a router when to prefer `trading_quote`/`trading_history` over `get_market_data`, so plain market-data queries from users with no broker connected have no deterministic winner — the broker-view tools can only fail at runtime for them, yet they compete for the same queries. The eight tools also had no workflow order: a first-time connector user saw eight parallel-looking tools with no "start here".

Deliberately out of scope (tracked in #1218 as Stage B/C): capability-aware exposure of the 17 agent-only extended trading tools, and disclosure-tier / lazy-recall work. Registration-time gating of the eight tools was investigated and rejected in #1218 — the 13 seed profiles are always present, the default `ibkr-paper-local` profile is a documented zero-config path, and every tool accepts an explicit `connection` parameter, so no non-breaking gate predicate exists.

## Changes

- `agent/src/tools/trading_connector_tool.py`: description updates on the eight MCP-surface tool classes (`TradingConnectionsTool`, `TradingSelectConnectionTool`, `TradingCheckTool`, `TradingAccountTool`, `TradingPositionsTool`, `TradingOrdersTool`, `TradingQuoteTool`, `TradingHistoryTool`).
- `agent/mcp_server.py`: the same hints in the eight wrapper docstrings, so MCP clients see identical routing guidance.

Description-only: no execute-path, parameter-schema, or registration change; MCP tool count stays 74.

## Test Plan

- [x] Existing tests pass (narrowed to the touched surfaces: `pytest tests/test_mcp_server_smoke.py tests/test_mcp_regression.py tests/test_readme_counts.py -q` → 78 passed)
- [x] `ruff check` clean on both changed files; changed lines are black-clean (pre-existing reformat candidates in the same files left untouched per CONTRIBUTING.md)
- [x] `python -m py_compile` on both changed files
- [x] Verified rendered descriptions on both surfaces: `mcp.list_tools()` shows the new MCP docstrings (74 tools, unchanged); agent tool classes expose the new descriptions
- [ ] Tested manually: not applicable — description-only change, no runtime path altered

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Documentation updated (if user-facing change) — the tool descriptions are the user-facing surface here; README counts are unaffected (verified by `test_readme_counts.py`)

## Risk and rollback

No broker, live-trading, network, secret, or deployment behavior is changed — only routing-surface text. MCP surface change is additive description text; clients that cache `tools/list` simply see the new guidance on next fetch. Rollback is reverting the one commit.
