### PR TITLE
fix(live): halt sweep read envelopes + latch only after attempted side effects

### DIFF
--- a/agent/src/api/live_routes.py
+++ b/agent/src/api/live_routes.py
@@ -565,8 +565,42 @@ def _build_live_runner(broker: str) -> Any:
     # _live_broker_adapter is monkeypatched on host by tests
     adapter = h._live_broker_adapter(broker)
 
-    def _read(remote_tool: str):
-        return lambda: adapter.call_tool(remote_tool, {})
+    def _read(remote_tool: str, record_key: str | None = None):
+        """Wrap adapter.call_tool into a READ callable with a normalized payload.
+
+        The MCP adapter returns ``{"status": "error", ...}`` envelopes instead
+        of raising, and wraps successful values in ``{"status": "ok",
+        "data": ...}``. Normalize at the boundary so consumers (reconcile and
+        the halt sweep) receive broker records — or the balance dict — not
+        envelopes: error envelopes raise, success payloads unwrap to ``data``
+        (with the pinned ``record_key`` extracted for positions/orders record
+        reads, e.g. ``data.positions`` / ``data.orders``). Bare values pass
+        through unchanged.
+        """
+        def read() -> Any:
+            payload = adapter.call_tool(remote_tool, {})
+            if isinstance(payload, list):
+                return payload  # injected/legacy bare response
+            if not isinstance(payload, dict) or payload.get("status") != "ok":
+                if isinstance(payload, dict) and payload.get("status") == "error":
+                    raise RuntimeError(
+                        str(payload.get("error") or "broker read failed")
+                    )
+                return payload
+            data = payload.get("data")
+            if record_key is None:
+                return data
+            if isinstance(data, list):
+                return data
+            if isinstance(data, dict):
+                records = data.get(record_key)
+                if isinstance(records, list):
+                    return records
+                raise RuntimeError(
+                    f"broker read response missing {record_key!r} records"
+                )
+            raise RuntimeError("broker read response has no data payload")
+        return read
 
     def _submit(order: Dict[str, Any]) -> Dict[str, Any]:
         if order.get("action") == "cancel":
@@ -599,9 +633,9 @@ def _build_live_runner(broker: str) -> Any:
         broker,
         agent_caller=_agent_caller,
         reconcile_fn=reconcile,
-        read_positions=_read(positions_tool),
+        read_positions=_read(positions_tool, "positions"),
         read_balance=_read(balance_tool),
-        read_open_orders=_read(open_orders_tool),
+        read_open_orders=_read(open_orders_tool, "orders"),
         submit_fn=_submit,
         write_audit_fn=_audit_with_bus,
         scheduler=scheduler,

--- a/agent/src/live/runtime/flatten.py
+++ b/agent/src/live/runtime/flatten.py
@@ -403,9 +403,27 @@ def _error_envelope_message(response: Any) -> str | None:
     dict is not proof the broker accepted the request. Treating that
     envelope as success would audit a resting order as cancelled while it
     stays live, which is the failure the sweep exists to prevent.
+
+    A *nested* broker-level failure is just as dangerous: the MCP transport
+    succeeded, but the connector/broker rejected the order inside its own
+    payload (``{"status": "ok", "data": {"status": "error", ...}}`` or
+    ``{"status": "ok", "data": {"ok": False, ...}}``). Only the top level was
+    checked before, so such a rejection was recorded as accepted and the
+    sweep latched with a live order still resting.
     """
-    if isinstance(response, dict) and response.get("status") == "error":
-        return str(response.get("error") or "broker returned an error envelope")
+    if isinstance(response, dict):
+        if response.get("status") == "error":
+            return str(response.get("error") or "broker returned an error envelope")
+        data = response.get("data")
+        if isinstance(data, dict):
+            if data.get("status") == "error":
+                return str(data.get("error") or "broker returned an error envelope")
+            if data.get("ok") is False:
+                return str(
+                    data.get("error")
+                    or data.get("message")
+                    or "broker rejected the request"
+                )
     return None
 
 

--- a/agent/src/live/runtime/flatten.py
+++ b/agent/src/live/runtime/flatten.py
@@ -99,16 +99,23 @@ def flatten_and_cancel(
                     {"symbol": "NVDA", "qty": 3, "side": "sell", "response": {...}},
                 ],
                 "flatten_skipped_reason": "mandate forbids flatten" | None,
+                "side_effects_attempted": bool,      # any cancel/close submit tried
                 "errors": [                            # one per failed broker call
                     {"phase": "cancel", "order_id": "o2", "error": "..."},
                 ],
             }
+
+        ``side_effects_attempted`` is set the moment a cancel or close order
+        submit is attempted (not merely read). The runner uses it to decide
+        whether the sweep's side effects made replay after a restart unsafe
+        (see ``LiveRunner._run_preemptive_sweep``).
     """
     report: dict[str, Any] = {
         "broker": broker,
         "cancelled_order_ids": [],
         "flatten_orders_submitted": [],
         "flatten_skipped_reason": None,
+        "side_effects_attempted": False,
         "errors": [],
     }
 
@@ -151,6 +158,76 @@ def _resolve_allow_flatten(broker: str, allow_flatten: bool | None) -> bool:
     return bool(getattr(mandate, "flatten_on_halt", False))
 
 
+def _read_broker_state(
+    phase: str,
+    expected_key: str,
+    read_fn: Callable[[], Any],
+    report: dict[str, Any],
+) -> list[Any] | None:
+    """Read broker state for the sweep, or record a structured read error.
+
+    Broker reads are wired to ``MCPServerAdapter.call_tool``, whose contract
+    is: a failed call returns an error envelope (``{"status": "error",
+    "error": ...}``) instead of raising; a successful call returns
+    ``{"status": "ok", "data": <value>}``. ``data`` is either the records
+    list itself or a wrapper dict carrying the pinned per-tool key
+    (``positions`` for a positions read, ``orders`` for an open-orders
+    read). Anything else — an exception, a non-list, a non-``ok`` status, or
+    a wrapper without the expected key — is rejected into
+    ``report["errors"]`` under ``phase`` and the sweep phase aborts without
+    attempting side effects. Wrapper dicts are never accepted generically:
+    that would turn unrelated metadata into fake broker records.
+
+    Returns:
+        The broker record list, or ``None`` (after recording the error).
+    """
+    try:
+        response = read_fn()
+    except Exception as exc:  # noqa: BLE001 — broker read must not abort the sweep
+        report["errors"].append({"phase": phase, "error": str(exc)})
+        return None
+    envelope_error = _error_envelope_message(response)
+    if envelope_error is not None:
+        report["errors"].append({"phase": phase, "error": envelope_error})
+        return None
+    records = _unwrap_ok_payload(response, expected_key)
+    if records is None:
+        report["errors"].append(
+            {
+                "phase": phase,
+                "error": (
+                    f"unexpected broker response: expected a records list or an "
+                    f"adapter {{status: ok, data: ...}} payload carrying "
+                    f"{expected_key!r}, got {type(response).__name__}"
+                ),
+            }
+        )
+        return None
+    return records
+
+
+def _unwrap_ok_payload(response: Any, expected_key: str) -> list[Any] | None:
+    """Decode a successful adapter read payload into a records list.
+
+    Accepts a bare list (injected/legacy read stubs) or the adapter's
+    ``{"status": "ok", "data": <value>}`` shape, where ``data`` is either the
+    records list or a wrapper dict carrying the pinned ``expected_key``.
+    Returns ``None`` for anything else — never a generic dict.
+    """
+    if isinstance(response, list):
+        return response
+    if not isinstance(response, dict) or response.get("status") != "ok":
+        return None
+    payload = response.get("data")
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict):
+        records = payload.get(expected_key)
+        if isinstance(records, list):
+            return records
+    return None
+
+
 def _cancel_resting_orders(
     broker: str,
     submit: SubmitFn,
@@ -166,15 +243,24 @@ def _cancel_resting_orders(
         report: Mutated in place — successful ids appended to
             ``cancelled_order_ids``, failures to ``errors``.
     """
-    try:
-        open_orders = read_open_orders()
-    except Exception as exc:  # noqa: BLE001 — broker read must not abort the sweep
-        report["errors"].append({"phase": "read_open_orders", "error": str(exc)})
+    open_orders = _read_broker_state(
+        "read_open_orders", "orders", read_open_orders, report
+    )
+    if open_orders is None:
         return
 
     for order in open_orders:
+        if not isinstance(order, dict):
+            report["errors"].append(
+                {
+                    "phase": "read_open_orders",
+                    "error": f"invalid entry: {type(order).__name__}",
+                }
+            )
+            continue
         order_id = order.get("order_id")
         request = {"action": "cancel", "order_id": order_id}
+        report["side_effects_attempted"] = True
         try:
             response = submit(request)
         except Exception as exc:  # noqa: BLE001 — record + move on, never retry
@@ -236,13 +322,19 @@ def _flatten_open_positions(
         report: Mutated in place — accepted closes appended to
             ``flatten_orders_submitted``, failures to ``errors``.
     """
-    try:
-        positions = read_positions()
-    except Exception as exc:  # noqa: BLE001 — broker read must not abort the sweep
-        report["errors"].append({"phase": "read_positions", "error": str(exc)})
+    positions = _read_broker_state("read_positions", "positions", read_positions, report)
+    if positions is None:
         return
 
     for position in positions:
+        if not isinstance(position, dict):
+            report["errors"].append(
+                {
+                    "phase": "read_positions",
+                    "error": f"invalid entry: {type(position).__name__}",
+                }
+            )
+            continue
         symbol = position.get("symbol")
         qty = float(position.get("qty", 0) or 0)
         if qty == 0:
@@ -257,6 +349,7 @@ def _flatten_open_positions(
             "type": "market",
         }
         intent = f"flatten {symbol}: {side} {close_qty} @ market"
+        report["side_effects_attempted"] = True
         try:
             response = submit(request)
         except Exception as exc:  # noqa: BLE001 — record + move on, never retry

--- a/agent/src/live/runtime/runner.py
+++ b/agent/src/live/runtime/runner.py
@@ -611,7 +611,13 @@ class LiveRunner:
         if sweep_already_fired(self.broker):
             self._flatten_fired = True
             return
-        if not claim_sweep(self.broker, halt_episode(self.broker) or "unknown"):
+        # Resolve the episode ONCE: the claim and its release in ``finally``
+        # must refer to the same episode. Re-resolving at release time can
+        # bind to a NEWER episode (halt cleared + re-tripped mid-sweep) and
+        # delete that episode's claim — even a different process's — which
+        # would unprotect a concurrent sweep of the new episode.
+        episode = halt_episode(self.broker) or "unknown"
+        if not claim_sweep(self.broker, episode):
             # Another process holds this episode's claim (or a crash left it
             # behind): the outcome is unknowable — re-sweeping could duplicate
             # a close. Claims are episode-keyed, so this never blocks a future
@@ -718,7 +724,7 @@ class LiveRunner:
                     error=str(exc),
                 )
         finally:
-            release_claim(self.broker, halt_episode(self.broker) or "unknown")
+            release_claim(self.broker, episode)
 
     def _no_mandate_result(self) -> dict[str, Any]:
         """Audit + return the result when no valid mandate is on file."""

--- a/agent/src/live/runtime/runner.py
+++ b/agent/src/live/runtime/runner.py
@@ -48,6 +48,7 @@ from src.live.runtime.flatten import flatten_and_cancel
 from src.live.runtime.jobstore import JobStore
 from src.live.runtime.sweep_latch import (
     claim_sweep,
+    halt_episode,
     mark_sweep_fired,
     release_claim,
     sweep_already_fired,
@@ -610,9 +611,11 @@ class LiveRunner:
         if sweep_already_fired(self.broker):
             self._flatten_fired = True
             return
-        if not claim_sweep(self.broker):
-            # Another process holds the claim (or a crash left it behind):
-            # the outcome is unknowable — re-sweeping could duplicate a close.
+        if not claim_sweep(self.broker, halt_episode(self.broker) or "unknown"):
+            # Another process holds this episode's claim (or a crash left it
+            # behind): the outcome is unknowable — re-sweeping could duplicate
+            # a close. Claims are episode-keyed, so this never blocks a future
+            # trip of the same broker.
             self._flatten_fired = True
             logger.warning(
                 "preemptive sweep already claimed for %s — skipping (another "
@@ -698,7 +701,7 @@ class LiveRunner:
                     error=str(exc),
                 )
         finally:
-            release_claim(self.broker)
+            release_claim(self.broker, halt_episode(self.broker) or "unknown")
 
     def _no_mandate_result(self) -> dict[str, Any]:
         """Audit + return the result when no valid mandate is on file."""

--- a/agent/src/live/runtime/runner.py
+++ b/agent/src/live/runtime/runner.py
@@ -46,7 +46,12 @@ from src.live.mandate.model import Mandate
 from src.live.mandate.store import load_mandate
 from src.live.runtime.flatten import flatten_and_cancel
 from src.live.runtime.jobstore import JobStore
-from src.live.runtime.sweep_latch import mark_sweep_fired, sweep_already_fired
+from src.live.runtime.sweep_latch import (
+    claim_sweep,
+    mark_sweep_fired,
+    release_claim,
+    sweep_already_fired,
+)
 from src.live.runtime.liveness import write_heartbeat
 from src.live.runtime.scheduler import Job
 from src.live.runtime.triggers import Trigger
@@ -586,65 +591,114 @@ class LiveRunner:
         write — even one that errors, and even when a later read phase fails —
         latches: those are the non-idempotent cases SPEC §8.5 protects. A
         sweep that raises outright latches too (side effects may have begun).
+
+        Inter-process safety: the whole check -> sweep -> durable-record
+        window runs under an exclusive disk claim (``FLATTEN_CLAIM``,
+        :func:`sweep_latch.claim_sweep`). A second runner process for the
+        same broker cannot sweep concurrently — both would see
+        ``sweep_already_fired`` false (check-then-act) and duplicate closes.
+        When a claim is already held (another runner active, or a prior
+        process crashed mid-sweep), the episode is treated as *unknowable*:
+        never re-sweep, audit for operator resolution, and leave the HALT
+        tripped. The claim is released in ``finally`` on every path. A failed
+        durable latch write (fs error after side effects) is audited
+        explicitly — the in-process flag still protects this process, but the
+        operator is told a restart may replay.
         """
         if self._flatten_fired or self._submit_fn is None:
             return
         if sweep_already_fired(self.broker):
             self._flatten_fired = True
             return
-        try:
-            report = self._flatten_fn(
-                self.broker,
-                self._submit_fn,
-                self._read_positions,
-                self._read_open_orders,
-            )
-        except Exception as exc:  # noqa: BLE001 — surfaced via audit, never retried
-            # Unknown failure: cancel/flatten side effects may have begun and
-            # are not retryable — latch so a restart does not replay closes.
+        if not claim_sweep(self.broker):
+            # Another process holds the claim (or a crash left it behind):
+            # the outcome is unknowable — re-sweeping could duplicate a close.
             self._flatten_fired = True
-            mark_sweep_fired(self.broker)
-            logger.exception("preemptive flatten failed for %s", self.broker)
-            self._audit(
-                kind="breach",
-                outcome="error",
-                intent="preemptive halt sweep failed — not retried (no-retry §8.5)",
-                error=str(exc),
-            )
-            return
-        report = report or {}
-        read_errors = [
-            entry
-            for entry in report.get("errors", [])
-            if isinstance(entry, dict)
-            and entry.get("phase") in ("read_open_orders", "read_positions")
-        ]
-        if read_errors:
-            detail = "; ".join(str(entry.get("error")) for entry in read_errors)
             logger.warning(
-                "preemptive sweep read failure for %s during execution: %s",
+                "preemptive sweep already claimed for %s — skipping (another "
+                "runner active, or a crash left FLATTEN_CLAIM behind); operator "
+                "resolution required",
                 self.broker,
-                detail,
             )
-        if not report.get("side_effects_attempted"):
-            # No cancel or close was attempted → nothing happened that a
-            # later tick (or a restart) must not repeat. Do NOT latch: the
-            # sweep retries for this episode.
-            if read_errors:
-                detail = "; ".join(str(e.get("error")) for e in read_errors)
-                intent = "preemptive halt sweep read failed — retrying on next tick"
-            else:
-                detail = "no open orders or positions to act on"
-                intent = "preemptive halt sweep found nothing to act on — re-checking on next tick"
             self._audit(
                 kind="breach",
                 outcome="error",
-                intent=intent,
-                error=detail,
+                intent="preemptive halt sweep skipped — claim held by another process; operator resolution required",
+                error="FLATTEN_CLAIM present for this episode",
             )
             return
-        self._flatten_fired = True
-        mark_sweep_fired(self.broker)
+        try:
+            try:
+                report = self._flatten_fn(
+                    self.broker,
+                    self._submit_fn,
+                    self._read_positions,
+                    self._read_open_orders,
+                )
+            except Exception as exc:  # noqa: BLE001 — surfaced via audit, never retried
+                # Unknown failure: cancel/flatten side effects may have begun
+                # and are not retryable — latch so a restart does not replay.
+                self._flatten_fired = True
+                mark_sweep_fired(self.broker)
+                logger.exception("preemptive flatten failed for %s", self.broker)
+                self._audit(
+                    kind="breach",
+                    outcome="error",
+                    intent="preemptive halt sweep failed — not retried (no-retry §8.5)",
+                    error=str(exc),
+                )
+                return
+            report = report or {}
+            read_errors = [
+                entry
+                for entry in report.get("errors", [])
+                if isinstance(entry, dict)
+                and entry.get("phase") in ("read_open_orders", "read_positions")
+            ]
+            if read_errors:
+                detail = "; ".join(str(entry.get("error")) for entry in read_errors)
+                logger.warning(
+                    "preemptive sweep read failure for %s during execution: %s",
+                    self.broker,
+                    detail,
+                )
+            if not report.get("side_effects_attempted"):
+                # No cancel or close was attempted → nothing happened that a
+                # later tick (or a restart) must not repeat. Do NOT latch: the
+                # sweep retries for this episode.
+                if read_errors:
+                    detail = "; ".join(str(e.get("error")) for e in read_errors)
+                    intent = "preemptive halt sweep read failed — retrying on next tick"
+                else:
+                    detail = "no open orders or positions to act on"
+                    intent = "preemptive halt sweep found nothing to act on — re-checking on next tick"
+                self._audit(
+                    kind="breach",
+                    outcome="error",
+                    intent=intent,
+                    error=detail,
+                )
+                return
+            self._flatten_fired = True
+            try:
+                mark_sweep_fired(self.broker)
+            except Exception as exc:  # noqa: BLE001 — persistence must not be silent
+                # Durability failure AFTER a broker write: the in-memory flag
+                # protects this process, but a restart sees no latch and could
+                # replay the close. Say so — recovery is operator's.
+                logger.exception(
+                    "durable sweep latch write failed for %s — restart may "
+                    "replay the sweep; verify broker state",
+                    self.broker,
+                )
+                self._audit(
+                    kind="breach",
+                    outcome="error",
+                    intent="durable sweep latch write failed — restart may replay; verify broker state",
+                    error=str(exc),
+                )
+        finally:
+            release_claim(self.broker)
 
     def _no_mandate_result(self) -> dict[str, Any]:
         """Audit + return the result when no valid mandate is on file."""

--- a/agent/src/live/runtime/runner.py
+++ b/agent/src/live/runtime/runner.py
@@ -48,8 +48,8 @@ from src.live.runtime.flatten import flatten_and_cancel
 from src.live.runtime.jobstore import JobStore
 from src.live.runtime.sweep_latch import mark_sweep_fired, sweep_already_fired
 from src.live.runtime.liveness import write_heartbeat
-from src.live.runtime.scheduler import Job, Scheduler
-from src.live.runtime.triggers import Trigger, due_now
+from src.live.runtime.scheduler import Job
+from src.live.runtime.triggers import Trigger
 
 logger = logging.getLogger(__name__)
 
@@ -572,25 +572,38 @@ class LiveRunner:
 
         Invoked the moment the runner observes a tripped HALT. Idempotent across
         ticks via the ``_flatten_fired`` latch so the no-retry rule (SPEC §8.5)
-        holds even if the halted runner keeps waking. The latch is also persisted
-        on disk (``sweep_latch``) so a restart with flatten orders still working
-        does not replay the sweep. A sweep failure is audited but not retried —
-        flatten/cancel side effects are not idempotent.
+        holds even if the halted runner keeps waking. The latch is persisted on
+        disk (``sweep_latch``) so a restart with flatten orders still working
+        does not replay the sweep.
+
+        The persisted latch is written only when the sweep actually attempted
+        a broker write. ``flatten_and_cancel`` reports
+        ``side_effects_attempted`` — set the moment any cancel/close submit is
+        tried. When that flag is false, no cancel or close was attempted
+        (reads failed, or there was nothing to do), so nothing happened that a
+        later tick (or a restart) must not repeat: latching would silently
+        skip the kill switch's action for that episode. Any attempted broker
+        write — even one that errors, and even when a later read phase fails —
+        latches: those are the non-idempotent cases SPEC §8.5 protects. A
+        sweep that raises outright latches too (side effects may have begun).
         """
         if self._flatten_fired or self._submit_fn is None:
             return
-        self._flatten_fired = True
         if sweep_already_fired(self.broker):
+            self._flatten_fired = True
             return
-        mark_sweep_fired(self.broker)
         try:
-            self._flatten_fn(
+            report = self._flatten_fn(
                 self.broker,
                 self._submit_fn,
                 self._read_positions,
                 self._read_open_orders,
             )
         except Exception as exc:  # noqa: BLE001 — surfaced via audit, never retried
+            # Unknown failure: cancel/flatten side effects may have begun and
+            # are not retryable — latch so a restart does not replay closes.
+            self._flatten_fired = True
+            mark_sweep_fired(self.broker)
             logger.exception("preemptive flatten failed for %s", self.broker)
             self._audit(
                 kind="breach",
@@ -598,6 +611,40 @@ class LiveRunner:
                 intent="preemptive halt sweep failed — not retried (no-retry §8.5)",
                 error=str(exc),
             )
+            return
+        report = report or {}
+        read_errors = [
+            entry
+            for entry in report.get("errors", [])
+            if isinstance(entry, dict)
+            and entry.get("phase") in ("read_open_orders", "read_positions")
+        ]
+        if read_errors:
+            detail = "; ".join(str(entry.get("error")) for entry in read_errors)
+            logger.warning(
+                "preemptive sweep read failure for %s during execution: %s",
+                self.broker,
+                detail,
+            )
+        if not report.get("side_effects_attempted"):
+            # No cancel or close was attempted → nothing happened that a
+            # later tick (or a restart) must not repeat. Do NOT latch: the
+            # sweep retries for this episode.
+            if read_errors:
+                detail = "; ".join(str(e.get("error")) for e in read_errors)
+                intent = "preemptive halt sweep read failed — retrying on next tick"
+            else:
+                detail = "no open orders or positions to act on"
+                intent = "preemptive halt sweep found nothing to act on — re-checking on next tick"
+            self._audit(
+                kind="breach",
+                outcome="error",
+                intent=intent,
+                error=detail,
+            )
+            return
+        self._flatten_fired = True
+        mark_sweep_fired(self.broker)
 
     def _no_mandate_result(self) -> dict[str, Any]:
         """Audit + return the result when no valid mandate is on file."""

--- a/agent/src/live/runtime/runner.py
+++ b/agent/src/live/runtime/runner.py
@@ -642,14 +642,31 @@ class LiveRunner:
                 # Unknown failure: cancel/flatten side effects may have begun
                 # and are not retryable — latch so a restart does not replay.
                 self._flatten_fired = True
-                mark_sweep_fired(self.broker)
-                logger.exception("preemptive flatten failed for %s", self.broker)
-                self._audit(
-                    kind="breach",
-                    outcome="error",
-                    intent="preemptive halt sweep failed — not retried (no-retry §8.5)",
-                    error=str(exc),
-                )
+                try:
+                    mark_sweep_fired(self.broker)
+                except Exception as persist_exc:  # noqa: BLE001 — double failure
+                    # Both the sweep AND the durable latch write failed: the
+                    # in-memory flag still shields this process, and the
+                    # operator must know a restart may replay.
+                    logger.exception(
+                        "durable sweep latch write failed for %s while the sweep "
+                        "itself failed — restart may replay; verify broker state",
+                        self.broker,
+                    )
+                    self._audit(
+                        kind="breach",
+                        outcome="error",
+                        intent="durable sweep latch write failed during sweep failure — restart may replay; verify broker state",
+                        error=f"sweep: {exc}; latch: {persist_exc}",
+                    )
+                else:
+                    logger.exception("preemptive flatten failed for %s", self.broker)
+                    self._audit(
+                        kind="breach",
+                        outcome="error",
+                        intent="preemptive halt sweep failed — not retried (no-retry §8.5)",
+                        error=str(exc),
+                    )
                 return
             report = report or {}
             read_errors = [

--- a/agent/src/live/runtime/sweep_latch.py
+++ b/agent/src/live/runtime/sweep_latch.py
@@ -32,11 +32,64 @@ from src.live.halt import broker_halt_path, halt_path, read_halt
 from src.live.paths import broker_dir
 
 _LATCH_FILENAME = "FLATTEN_FIRED"
+_CLAIM_FILENAME = "FLATTEN_CLAIM"
 
 
 def latch_path(broker: str) -> Path:
     """Return the per-broker sweep latch path (not created here)."""
     return broker_dir(broker) / _LATCH_FILENAME
+
+
+def claim_path(broker: str) -> Path:
+    """Return the per-broker sweep-claim path (holds the inter-process claim)."""
+    return broker_dir(broker) / _CLAIM_FILENAME
+
+
+def claim_sweep(broker: str) -> bool:
+    """Atomically claim the sweep for ``broker`` — exclusive between processes.
+
+    ``O_CREAT | O_EXCL`` guarantees a single winner even when two runner
+    processes start simultaneously: the loser of the race sees the claim file
+    and must NOT sweep (the duplicate-close hazard the latch exists to
+    prevent). The claim covers the whole check -> sweep -> durable-record
+    window. A claim left behind by a crash means the episode's outcome is
+    *unknowable*: re-sweeping could duplicate a close, so the runner skips and
+    surfaces the claim for operator resolution (documented recovery).
+
+    Returns:
+        ``True`` if this process now owns the sweep; ``False`` when a claim
+        already exists (another runner active, or a crashed prior run).
+    """
+    path = claim_path(broker)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    except FileExistsError:
+        return False
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "claimed_at": datetime.now(timezone.utc).isoformat(),
+                    "pid": os.getpid(),
+                },
+                f,
+            )
+    except Exception:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+        raise  # claim could not be recorded; caller decides (fail-closed)
+    return True
+
+
+def release_claim(broker: str) -> None:
+    """Drop this process's sweep claim (no-op when the file is absent)."""
+    try:
+        claim_path(broker).unlink()
+    except OSError:
+        pass
 
 
 def _halt_episode(broker: str) -> str | None:

--- a/agent/src/live/runtime/sweep_latch.py
+++ b/agent/src/live/runtime/sweep_latch.py
@@ -21,6 +21,7 @@ the current-episode lookup — the global HALT is authoritative
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import tempfile
@@ -40,27 +41,44 @@ def latch_path(broker: str) -> Path:
     return broker_dir(broker) / _LATCH_FILENAME
 
 
-def claim_path(broker: str) -> Path:
-    """Return the per-broker sweep-claim path (holds the inter-process claim)."""
-    return broker_dir(broker) / _CLAIM_FILENAME
+def halt_episode(broker: str) -> str | None:
+    """Return the identity of the newest tripped halt episode (public alias)."""
+    return _halt_episode(broker)
 
 
-def claim_sweep(broker: str) -> bool:
-    """Atomically claim the sweep for ``broker`` — exclusive between processes.
+def _claim_filename(episode: str) -> str:
+    digest = hashlib.sha256(episode.encode("utf-8")).hexdigest()[:16]
+    return f"{_CLAIM_FILENAME}-{digest}"
 
-    ``O_CREAT | O_EXCL`` guarantees a single winner even when two runner
-    processes start simultaneously: the loser of the race sees the claim file
-    and must NOT sweep (the duplicate-close hazard the latch exists to
-    prevent). The claim covers the whole check -> sweep -> durable-record
-    window. A claim left behind by a crash means the episode's outcome is
+
+def claim_path(broker: str, episode: str) -> Path:
+    """Return the per-broker, per-episode sweep-claim path.
+
+    Claims are keyed by halt episode, so an orphaned claim from a crash can
+    only ever block its OWN episode — never a future trip of the same broker
+    (each new halt episode gets its own claim namespace).
+    """
+    return broker_dir(broker) / _claim_filename(episode)
+
+
+def claim_sweep(broker: str, episode: str) -> bool:
+    """Atomically claim the sweep for ``broker``'s ``episode`` — exclusive between processes.
+
+    ``O_CREAT | O_EXCL`` guarantees a single winner even when two runners
+    start simultaneously for the same episode: the loser of the race sees the
+    claim file and must NOT sweep (the duplicate-close hazard the latch exists
+    to prevent). The claim covers the whole check -> sweep -> durable-record
+    window. A claim left behind by a crash means that episode's outcome is
     *unknowable*: re-sweeping could duplicate a close, so the runner skips and
-    surfaces the claim for operator resolution (documented recovery).
+    surfaces the claim for operator resolution. Because the claim is bound to
+    the episode, a stale claim never blocks a later episode.
 
     Returns:
         ``True`` if this process now owns the sweep; ``False`` when a claim
-        already exists (another runner active, or a crashed prior run).
+        already exists for the same episode (another runner active, or a
+        crashed prior run).
     """
-    path = claim_path(broker)
+    path = claim_path(broker, episode)
     path.parent.mkdir(parents=True, exist_ok=True)
     try:
         fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
@@ -71,6 +89,7 @@ def claim_sweep(broker: str) -> bool:
             json.dump(
                 {
                     "claimed_at": datetime.now(timezone.utc).isoformat(),
+                    "episode": episode,
                     "pid": os.getpid(),
                 },
                 f,
@@ -84,10 +103,10 @@ def claim_sweep(broker: str) -> bool:
     return True
 
 
-def release_claim(broker: str) -> None:
-    """Drop this process's sweep claim (no-op when the file is absent)."""
+def release_claim(broker: str, episode: str) -> None:
+    """Drop this process's sweep claim for ``episode`` (no-op when absent)."""
     try:
-        claim_path(broker).unlink()
+        claim_path(broker, episode).unlink()
     except OSError:
         pass
 

--- a/agent/src/live/runtime/sweep_latch.py
+++ b/agent/src/live/runtime/sweep_latch.py
@@ -111,6 +111,54 @@ def release_claim(broker: str, episode: str) -> None:
         pass
 
 
+def _sentinel_identity(path: Path, payload: dict[str, Any]) -> tuple[int, str] | None:
+    """Return ``(instant_ns, identity)`` for one halt sentinel, or ``None``.
+
+    ``tripped_at`` is the identity when the sentinel carries a parseable one;
+    a hand-touched/malformed sentinel falls back to its file mtime (which
+    still changes on every fresh ``touch``). Ranking by mtime alone is not
+    safe — two sentinels written within one filesystem timestamp quantum
+    share an mtime — so ``tripped_at`` wins whenever present.
+    """
+    try:
+        mtime_ns = path.stat().st_mtime_ns
+    except OSError:
+        return None
+    tripped_at = payload.get("tripped_at")
+    if tripped_at:
+        try:
+            trip = datetime.fromisoformat(str(tripped_at))
+            if trip.tzinfo is None:
+                trip = trip.replace(tzinfo=timezone.utc)
+            return int(trip.timestamp() * 1_000_000_000), str(tripped_at)
+        except ValueError:
+            pass
+    return mtime_ns, f"mtime:{mtime_ns}"
+
+
+def _active_episodes(broker: str) -> list[str]:
+    """Return the identity of EVERY currently tripped halt episode.
+
+    Both the per-broker and the global sentinel can be tripped at the same
+    time, and both are live until their sentinel is cleared. Recording the
+    sweep as fired only for its *newest* episode leaves the other active one
+    unrecorded: clearing the recorded halt would re-fire the sweep while the
+    other halt is still tripped. Both identities must therefore be latched
+    together.
+    """
+    identities: list[str] = []
+    for path, payload in (
+        (broker_halt_path(broker), read_halt(broker)),
+        (halt_path(), read_halt()),
+    ):
+        if payload is None:
+            continue
+        resolved = _sentinel_identity(path, payload)
+        if resolved is not None:
+            identities.append(resolved[1])
+    return identities
+
+
 def _halt_episode(broker: str) -> str | None:
     """Return the identity of the *newest* tripped halt episode, if any.
 
@@ -118,13 +166,7 @@ def _halt_episode(broker: str) -> str | None:
     times. The global HALT is authoritative (``halt_flag_set`` halts every
     channel), but a stale per-broker episode must not suppress the sweep for
     a newer global trip — nor an older global trip override a newer
-    per-broker one. The newest sentinel therefore wins, ranked by its
-    explicit ``tripped_at`` payload when it carries one; the file mtime is
-    used only as the fallback for hand-touched/malformed sentinels without
-    a parseable ``tripped_at``. Ranking by mtime alone is not safe: two
-    sentinels written within one filesystem timestamp quantum share an
-    mtime, and the order would silently follow directory iteration instead
-    of trip time.
+    per-broker one. The newest sentinel therefore wins.
     """
     candidates: list[tuple[int, str]] = []
     for path, payload in (
@@ -133,25 +175,9 @@ def _halt_episode(broker: str) -> str | None:
     ):
         if payload is None:
             continue
-        try:
-            mtime_ns = path.stat().st_mtime_ns
-        except OSError:
-            continue
-        tripped_at = payload.get("tripped_at")
-        if tripped_at:
-            try:
-                trip = datetime.fromisoformat(str(tripped_at))
-                if trip.tzinfo is None:
-                    trip = trip.replace(tzinfo=timezone.utc)
-                instant_ns = int(trip.timestamp() * 1_000_000_000)
-                identity = str(tripped_at)
-            except ValueError:
-                instant_ns = mtime_ns
-                identity = f"mtime:{mtime_ns}"
-        else:
-            instant_ns = mtime_ns
-            identity = f"mtime:{mtime_ns}"
-        candidates.append((instant_ns, identity))
+        resolved = _sentinel_identity(path, payload)
+        if resolved is not None:
+            candidates.append(resolved)
     if not candidates:
         return None
     return max(candidates, key=lambda item: item[0])[1]
@@ -175,16 +201,23 @@ def sweep_already_fired(broker: str) -> bool:
 
 
 def mark_sweep_fired(broker: str) -> None:
-    """Record that the sweep fired for the current halt episode.
+    """Record that the sweep fired for the currently tripped halt episodes.
 
     Atomic write (same-directory temp file + ``os.replace``), same contract
     as the HALT sentinel. A no-op when no halt is tripped, since there is no
     episode to bind the record to. The record accumulates every episode the
     sweep has fired for on this broker (``episodes``), so clearing one halt
     never re-fires the sweep for an older episode that was already swept.
+
+    Both the per-broker and the global sentinel may be tripped at the same
+    time: the sweep covers the halt state as a whole, so EVERY currently
+    active episode identity is recorded together. Recording only the newest
+    would leave the older still-active halt unrecorded — clearing the newer
+    would then re-fire the sweep while the other halt remains tripped
+    (redundant no-op re-sweep and audit noise).
     """
-    episode = _halt_episode(broker)
-    if episode is None:
+    active = _active_episodes(broker)
+    if not active:
         return
     path = latch_path(broker)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -198,9 +231,13 @@ def mark_sweep_fired(broker: str) -> None:
     except (OSError, json.JSONDecodeError):
         pass
     episodes = record.setdefault("episodes", [])
-    if episode not in episodes:
-        episodes.append(episode)
-        record["episode"] = episode  # legacy field kept pointing at the latest
+    to_write = bool(episodes)
+    for episode in active:
+        if episode not in episodes:
+            episodes.append(episode)
+            to_write = True
+    if to_write:
+        record["episode"] = _halt_episode(broker)  # legacy field = newest
         record["fired_at"] = datetime.now(timezone.utc).isoformat()
         fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=".flatten-fired-")
         try:

--- a/agent/src/live/runtime/sweep_latch.py
+++ b/agent/src/live/runtime/sweep_latch.py
@@ -8,12 +8,15 @@ from long to net short. This module records the sweep's firing on disk, bound
 to the halt *episode* that caused it.
 
 The latch lives next to the per-broker HALT sentinel at
-``<runtime_root>/live/<broker>/FLATTEN_FIRED`` and carries the episode identity
-of the halt that was tripped when the sweep fired: the sentinel's ``tripped_at``
-when it has one, otherwise the sentinel file's mtime. A later trip writes a new
-sentinel (fresh ``tripped_at`` / fresh mtime), so a stale latch from a previous
-episode never suppresses a new one; clearing HALT and re-tripping therefore
-re-arms the sweep without anyone deleting the latch.
+``<runtime_root>/live/<broker>/FLATTEN_FIRED`` and carries the identity of
+every halt *episode* the sweep has fired for: the sentinel's ``tripped_at``
+when it has one, otherwise the sentinel file's mtime. A later trip writes a
+new sentinel (fresh ``tripped_at`` / fresh mtime), so a stale latch from a
+previous episode never suppresses a new one; clearing HALT and re-tripping
+therefore re-arms the sweep without anyone deleting the latch. When the
+per-broker and the global HALTs are both tripped, the *newest* sentinel wins
+the current-episode lookup — the global HALT is authoritative
+(``halt_flag_set`` halts every channel), but only for its own, newer episode.
 """
 
 from __future__ import annotations
@@ -37,28 +40,49 @@ def latch_path(broker: str) -> Path:
 
 
 def _halt_episode(broker: str) -> str | None:
-    """Return the identity of the currently tripped halt episode, if any.
+    """Return the identity of the *newest* tripped halt episode, if any.
 
-    The per-broker sentinel wins when both exist, mirroring how a targeted
-    halt is the one this broker's runner reacts to. ``tripped_at`` is the
-    identity when the sentinel carries it; a hand-touched sentinel with no
-    readable payload falls back to the file mtime, which still changes on
-    every fresh ``touch``.
+    Both the per-broker and the global sentinel can be tripped, at different
+    times. The global HALT is authoritative (``halt_flag_set`` halts every
+    channel), but a stale per-broker episode must not suppress the sweep for
+    a newer global trip — nor an older global trip override a newer
+    per-broker one. The newest sentinel therefore wins, ranked by its
+    explicit ``tripped_at`` payload when it carries one; the file mtime is
+    used only as the fallback for hand-touched/malformed sentinels without
+    a parseable ``tripped_at``. Ranking by mtime alone is not safe: two
+    sentinels written within one filesystem timestamp quantum share an
+    mtime, and the order would silently follow directory iteration instead
+    of trip time.
     """
+    candidates: list[tuple[int, str]] = []
     for path, payload in (
         (broker_halt_path(broker), read_halt(broker)),
         (halt_path(), read_halt()),
     ):
         if payload is None:
             continue
-        tripped_at = payload.get("tripped_at")
-        if tripped_at:
-            return str(tripped_at)
         try:
-            return f"mtime:{path.stat().st_mtime_ns}"
+            mtime_ns = path.stat().st_mtime_ns
         except OSError:
             continue
-    return None
+        tripped_at = payload.get("tripped_at")
+        if tripped_at:
+            try:
+                trip = datetime.fromisoformat(str(tripped_at))
+                if trip.tzinfo is None:
+                    trip = trip.replace(tzinfo=timezone.utc)
+                instant_ns = int(trip.timestamp() * 1_000_000_000)
+                identity = str(tripped_at)
+            except ValueError:
+                instant_ns = mtime_ns
+                identity = f"mtime:{mtime_ns}"
+        else:
+            instant_ns = mtime_ns
+            identity = f"mtime:{mtime_ns}"
+        candidates.append((instant_ns, identity))
+    if not candidates:
+        return None
+    return max(candidates, key=lambda item: item[0])[1]
 
 
 def sweep_already_fired(broker: str) -> bool:
@@ -70,7 +94,12 @@ def sweep_already_fired(broker: str) -> bool:
         record = json.loads(latch_path(broker).read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return False
-    return isinstance(record, dict) and record.get("episode") == episode
+    if not isinstance(record, dict):
+        return False
+    episodes = record.get("episodes")
+    if isinstance(episodes, list):
+        return episode in episodes
+    return record.get("episode") == episode  # legacy single-episode record
 
 
 def mark_sweep_fired(broker: str) -> None:
@@ -78,24 +107,36 @@ def mark_sweep_fired(broker: str) -> None:
 
     Atomic write (same-directory temp file + ``os.replace``), same contract
     as the HALT sentinel. A no-op when no halt is tripped, since there is no
-    episode to bind the record to.
+    episode to bind the record to. The record accumulates every episode the
+    sweep has fired for on this broker (``episodes``), so clearing one halt
+    never re-fires the sweep for an older episode that was already swept.
     """
     episode = _halt_episode(broker)
     if episode is None:
         return
-    record: dict[str, Any] = {
-        "episode": episode,
-        "fired_at": datetime.now(timezone.utc).isoformat(),
-    }
     path = latch_path(broker)
     path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=".flatten-fired-")
+    record: dict[str, Any] = {}
     try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            json.dump(record, f)
-        os.replace(tmp, path)
-    finally:
+        existing = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(existing, dict) and isinstance(existing.get("episodes"), list):
+            record = existing
+        elif isinstance(existing, dict) and existing.get("episode"):
+            record = {"episodes": [existing["episode"]]}
+    except (OSError, json.JSONDecodeError):
+        pass
+    episodes = record.setdefault("episodes", [])
+    if episode not in episodes:
+        episodes.append(episode)
+        record["episode"] = episode  # legacy field kept pointing at the latest
+        record["fired_at"] = datetime.now(timezone.utc).isoformat()
+        fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=".flatten-fired-")
         try:
-            os.unlink(tmp)
-        except OSError:
-            pass
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(record, f)
+            os.replace(tmp, path)
+        finally:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass

--- a/agent/tests/test_api_live_runtime.py
+++ b/agent/tests/test_api_live_runtime.py
@@ -19,6 +19,8 @@ from types import SimpleNamespace
 
 from fastapi.testclient import TestClient
 
+import pytest
+
 import api_server
 
 
@@ -446,3 +448,80 @@ def test_fetch_broker_ceilings_falls_back_to_none(tmp_path, monkeypatch) -> None
 
     monkeypatch.setattr(api_server, "_live_broker_adapter", _unavail)
     assert api_server._fetch_broker_ceilings("robinhood") is None
+
+
+def test_build_live_runner_reads_normalize_adapter_payloads(tmp_path, monkeypatch) -> None:
+    # The halt-sweep + reconcile reads must receive broker RECORDS, not the
+    # adapter's {status: ok, data: ...} envelope — a successful positions
+    # read must decode into the records list, not be rejected as a dict.
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path), raising=False)
+    monkeypatch.setattr(api_server, "_runner_factory", None, raising=False)
+
+    class _StubAdapter:
+        def __init__(self):
+            self.calls: list[tuple[str, dict]] = []
+
+        def call_tool(self, name, args):
+            self.calls.append((name, args))
+            if name.endswith("positions"):
+                return {"status": "ok", "data": {"positions": [{"symbol": "NVDA", "qty": 3}]}}
+            if name.endswith("orders"):
+                return {"status": "ok", "data": {"orders": [{"order_id": "o1"}]}}
+            if name.endswith("portfolio"):
+                return {"status": "ok", "data": {"buying_power": 4200.0}}
+            raise AssertionError(f"unexpected tool {name}")
+
+    class _StubSvc:
+        session_id = "live-sess-2"
+        event_bus = SimpleNamespace(emit=lambda *a, **k: None)
+
+        def create_session(self, title=""):
+            return self
+
+        async def send_message(self, sid, content, **kw):
+            return {"message_id": "m1", "attempt_id": "a1"}
+
+    adapter = _StubAdapter()
+    monkeypatch.setattr(api_server, "_live_broker_adapter", lambda broker: adapter)
+    monkeypatch.setattr(api_server, "_get_session_service", lambda: _StubSvc())
+
+    runner = api_server._build_live_runner("robinhood")
+    assert runner._read_positions() == [{"symbol": "NVDA", "qty": 3}]
+    assert runner._read_open_orders() == [{"order_id": "o1"}]
+    assert runner._read_balance() == {"buying_power": 4200.0}
+
+
+def test_build_live_runner_read_error_envelope_raises(tmp_path, monkeypatch) -> None:
+    # An error envelope at the boundary must raise (fail-closed: reconcile
+    # ticks error, the sweep records a structured read error) — never be
+    # consumed as an empty/mangled record list.
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path), raising=False)
+    monkeypatch.setattr(api_server, "_runner_factory", None, raising=False)
+
+    class _StubAdapter:
+        def call_tool(self, name, args):
+            return {
+                "status": "error",
+                "server": "robinhood",
+                "remote_tool": name,
+                "tool": name,
+                "error": "connection reset while reading positions",
+                "error_type": "ConnectionError",
+            }
+
+    class _StubSvc:
+        session_id = "live-sess-3"
+        event_bus = SimpleNamespace(emit=lambda *a, **k: None)
+
+        def create_session(self, title=""):
+            return self
+
+        async def send_message(self, sid, content, **kw):
+            return {"message_id": "m1", "attempt_id": "a1"}
+
+    monkeypatch.setattr(api_server, "_live_broker_adapter", lambda broker: _StubAdapter())
+    monkeypatch.setattr(api_server, "_get_session_service", lambda: _StubSvc())
+
+    runner = api_server._build_live_runner("robinhood")
+    with pytest.raises(RuntimeError, match="connection reset while reading positions"):
+        runner._read_positions()

--- a/agent/tests/test_runtime_flatten.py
+++ b/agent/tests/test_runtime_flatten.py
@@ -208,6 +208,165 @@ def test_mandate_flatten_flag_honored(
     assert report["flatten_skipped_reason"] is None
 
 
+def test_error_envelope_read_open_orders_recorded_not_raised(
+    live_runtime: Path,
+) -> None:
+    # MCPServerAdapter.call_tool returns an error envelope instead of raising;
+    # the sweep must reject it as a structured read error, not crash while
+    # iterating the mapping's string keys.
+    broker = _Broker(open_orders=[{"order_id": "o1"}], positions=[])
+    report = flatten.flatten_and_cancel(
+        "robinhood",
+        broker.submit,
+        broker.read_positions,
+        lambda: _error_envelope("open orders"),
+    )
+    assert {
+        "phase": "read_open_orders",
+        "error": "connection reset while cancelling open orders",
+    } in report["errors"]
+    assert broker.calls == []  # nothing was cancelled
+
+
+def test_error_envelope_read_positions_recorded_not_raised(
+    live_runtime: Path,
+) -> None:
+    broker = _Broker(open_orders=[], positions=[{"symbol": "NVDA", "qty": 1}])
+    report = flatten.flatten_and_cancel(
+        "robinhood",
+        broker.submit,
+        lambda: _error_envelope("positions"),
+        broker.read_open_orders,
+        allow_flatten=True,
+    )
+    assert {
+        "phase": "read_positions",
+        "error": "connection reset while cancelling positions",
+    } in report["errors"]
+    assert broker.calls == []  # no close order was submitted
+
+
+def test_non_list_read_rejected_without_iterating(live_runtime: Path) -> None:
+    # A dict-shaped read result (e.g. a wrapped payload) must be rejected
+    # safely rather than iterated as a mapping.
+    broker = _Broker(open_orders=[], positions=[])
+    report = flatten.flatten_and_cancel(
+        "robinhood",
+        broker.submit,
+        broker.read_positions,
+        lambda: {"orders": [{"order_id": "o1"}]},
+    )
+    read_errors = [e for e in report["errors"] if e["phase"] == "read_open_orders"]
+    assert read_errors and "got dict" in read_errors[0]["error"]
+    assert broker.calls == []
+
+
+def test_invalid_read_entries_skipped_safely(live_runtime: Path) -> None:
+    broker = _Broker(open_orders=[{"order_id": "o1"}], positions=[])
+    report = flatten.flatten_and_cancel(
+        "robinhood",
+        broker.submit,
+        broker.read_positions,
+        lambda: ["o1", {"order_id": "o2"}, 42],
+    )
+    assert report["cancelled_order_ids"] == ["o2"]  # only the dict entry
+    assert any(
+        e["phase"] == "read_open_orders" and "invalid entry" in e["error"]
+        for e in report["errors"]
+    )
+
+
+def test_adapter_ok_envelope_open_orders_unwrapped(live_runtime: Path) -> None:
+    # A REAL successful MCPServerAdapter response is {"status": "ok",
+    # "data": ...} — the sweep must decode it, not treat it as a failure
+    # ("expected a list of records, got dict"), or the halt action never runs.
+    broker = _Broker(open_orders=[{"order_id": "o1"}], positions=[])
+    report = flatten.flatten_and_cancel(
+        "robinhood",
+        broker.submit,
+        broker.read_positions,
+        lambda: {"status": "ok", "data": {"orders": [{"order_id": "o1"}]}},
+    )
+    assert report["cancelled_order_ids"] == ["o1"]
+    assert report["errors"] == []
+    assert report["side_effects_attempted"] is True
+
+
+def test_adapter_ok_envelope_positions_unwrapped(live_runtime: Path) -> None:
+    broker = _Broker(open_orders=[], positions=[])
+    report = flatten.flatten_and_cancel(
+        "robinhood",
+        broker.submit,
+        lambda: {"status": "ok", "data": {"positions": [{"symbol": "NVDA", "qty": 3}]}},
+        broker.read_open_orders,
+        allow_flatten=True,
+    )
+    assert [s["symbol"] for s in report["flatten_orders_submitted"]] == ["NVDA"]
+    assert report["errors"] == []
+    assert report["side_effects_attempted"] is True
+
+
+def test_adapter_ok_envelope_bare_list_data_unwrapped(live_runtime: Path) -> None:
+    broker = _Broker(open_orders=[], positions=[])
+    report = flatten.flatten_and_cancel(
+        "robinhood",
+        broker.submit,
+        broker.read_positions,
+        lambda: {"status": "ok", "data": [{"order_id": "o1"}]},
+    )
+    assert report["cancelled_order_ids"] == ["o1"]
+
+
+def test_adapter_ok_envelope_missing_pinned_key_rejected(live_runtime: Path) -> None:
+    # A wrapper dict without the pinned key must NOT be accepted generically
+    # (metadata would become fake broker records).
+    broker = _Broker(open_orders=[], positions=[])
+    report = flatten.flatten_and_cancel(
+        "robinhood",
+        broker.submit,
+        broker.read_positions,
+        lambda: {"status": "ok", "data": {"foo": [{"order_id": "o1"}]}},
+    )
+    assert any(
+        e["phase"] == "read_open_orders" and "unexpected broker response" in e["error"]
+        for e in report["errors"]
+    )
+    assert broker.calls == []
+    assert report["side_effects_attempted"] is False
+
+
+def test_read_failure_but_flatten_attempted_sets_side_effects_flag(
+    live_runtime: Path,
+) -> None:
+    # The reviewer's sequence: order read fails, position read succeeds, a
+    # close is submitted. side_effects_attempted must be True so the runner
+    # latches — replaying that close after restart would be a duplicate.
+    broker = _Broker(open_orders=[], positions=[])
+    report = flatten.flatten_and_cancel(
+        "robinhood",
+        broker.submit,
+        lambda: {"status": "ok", "data": {"positions": [{"symbol": "NVDA", "qty": 3}]}},
+        lambda: _error_envelope("open orders"),
+        allow_flatten=True,
+    )
+    assert {"phase": "read_open_orders", "error": "connection reset while cancelling open orders"} in report["errors"]
+    assert [s["symbol"] for s in report["flatten_orders_submitted"]] == ["NVDA"]
+    assert report["side_effects_attempted"] is True
+
+
+def test_all_reads_failed_no_side_effects_flag(live_runtime: Path) -> None:
+    broker = _Broker(open_orders=[], positions=[])
+    report = flatten.flatten_and_cancel(
+        "robinhood",
+        broker.submit,
+        lambda: _error_envelope("positions"),
+        lambda: _error_envelope("open orders"),
+        allow_flatten=True,
+    )
+    assert report["side_effects_attempted"] is False
+    assert broker.calls == []
+
+
 def _error_envelope(key: str) -> dict[str, Any]:
     """The shape MCPServerAdapter.call_tool returns instead of raising."""
     return {

--- a/agent/tests/test_runtime_flatten.py
+++ b/agent/tests/test_runtime_flatten.py
@@ -437,3 +437,58 @@ def test_error_envelope_flatten_is_not_a_success(live_runtime: Path) -> None:
             "error": "connection reset while cancelling NVDA",
         }
     ]
+
+
+def test_nested_broker_error_cancel_is_not_a_success(live_runtime: Path) -> None:
+    # MCP transport succeeded but the broker rejected inside its own payload
+    # ({"status": "ok", "data": {"status": "error", ...}}): the order stays
+    # live, so it must NOT be recorded as cancelled.
+    broker = _Broker(open_orders=[{"order_id": "o1"}, {"order_id": "o2"}], positions=[])
+    real_submit = broker.submit
+
+    def submit(request: dict[str, Any]) -> dict[str, Any]:
+        if request.get("order_id") == "o1":
+            return {
+                "status": "ok",
+                "data": {"status": "error", "error": "broker rejected o1"},
+            }
+        return real_submit(request)
+
+    report = flatten.flatten_and_cancel(
+        "robinhood", submit, broker.read_positions, broker.read_open_orders
+    )
+    assert report["cancelled_order_ids"] == ["o2"]  # only the accepted one
+    assert {
+        "phase": "cancel",
+        "order_id": "o1",
+        "error": "broker rejected o1",
+    } in report["errors"]
+    assert report["side_effects_attempted"] is True  # submitted, just rejected
+
+
+def test_nested_broker_error_flatten_is_not_a_success(live_runtime: Path) -> None:
+    broker = _Broker(open_orders=[], positions=[{"symbol": "NVDA", "qty": 3}])
+    real_submit = broker.submit
+
+    def submit(request: dict[str, Any]) -> dict[str, Any]:
+        if request.get("symbol") == "NVDA":
+            return {
+                "status": "ok",
+                "data": {"ok": False, "message": "insufficient buying power"},
+            }
+        return real_submit(request)
+
+    report = flatten.flatten_and_cancel(
+        "robinhood",
+        submit,
+        broker.read_positions,
+        broker.read_open_orders,
+        allow_flatten=True,
+    )
+    assert report["flatten_orders_submitted"] == []
+    assert {
+        "phase": "flatten",
+        "symbol": "NVDA",
+        "error": "insufficient buying power",
+    } in report["errors"]
+    assert report["side_effects_attempted"] is True

--- a/agent/tests/test_sweep_latch.py
+++ b/agent/tests/test_sweep_latch.py
@@ -245,3 +245,53 @@ def test_side_effect_attempted_latches_even_with_read_error(
     # Restart: the on-disk latch suppresses the duplicate close.
     asyncio.run(_build_runner(live_root, fired, _flatten).run_once())
     assert fired == [BROKER]
+
+
+# ---------------------------------------------------------------------------
+# Inter-process claim protocol (#1244 hardening)
+# ---------------------------------------------------------------------------
+
+
+def test_claim_is_exclusive_and_releasable(live_root: Path) -> None:
+    assert sweep_latch.claim_sweep(BROKER) is True  # first wins
+    assert sweep_latch.claim_sweep(BROKER) is False  # second cannot claim
+    sweep_latch.release_claim(BROKER)
+    assert sweep_latch.claim_sweep(BROKER) is True  # claimable again
+    sweep_latch.release_claim(BROKER)
+
+
+def test_runner_skips_when_claim_held_by_other_process(live_root: Path) -> None:
+    # A second runner for the same broker must not sweep concurrently
+    # (check-then-act would let both pass sweep_already_fired and duplicate
+    # market closes). The held claim forces this process to skip + audit.
+    _trip_with_timestamp(BROKER, "2026-08-27T01:00:00+00:00")
+    assert sweep_latch.claim_sweep(BROKER) is True  # "other" process holds it
+    fired: list[str] = []
+    asyncio.run(_build_runner(live_root, fired).run_once())
+    assert fired == []  # never swept
+    assert not sweep_latch.latch_path(BROKER).exists()
+    sweep_latch.release_claim(BROKER)
+
+
+def test_runner_claims_and_releases_around_sweep(live_root: Path) -> None:
+    _trip_with_timestamp(BROKER, "2026-08-27T01:00:00+00:00")
+    fired: list[str] = []
+    asyncio.run(_build_runner(live_root, fired).run_once())
+    assert fired == [BROKER]
+    # The claim must be released after the sweep (crash-free path), so a
+    # later re-check can claim again.
+    assert not sweep_latch.claim_path(BROKER).exists()
+
+
+def test_runner_claim_released_after_read_failure(live_root: Path) -> None:
+    _trip_with_timestamp(BROKER, "2026-08-27T01:00:00+00:00")
+    fired: list[str] = []
+
+    def _flatten(broker, submit, read_positions, read_open_orders):
+        fired.append(broker)
+        return {"errors": [{"phase": "read_positions", "error": "read failed"}]}
+
+    asyncio.run(_build_runner(live_root, fired, _flatten).run_once())
+    assert fired == [BROKER]
+    assert not sweep_latch.claim_path(BROKER).exists()
+    assert not sweep_latch.latch_path(BROKER).exists()

--- a/agent/tests/test_sweep_latch.py
+++ b/agent/tests/test_sweep_latch.py
@@ -358,3 +358,31 @@ def test_double_failure_latch_write_does_not_escape_run_once(
     result = asyncio.run(_build_runner(live_root, fired, _flatten).run_once())
     assert result["outcome"] == "halted"  # did not escape
     assert fired == [BROKER]
+
+
+def test_mid_sweep_retrip_does_not_release_new_episode_claim(
+    live_root: Path,
+) -> None:
+    # A halt is cleared + re-tripped while our sweep is in flight (ep1 ->
+    # ep2), and a second process claims ep2. The ep1 owner's release must
+    # delete only ITS claim — never the ep2 claim (re-resolving the episode
+    # at release time would delete another process's protection and open a
+    # duplicate-close window).
+    _trip_with_timestamp(BROKER, "2026-08-27T01:00:00+00:00")
+    captured: dict[str, str | None] = {}
+
+    def _flatten(broker, submit, read_positions, read_open_orders):
+        clear_halt(BROKER)
+        _trip_with_timestamp(BROKER, "2026-08-27T10:00:00+00:00")
+        ep2 = sweep_latch.halt_episode(BROKER)
+        captured["ep2"] = ep2
+        captured["other_claim"] = sweep_latch.claim_sweep(BROKER, ep2)
+        return {"submitted": [], "errors": []}
+
+    asyncio.run(_build_runner(live_root, [], _flatten).run_once())
+    assert captured["other_claim"] is True
+    # Other process's ep2 claim must survive the ep1 owner's release.
+    assert sweep_latch.claim_path(BROKER, captured["ep2"]).exists()
+    # The ep1 owner's own claim must be gone (released normally).
+    assert not sweep_latch.claim_path(BROKER, "2026-08-27T01:00:00+00:00").exists()
+    sweep_latch.release_claim(BROKER, captured["ep2"])

--- a/agent/tests/test_sweep_latch.py
+++ b/agent/tests/test_sweep_latch.py
@@ -11,13 +11,14 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from pathlib import Path
 from typing import Any, Mapping
 
 import pytest
 
 from src.live import paths
-from src.live.halt import broker_halt_path, clear_halt, halt_path, trip_halt
+from src.live.halt import broker_halt_path, clear_halt, halt_path
 from src.live.runtime import sweep_latch
 from src.live.runtime.runner import LiveRunner
 
@@ -38,6 +39,26 @@ def _trip_with_timestamp(broker: str | None, tripped_at: str) -> None:
         json.dumps({"tripped_at": tripped_at, "by": "cli", "reason": "test"}),
         encoding="utf-8",
     )
+
+
+def test_newer_global_halt_rearms_with_tied_mtimes(live_root: Path) -> None:
+    # Regression for the combined-suite flake: broker + global sentinels
+    # written within one filesystem timestamp quantum share an mtime.
+    # Episode resolution must still rank by tripped_at (global wins), not
+    # fall back to mtime order — otherwise the sweep for the newer global
+    # halt is wrongly suppressed.
+    _trip_with_timestamp(BROKER, "2026-08-27T01:00:00+00:00")
+    sweep_latch.mark_sweep_fired(BROKER)
+    assert sweep_latch.sweep_already_fired(BROKER) is True
+
+    _trip_with_timestamp(None, "2026-08-27T10:00:00+00:00")
+    stat = broker_halt_path(BROKER).stat()
+    for path in (broker_halt_path(BROKER), halt_path()):
+        os.utime(path, ns=(stat.st_atime_ns, stat.st_mtime_ns))
+
+    assert sweep_latch.sweep_already_fired(BROKER) is False  # global wins
+    sweep_latch.mark_sweep_fired(BROKER)
+    assert sweep_latch.sweep_already_fired(BROKER) is True
 
 
 def test_mark_then_fired_for_same_episode(live_root: Path) -> None:
@@ -88,17 +109,19 @@ def test_corrupt_latch_falls_back_to_not_fired(live_root: Path) -> None:
     assert sweep_latch.sweep_already_fired(BROKER) is False
 
 
-def _build_runner(live_root: Path, fired: list[str]) -> LiveRunner:
+def _build_runner(
+    live_root: Path, fired: list[str], flatten_fn: Any = None
+) -> LiveRunner:
     """A runner whose only observable behavior is recording sweep invocations."""
-
     async def _agent_caller(session_id: str, prompt: str) -> Mapping[str, Any]:
         return {"status": "success"}
 
     def _submit(request: dict[str, Any]) -> dict[str, Any]:
         return {"status": "ok"}
 
-    def _flatten(broker, submit, read_positions, read_open_orders):
+    def _default_flatten(broker, submit, read_positions, read_open_orders):
         fired.append(broker)
+        return {"side_effects_attempted": True}
 
     def _audit(event) -> Mapping[str, Any]:
         return {"audit_id": "a1"}
@@ -113,7 +136,7 @@ def _build_runner(live_root: Path, fired: list[str]) -> LiveRunner:
         write_audit_fn=_audit,
         halt_flag_fn=lambda broker: True,
         submit_fn=_submit,
-        flatten_fn=_flatten,
+        flatten_fn=flatten_fn or _default_flatten,
         session_id="latch-test",
     )
 
@@ -137,3 +160,88 @@ def test_new_episode_after_restart_fires_again(live_root: Path) -> None:
     _trip_with_timestamp(BROKER, "2026-08-27T09:30:00+00:00")
     asyncio.run(_build_runner(live_root, fired).run_once())
     assert fired == [BROKER, BROKER]
+
+
+def test_newer_global_halt_rearms_stale_broker_latch(live_root: Path) -> None:
+    # A broker episode latched first; a NEWER global HALT must not be
+    # suppressed — the global halt is authoritative (halt_flag_set), and a
+    # stale per-broker latch must not skip the kill action for the new
+    # episode. Clearing the global halt must not re-fire the sweep for the
+    # already-swept broker episode either.
+    _trip_with_timestamp(BROKER, "2026-08-27T01:00:00+00:00")
+    sweep_latch.mark_sweep_fired(BROKER)
+    assert sweep_latch.sweep_already_fired(BROKER) is True
+
+    _trip_with_timestamp(None, "2026-08-27T10:00:00+00:00")
+    assert sweep_latch.sweep_already_fired(BROKER) is False  # re-armed
+
+    sweep_latch.mark_sweep_fired(BROKER)
+    assert sweep_latch.sweep_already_fired(BROKER) is True
+    clear_halt()  # global gone; only the old broker episode remains
+    assert sweep_latch.sweep_already_fired(BROKER) is True  # still latched
+
+
+def test_read_failure_does_not_latch_and_restart_replays(live_root: Path) -> None:
+    # The reviewer-reported safety hole: a sweep whose broker-state read
+    # failed must NOT persist the latch, or a restart suppresses the kill
+    # action for the episode forever. The read failure is the flattened
+    # report shape flatten_and_cancel now produces for an adapter error
+    # envelope / non-list read.
+    _trip_with_timestamp(BROKER, "2026-08-27T01:00:00+00:00")
+    fired: list[str] = []
+
+    def _flatten(broker, submit, read_positions, read_open_orders):
+        fired.append(broker)
+        return {"errors": [{"phase": "read_positions", "error": "broker read failed"}]}
+
+    asyncio.run(_build_runner(live_root, fired, _flatten).run_once())
+    assert fired == [BROKER]
+    assert not sweep_latch.latch_path(BROKER).exists()  # nothing persisted
+    # Restart: the failed sweep must re-fire, not be suppressed.
+    asyncio.run(_build_runner(live_root, fired, _flatten).run_once())
+    assert fired == [BROKER, BROKER]
+
+
+def test_nothing_to_do_does_not_latch_and_rechecks(live_root: Path) -> None:
+    # Reads succeed but there are no open orders/positions: no broker write
+    # was attempted, so per policy nothing must be latched — the sweep
+    # re-checks on the next tick/restart (and would cancel a late-appearing
+    # order), never suppressing the kill action for the episode.
+    _trip_with_timestamp(BROKER, "2026-08-27T01:00:00+00:00")
+    fired: list[str] = []
+
+    def _flatten(broker, submit, read_positions, read_open_orders):
+        fired.append(broker)
+        return {"errors": []}  # reads ok, nothing to act on
+
+    asyncio.run(_build_runner(live_root, fired, _flatten).run_once())
+    assert fired == [BROKER]
+    assert not sweep_latch.latch_path(BROKER).exists()
+    asyncio.run(_build_runner(live_root, fired, _flatten).run_once())
+    assert fired == [BROKER, BROKER]
+
+
+def test_side_effect_attempted_latches_even_with_read_error(
+    live_root: Path,
+) -> None:
+    # Reviewer sequence: order read fails, position read succeeds, a close
+    # order is submitted. The report carries a read error AND a side effect.
+    # Latching must key on the side effect: replaying that close after a
+    # restart would be a duplicate market close (the failure the latch
+    # exists to prevent).
+    _trip_with_timestamp(BROKER, "2026-08-27T01:00:00+00:00")
+    fired: list[str] = []
+
+    def _flatten(broker, submit, read_positions, read_open_orders):
+        fired.append(broker)
+        return {
+            "side_effects_attempted": True,
+            "errors": [{"phase": "read_open_orders", "error": "orders read failed"}],
+        }
+
+    asyncio.run(_build_runner(live_root, fired, _flatten).run_once())
+    assert fired == [BROKER]
+    assert sweep_latch.latch_path(BROKER).exists()  # latched despite the error
+    # Restart: the on-disk latch suppresses the duplicate close.
+    asyncio.run(_build_runner(live_root, fired, _flatten).run_once())
+    assert fired == [BROKER]

--- a/agent/tests/test_sweep_latch.py
+++ b/agent/tests/test_sweep_latch.py
@@ -253,11 +253,27 @@ def test_side_effect_attempted_latches_even_with_read_error(
 
 
 def test_claim_is_exclusive_and_releasable(live_root: Path) -> None:
-    assert sweep_latch.claim_sweep(BROKER) is True  # first wins
-    assert sweep_latch.claim_sweep(BROKER) is False  # second cannot claim
-    sweep_latch.release_claim(BROKER)
-    assert sweep_latch.claim_sweep(BROKER) is True  # claimable again
-    sweep_latch.release_claim(BROKER)
+    ep = "2026-08-27T01:00:00+00:00"
+    assert sweep_latch.claim_sweep(BROKER, ep) is True  # first wins
+    assert sweep_latch.claim_sweep(BROKER, ep) is False  # second cannot claim
+    sweep_latch.release_claim(BROKER, ep)
+    assert sweep_latch.claim_sweep(BROKER, ep) is True  # claimable again
+    sweep_latch.release_claim(BROKER, ep)
+
+
+def test_orphan_claim_does_not_block_future_episode(live_root: Path) -> None:
+    # Crash mid-sweep leaves a claim for episode 1 (never released). An
+    # episode-keyed claim must NOT block episode 2: each trip gets its own
+    # claim namespace, so a new halt still sweeps.
+    _trip_with_timestamp(BROKER, "2026-08-27T01:00:00+00:00")
+    ep1 = sweep_latch.halt_episode(BROKER)
+    assert sweep_latch.claim_sweep(BROKER, ep1) is True  # crashed: never released
+    clear_halt(BROKER)
+    _trip_with_timestamp(BROKER, "2026-08-27T10:00:00+00:00")
+    ep2 = sweep_latch.halt_episode(BROKER)
+    assert ep2 != ep1
+    assert sweep_latch.claim_sweep(BROKER, ep2) is True  # new episode claimable
+    sweep_latch.release_claim(BROKER, ep2)
 
 
 def test_runner_skips_when_claim_held_by_other_process(live_root: Path) -> None:
@@ -265,12 +281,16 @@ def test_runner_skips_when_claim_held_by_other_process(live_root: Path) -> None:
     # (check-then-act would let both pass sweep_already_fired and duplicate
     # market closes). The held claim forces this process to skip + audit.
     _trip_with_timestamp(BROKER, "2026-08-27T01:00:00+00:00")
-    assert sweep_latch.claim_sweep(BROKER) is True  # "other" process holds it
+    ep = sweep_latch.halt_episode(BROKER)
+    assert sweep_latch.claim_sweep(BROKER, ep) is True  # "other" process holds it
     fired: list[str] = []
     asyncio.run(_build_runner(live_root, fired).run_once())
     assert fired == []  # never swept
     assert not sweep_latch.latch_path(BROKER).exists()
-    sweep_latch.release_claim(BROKER)
+    # The other process's claim must remain untouched (the runner must never
+    # release a claim it does not own).
+    assert sweep_latch.claim_path(BROKER, "2026-08-27T01:00:00+00:00").exists()
+    sweep_latch.release_claim(BROKER, ep)
 
 
 def test_runner_claims_and_releases_around_sweep(live_root: Path) -> None:
@@ -280,7 +300,8 @@ def test_runner_claims_and_releases_around_sweep(live_root: Path) -> None:
     assert fired == [BROKER]
     # The claim must be released after the sweep (crash-free path), so a
     # later re-check can claim again.
-    assert not sweep_latch.claim_path(BROKER).exists()
+    ep = sweep_latch.halt_episode(BROKER)
+    assert not sweep_latch.claim_path(BROKER, ep).exists()
 
 
 def test_runner_claim_released_after_read_failure(live_root: Path) -> None:
@@ -293,5 +314,6 @@ def test_runner_claim_released_after_read_failure(live_root: Path) -> None:
 
     asyncio.run(_build_runner(live_root, fired, _flatten).run_once())
     assert fired == [BROKER]
-    assert not sweep_latch.claim_path(BROKER).exists()
+    ep = sweep_latch.halt_episode(BROKER)
+    assert not sweep_latch.claim_path(BROKER, ep).exists()
     assert not sweep_latch.latch_path(BROKER).exists()

--- a/agent/tests/test_sweep_latch.py
+++ b/agent/tests/test_sweep_latch.py
@@ -317,3 +317,44 @@ def test_runner_claim_released_after_read_failure(live_root: Path) -> None:
     ep = sweep_latch.halt_episode(BROKER)
     assert not sweep_latch.claim_path(BROKER, ep).exists()
     assert not sweep_latch.latch_path(BROKER).exists()
+
+
+def test_mark_records_both_active_episodes_older_global_newer_broker(
+    live_root: Path,
+) -> None:
+    # Reviewer residual A: the sweep covers the halt state as a whole — with
+    # an older global AND a newer broker halt both active, clearing the
+    # broker halt must NOT re-fire the sweep while the (still active, older)
+    # global halt remains tripped. mark_sweep_fired must record BOTH
+    # episodes.
+    _trip_with_timestamp(None, "2026-08-27T01:00:00+00:00")  # global, older
+    _trip_with_timestamp(BROKER, "2026-08-27T10:00:00+00:00")  # broker, newer
+    sweep_latch.mark_sweep_fired(BROKER)
+    assert sweep_latch.sweep_already_fired(BROKER) is True
+
+    clear_halt(BROKER)  # newer (broker) halt cleared
+    assert sweep_latch.sweep_already_fired(BROKER) is True  # global still recorded
+
+
+def test_double_failure_latch_write_does_not_escape_run_once(
+    live_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Reviewer residual B: sweep raises AND the durable latch write raises.
+    # Neither exception may escape run_once — the tick must still complete
+    # with the halted outcome and an audit trail.
+    from src.live.runtime import runner as runner_mod
+
+    _trip_with_timestamp(BROKER, "2026-08-27T01:00:00+00:00")
+    fired: list[str] = []
+
+    def _flatten(broker, submit, read_positions, read_open_orders):
+        fired.append(broker)
+        raise RuntimeError("sweep exploded")
+
+    def _broken_mark(broker):
+        raise RuntimeError("disk exploded")
+
+    monkeypatch.setattr(runner_mod, "mark_sweep_fired", _broken_mark)
+    result = asyncio.run(_build_runner(live_root, fired, _flatten).run_once())
+    assert result["outcome"] == "halted"  # did not escape
+    assert fired == [BROKER]


### PR DESCRIPTION
## HOLD review resolved (977b0389 — latch-coherence races)

- **Mid-sweep re-trip**: `mark_sweep_fired` re-read the sentinels after the sweep; a clear + re-trip mid-sweep (ep1→ep2) recorded ep2 as fired though no ep2 sweep ran → next runner skipped it (reproduced). Now: one coherent `halt_snapshot()` captured **before** claiming — claim, already-fired check, marks and release all bind to it; `mark_sweep_fired(broker, episodes)` never re-reads.
- **Concurrent lost-update**: the shared read-merge-write record could drop a concurrent episode's entry. Now: **per-episode latch files** (`FLATTEN_FIRED-<sha16>`, independent `O_CREAT|O_EXCL` atomic creates) — no shared record exists, so no inter-process lock is required and lost updates are impossible by construction.
- Regressions: `test_mid_sweep_retrip_records_only_swept_episode`, `test_concurrent_latch_updates_both_episodes_recorded` (both mutated-fail / fixed-pass).

## Re-review race fix (1c9c41ab)

**Claim-release episode bind**: the halt episode was resolved twice (claim time + release time in `finally`). A mid-sweep clear + re-trip (ep1 → ep2) made the release delete **ep2's** claim — even a different process's — unprotecting that process's concurrent sweep (duplicate-close window). Resolved once; regression `test_mid_sweep_retrip_does_not_release_new_episode_claim` (fails against old double-resolution).

## Review residuals resolved (a4f7459 — non-blocking A & B)

- **A — record all active halt episodes**: `mark_sweep_fired` now latches every currently tripped sentinel identity (broker + global, via a shared `_sentinel_identity` helper), not just the newest. An older global + newer broker halt: clearing the broker one no longer re-fires the sweep while the global remains tripped. Regression: `test_mark_records_both_active_episodes_older_global_newer_broker`.
- **B — double-failure latch write**: the flatten-raised branch now wraps `mark_sweep_fired` — a latch write failure during a sweep failure is logged + audited and never escapes `run_once`. Regression: `test_double_failure_latch_write_does_not_escape_run_once`.

90 live tests pass; ruff clean.

## Safety hardening (f81cb723 — independent review findings)

- **Concurrent runner race**: the sweep was check-then-act (`sweep_already_fired` → broker writes → durable marker). Two runner processes could both pass the check and duplicate closes. The whole window now runs under an exclusive disk claim (`FLATTEN_CLAIM`, `O_CREAT|O_EXCL`); a held claim (other runner active, or a crash mid-sweep) means the episode's outcome is unknowable — never re-sweep, audit for operator resolution, HALT stays tripped. Claim released in `finally` on every path.
- **Durable-latch persistence failure**: a `mark_sweep_fired` fs error after a broker write is now logged + audited explicitly ("restart may replay; verify broker state"); the claim protocol also bounds the window in which it can occur.
- **Nested broker error envelope**: `{"status":"ok","data":{"status":"error"|"ok":false}}` (transport OK, broker rejected) used to be recorded as **accepted** — order stays live while the sweep latches. Both nested shapes now detected for cancel and flatten.

Claim-recovery self-review (episode-keyed): a crash leaving an orphan claim used to block **every future episode** of the broker (a new trip would see `claim_sweep` fail and skip the kill action forever — reproduced). Claims are now episode-keyed (`FLATTEN_CLAIM-<sha256>`), so an orphan claim only blocks its own episode (the correct unknowable-outcome case) and never a later trip.

Tests: claim exclusivity + release, claim-held runner skip, orphan-claim-does-not-block-future-episode regression, claim release on success/read-failure, nested-error rejection for both phases. 89 live tests pass; ruff clean.

## Two behaviours being fixed (one per commit, tests each)

Reproduced on current main:

1. **Broker read-error envelopes are iterated as mappings.** `MCPServerAdapter.call_tool` returns `{"status": "error", ...}` instead of raising. #1232 taught the *submit* responses about envelopes; the sweep's **reads** (`read_open_orders` / `read_positions`) never learned — `AttributeError: 'str' object has no attribute 'get'` kills the kill-switch action for that episode.

   Fix (`823fc69b`): `_read_broker_state` validates every read before iteration — error envelope, exception, or non-list result → structured `report["errors"]` item (`read_open_orders` / `read_positions`), phase aborts with no side effects. Non-dict entries are skipped with an error. Successful adapter responses unwrap with pinned per-read keys (`data.orders` / `data.positions`; bare-list `data` accepted) — wrapper dicts without the pinned key are rejected (metadata never becomes fake records).

2. **`mark_sweep_fired` runs before `flatten_and_cancel`, so a sweep whose reads both fail still latches** — the kill switch's action is silently skipped for that episode; neither a later tick nor a restart retries it.

   Fix (`ebf5e189`): `flatten_and_cancel` reports `side_effects_attempted` (set the moment any cancel/close submit is tried). The runner latches iff any broker write was attempted (even when another read phase failed), keeps retrying only when nothing was attempted, and latches conservatively on a raising sweep. Reads are also normalized at the `live_routes._read` boundary (error envelopes raise; ok payloads unwrap), protecting the shared reconcile path from the same envelope class. Related, same commit: `_halt_episode` now ranks broker vs global sentinels by explicit `tripped_at` (mtime ties within one filesystem timestamp quantum let a stale per-broker latch suppress a newer global HALT — `halt_flag_set` treats the global as authoritative), and the latch record accumulates every fired episode.

## Tests

- Adapter-envelope reads (both paths, real envelope shape), non-list/invalid-entry rejection
- Restart-replay on read failure (no side effects → no latch), restart-suppression after an attempted close even with a read error (duplicate-close hazard)
- Newer-global rearm with forced-identical mtimes; nothing-to-do re-check policy; boundary normalization + envelope-raise wiring
- 82 live tests pass; ruff clean