### PR TITLE
fix(live): fail closed on broker error envelopes during the halt sweep

### DIFF
--- a/agent/src/live/runtime/flatten.py
+++ b/agent/src/live/runtime/flatten.py
@@ -191,6 +191,21 @@ def _cancel_resting_orders(
                 str(exc),
             )
             continue
+        envelope_error = _error_envelope_message(response)
+        if envelope_error is not None:
+            report["errors"].append(
+                {"phase": "cancel", "order_id": order_id, "error": envelope_error}
+            )
+            _audit(
+                broker,
+                _sweep_tool(broker, "cancel_order", _CANCEL_TOOL),
+                f"cancel order {order_id}",
+                request,
+                response,
+                "error",
+                envelope_error,
+            )
+            continue
         report["cancelled_order_ids"].append(order_id)
         _audit(
             broker,
@@ -258,6 +273,21 @@ def _flatten_open_positions(
                 str(exc),
             )
             continue
+        envelope_error = _error_envelope_message(response)
+        if envelope_error is not None:
+            report["errors"].append(
+                {"phase": "flatten", "symbol": symbol, "error": envelope_error}
+            )
+            _audit(
+                broker,
+                _sweep_tool(broker, "submit_order", _FLATTEN_TOOL),
+                intent,
+                request,
+                response,
+                "error",
+                envelope_error,
+            )
+            continue
         report["flatten_orders_submitted"].append(
             {"symbol": symbol, "qty": close_qty, "side": side, "response": response}
         )
@@ -270,6 +300,20 @@ def _flatten_open_positions(
             "accepted",
             None,
         )
+
+
+def _error_envelope_message(response: Any) -> str | None:
+    """Return the error string when a broker call failed via envelope.
+
+    The MCP adapter converts a failed remote call into
+    ``{"status": "error", "error": ...}`` instead of raising, so a returned
+    dict is not proof the broker accepted the request. Treating that
+    envelope as success would audit a resting order as cancelled while it
+    stays live, which is the failure the sweep exists to prevent.
+    """
+    if isinstance(response, dict) and response.get("status") == "error":
+        return str(response.get("error") or "broker returned an error envelope")
+    return None
 
 
 def _sweep_tool(broker: str, operation: str, fallback: str) -> str:

--- a/agent/tests/test_runtime_flatten.py
+++ b/agent/tests/test_runtime_flatten.py
@@ -206,3 +206,75 @@ def test_mandate_flatten_flag_honored(
     )
     assert [s["symbol"] for s in report["flatten_orders_submitted"]] == ["NVDA"]
     assert report["flatten_skipped_reason"] is None
+
+
+def _error_envelope(key: str) -> dict[str, Any]:
+    """The shape MCPServerAdapter.call_tool returns instead of raising."""
+    return {
+        "status": "error",
+        "server": "robinhood",
+        "remote_tool": "cancel_equity_order",
+        "tool": "cancel_equity_order",
+        "error": f"connection reset while cancelling {key}",
+        "error_type": "ConnectionError",
+    }
+
+
+def test_error_envelope_cancel_is_not_a_success(live_runtime: Path) -> None:
+    # A broker failure that comes back as an envelope must not be recorded
+    # as a cancelled order: the resting order is still live.
+    broker = _Broker(
+        open_orders=[{"order_id": "o1"}, {"order_id": "o2"}], positions=[]
+    )
+    real_submit = broker.submit
+
+    def submit(request: dict[str, Any]) -> dict[str, Any]:
+        if request.get("order_id") == "o1":
+            return _error_envelope("o1")
+        return real_submit(request)
+
+    report = flatten.flatten_and_cancel(
+        "robinhood", submit, broker.read_positions, broker.read_open_orders
+    )
+    assert report["cancelled_order_ids"] == ["o2"]
+    assert report["errors"] == [
+        {
+            "phase": "cancel",
+            "order_id": "o1",
+            "error": "connection reset while cancelling o1",
+        }
+    ]
+    rejected = [r for r in _read_ledger() if r["kind"] == "order_rejected"]
+    assert len(rejected) == 1
+    assert rejected[0]["outcome"] == "error"
+    assert rejected[0]["error"] == "connection reset while cancelling o1"
+    assert rejected[0]["broker_response"]["status"] == "error"
+
+
+def test_error_envelope_flatten_is_not_a_success(live_runtime: Path) -> None:
+    broker = _Broker(
+        open_orders=[],
+        positions=[{"symbol": "NVDA", "qty": 3}, {"symbol": "AAPL", "qty": 1}],
+    )
+    real_submit = broker.submit
+
+    def submit(request: dict[str, Any]) -> dict[str, Any]:
+        if request.get("symbol") == "NVDA":
+            return _error_envelope("NVDA")
+        return real_submit(request)
+
+    report = flatten.flatten_and_cancel(
+        "robinhood",
+        submit,
+        broker.read_positions,
+        broker.read_open_orders,
+        allow_flatten=True,
+    )
+    assert [s["symbol"] for s in report["flatten_orders_submitted"]] == ["AAPL"]
+    assert report["errors"] == [
+        {
+            "phase": "flatten",
+            "symbol": "NVDA",
+            "error": "connection reset while cancelling NVDA",
+        }
+    ]


### PR DESCRIPTION
## Summary

- The kill-switch sweep treated any non-exception broker response as success, but `MCPServerAdapter.call_tool` converts a failed remote call into a `{"status": "error"}` envelope instead of raising.
- Error envelopes now count as failures in both the cancel pass and the flatten pass: they land in `report["errors"]` and get an `error` audit outcome instead of a fake `accepted`.

## Why

Refs #1207 (Phase 0, item 3). During a halt, a flaky broker connection produced a compliant-looking audit trail while the resting order stayed live, which is exactly the failure the sweeper exists to prevent. Verified against current main: `call_tool` returns the envelope on exception (`agent/src/tools/mcp.py`), the production `_submit` wiring passes it straight through (`agent/src/api/live_routes.py`), and the sweep only branched on exceptions (`agent/src/live/runtime/flatten.py`).

## Changes

- `flatten._error_envelope_message`: recognizes the adapter's error envelope and extracts its message.
- `_cancel_resting_orders` and `_flatten_open_positions`: an error envelope is recorded in `report["errors"]` and audited with outcome `error` (the envelope itself is kept as `broker_response`), never appended to `cancelled_order_ids` / `flatten_orders_submitted`. Success payloads without the error status are untouched.

## Test Plan

- [x] New regression tests: an error envelope on cancel keeps the order out of `cancelled_order_ids`, records the failure, and writes an `order_rejected` audit carrying the envelope; same for the flatten pass.
- [x] `pytest agent/tests/test_runtime_flatten.py -q`: 10 passed.
- [x] Live safety set (`test_sdk_order_gate`, `test_mandate_enforcement`, `test_killswitch_blocks_orders`, `test_readonly_default`): 112 passed. `test_runtime_runner` + `test_api_live_runtime`: 47 passed.
- [ ] Full suite and e2e not run; change is confined to the sweep's response handling. `ruff check` clean on both files.

Risk: no new broker surface, the sweep still never retries and never touches live accounts in tests. Behavior change is fail-closed only: responses previously misread as success now surface as errors. Rollback is a plain revert.

Prepared with AI assistance (Kimi K3); all verification above was run locally.
