### PR TITLE
fix(live): recover Alpaca submissions by exact client IDFix/live resolve submit by client

### DIFF
--- a/agent/src/live/audit.py
+++ b/agent/src/live/audit.py
@@ -251,6 +251,7 @@ def write_live_action(
     event_callback: EventCallback | None = None,
     trace_writer: _TraceWriterLike | None = None,
     chain: bool = True,
+    require_durable: bool = False,
 ) -> dict[str, Any]:
     """Fan a redacted live-action record out to up to three sinks (SPEC §5).
 
@@ -290,6 +291,7 @@ def write_live_action(
             exact historical record shape and ledger file. Raises
             :class:`src.governance.ledger.LedgerCorruptionError` if that
             chain ledger's existing history is already broken.
+        require_durable: Raise when the classic ledger fsync fails.
 
     Returns:
         The redacted record dict — identical to what was written to every sink —
@@ -312,6 +314,8 @@ def write_live_action(
             os.fsync(handle.fileno())
         except OSError as exc:
             _warn_fsync_failure(exc, path)
+            if require_durable:
+                raise
 
     if chain:
         from src.governance.ledger import append_record

--- a/agent/src/live/daily_count.py
+++ b/agent/src/live/daily_count.py
@@ -35,6 +35,10 @@ class DailyOrderLockUnavailable(RuntimeError):
     """Raised when another process holds the broker's order permit lock."""
 
 
+class DailyCountError(RuntimeError):
+    """Raised when action-ID accounting cannot be trusted or persisted."""
+
+
 def _counter_path(broker: str):
     return broker_dir(broker) / _COUNTER_FILENAME
 
@@ -120,15 +124,67 @@ def read_daily_count(broker: str) -> int:
         return 0
 
 
-def increment_daily_count(broker: str) -> int:
+def increment_daily_count(broker: str, action_id: str | None = None) -> int:
     """Persist ``broker``'s incremented count for today (atomic). Returns new count."""
     today = _utc_today()
-    count = read_daily_count(broker) + 1
+    if action_id is not None and not (1 <= len(action_id) <= 128):
+        raise DailyCountError("action_id must contain 1-128 characters")
+    try:
+        action_ids = _read_action_ids(broker)
+    except DailyCountError:
+        if action_id is not None:
+            raise
+        action_ids = []
+    count = read_daily_count(broker)
+    if action_id is not None and action_id in action_ids:
+        return count
+    count += 1
+    if action_id is not None:
+        action_ids.append(action_id)
     path = _counter_path(broker)
     path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     tmp = path.with_name(
         f".{path.name}.{os.getpid()}.{threading.get_ident()}.tmp"
     )
-    tmp.write_text(json.dumps({"date": today, "count": count}, ensure_ascii=False), encoding="utf-8")
-    tmp.replace(path)
+    payload = json.dumps({"date": today, "count": count, "action_ids": action_ids}, ensure_ascii=False)
+    try:
+        with tmp.open("x", encoding="utf-8", newline="\n") as handle:
+            handle.write(payload + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        tmp.replace(path)
+        if os.name != "nt":
+            descriptor = os.open(path.parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+            try:
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+    except Exception as exc:
+        try:
+            tmp.unlink()
+        except OSError as cleanup_exc:
+            exc.add_note(f"temporary count cleanup also failed: {cleanup_exc}")
+        raise DailyCountError("daily order count could not be persisted") from exc
     return count
+
+
+def _read_action_ids(broker: str) -> list[str]:
+    path = _counter_path(broker)
+    if not path.is_file():
+        return []
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise DailyCountError("daily order count cannot be read") from exc
+    if not isinstance(raw, dict) or raw.get("date") != _utc_today():
+        return []
+    count, values = raw.get("count"), raw.get("action_ids", [])
+    if (
+        isinstance(count, bool) or not isinstance(count, int) or count < 0
+        or not isinstance(values, list)
+        or any(not isinstance(value, str) or not value for value in values)
+        or len(set(values)) != len(values)
+        or len(values) > count
+    ):
+        raise DailyCountError("daily order count has an invalid schema")
+    return values

--- a/agent/src/live/daily_count.py
+++ b/agent/src/live/daily_count.py
@@ -12,6 +12,7 @@ import json
 import os
 import threading
 from contextlib import contextmanager
+from datetime import date as calendar_date
 from datetime import datetime, timezone
 from typing import BinaryIO, Iterator
 
@@ -136,6 +137,8 @@ def increment_daily_count(broker: str, action_id: str | None = None) -> int:
             raise
         counter_date = None
         action_ids = []
+    if action_id is not None and counter_date is not None and counter_date > today:
+        raise DailyCountError("daily order count date is in the future")
     count = read_daily_count(broker)
     if action_id is not None and action_id in action_ids:
         return count
@@ -145,12 +148,12 @@ def increment_daily_count(broker: str, action_id: str | None = None) -> int:
     if action_id is not None:
         action_ids.append(action_id)
     path = _counter_path(broker)
-    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     tmp = path.with_name(
         f".{path.name}.{os.getpid()}.{threading.get_ident()}.tmp"
     )
     payload = json.dumps({"date": today, "count": count, "action_ids": action_ids}, ensure_ascii=False)
     try:
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
         with tmp.open("x", encoding="utf-8", newline="\n") as handle:
             handle.write(payload + "\n")
             handle.flush()
@@ -182,11 +185,21 @@ def _read_action_ids(broker: str) -> tuple[str | None, list[str]]:
     if not isinstance(raw, dict):
         raise DailyCountError("daily order count has an invalid schema")
     date, count, values = raw.get("date"), raw.get("count"), raw.get("action_ids", [])
+    try:
+        valid_date = (
+            isinstance(date, str)
+            and calendar_date.fromisoformat(date).isoformat() == date
+        )
+    except ValueError:
+        valid_date = False
     if (
-        not isinstance(date, str) or not date
+        not valid_date
         or isinstance(count, bool) or not isinstance(count, int) or count < 0
         or not isinstance(values, list)
-        or any(not isinstance(value, str) or not value for value in values)
+        or any(
+            not isinstance(value, str) or not (1 <= len(value) <= 128)
+            for value in values
+        )
         or len(set(values)) != len(values)
         or len(values) > count
     ):

--- a/agent/src/live/daily_count.py
+++ b/agent/src/live/daily_count.py
@@ -130,14 +130,17 @@ def increment_daily_count(broker: str, action_id: str | None = None) -> int:
     if action_id is not None and not (1 <= len(action_id) <= 128):
         raise DailyCountError("action_id must contain 1-128 characters")
     try:
-        action_ids = _read_action_ids(broker)
+        counter_date, action_ids = _read_action_ids(broker)
     except DailyCountError:
         if action_id is not None:
             raise
+        counter_date = None
         action_ids = []
     count = read_daily_count(broker)
     if action_id is not None and action_id in action_ids:
         return count
+    if counter_date != today:
+        action_ids = []
     count += 1
     if action_id is not None:
         action_ids.append(action_id)
@@ -168,23 +171,24 @@ def increment_daily_count(broker: str, action_id: str | None = None) -> int:
     return count
 
 
-def _read_action_ids(broker: str) -> list[str]:
+def _read_action_ids(broker: str) -> tuple[str | None, list[str]]:
     path = _counter_path(broker)
     if not path.is_file():
-        return []
+        return None, []
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError) as exc:
         raise DailyCountError("daily order count cannot be read") from exc
-    if not isinstance(raw, dict) or raw.get("date") != _utc_today():
-        return []
-    count, values = raw.get("count"), raw.get("action_ids", [])
+    if not isinstance(raw, dict):
+        raise DailyCountError("daily order count has an invalid schema")
+    date, count, values = raw.get("date"), raw.get("count"), raw.get("action_ids", [])
     if (
-        isinstance(count, bool) or not isinstance(count, int) or count < 0
+        not isinstance(date, str) or not date
+        or isinstance(count, bool) or not isinstance(count, int) or count < 0
         or not isinstance(values, list)
         or any(not isinstance(value, str) or not value for value in values)
         or len(set(values)) != len(values)
         or len(values) > count
     ):
         raise DailyCountError("daily order count has an invalid schema")
-    return values
+    return date, values

--- a/agent/src/live/pending_action.py
+++ b/agent/src/live/pending_action.py
@@ -44,20 +44,38 @@ class PendingOrderRequest(BaseModel):
         return self
 
 
+class RecoveredOrderEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    broker_order_id: str = Field(min_length=1)
+    client_order_id: str = Field(min_length=1, max_length=48)
+    symbol: str = Field(min_length=1)
+    side: Literal["buy", "sell"]
+    order_type: Literal["market", "limit"]
+    time_in_force: Literal["day", "gtc"]
+    quantity: float | int | None
+    notional: float | int | None
+    limit_price: float | int | None
+    filled_qty: float | int
+    order_status: str = Field(min_length=1)
+    submitted_at: str = Field(min_length=1)
+
+
 class PendingAction(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
 
     schema_version: Literal[1]
     broker: Literal["alpaca"]
     action_id: str = Field(pattern=r"^act_[0-9a-f]{32}$")
-    phase: Literal["pending_write"]
+    phase: Literal["pending_write", "resolved_needs_revalidation"]
     kind: Literal["place_order"]
     created_at: datetime
     client_order_id: str = Field(min_length=1, max_length=48)
-    broker_order_id: None = None
+    broker_order_id: str | None = None
     request: PendingOrderRequest
     pre_position_qty: float | int | None
     remediation_attempts: Literal[0]
+    resolution: RecoveredOrderEvidence | None = None
 
     @model_validator(mode="after")
     def validate_evidence(self) -> Self:
@@ -67,6 +85,16 @@ class PendingAction(BaseModel):
             self.pre_position_qty
         ):
             raise ValueError("pre-position quantity must be finite")
+        if self.phase == "pending_write" and (
+            self.broker_order_id is not None or self.resolution is not None
+        ):
+            raise ValueError("pending write cannot contain resolved evidence")
+        if self.phase == "resolved_needs_revalidation" and (
+            self.resolution is None
+            or self.broker_order_id != self.resolution.broker_order_id
+            or self.client_order_id != self.resolution.client_order_id
+        ):
+            raise ValueError("resolved phase requires matching exact evidence")
         return self
 
 
@@ -125,6 +153,30 @@ def save_pending_action(action: PendingAction) -> None:
     path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     if path.exists() or path.is_symlink():
         raise PendingActionError("a pending broker action already exists")
+    _write_action(path, action)
+
+
+def transition_to_revalidation(
+    action: PendingAction, evidence: Mapping[str, object]
+) -> PendingAction:
+    """Durably retain exact working-order truth for later policy revalidation."""
+    resolution = RecoveredOrderEvidence.model_validate(evidence)
+    updated = PendingAction.model_validate(
+        {
+            **action.model_dump(mode="python"),
+            "phase": "resolved_needs_revalidation",
+            "broker_order_id": resolution.broker_order_id,
+            "resolution": resolution,
+        }
+    )
+    current = load_pending_action(action.broker)
+    if current is None or current.action_id != action.action_id:
+        raise PendingActionError("pending action changed before transition")
+    _write_action(pending_action_path(action.broker), updated)
+    return updated
+
+
+def _write_action(path: Path, action: PendingAction) -> None:
     payload = json.dumps(
         action.model_dump(mode="json"),
         allow_nan=False,

--- a/agent/src/live/pending_action.py
+++ b/agent/src/live/pending_action.py
@@ -7,6 +7,7 @@ import math
 import os
 import uuid
 from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Literal, Mapping, Self
 
@@ -60,6 +61,57 @@ class RecoveredOrderEvidence(BaseModel):
     order_status: str = Field(min_length=1)
     submitted_at: str = Field(min_length=1)
 
+    @model_validator(mode="after")
+    def validate_order_evidence(self) -> Self:
+        try:
+            quantity = (
+                Decimal(str(self.quantity)) if self.quantity is not None else None
+            )
+            notional = (
+                Decimal(str(self.notional)) if self.notional is not None else None
+            )
+            limit_price = (
+                Decimal(str(self.limit_price)) if self.limit_price is not None else None
+            )
+            filled = Decimal(str(self.filled_qty))
+            submitted = datetime.fromisoformat(self.submitted_at.replace("Z", "+00:00"))
+        except (InvalidOperation, ValueError) as exc:
+            raise ValueError("recovered order evidence is malformed") from exc
+        numerics = [
+            value
+            for value in (quantity, notional, limit_price, filled)
+            if value is not None
+        ]
+        supported = {
+            "accepted",
+            "new",
+            "open",
+            "pending_new",
+            "accepted_for_bidding",
+            "rejected",
+            "canceled",
+            "expired",
+            "partially_filled",
+            "filled",
+        }
+        working = {"accepted", "new", "open", "pending_new", "accepted_for_bidding"}
+        fill_statuses = {"partially_filled", "filled"}
+        if (
+            (quantity is None) == (notional is None)
+            or any(not value.is_finite() for value in numerics)
+            or any(value <= 0 for value in (quantity, notional) if value is not None)
+            or filled < 0
+            or (self.order_type == "limit") != (limit_price is not None)
+            or (limit_price is not None and limit_price <= 0)
+            or submitted.tzinfo is None
+            or self.order_status not in supported
+            or (filled == 0 and self.order_status in fill_statuses)
+            or (filled > 0 and self.order_status in working | {"rejected"})
+            or (quantity is not None and filled > quantity)
+        ):
+            raise ValueError("recovered order evidence is contradictory")
+        return self
+
 
 class PendingAction(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
@@ -95,6 +147,28 @@ class PendingAction(BaseModel):
             or self.client_order_id != self.resolution.client_order_id
         ):
             raise ValueError("resolved phase requires matching exact evidence")
+        if self.resolution is not None:
+            request = self.request
+            resolution = self.resolution
+            numeric_pairs = (
+                (resolution.quantity, request.quantity),
+                (resolution.notional, request.notional),
+                (resolution.limit_price, request.limit_price),
+            )
+            if (
+                resolution.symbol != request.symbol
+                or resolution.side != request.side
+                or resolution.order_type != request.order_type
+                or resolution.time_in_force != request.time_in_force
+                or any(
+                    actual is None
+                    or expected is None
+                    or Decimal(str(actual)) != Decimal(str(expected))
+                    for actual, expected in numeric_pairs
+                    if actual is not None or expected is not None
+                )
+            ):
+                raise ValueError("resolved evidence contradicts the owned request")
         return self
 
 

--- a/agent/src/live/pending_action.py
+++ b/agent/src/live/pending_action.py
@@ -1,0 +1,175 @@
+"""Crash-safe ownership marker for one unresolved broker side effect."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal, Mapping, Self
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from src.live.paths import broker_dir
+
+_FILENAME = "pending_action.json"
+
+
+class PendingActionError(RuntimeError):
+    """Raised when pending state cannot be trusted or durably changed."""
+
+
+class PendingOrderRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    symbol: str = Field(min_length=1)
+    side: Literal["buy", "sell"]
+    quantity: float | int | None
+    notional: float | int | None
+    order_type: Literal["market", "limit"]
+    limit_price: float | int | None
+    time_in_force: Literal["day", "gtc"]
+
+    @model_validator(mode="after")
+    def validate_order(self) -> Self:
+        if (self.quantity is None) == (self.notional is None):
+            raise ValueError("exactly one order size is required")
+        for value in (self.quantity, self.notional, self.limit_price):
+            if value is not None and (not math.isfinite(value) or value <= 0):
+                raise ValueError("order numerics must be finite and positive")
+        if (self.order_type == "limit") != (self.limit_price is not None):
+            raise ValueError("limit price must match the order type")
+        return self
+
+
+class PendingAction(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    schema_version: Literal[1]
+    broker: Literal["alpaca"]
+    action_id: str = Field(pattern=r"^act_[0-9a-f]{32}$")
+    phase: Literal["pending_write"]
+    kind: Literal["place_order"]
+    created_at: datetime
+    client_order_id: str = Field(min_length=1, max_length=48)
+    broker_order_id: None = None
+    request: PendingOrderRequest
+    pre_position_qty: float | int | None
+    remediation_attempts: Literal[0]
+
+    @model_validator(mode="after")
+    def validate_evidence(self) -> Self:
+        if self.created_at.tzinfo is None:
+            raise ValueError("created_at requires a timezone")
+        if self.pre_position_qty is not None and not math.isfinite(
+            self.pre_position_qty
+        ):
+            raise ValueError("pre-position quantity must be finite")
+        return self
+
+
+def new_pending_order(
+    broker: str,
+    request: Mapping[str, object],
+    *,
+    pre_position_qty: float | None,
+) -> PendingAction:
+    """Build the redaction-safe marker written immediately before submission."""
+    key = _broker_key(broker)
+    return PendingAction(
+        schema_version=1,
+        broker=key,
+        action_id=f"act_{uuid.uuid4().hex}",
+        phase="pending_write",
+        kind="place_order",
+        created_at=datetime.now(timezone.utc),
+        client_order_id=f"vt-{uuid.uuid4().hex}",
+        request=PendingOrderRequest(
+            symbol=str(request.get("symbol") or "").strip().upper(),
+            side=str(request.get("side") or "").strip().lower(),
+            quantity=request.get("quantity"),
+            notional=request.get("notional"),
+            order_type=str(request.get("order_type") or "market").strip().lower(),
+            limit_price=request.get("limit_price"),
+            time_in_force=str(request.get("time_in_force") or "day").strip().lower(),
+        ),
+        pre_position_qty=pre_position_qty,
+        remediation_attempts=0,
+    )
+
+
+def pending_action_path(broker: str) -> Path:
+    return broker_dir(_broker_key(broker)) / _FILENAME
+
+
+def load_pending_action(broker: str) -> PendingAction | None:
+    """Load strict pending evidence; malformed state raises and fails closed."""
+    path = pending_action_path(broker)
+    try:
+        payload = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise PendingActionError("pending action cannot be read") from exc
+    try:
+        return PendingAction.model_validate_json(payload)
+    except ValidationError as exc:
+        raise PendingActionError("pending action has an invalid schema") from exc
+
+
+def save_pending_action(action: PendingAction) -> None:
+    """Durably create pending evidence without replacing an existing marker."""
+    path = pending_action_path(action.broker)
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if path.exists() or path.is_symlink():
+        raise PendingActionError("a pending broker action already exists")
+    payload = json.dumps(
+        action.model_dump(mode="json"),
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
+    try:
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(payload + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+        _fsync_directory(path.parent)
+    except Exception:
+        try:
+            temporary.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def clear_pending_action(broker: str, action_id: str) -> None:
+    """Durably remove exactly the marker whose resolution was audited."""
+    action = load_pending_action(broker)
+    if action is None or action.action_id != action_id:
+        raise PendingActionError("pending action changed before clear")
+    path = pending_action_path(broker)
+    path.unlink()
+    _fsync_directory(path.parent)
+
+
+def _broker_key(broker: str) -> str:
+    key = str(broker or "").strip().lower()
+    if key != "alpaca":
+        raise ValueError("pending submit ownership currently supports Alpaca only")
+    return key
+
+
+def _fsync_directory(directory: Path) -> None:
+    if os.name == "nt":  # Windows has no portable directory fsync.
+        return
+    descriptor = os.open(directory, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)

--- a/agent/src/live/sdk_order_gate.py
+++ b/agent/src/live/sdk_order_gate.py
@@ -473,7 +473,12 @@ def _allow(broker, session_id, connector_module, config, intent, place_kwargs, m
         result = {**result, LIVE_ACTION_RESULT_KEY: record}
     if pending is not None:
         cleared = False
-        if not is_error and record is not None:
+        exact_ack = (
+            isinstance(result, dict)
+            and result.get("client_order_id") == pending.client_order_id
+            and bool(result.get("order_id"))
+        )
+        if not is_error and exact_ack and record is not None:
             try:
                 pending_action.clear_pending_action(broker, pending.action_id)
                 cleared = True

--- a/agent/src/live/sdk_order_gate.py
+++ b/agent/src/live/sdk_order_gate.py
@@ -25,11 +25,13 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
 from typing import Any
 
 from src.live import pending_action
 from src.live.audit import LiveActionEvent, write_live_action
 from src.live.daily_count import (
+    DailyCountError,
     DailyOrderLockUnavailable,
     daily_order_lock,
     increment_daily_count,
@@ -134,10 +136,14 @@ def execute_live_order(
                         intent=intent, reason_code="pending_action_invalid",
                     )
                 if unresolved is not None:
-                    return _deny(
-                        broker, session_id, "pending broker action requires recovery",
-                        ["mandate", "expiry", "halt_flag", "pending_action"], mandate,
-                        intent=intent, reason_code="pending_action_unresolved",
+                    if unresolved.phase == "resolved_needs_revalidation":
+                        return _deny(
+                            broker, session_id, "recovered broker order requires policy revalidation",
+                            ["mandate", "expiry", "halt_flag", "pending_action"], mandate,
+                            intent=intent, reason_code="pending_action_needs_revalidation",
+                        )
+                    return _recover_pending_order(
+                        broker, session_id, connector_module, config, mandate, unresolved
                     )
             daily_count = read_daily_count(broker)
             breach = check_mandate(
@@ -428,6 +434,7 @@ def _allow(broker, session_id, connector_module, config, intent, place_kwargs, m
         result = {"status": "error", "error": str(exc)}
 
     is_error = not isinstance(result, dict) or str(result.get("status", "")).lower() != "ok"
+    accounting_failed = False
     checked = [
         "mandate",
         "expiry",
@@ -457,7 +464,13 @@ def _allow(broker, session_id, connector_module, config, intent, place_kwargs, m
             error=_error_message(result),
         )
     else:
-        increment_daily_count(broker)
+        try:
+            if pending is not None:
+                increment_daily_count(broker, pending.action_id)
+            else:
+                increment_daily_count(broker)
+        except DailyCountError:
+            accounting_failed = True
         record = _audit(
             broker,
             session_id,
@@ -467,7 +480,8 @@ def _allow(broker, session_id, connector_module, config, intent, place_kwargs, m
             intent=intent,
             broker_request=dict(place_kwargs),
             broker_response=result,
-            gate_decision={"allowed": True, "decision": _DECISION_ALLOW, "checked_limits": checked},
+            gate_decision={"allowed": True, "decision": _DECISION_ALLOW, "checked_limits": checked,
+                           **({"reason_code": "daily_action_accounting_failed"} if accounting_failed else {})},
         )
     if isinstance(result, dict) and record is not None:
         result = {**result, LIVE_ACTION_RESULT_KEY: record}
@@ -478,7 +492,7 @@ def _allow(broker, session_id, connector_module, config, intent, place_kwargs, m
             and result.get("client_order_id") == pending.client_order_id
             and bool(result.get("order_id"))
         )
-        if not is_error and exact_ack and record is not None:
+        if not is_error and not accounting_failed and exact_ack and record is not None:
             try:
                 pending_action.clear_pending_action(broker, pending.action_id)
                 cleared = True
@@ -492,6 +506,130 @@ def _allow(broker, session_id, connector_module, config, intent, place_kwargs, m
                 "reason_code": "pending_action_unresolved",
             }
     return result if isinstance(result, dict) else {"status": "error", "error": "non-dict broker result"}
+
+
+def _recover_pending_order(broker, session_id, connector, config, mandate, action):
+    """Resolve one Alpaca submission by exact identity, never by resubmission."""
+    checked = ["mandate", "expiry", "halt_flag", "pending_action", "exact_broker_evidence"]
+
+    def unresolved(reason):
+        return _deny(
+            broker, session_id, reason, checked, mandate,
+            intent=None, reason_code="pending_action_unresolved",
+        )
+
+    lookup = getattr(connector, "get_order_by_client_order_id", None)
+    if lookup is None:
+        return unresolved("connector lacks exact order recovery")
+    try:
+        response = lookup(config, client_order_id=action.client_order_id)
+    except Exception as exc:  # noqa: BLE001 - read failure is insufficient evidence
+        response = {"status": "error", "error": str(exc)}
+    evidence = _validate_recovery_evidence(action, response)
+    if evidence is None:
+        return unresolved("exact broker evidence is missing or contradictory")
+
+    status = evidence["order_status"]
+    filled = Decimal(str(evidence["filled_qty"]))
+    working = {"accepted", "new", "open", "pending_new", "accepted_for_bidding"}
+    terminal = {"rejected", "canceled", "expired"}
+    if ((status in working or status in terminal) and filled != 0) or (
+        status in {"partially_filled", "filled"} and filled <= 0
+    ):
+        return unresolved("broker status contradicts filled quantity")
+    if status != "rejected":
+        try:
+            increment_daily_count(broker, action.action_id)
+        except DailyCountError:
+            return unresolved("recovered order could not be durably accounted")
+
+    record = _audit(
+        broker, session_id,
+        kind="order_rejected" if status == "rejected" else "order_placed",
+        outcome="rejected" if status == "rejected" else ("filled" if status == "filled" else "accepted"),
+        mandate=mandate, intent=None,
+        broker_request=action.request.model_dump(mode="json"), broker_response=evidence,
+        gate_decision={"allowed": False, "decision": _DECISION_DENY,
+                       "checked_limits": checked, "reason_code": "exact_submit_recovered",
+                       "action_id": action.action_id},
+    )
+    if record is None:
+        return _recovery_refusal(broker, "recovery audit was not durable")
+    if status in working:
+        try:
+            pending_action.transition_to_revalidation(action, evidence)
+        except Exception as exc:  # noqa: BLE001 - retain the recovery block
+            logger.warning("pending action transition failed for %s: %s", broker, exc)
+            return _recovery_refusal(broker, "recovered order transition was not durable", record)
+        return _recovery_refusal(
+            broker, "recovered working order requires policy revalidation", record,
+            reason_code="pending_action_needs_revalidation",
+        )
+    if status in terminal:
+        try:
+            pending_action.clear_pending_action(broker, action.action_id)
+        except Exception as exc:  # noqa: BLE001 - retain the recovery block
+            logger.warning("pending action clear failed for %s: %s", broker, exc)
+            return _recovery_refusal(broker, "terminal recovery could not be cleared", record)
+        return _recovery_refusal(
+            broker, "exact terminal broker outcome recovered", record,
+            reason_code="pending_action_resolved_terminal", recovery_pending=False,
+        )
+    return _recovery_refusal(broker, "exact fill requires position attribution", record)
+
+
+def _validate_recovery_evidence(action, response) -> dict[str, Any] | None:
+    order = response.get("order") if isinstance(response, dict) and response.get("status") == "ok" else None
+    if (
+        not isinstance(order, dict)
+        or not isinstance(order.get("broker_order_id"), str)
+        or not order["broker_order_id"]
+    ):
+        return None
+    request = action.request
+    expected = {"client_order_id": action.client_order_id, "symbol": request.symbol,
+                "side": request.side, "order_type": request.order_type,
+                "time_in_force": request.time_in_force}
+    if any(order.get(key) != value for key, value in expected.items()):
+        return None
+    try:
+        submitted = datetime.fromisoformat(str(order.get("submitted_at") or "").replace("Z", "+00:00"))
+        normalized = dict(order)
+        for key in ("quantity", "notional", "limit_price"):
+            actual, wanted = _exact_decimal(order.get(key)), _exact_decimal(getattr(request, key))
+            if actual != wanted:
+                return None
+            normalized[key] = float(actual) if actual is not None else None
+        filled = _exact_decimal(order.get("filled_qty"))
+    except (InvalidOperation, ValueError):
+        return None
+    status = str(order.get("order_status") or "").strip().lower()
+    supported = {"accepted", "new", "open", "pending_new", "accepted_for_bidding",
+                 "rejected", "canceled", "expired", "partially_filled", "filled"}
+    if submitted.tzinfo is None or filled is None or filled < 0 or status not in supported:
+        return None
+    normalized.update(broker_order_id=str(order["broker_order_id"]), filled_qty=float(filled),
+                      order_status=status, submitted_at=submitted.isoformat())
+    return normalized
+
+
+def _exact_decimal(value) -> Decimal | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise InvalidOperation
+    number = Decimal(str(value))
+    if not number.is_finite():
+        raise InvalidOperation
+    return number
+
+
+def _recovery_refusal(
+    broker, reason, record=None, *, reason_code="pending_action_unresolved", recovery_pending=True
+) -> dict[str, Any]:
+    result = _refusal(broker, decision=_DECISION_DENY, reason=reason, reauth=False, record=record)
+    result.update(reason_code=reason_code, recovery_pending=recovery_pending)
+    return result
 
 
 def _deny(broker, session_id, reason, checked, mandate, *, intent, reauth=False, reason_code=None) -> dict[str, Any]:

--- a/agent/src/live/sdk_order_gate.py
+++ b/agent/src/live/sdk_order_gate.py
@@ -89,6 +89,20 @@ def execute_live_order(
     broker = (broker or "").strip().lower()
 
     mandate = load_mandate(broker)
+    if broker == "alpaca":
+        try:
+            with daily_order_lock(broker):
+                recovery = _pending_recovery_result(
+                    broker, session_id, connector_module, config, mandate
+                )
+        except DailyOrderLockUnavailable as exc:
+            return _deny(
+                broker, session_id, str(exc),
+                ["pending_action", "daily_order_lock"], mandate, intent=None,
+            )
+        if recovery is not None:
+            return recovery
+
     if mandate is None or mandate.schema_version != MANDATE_SCHEMA_VERSION:
         return _deny(broker, session_id, "no valid mandate on file", ["mandate"], mandate, intent=None)
 
@@ -126,25 +140,11 @@ def execute_live_order(
     try:
         with daily_order_lock(broker):
             if broker == "alpaca":
-                try:
-                    unresolved = pending_action.load_pending_action(broker)
-                except pending_action.PendingActionError:
-                    return _deny(
-                        broker, session_id,
-                        "pending broker action is invalid and requires recovery",
-                        ["mandate", "expiry", "halt_flag", "pending_action"], mandate,
-                        intent=intent, reason_code="pending_action_invalid",
-                    )
-                if unresolved is not None:
-                    if unresolved.phase == "resolved_needs_revalidation":
-                        return _deny(
-                            broker, session_id, "recovered broker order requires policy revalidation",
-                            ["mandate", "expiry", "halt_flag", "pending_action"], mandate,
-                            intent=intent, reason_code="pending_action_needs_revalidation",
-                        )
-                    return _recover_pending_order(
-                        broker, session_id, connector_module, config, mandate, unresolved
-                    )
+                recovery = _pending_recovery_result(
+                    broker, session_id, connector_module, config, mandate
+                )
+                if recovery is not None:
+                    return recovery
             daily_count = read_daily_count(broker)
             breach = check_mandate(
                 mandate,
@@ -179,6 +179,29 @@ def execute_live_order(
 
     reauth = breach.kind not in (BREACH_KIND_UNIVERSE, BREACH_KIND_INSTRUMENT)
     return _deny_breach(broker, session_id, breach, mandate, intent, reauth)
+
+
+def _pending_recovery_result(broker, session_id, connector, config, mandate):
+    """Recover an existing marker under the caller-held broker lock."""
+    try:
+        unresolved = pending_action.load_pending_action(broker)
+    except pending_action.PendingActionError:
+        return _deny(
+            broker, session_id, "pending broker action is invalid and requires recovery",
+            ["pending_action", "exact_broker_evidence"], mandate,
+            intent=None, reason_code="pending_action_invalid",
+        )
+    if unresolved is None:
+        return None
+    if unresolved.phase == "resolved_needs_revalidation":
+        return _deny(
+            broker, session_id, "recovered broker order requires policy revalidation",
+            ["pending_action", "exact_broker_evidence"], mandate,
+            intent=None, reason_code="pending_action_needs_revalidation",
+        )
+    return _recover_pending_order(
+        broker, session_id, connector, config, mandate, unresolved
+    )
 
 
 def execute_live_action(

--- a/agent/src/live/sdk_order_gate.py
+++ b/agent/src/live/sdk_order_gate.py
@@ -27,6 +27,7 @@ import logging
 from datetime import datetime, timezone
 from typing import Any
 
+from src.live import pending_action
 from src.live.audit import LiveActionEvent, write_live_action
 from src.live.daily_count import (
     DailyOrderLockUnavailable,
@@ -122,6 +123,22 @@ def execute_live_order(
 
     try:
         with daily_order_lock(broker):
+            if broker == "alpaca":
+                try:
+                    unresolved = pending_action.load_pending_action(broker)
+                except pending_action.PendingActionError:
+                    return _deny(
+                        broker, session_id,
+                        "pending broker action is invalid and requires recovery",
+                        ["mandate", "expiry", "halt_flag", "pending_action"], mandate,
+                        intent=intent, reason_code="pending_action_invalid",
+                    )
+                if unresolved is not None:
+                    return _deny(
+                        broker, session_id, "pending broker action requires recovery",
+                        ["mandate", "expiry", "halt_flag", "pending_action"], mandate,
+                        intent=intent, reason_code="pending_action_unresolved",
+                    )
             daily_count = read_daily_count(broker)
             breach = check_mandate(
                 mandate,
@@ -142,6 +159,7 @@ def execute_live_order(
                     intent,
                     place_kwargs,
                     mandate,
+                    positions,
                 )
     except DailyOrderLockUnavailable as exc:
         return _deny(
@@ -384,8 +402,25 @@ def _execute_and_audit_live_action(
 # --------------------------------------------------------------------------- #
 
 
-def _allow(broker, session_id, connector_module, config, intent, place_kwargs, mandate) -> dict[str, Any]:
+def _allow(broker, session_id, connector_module, config, intent, place_kwargs, mandate, positions) -> dict[str, Any]:
     """Execute the order; consume a count + audit only on a non-error result."""
+    pending = None
+    if broker == "alpaca":
+        try:
+            pending = pending_action.new_pending_order(
+                broker, place_kwargs,
+                pre_position_qty=_pre_position_qty(positions, intent.symbol),
+            )
+            pending_action.save_pending_action(pending)
+        except Exception as exc:  # noqa: BLE001 - missing evidence forbids the write
+            logger.warning("pending action write failed for %s: %s", broker, exc)
+            return _deny(
+                broker, session_id, "pending broker action could not be persisted",
+                ["mandate", "expiry", "halt_flag", "pending_action"], mandate,
+                intent=intent, reason_code="pending_action_persist_failed",
+            )
+        place_kwargs = {**place_kwargs, "client_order_id": pending.client_order_id}
+
     try:
         result = connector_module.place_order(config, **place_kwargs)
     except Exception as exc:  # noqa: BLE001 - a connector raise must not escape the gate
@@ -417,7 +452,8 @@ def _allow(broker, session_id, connector_module, config, intent, place_kwargs, m
             intent=intent,
             broker_request=dict(place_kwargs),
             broker_response=result if isinstance(result, dict) else {"raw": result},
-            gate_decision={"allowed": True, "decision": _DECISION_ALLOW, "checked_limits": checked},
+            gate_decision={"allowed": True, "decision": _DECISION_ALLOW, "checked_limits": checked,
+                           **({"reason_code": "pending_action_unresolved"} if pending else {})},
             error=_error_message(result),
         )
     else:
@@ -435,10 +471,25 @@ def _allow(broker, session_id, connector_module, config, intent, place_kwargs, m
         )
     if isinstance(result, dict) and record is not None:
         result = {**result, LIVE_ACTION_RESULT_KEY: record}
+    if pending is not None:
+        cleared = False
+        if not is_error and record is not None:
+            try:
+                pending_action.clear_pending_action(broker, pending.action_id)
+                cleared = True
+            except Exception as exc:  # noqa: BLE001 - retain the recovery block
+                logger.warning("pending action clear failed for %s: %s", broker, exc)
+        if not cleared:
+            result = {
+                **(result if isinstance(result, dict) else {"status": "error"}),
+                "client_order_id": pending.client_order_id,
+                "recovery_pending": True,
+                "reason_code": "pending_action_unresolved",
+            }
     return result if isinstance(result, dict) else {"status": "error", "error": "non-dict broker result"}
 
 
-def _deny(broker, session_id, reason, checked, mandate, *, intent, reauth=False) -> dict[str, Any]:
+def _deny(broker, session_id, reason, checked, mandate, *, intent, reauth=False, reason_code=None) -> dict[str, Any]:
     """Audit + return a refusal for a pre-check / structural DENY."""
     record = _audit(
         broker,
@@ -449,10 +500,14 @@ def _deny(broker, session_id, reason, checked, mandate, *, intent, reauth=False)
         intent=intent,
         broker_request=None,
         broker_response=None,
-        gate_decision={"allowed": False, "decision": _DECISION_DENY, "checked_limits": checked},
+        gate_decision={"allowed": False, "decision": _DECISION_DENY, "checked_limits": checked,
+                       **({"reason_code": reason_code} if reason_code else {})},
         error=reason,
     )
-    return _refusal(broker, decision=_DECISION_DENY, reason=reason, reauth=reauth, record=record)
+    result = _refusal(broker, decision=_DECISION_DENY, reason=reason, reauth=reauth, record=record)
+    if reason_code:
+        result["reason_code"] = reason_code
+    return result
 
 
 def _deny_breach(broker, session_id, breach, mandate, intent, reauth) -> dict[str, Any]:
@@ -631,6 +686,24 @@ def _safe_read(connector_module: Any, fn_name: str, config: Any) -> object:
     return result
 
 
+def _pre_position_qty(positions: object, symbol: str) -> float | None:
+    rows = positions.get("positions", positions.get("data")) if isinstance(positions, dict) else positions
+    if not isinstance(rows, list):
+        return None
+    target = str(symbol or "").strip().upper()
+    for row in rows:
+        if not isinstance(row, dict) or str(row.get("symbol") or "").strip().upper() != target:
+            continue
+        try:
+            quantity = float(row.get("quantity", row.get("qty")))
+        except (TypeError, ValueError):
+            return None
+        if str(row.get("side") or "").strip().lower() in {"short", "sell"} and quantity > 0:
+            quantity = -quantity
+        return quantity
+    return 0.0
+
+
 # --------------------------------------------------------------------------- #
 # Audit + misc
 # --------------------------------------------------------------------------- #
@@ -651,6 +724,7 @@ def _audit(
         broker_response=broker_response,
         gate_decision=gate_decision,
         error=error,
+        require_durable=broker == "alpaca",
     )
 
 
@@ -667,6 +741,7 @@ def _audit_action(
     broker_response,
     gate_decision,
     error=None,
+    require_durable=False,
 ) -> dict | None:
     consent = mandate.consent if mandate is not None else None
     try:
@@ -685,9 +760,9 @@ def _audit_action(
             error=error,
         )
         try:
-            return write_live_action(event, event_callback=None, trace_writer=None)
+            return write_live_action(event, event_callback=None, trace_writer=None, require_durable=require_durable)
         except TypeError:
-            return write_live_action(event)
+            return None if require_durable else write_live_action(event)
     except Exception as exc:  # auditing must never block a decision
         logger.warning("live-action audit write failed (%s): %s", kind, exc)
         return None

--- a/agent/src/trading/connectors/alpaca/sdk.py
+++ b/agent/src/trading/connectors/alpaca/sdk.py
@@ -28,6 +28,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from types import ModuleType
 from typing import Any, Mapping
+from urllib.parse import urlencode
 
 from src.config.paths import get_runtime_root
 from src.trading import tap_forward
@@ -364,6 +365,33 @@ def get_open_orders(config: AlpacaConfig | None = None, *, include_executions: b
     return result
 
 
+def get_order_by_client_order_id(
+    config: AlpacaConfig | None = None, *, client_order_id: str
+) -> dict[str, Any]:
+    """Read one order by the caller-owned exact Alpaca client order ID."""
+    cfg = config or load_config()
+    client_id = str(client_order_id or "").strip()
+    if not (1 <= len(client_id) <= 48):
+        return {"status": "error", "error": "client_order_id must contain 1-48 characters"}
+    try:
+        if tap_forward.tap_enabled():
+            query = urlencode({"client_order_id": client_id})
+            order = _read_via_tap(f"{cfg.host}/v2/orders:by_client_order_id?{query}")
+        else:
+            order = _trading_client(cfg).get_order_by_client_id(client_id)
+    except Exception as exc:  # noqa: BLE001 - read failure is insufficient evidence
+        return {"status": "error", "error": str(exc)}
+    item = _order_to_dict(order)
+    return {"status": "ok", "profile": cfg.profile, "is_paper": cfg.is_paper, "order": {
+        "broker_order_id": item["order_id"], "client_order_id": item["client_order_id"],
+        "symbol": item["symbol"], "side": item["side"], "order_type": item["order_type"],
+        "time_in_force": item["time_in_force"], "quantity": item["quantity"],
+        "notional": item["notional"], "limit_price": item["limit_price"],
+        "filled_qty": item["filled_qty"], "order_status": item["status"],
+        "submitted_at": item["submitted_at"],
+    }}
+
+
 def get_quote(symbol: str, *, config: AlpacaConfig | None = None, **_: Any) -> dict[str, Any]:
     """Fetch a latest quote snapshot for ``symbol``."""
     cfg = config or load_config()
@@ -573,6 +601,7 @@ def place_order(
     return {
         "status": "ok",
         "order_id": str(_obj_get(order, "id", "")),
+        "client_order_id": str(_obj_get(order, "client_order_id", "")),
         "symbol": clean_symbol,
         "side": side_token,
         "profile": cfg.profile,
@@ -663,6 +692,7 @@ def _submit_via_tap(
     return {
         "status": "ok",
         "order_id": str(payload.get("id", "")),
+        "client_order_id": str(payload.get("client_order_id", "")),
         "symbol": symbol,
         "side": side,
         "profile": cfg.profile,
@@ -886,17 +916,23 @@ def _position_to_dict(item: Any) -> dict[str, Any]:
 def _order_to_dict(item: Any) -> dict[str, Any]:
     return {
         "order_id": str(_obj_get(item, "id", "")),
+        "client_order_id": str(_obj_get(item, "client_order_id", "")),
         "symbol": _obj_get(item, "symbol"),
-        "side": str(_obj_get(item, "side", "")),
-        "order_type": str(_obj_get(item, "order_type", "") or _obj_get(item, "type", "")),
+        "side": _enum_token(_obj_get(item, "side", "")),
+        "order_type": _enum_token(_obj_get(item, "order_type", "") or _obj_get(item, "type", "")),
+        "time_in_force": _enum_token(_obj_get(item, "time_in_force", "")),
         "quantity": _obj_get(item, "qty"),
         "notional": _obj_get(item, "notional"),
         "filled_qty": _obj_get(item, "filled_qty"),
         "filled_avg_price": _obj_get(item, "filled_avg_price"),
         "limit_price": _obj_get(item, "limit_price"),
-        "status": str(_obj_get(item, "status", "")),
+        "status": _enum_token(_obj_get(item, "status", "")),
         "submitted_at": str(_obj_get(item, "submitted_at", "")),
     }
+
+
+def _enum_token(value: Any) -> str:
+    return str(getattr(value, "value", value)).strip().lower()
 
 
 def _bar_to_dict(item: Any) -> dict[str, Any]:

--- a/agent/src/trading/connectors/alpaca/sdk.py
+++ b/agent/src/trading/connectors/alpaca/sdk.py
@@ -436,6 +436,7 @@ def place_order(
     order_type: str = "market",
     limit_price: float | None = None,
     time_in_force: str = "day",
+    client_order_id: str | None = None,
 ) -> dict[str, Any]:
     """Submit an order to the configured Alpaca account.
 
@@ -454,6 +455,7 @@ def place_order(
         order_type: ``market`` or ``limit``.
         limit_price: Required when ``order_type`` is ``limit``.
         time_in_force: ``day`` or ``gtc``.
+        client_order_id: Optional caller-owned exact order identity.
 
     Returns:
         On success ``{"status": "ok", "order_id", "symbol", "side", "profile",
@@ -479,6 +481,10 @@ def place_order(
     tif_token = str(time_in_force or "").strip().lower()
     if tif_token not in ("day", "gtc"):
         return {"status": "error", "error": "time_in_force must be 'day' or 'gtc'"}
+
+    client_id = str(client_order_id).strip() if client_order_id is not None else None
+    if client_id is not None and not (1 <= len(client_id) <= 48):
+        return {"status": "error", "error": "client_order_id must contain 1-48 characters"}
 
     has_qty = quantity is not None
     has_notional = notional is not None
@@ -524,6 +530,7 @@ def place_order(
             order_type=type_token,
             limit_price=limit_value,
             time_in_force=tif_token,
+            client_order_id=client_id,
         )
 
     try:
@@ -537,6 +544,7 @@ def place_order(
         order_side = OrderSide.BUY if side_token == "buy" else OrderSide.SELL
         tif = TimeInForce.DAY if tif_token == "day" else TimeInForce.GTC
         amount = {"qty": qty_value} if has_qty else {"notional": notional_value}
+        identity = {"client_order_id": client_id} if client_id is not None else {}
 
         if type_token == "limit":
             req = LimitOrderRequest(
@@ -545,6 +553,7 @@ def place_order(
                 time_in_force=tif,
                 limit_price=limit_value,
                 **amount,
+                **identity,
             )
         else:
             req = MarketOrderRequest(
@@ -552,6 +561,7 @@ def place_order(
                 side=order_side,
                 time_in_force=tif,
                 **amount,
+                **identity,
             )
 
         order = client.submit_order(order_data=req)
@@ -587,6 +597,7 @@ def _submit_via_tap(
     order_type: str,
     limit_price: float | None,
     time_in_force: str,
+    client_order_id: str | None,
 ) -> dict[str, Any]:
     """Place the order through the TAP proxy instead of the Alpaca SDK.
 
@@ -617,12 +628,14 @@ def _submit_via_tap(
     # forwarded the order but the agent saw a timeout) is deduplicated by Alpaca
     # — a duplicate id is rejected, never double-placed. Trade-off: two
     # intentionally-identical orders collide; vary any field for a real duplicate.
-    order["client_order_id"] = "tap-" + hashlib.sha256(
-        "|".join(
-            str(x)
-            for x in (cfg.profile, symbol, side, quantity, notional, order_type, limit_price, time_in_force)
-        ).encode()
-    ).hexdigest()[:24]
+    order["client_order_id"] = client_order_id or (
+        "tap-" + hashlib.sha256(
+            "|".join(
+                str(x)
+                for x in (cfg.profile, symbol, side, quantity, notional, order_type, limit_price, time_in_force)
+            ).encode()
+        ).hexdigest()[:24]
+    )
 
     cred_headers = _tap_cred_headers()
     target = f"{cfg.host}/v2/orders"

--- a/agent/tests/test_daily_count.py
+++ b/agent/tests/test_daily_count.py
@@ -12,7 +12,12 @@ import pytest
 
 import src.live.paths as live_paths
 from src.live import daily_count
-from src.live.daily_count import daily_order_lock, increment_daily_count, read_daily_count
+from src.live.daily_count import (
+    DailyCountError,
+    daily_order_lock,
+    increment_daily_count,
+    read_daily_count,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -87,3 +92,36 @@ def test_action_id_deduplicates_after_utc_rollover(tmp_path, monkeypatch) -> Non
         "count": 1,
         "action_ids": ["act_new"],
     }
+
+
+@pytest.mark.parametrize(
+    ("counter_date", "action_ids"),
+    [
+        ("not-a-date", ["act_recovered"]),
+        ("9999-12-31", ["act_recovered"]),
+        ("2026-08-25", ["x" * 129]),
+    ],
+)
+def test_action_id_accounting_rejects_malformed_evidence(
+    tmp_path, monkeypatch, counter_date, action_ids
+) -> None:
+    runtime_root = tmp_path / ".vibe-trading"
+    monkeypatch.setattr(live_paths, "get_runtime_root", lambda: runtime_root)
+    path = runtime_root / "live" / "alpaca" / "trade_counter.json"
+    path.parent.mkdir(parents=True)
+    original = json.dumps({"date": counter_date, "count": 1, "action_ids": action_ids})
+    path.write_text(original, encoding="utf-8")
+
+    with pytest.raises(DailyCountError):
+        increment_daily_count("alpaca", action_id="act_recovered")
+
+    assert path.read_text(encoding="utf-8") == original
+
+
+def test_action_id_accounting_wraps_directory_failure(tmp_path, monkeypatch) -> None:
+    runtime_root = tmp_path / ".vibe-trading"
+    runtime_root.write_text("not a directory", encoding="utf-8")
+    monkeypatch.setattr(live_paths, "get_runtime_root", lambda: runtime_root)
+
+    with pytest.raises(DailyCountError):
+        increment_daily_count("alpaca", action_id="act_recovered")

--- a/agent/tests/test_daily_count.py
+++ b/agent/tests/test_daily_count.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -10,7 +11,7 @@ from pathlib import Path
 import pytest
 
 import src.live.paths as live_paths
-from src.live.daily_count import daily_order_lock
+from src.live.daily_count import daily_order_lock, increment_daily_count, read_daily_count
 
 pytestmark = pytest.mark.unit
 
@@ -54,3 +55,15 @@ def test_daily_order_lock_is_cross_process(
 
     assert blocked.stdout.strip() == "blocked"
     assert acquired.stdout.strip() == "acquired"
+
+
+def test_action_id_increment_is_durable_and_deduplicated(tmp_path, monkeypatch) -> None:
+    runtime_root = tmp_path / ".vibe-trading"
+    monkeypatch.setattr(live_paths, "get_runtime_root", lambda: runtime_root)
+
+    assert increment_daily_count("alpaca", action_id="act_one") == 1
+    assert increment_daily_count("alpaca", action_id="act_one") == 1
+    assert increment_daily_count("alpaca", action_id="act_two") == 2
+    assert read_daily_count("alpaca") == 2
+    payload = json.loads((runtime_root / "live" / "alpaca" / "trade_counter.json").read_text())
+    assert payload["action_ids"] == ["act_one", "act_two"]

--- a/agent/tests/test_daily_count.py
+++ b/agent/tests/test_daily_count.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 
 import src.live.paths as live_paths
+from src.live import daily_count
 from src.live.daily_count import daily_order_lock, increment_daily_count, read_daily_count
 
 pytestmark = pytest.mark.unit
@@ -67,3 +68,22 @@ def test_action_id_increment_is_durable_and_deduplicated(tmp_path, monkeypatch) 
     assert read_daily_count("alpaca") == 2
     payload = json.loads((runtime_root / "live" / "alpaca" / "trade_counter.json").read_text())
     assert payload["action_ids"] == ["act_one", "act_two"]
+
+
+def test_action_id_deduplicates_after_utc_rollover(tmp_path, monkeypatch) -> None:
+    runtime_root = tmp_path / ".vibe-trading"
+    current_day = ["2026-08-25"]
+    monkeypatch.setattr(live_paths, "get_runtime_root", lambda: runtime_root)
+    monkeypatch.setattr(daily_count, "_utc_today", lambda: current_day[0])
+
+    assert increment_daily_count("alpaca", action_id="act_recovered") == 1
+    current_day[0] = "2026-08-26"
+    assert increment_daily_count("alpaca", action_id="act_recovered") == 0
+    assert read_daily_count("alpaca") == 0
+    assert increment_daily_count("alpaca", action_id="act_new") == 1
+    payload = json.loads((runtime_root / "live" / "alpaca" / "trade_counter.json").read_text())
+    assert payload == {
+        "date": "2026-08-26",
+        "count": 1,
+        "action_ids": ["act_new"],
+    }

--- a/agent/tests/test_sdk_order_gate.py
+++ b/agent/tests/test_sdk_order_gate.py
@@ -333,8 +333,32 @@ def test_restart_recovers_exact_working_order_once_and_never_resubmits(monkeypat
     assert len(connector.placed) == 1 and connector.lookups == [action.client_order_id] * 2
 
 
+@pytest.mark.parametrize("blocker", ["missing_mandate", "expired", "halted"])
+def test_exact_recovery_precedes_current_policy_blockers(monkeypatch, blocker) -> None:
+    _patch_gate(monkeypatch, mandate=_mandate())
+    connector = _LostResponseConnector()
+    _place(connector)
+    action = load_pending_action("alpaca")
+    connector.lookup_result = _exact_order(action, status="canceled")
+    connector.get_positions = lambda config: pytest.fail("recovery read positions")
+    connector.get_account_snapshot = lambda config: pytest.fail("recovery read account")
+    if blocker == "missing_mandate":
+        monkeypatch.setattr(gate, "load_mandate", lambda broker: None)
+    elif blocker == "expired":
+        monkeypatch.setattr(gate, "_is_expired", lambda mandate: True)
+    else:
+        monkeypatch.setattr(gate, "halt_flag_set", lambda broker: True)
+
+    result = _place(connector)
+
+    assert result["reason_code"] == "pending_action_resolved_terminal"
+    assert load_pending_action("alpaca") is None
+    assert len(connector.placed) == 1
+    assert connector.lookups == [action.client_order_id]
+
+
 @pytest.mark.parametrize("change", [None, {"symbol": "MSFT"}, {"client_order_id": "manual"},
-                                     {"order_status": "mystery"}])
+                                      {"order_status": "mystery"}])
 def test_recovery_insufficient_or_mismatched_evidence_stays_blocked(monkeypatch, change) -> None:
     counted: list[str] = []
     _patch_gate(monkeypatch, mandate=_mandate())

--- a/agent/tests/test_sdk_order_gate.py
+++ b/agent/tests/test_sdk_order_gate.py
@@ -58,6 +58,8 @@ class _FakeConnector:
 
     def __init__(self, *, positions=None, balance=None, quote_last=100.0):
         self.placed: list[dict] = []
+        self.lookups: list[str] = []
+        self.lookup_result: dict | BaseException = {"status": "error", "error": "not found"}
         self._positions = positions if positions is not None else {"status": "ok", "positions": []}
         self._balance = balance if balance is not None else {"status": "ok", "account": {}}
         self._quote_last = quote_last
@@ -74,6 +76,18 @@ class _FakeConnector:
 
     def get_quote(self, symbol, *, config=None):
         return {"status": "ok", "symbol": symbol, "quote": {"last": self._quote_last}}
+
+    def get_order_by_client_order_id(self, config, *, client_order_id):
+        self.lookups.append(client_order_id)
+        if isinstance(self.lookup_result, BaseException):
+            raise self.lookup_result
+        return self.lookup_result
+
+
+class _LostResponseConnector(_FakeConnector):
+    def place_order(self, config, **kwargs):
+        self.placed.append(kwargs)
+        raise TimeoutError("response lost")
 
 
 def _mandate(
@@ -114,7 +128,7 @@ def _patch_gate(monkeypatch, *, mandate, halted=False):
     monkeypatch.setattr(gate, "halt_flag_set", lambda broker: halted)
     monkeypatch.setattr(gate, "write_live_action", lambda *a, **k: {"audited": True})
     monkeypatch.setattr(gate, "read_daily_count", lambda broker: 0)
-    monkeypatch.setattr(gate, "increment_daily_count", lambda broker: 1)
+    monkeypatch.setattr(gate, "increment_daily_count", lambda broker, action_id=None: 1)
     monkeypatch.setattr(gate, "daily_order_lock", lambda broker: nullcontext())
 
 
@@ -176,6 +190,7 @@ def test_gate_allows_in_bounds_and_places(monkeypatch) -> None:
 
 def test_alpaca_marker_precedes_submit_and_audit_precedes_clear(monkeypatch) -> None:
     events: list[str] = []
+    action_ids: list[str] = []
 
     class _OrderingConnector(_FakeConnector):
         def place_order(self, config, **kwargs):
@@ -192,6 +207,8 @@ def test_alpaca_marker_precedes_submit_and_audit_precedes_clear(monkeypatch) -> 
         return record
 
     monkeypatch.setattr(gate, "write_live_action", audited)
+    monkeypatch.setattr(gate, "increment_daily_count",
+                        lambda broker, action_id=None: action_ids.append(action_id) or 1)
     real_clear = pending_state.clear_pending_action
     monkeypatch.setattr(pending_state, "clear_pending_action",
                         lambda broker, action_id: events.append("clear") or real_clear(broker, action_id))
@@ -202,6 +219,7 @@ def test_alpaca_marker_precedes_submit_and_audit_precedes_clear(monkeypatch) -> 
 
     assert first["status"] == second["status"] == "ok"
     assert events == ["submit", "audit", "clear"] * 2
+    assert all(value and value.startswith("act_") for value in action_ids)
     assert connector.placed[0]["client_order_id"] != connector.placed[1]["client_order_id"]
     assert live_audit.audit_ledger_path().is_file()
     assert load_pending_action("alpaca") is None
@@ -273,6 +291,108 @@ def test_incomplete_or_mismatched_ack_retains_marker(monkeypatch, response) -> N
     assert len(connector.placed) == 1
 
 
+def _exact_order(action, *, status="new", filled_qty="0", **changes):
+    order = {
+        "broker_order_id": "broker-1", "client_order_id": action.client_order_id,
+        "symbol": action.request.symbol, "side": action.request.side,
+        "order_type": action.request.order_type, "time_in_force": action.request.time_in_force,
+        "quantity": action.request.quantity, "notional": action.request.notional,
+        "limit_price": action.request.limit_price, "filled_qty": filled_qty,
+        "order_status": status, "submitted_at": "2026-08-25T00:00:00Z",
+    }
+    order.update(changes)
+    return {"status": "ok", "order": order}
+
+
+def test_restart_recovers_exact_working_order_once_and_never_resubmits(monkeypatch) -> None:
+    counted: set[str] = set()
+    _patch_gate(monkeypatch, mandate=_mandate())
+    monkeypatch.setattr(gate, "increment_daily_count",
+                        lambda broker, action_id=None: counted.add(action_id) or 1)
+    connector = _LostResponseConnector()
+    _place(connector)
+    action = load_pending_action("alpaca")
+    connector.lookup_result = _exact_order(action)
+    real_transition = pending_state.transition_to_revalidation
+    attempts = iter((False, True))
+    def crash_once(pending, evidence):
+        if not next(attempts):
+            raise OSError("crash after audit")
+        return real_transition(pending, evidence)
+    monkeypatch.setattr(pending_state, "transition_to_revalidation", crash_once)
+
+    interrupted = _place(connector)
+    recovered = _place(connector)
+    replay = _place(connector)
+    persisted = load_pending_action("alpaca")
+
+    assert interrupted["reason_code"] == "pending_action_unresolved"
+    assert recovered["reason_code"] == replay["reason_code"] == "pending_action_needs_revalidation"
+    assert persisted.phase == "resolved_needs_revalidation" and persisted.broker_order_id == "broker-1"
+    assert counted == {action.action_id}
+    assert len(connector.placed) == 1 and connector.lookups == [action.client_order_id] * 2
+
+
+@pytest.mark.parametrize("change", [None, {"symbol": "MSFT"}, {"client_order_id": "manual"},
+                                     {"order_status": "mystery"}])
+def test_recovery_insufficient_or_mismatched_evidence_stays_blocked(monkeypatch, change) -> None:
+    counted: list[str] = []
+    _patch_gate(monkeypatch, mandate=_mandate())
+    monkeypatch.setattr(gate, "increment_daily_count",
+                        lambda broker, action_id=None: counted.append(action_id) or 1)
+    connector = _LostResponseConnector()
+    _place(connector)
+    action = load_pending_action("alpaca")
+    connector.lookup_result = ({"status": "error", "error": "not found"}
+                               if change is None else _exact_order(action, **change))
+
+    result = _place(connector)
+
+    assert result["reason_code"] == "pending_action_unresolved"
+    assert load_pending_action("alpaca").phase == "pending_write"
+    assert counted == [] and len(connector.placed) == 1
+
+
+@pytest.mark.parametrize(("status", "was_counted"), [("rejected", False), ("canceled", True),
+                                                      ("expired", True)])
+def test_exact_zero_fill_terminal_is_audited_then_cleared(
+    monkeypatch, status, was_counted,
+) -> None:
+    counted: list[str] = []
+    _patch_gate(monkeypatch, mandate=_mandate())
+    monkeypatch.setattr(gate, "increment_daily_count",
+                        lambda broker, action_id=None: counted.append(action_id) or 1)
+    connector = _LostResponseConnector()
+    _place(connector)
+    action = load_pending_action("alpaca")
+    connector.lookup_result = _exact_order(action, status=status)
+
+    result = _place(connector)
+
+    assert result["reason_code"] == "pending_action_resolved_terminal"
+    assert load_pending_action("alpaca") is None
+    assert counted == ([action.action_id] if was_counted else [])
+    assert len(connector.placed) == 1
+
+
+@pytest.mark.parametrize("status", ["partially_filled", "filled"])
+def test_exact_fill_is_counted_but_retained_for_position_attribution(monkeypatch, status) -> None:
+    counted: list[str] = []
+    _patch_gate(monkeypatch, mandate=_mandate())
+    monkeypatch.setattr(gate, "increment_daily_count",
+                        lambda broker, action_id=None: counted.append(action_id) or 1)
+    connector = _LostResponseConnector()
+    _place(connector)
+    action = load_pending_action("alpaca")
+    connector.lookup_result = _exact_order(action, status=status, filled_qty="1")
+
+    result = _place(connector)
+
+    assert result["reason_code"] == "pending_action_unresolved"
+    assert load_pending_action("alpaca").phase == "pending_write"
+    assert counted == [action.action_id] and len(connector.placed) == 1
+
+
 def test_corrupt_pending_marker_and_failed_audit_both_fail_closed(monkeypatch) -> None:
     _patch_gate(monkeypatch, mandate=_mandate())
     connector = _FakeConnector()
@@ -293,6 +413,21 @@ def test_audit_durability_failure_retains_pending_marker(monkeypatch) -> None:
     monkeypatch.setattr(gate, "write_live_action", live_audit.write_live_action)
     connector = _FakeConnector()
     patch_module_os(monkeypatch, live_audit, fsync=lambda fd: (_ for _ in ()).throw(OSError("disk")))
+
+    result = _place(connector)
+
+    assert result["status"] == "ok" and result["recovery_pending"] is True
+    assert result["reason_code"] == "pending_action_unresolved"
+    assert len(connector.placed) == 1 and load_pending_action("alpaca") is not None
+
+
+def test_acknowledged_submit_count_failure_retains_recovery_marker(monkeypatch) -> None:
+    _patch_gate(monkeypatch, mandate=_mandate())
+    monkeypatch.setattr(
+        gate, "increment_daily_count",
+        lambda *args: (_ for _ in ()).throw(gate.DailyCountError("disk")),
+    )
+    connector = _FakeConnector()
 
     result = _place(connector)
 
@@ -342,6 +477,33 @@ def test_external_client_id_reaches_direct_sdk_and_tap(monkeypatch) -> None:
         quantity=1, client_order_id="vt-tap",
     )
     assert tap["status"] == "ok" and captured["tap"]["client_order_id"] == "vt-tap"
+
+
+def test_exact_lookup_normalizes_equivalent_direct_and_tap_evidence(monkeypatch) -> None:
+    payload = {"id": "oid", "client_order_id": "vt-exact", "symbol": "AAPL",
+               "side": "buy", "type": "market", "time_in_force": "day", "qty": "1",
+               "notional": None, "limit_price": None, "filled_qty": "0", "status": "new",
+               "submitted_at": "2026-08-25T00:00:00Z"}
+
+    class _Client:
+        def get_order_by_client_id(self, client_id):
+            assert client_id == "vt-exact"
+            return SimpleNamespace(**payload)
+
+    monkeypatch.setattr(alpaca_sdk, "_trading_client", lambda cfg: _Client())
+    monkeypatch.setattr(alpaca_sdk.tap_forward, "tap_enabled", lambda: False)
+    direct = alpaca_sdk.get_order_by_client_order_id(
+        alpaca_sdk.AlpacaConfig(profile="paper"), client_order_id="vt-exact")
+    captured: dict[str, str] = {}
+    monkeypatch.setattr(alpaca_sdk.tap_forward, "tap_enabled", lambda: True)
+    monkeypatch.setattr(alpaca_sdk.tap_forward, "forward",
+                        lambda target, method, body, headers:
+                        captured.update(target=target, method=method) or {"ok": True, "body": payload})
+    tap = alpaca_sdk.get_order_by_client_order_id(
+        alpaca_sdk.AlpacaConfig(profile="paper"), client_order_id="vt-exact")
+
+    assert direct == tap and direct["order"]["client_order_id"] == "vt-exact"
+    assert captured["method"] == "GET" and "client_order_id=vt-exact" in captured["target"]
 
 
 def test_gate_blocks_oversized_order(monkeypatch) -> None:

--- a/agent/tests/test_sdk_order_gate.py
+++ b/agent/tests/test_sdk_order_gate.py
@@ -247,6 +247,32 @@ def test_uncertain_submit_survives_restart_and_blocks_new_risk(monkeypatch) -> N
     }
 
 
+@pytest.mark.parametrize(
+    "response",
+    [
+        {"status": "ok", "order_id": ""},
+        {"status": "ok", "order_id": "broker-1", "client_order_id": "other"},
+        {},
+        None,
+    ],
+)
+def test_incomplete_or_mismatched_ack_retains_marker(monkeypatch, response) -> None:
+    class _IncompleteAckConnector(_FakeConnector):
+        def place_order(self, config, **kwargs):
+            self.placed.append(kwargs)
+            return response
+
+    _patch_gate(monkeypatch, mandate=_mandate())
+    connector = _IncompleteAckConnector()
+
+    result = _place(connector)
+
+    assert result["recovery_pending"] is True
+    assert result["reason_code"] == "pending_action_unresolved"
+    assert load_pending_action("alpaca") is not None
+    assert len(connector.placed) == 1
+
+
 def test_corrupt_pending_marker_and_failed_audit_both_fail_closed(monkeypatch) -> None:
     _patch_gate(monkeypatch, mandate=_mandate())
     connector = _FakeConnector()

--- a/agent/tests/test_sdk_order_gate.py
+++ b/agent/tests/test_sdk_order_gate.py
@@ -7,16 +7,22 @@ connector module + a stubbed mandate/halt so they need no broker SDK.
 
 from __future__ import annotations
 
+import json
+import sys
 import threading
 from contextlib import nullcontext
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
 import src.live.paths as live_paths
 from src.config.accessor import reset_env_config
+from src.live import audit as live_audit
+from src.live import pending_action as pending_state
 from src.live import sdk_order_gate as gate
 from src.live.daily_count import read_daily_count
 from src.live.enforcement import OrderIntent
+from src.live.pending_action import load_pending_action, pending_action_path
 from src.live.mandate.model import (
     AssetClass,
     ConsentMeta,
@@ -26,7 +32,9 @@ from src.live.mandate.model import (
     UniverseConstraint,
 )
 from src.trading import service
+from src.trading.connectors.alpaca import sdk as alpaca_sdk
 from src.trading.connectors.longbridge import credentials as lb_credentials
+from tests.module_os_helpers import patch_module_os
 
 pytestmark = pytest.mark.unit
 
@@ -42,6 +50,7 @@ def _isolate_longbridge_credentials(monkeypatch, tmp_path):
         monkeypatch.delenv(env_name, raising=False)
     reset_env_config()
     monkeypatch.setattr(lb_credentials, "get_runtime_root", lambda: tmp_path)
+    monkeypatch.setattr(live_paths, "get_runtime_root", lambda: tmp_path)
 
 
 class _FakeConnector:
@@ -116,6 +125,14 @@ def _intent(notional=500.0, qty=None, asset=AssetClass.US_EQUITY):
     )
 
 
+def _place(connector, **place_kwargs):
+    return gate.execute_live_order(
+        broker="alpaca", connector_module=connector, config=object(),
+        intent=_intent(),
+        place_kwargs={"symbol": "AAPL", "side": "buy", "notional": 500.0, **place_kwargs},
+    )
+
+
 # --------------------------------------------------------------------------- #
 # Gate decisions
 # --------------------------------------------------------------------------- #
@@ -155,6 +172,150 @@ def test_gate_allows_in_bounds_and_places(monkeypatch) -> None:
     assert out["status"] == "ok" and out["order_id"] == "OID-1"
     assert len(conn.placed) == 1  # forwarded to broker
     assert "live_action" in out
+
+
+def test_alpaca_marker_precedes_submit_and_audit_precedes_clear(monkeypatch) -> None:
+    events: list[str] = []
+
+    class _OrderingConnector(_FakeConnector):
+        def place_order(self, config, **kwargs):
+            pending = load_pending_action("alpaca")
+            assert pending is not None and pending.phase == "pending_write"
+            assert pending.client_order_id == kwargs["client_order_id"]
+            events.append("submit")
+            return super().place_order(config, **kwargs)
+
+    _patch_gate(monkeypatch, mandate=_mandate())
+    def audited(*args, **kwargs):
+        record = live_audit.write_live_action(*args, **kwargs)
+        events.append("audit")
+        return record
+
+    monkeypatch.setattr(gate, "write_live_action", audited)
+    real_clear = pending_state.clear_pending_action
+    monkeypatch.setattr(pending_state, "clear_pending_action",
+                        lambda broker, action_id: events.append("clear") or real_clear(broker, action_id))
+
+    connector = _OrderingConnector()
+    first = _place(connector)
+    second = _place(connector)
+
+    assert first["status"] == second["status"] == "ok"
+    assert events == ["submit", "audit", "clear"] * 2
+    assert connector.placed[0]["client_order_id"] != connector.placed[1]["client_order_id"]
+    assert live_audit.audit_ledger_path().is_file()
+    assert load_pending_action("alpaca") is None
+
+
+def test_pending_persist_failure_makes_zero_broker_calls(monkeypatch) -> None:
+    _patch_gate(monkeypatch, mandate=_mandate())
+    connector = _FakeConnector()
+    patch_module_os(
+        monkeypatch, pending_state,
+        fsync=lambda descriptor: (_ for _ in ()).throw(OSError("disk full")),
+    )
+
+    result = _place(connector)
+
+    assert result["status"] == "blocked"
+    assert result["reason_code"] == "pending_action_persist_failed"
+    assert connector.placed == []
+    assert load_pending_action("alpaca") is None
+
+
+def test_uncertain_submit_survives_restart_and_blocks_new_risk(monkeypatch) -> None:
+    class _TimeoutConnector(_FakeConnector):
+        def place_order(self, config, **kwargs):
+            self.placed.append(kwargs)
+            raise TimeoutError("response lost")
+
+    _patch_gate(monkeypatch, mandate=_mandate())
+    connector = _TimeoutConnector()
+    first = _place(connector, api_key="must-not-persist")
+    restarted = load_pending_action("alpaca")
+    second = _place(connector)
+    raw = pending_action_path("alpaca").read_text(encoding="utf-8")
+
+    assert first["status"] == "error" and first["recovery_pending"] is True
+    assert first["reason_code"] == "pending_action_unresolved"
+    assert restarted is not None and restarted.client_order_id == connector.placed[0]["client_order_id"]
+    assert second["status"] == "blocked" and second["reason_code"] == "pending_action_unresolved"
+    assert len(connector.placed) == 1
+    assert "must-not-persist" not in raw and "api_key" not in raw
+    assert set(json.loads(raw)["request"]) == {
+        "symbol", "side", "quantity", "notional", "order_type", "limit_price", "time_in_force"
+    }
+
+
+def test_corrupt_pending_marker_and_failed_audit_both_fail_closed(monkeypatch) -> None:
+    _patch_gate(monkeypatch, mandate=_mandate())
+    connector = _FakeConnector()
+    monkeypatch.setattr(gate, "write_live_action", lambda *a, **k: None)
+
+    result = _place(connector)
+    assert result["status"] == "ok" and result["recovery_pending"] is True
+    assert len(connector.placed) == 1
+
+    pending_action_path("alpaca").write_text('{"schema_version":999}\n', encoding="utf-8")
+    blocked = _place(connector)
+    assert blocked["status"] == "blocked" and blocked["reason_code"] == "pending_action_invalid"
+    assert len(connector.placed) == 1
+
+
+def test_audit_durability_failure_retains_pending_marker(monkeypatch) -> None:
+    _patch_gate(monkeypatch, mandate=_mandate())
+    monkeypatch.setattr(gate, "write_live_action", live_audit.write_live_action)
+    connector = _FakeConnector()
+    patch_module_os(monkeypatch, live_audit, fsync=lambda fd: (_ for _ in ()).throw(OSError("disk")))
+
+    result = _place(connector)
+
+    assert result["status"] == "ok" and result["recovery_pending"] is True
+    assert result["reason_code"] == "pending_action_unresolved"
+    assert len(connector.placed) == 1 and load_pending_action("alpaca") is not None
+
+
+def test_external_client_id_reaches_direct_sdk_and_tap(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class _Request:
+        def __init__(self, **kwargs):
+            captured["request"] = kwargs
+
+    class _Client:
+        def submit_order(self, *, order_data):
+            return SimpleNamespace(id="oid", status="accepted", filled_qty="0")
+
+    enums = ModuleType("alpaca.trading.enums")
+    enums.OrderSide = SimpleNamespace(BUY="buy", SELL="sell")
+    enums.TimeInForce = SimpleNamespace(DAY="day", GTC="gtc")
+    requests = ModuleType("alpaca.trading.requests")
+    requests.LimitOrderRequest = requests.MarketOrderRequest = _Request
+    monkeypatch.setitem(sys.modules, "alpaca.trading.enums", enums)
+    monkeypatch.setitem(sys.modules, "alpaca.trading.requests", requests)
+    monkeypatch.setattr(alpaca_sdk, "_trading_client", lambda cfg: _Client())
+    monkeypatch.setattr(alpaca_sdk.tap_forward, "tap_enabled", lambda: False)
+
+    direct = alpaca_sdk.place_order(
+        alpaca_sdk.AlpacaConfig(profile="paper"), symbol="AAPL", side="buy",
+        quantity=1, client_order_id="vt-direct",
+    )
+    assert direct["status"] == "ok" and captured["request"]["client_order_id"] == "vt-direct"
+    alpaca_sdk.place_order(alpaca_sdk.AlpacaConfig(profile="paper"),
+                           symbol="AAPL", side="buy", quantity=1)
+    assert "client_order_id" not in captured["request"]
+
+    monkeypatch.setattr(alpaca_sdk.tap_forward, "tap_enabled", lambda: True)
+    monkeypatch.setattr(
+        alpaca_sdk.tap_forward, "forward",
+        lambda target, method, body, headers: captured.update(tap=json.loads(body))
+        or {"ok": True, "body": {"id": "tap-oid", "status": "accepted"}},
+    )
+    tap = alpaca_sdk.place_order(
+        alpaca_sdk.AlpacaConfig(profile="paper"), symbol="AAPL", side="buy",
+        quantity=1, client_order_id="vt-tap",
+    )
+    assert tap["status"] == "ok" and captured["tap"]["client_order_id"] == "vt-tap"
 
 
 def test_gate_blocks_oversized_order(monkeypatch) -> None:
@@ -291,6 +452,8 @@ def test_gate_count_consumed_only_on_success(monkeypatch) -> None:
     )
     assert out["status"] == "error"
     assert increments == []  # failed placement must not consume a daily count
+    assert out["recovery_pending"] is True
+    assert load_pending_action("alpaca") is not None
 
 
 def test_concurrent_orders_share_one_daily_cap_permit(

--- a/agent/tests/test_sdk_order_gate.py
+++ b/agent/tests/test_sdk_order_gate.py
@@ -333,6 +333,33 @@ def test_restart_recovers_exact_working_order_once_and_never_resubmits(monkeypat
     assert len(connector.placed) == 1 and connector.lookups == [action.client_order_id] * 2
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("order_status", "mystery"),
+        ("submitted_at", "not-a-time"),
+        ("filled_qty", -1),
+        ("symbol", "MSFT"),
+    ],
+)
+def test_persisted_resolution_revalidates_semantic_evidence(monkeypatch, field, value) -> None:
+    _patch_gate(monkeypatch, mandate=_mandate())
+    connector = _LostResponseConnector()
+    _place(connector)
+    action = load_pending_action("alpaca")
+    connector.lookup_result = _exact_order(action)
+    _place(connector)
+    path = pending_action_path("alpaca")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["resolution"][field] = value
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = _place(connector)
+
+    assert result["reason_code"] == "pending_action_invalid"
+    assert len(connector.placed) == 1
+
+
 @pytest.mark.parametrize("blocker", ["missing_mandate", "expired", "halted"])
 def test_exact_recovery_precedes_current_policy_blockers(monkeypatch, blocker) -> None:
     _patch_gate(monkeypatch, mandate=_mandate())


### PR DESCRIPTION
## Summary

- Recover an unresolved Alpaca submission using the exact agent-owned `client_order_id`.
- Account accepted recovered actions idempotently in the existing daily counter.
- Resolve exact terminal zero-fill outcomes and retain working orders for later policy revalidation.

## Motivation

After PR1, an uncertain submission is safely owned and blocks new risk, but availability cannot be restored until the exact external outcome is known.

Recovery must use Broker-authoritative identity and evidence, consume no new submission permit more than once, and remain available even when the current mandate is missing or expired or the broker is halted. It must never infer an order from symbol, size, side, or time proximity.

## Changes

- Add exact Alpaca lookup by `client_order_id` for direct SDK and TAP.
- Normalize Broker order ID, client ID, symbol, side, order type, time in force, requested size, filled quantity, status, and submitted timestamp.
- Run unresolved truth recovery before current mandate, expiry, HALT, quote, account, and position admission checks.
- Validate exact identity and request equality using deterministic Decimal comparisons.
- Validate persisted recovery evidence semantically on every load.
- Extend the existing daily counter with durable, action-ID-aware deduplication.
- Preserve action-ID deduplication across UTC rollover without charging the same old action to the new day.
- Reject corrupt, future-dated, duplicate, oversized, or internally inconsistent counter evidence.
- Wrap counter directory and persistence failures in a stable fail-closed error.
- Clear exact rejected/canceled/expired zero-fill terminal outcomes only after durable audit.
- Transition exact working zero-fill orders to `resolved_needs_revalidation`.
- Retain every positive-fill outcome for PR3 position attribution.
- Perform zero Broker submissions during recovery.

## Tests

- 136 required independent-prefix safety tests passed.
- 67 focused gate and daily-counter tests passed.
- Verified exact working recovery performs one original submission and zero resubmissions.
- Verified missing, expired, and halted current policy states do not prevent read-only truth recovery.
- Verified missing, mismatched, malformed, unsupported, and contradictory evidence remains blocked.
- Verified action-ID accounting is durable, idempotent, and safe across UTC rollover.
- Verified malformed/future counter dates and directory persistence failures fail closed.
- Verified direct SDK and TAP normalize equivalent exact evidence.
- `compileall`, Ruff, and `git diff --check` passed.

## Safety

- Recovery uses only exact `client_order_id` equality; there is no fuzzy matching.
- Recovery performs no risk-increasing Broker write.
- Accepted recovered actions cannot leave daily accounting below known Broker truth.
- Replaying unchanged recovery does not increment the same action repeatedly.
- Missing or contradictory Broker/counter evidence retains the unresolved marker.
- Working orders remain blocked for deterministic revalidation.
- Existing mandate, risk, halt, audit, readonly, and broker isolation are not weakened.
- Tests use fakes and fixtures only.

## Out of Scope

- Positive-fill position attribution; those markers remain unresolved for PR3.
- Cancel request recovery and terminal cancel verification.
- Automatic RESUME, automatic CANCEL, or remaining-size submission.
- Notional fill automation.
- Additional brokers or a generic recovery framework.

## Rollback

Halt Alpaca live trading and inspect any pending marker before reverting. A marker in a recovered phase may not be understood by the PR1 schema and will therefore fail closed; it must not be deleted or force-cleared. Preserve Broker evidence, reconcile the exact order, then revert the PR2 commits if rollback remains necessary.