### PR TITLE
test(quantlib): pin that rows between combinatorial test blocks stay trainable

### DIFF
--- a/agent/tests/quantlib/test_crossvalidation.py
+++ b/agent/tests/quantlib/test_crossvalidation.py
@@ -212,6 +212,27 @@ def test_combinatorial_holds_out_more_than_one_block_at_a_time():
         assert split.test.size >= 3 * (n // 6) - 3
 
 
+def test_combinatorial_gap_between_test_blocks_stays_trainable():
+    # Rows between two held-out blocks belong to neither test segment, so
+    # with zero-width labels and no embargo they must survive the purge.
+    n = 600
+    labels = np.arange(n)
+    saw_gap = False
+    for split in combinatorial_purged_splits(
+        n, labels, n_groups=6, n_test_groups=2, embargo_fraction=0.0
+    ):
+        test = np.sort(split.test)
+        blocks = np.split(test, np.flatnonzero(np.diff(test) > 1) + 1)
+        if len(blocks) < 2:
+            continue  # adjacent held-out groups merge into one segment
+        saw_gap = True
+        for left, right in zip(blocks, blocks[1:]):
+            gap = np.arange(left[-1] + 1, right[0])
+            assert gap.size > 0
+            assert np.isin(gap, split.train).all()
+    assert saw_gap
+
+
 # --- label end times as a pandas Series of timestamps ---
 
 


### PR DESCRIPTION
## Summary

- Adds the regression pin #1204 shipped without: rows sitting between two non-contiguous test blocks must survive purge and embargo.

## Why

#1204 fixed the single-span purge treating the whole first-to-last test span as test, but its tests only cover the empty-training guard. This test fails on 10 of the combinatorial folds against the pre-#1204 implementation and passes on current main, so the multi-segment behavior is now pinned against regressions.

## Changes

- One test in `agent/tests/quantlib/test_crossvalidation.py`: with zero-width labels and no embargo, every gap row between two held-out blocks stays in the training set.

## Test Plan

- [x] `pytest agent/tests/quantlib/test_crossvalidation.py -q`: 37 passed.
- [x] Verified the test fails against the pre-#1204 module (10 folds purge gap rows).
- [x] `ruff check` clean.

Risk: test-only change, no runtime code touched. Rollback is a plain revert.

Prepared with AI assistance (Kimi K3); verification above was run locally.
