### PR TITLE
feat(backtest): surface silent order-plan rejections via an _on_plan_rejected hook

### DIFF
--- a/agent/backtest/engines/base.py
+++ b/agent/backtest/engines/base.py
@@ -689,6 +689,25 @@ class BaseEngine(ABC):
         """Allow engines to update risk state/evidence after a committed delta fill."""
         return None
 
+    def _on_plan_rejected(self, symbol: str, reason: str, timestamp: pd.Timestamp) -> None:
+        """Observe a silently rejected opening-order plan.
+
+        ``_plan_open_order`` returns ``None`` for several distinct reasons —
+        nothing wanted, already held, missing data, missing bar, market rule
+        block, unusable price, or a target too small to fill after lot
+        rounding. Callers only see ``None``, so this hook is the only way for
+        an engine subclass to tell "nothing to do" apart from "wanted but
+        unfillable".
+
+        Args:
+            symbol: Instrument the plan was for.
+            reason: Machine-readable cause: ``no_target_weight``,
+                ``already_held``, ``no_data``, ``no_bar``,
+                ``execution_blocked``, ``invalid_price`` or ``zero_size``.
+            timestamp: Decision bar timestamp.
+        """
+        return None
+
     def execution_open(self, bar: pd.Series) -> float:
         """Return the normal market-fill price for a bar."""
         return float(bar.get("open", bar.get("close", 0)))
@@ -1323,15 +1342,21 @@ class BaseEngine(ABC):
         """Price an opening order without mutating portfolio state."""
         self._active_symbol = symbol
         direction = 1 if target_weight > 1e-9 else (-1 if target_weight < -1e-9 else 0)
-        if (
-            direction == 0
-            or (symbol in self.positions and not allow_existing)
-            or df is None
-            or ts not in df.index
-        ):
+        if direction == 0:
+            self._on_plan_rejected(symbol, "no_target_weight", ts)
+            return None
+        if symbol in self.positions and not allow_existing:
+            self._on_plan_rejected(symbol, "already_held", ts)
+            return None
+        if df is None:
+            self._on_plan_rejected(symbol, "no_data", ts)
+            return None
+        if ts not in df.index:
+            self._on_plan_rejected(symbol, "no_bar", ts)
             return None
         bar = df.loc[ts]
         if not self.can_execute(symbol, direction, bar):
+            self._on_plan_rejected(symbol, "execution_blocked", ts)
             return None
         open_price = self.execution_open(bar)
         if require_positive_price:
@@ -1340,6 +1365,7 @@ class BaseEngine(ABC):
         # negatives are rejected unless this engine opted into non-positive
         # prices, in which case abs()-based sizing/margin below handle them.
         elif open_price == 0 or (open_price < 0 and not self.allow_nonpositive_prices):
+            self._on_plan_rejected(symbol, "invalid_price", ts)
             return None
         price = self.apply_slippage(open_price, direction)
         if require_positive_price:
@@ -1350,6 +1376,7 @@ class BaseEngine(ABC):
             self._calc_raw_size(symbol, target_notional, price), price
         )
         if size <= 0:
+            self._on_plan_rejected(symbol, "zero_size", ts)
             return None
         margin = self._calc_margin(symbol, size, price, leverage)
         commission = self.calc_commission(

--- a/agent/tests/test_plan_rejected.py
+++ b/agent/tests/test_plan_rejected.py
@@ -1,0 +1,203 @@
+"""Tests for the BaseEngine._on_plan_rejected observation hook.
+
+``_plan_open_order`` returns ``None`` for seven distinct reasons; these tests
+pin each cause to its exact machine-readable reason string and prove the hook
+is purely observational (no behavior change).
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from backtest.engines.base import BaseEngine
+from backtest.models import Position
+
+_TS = pd.Timestamp("2026-01-02")
+_REASONS = (
+    "no_target_weight",
+    "already_held",
+    "no_data",
+    "no_bar",
+    "execution_blocked",
+    "invalid_price",
+    "zero_size",
+)
+
+
+class _RecorderEngine(BaseEngine):
+    """Minimal engine whose _on_plan_rejected records (symbol, reason, ts)."""
+
+    def __init__(self, **overrides):
+        config = {"initial_cash": 1_000.0, "leverage": 1.0, "position_adjustment": "rebalance"}
+        config.update(overrides)
+        super().__init__(config)
+        self.rejections: list[tuple[str, str, pd.Timestamp]] = []
+        self.execute_ok = True
+
+    def can_execute(self, symbol, direction, bar):
+        return self.execute_ok
+
+    def round_size(self, raw_size, price):
+        return round(max(raw_size, 0.0), 6)
+
+    def calc_commission(self, size, price, direction, is_open):
+        return size * price * 0.0
+
+    def apply_slippage(self, price, direction):
+        return price
+
+    def _on_plan_rejected(self, symbol, reason, timestamp):
+        self.rejections.append((symbol, reason, timestamp))
+
+
+class _ZeroLotEngine(_RecorderEngine):
+    """Lot rounding that always truncates to zero (silent zero-fill)."""
+
+    def round_size(self, raw_size, price):
+        return 0.0
+
+
+class _FuturesLotEngine(_RecorderEngine):
+    """Futures-style whole-contract rounding: max(int(raw_size), 0)."""
+
+    def round_size(self, raw_size, price):
+        return float(max(int(raw_size), 0))
+
+
+class _NoopHookEngine(_RecorderEngine):
+    def _on_plan_rejected(self, symbol, reason, timestamp):
+        pass
+
+
+def _frame(open_price=100.0, ts=_TS):
+    return pd.DataFrame({"open": [open_price], "close": [100.0]}, index=[ts])
+
+
+def _force(engine, reason):
+    """Call _plan_open_order in a way that triggers exactly `reason`."""
+    if reason == "no_target_weight":
+        return engine._plan_open_order("A", 0.0, _frame(), _TS, 1_000.0)
+    if reason == "already_held":
+        engine.positions["A"] = Position("A", 1, 100.0, _TS, 5.0)
+        return engine._plan_open_order("A", 0.5, _frame(), _TS, 1_000.0)
+    if reason == "no_data":
+        return engine._plan_open_order("A", 0.5, None, _TS, 1_000.0)
+    if reason == "no_bar":
+        other_ts = pd.Timestamp("2026-01-03")
+        return engine._plan_open_order("A", 0.5, _frame(), other_ts, 1_000.0)
+    if reason == "execution_blocked":
+        engine.execute_ok = False
+        return engine._plan_open_order("A", 0.5, _frame(), _TS, 1_000.0)
+    if reason == "invalid_price":
+        return engine._plan_open_order("A", 0.5, _frame(open_price=0.0), _TS, 1_000.0)
+    if reason == "zero_size":
+        return engine._plan_open_order("A", 0.5, _frame(), _TS, 1_000.0)
+    raise AssertionError(f"unknown reason {reason}")
+
+
+@pytest.mark.parametrize("reason", _REASONS)
+def test_each_cause_records_exact_reason(reason):
+    engine = _ZeroLotEngine() if reason == "zero_size" else _RecorderEngine()
+    ts = pd.Timestamp("2026-01-03") if reason == "no_bar" else _TS
+
+    order = _force(engine, reason)
+
+    assert order is None
+    assert engine.rejections == [("A", reason, ts)]
+
+
+def test_all_seven_reasons_are_pairwise_distinct():
+    seen = []
+    for reason in _REASONS:
+        engine = _ZeroLotEngine() if reason == "zero_size" else _RecorderEngine()
+        _force(engine, reason)
+        seen.append(engine.rejections[0][1])
+
+    assert len(seen) == len(_REASONS)
+    assert len(set(seen)) == len(_REASONS)
+    assert set(seen) == set(_REASONS)
+
+
+def test_hook_not_called_when_order_is_planned():
+    engine = _RecorderEngine()
+
+    order = engine._plan_open_order("A", 0.5, _frame(), _TS, 1_000.0)
+
+    assert order is not None
+    assert order.size == 5.0
+    assert engine.rejections == []
+
+
+class _DefaultEngine(BaseEngine):
+    """Engine with NO _on_plan_rejected override: inherits the BaseEngine no-op."""
+
+    def __init__(self):
+        super().__init__({"initial_cash": 1_000.0, "leverage": 1.0, "position_adjustment": "rebalance"})
+
+    def can_execute(self, symbol, direction, bar):
+        return True
+
+    def round_size(self, raw_size, price):
+        return round(max(raw_size, 0.0), 6)
+
+    def calc_commission(self, size, price, direction, is_open):
+        return size * price * 0.0
+
+    def apply_slippage(self, price, direction):
+        return price
+
+
+def test_default_engine_has_zero_side_effects_for_every_cause():
+    engine = _DefaultEngine()
+    capital_before = engine.capital
+    for reason in _REASONS:
+        assert _force(engine, reason) is None
+
+    assert engine.capital == capital_before
+    assert engine.trades == []
+    assert engine.fill_records == []
+
+
+def test_futures_whole_contract_truncation_surfaces_zero_size():
+    engine = _FuturesLotEngine()
+
+    order = engine._plan_open_order("A", 0.0005, _frame(), _TS, 1_000.0)
+
+    assert order is None
+    assert engine.rejections == [("A", "zero_size", _TS)]
+    assert engine.positions == {}
+
+
+def test_recording_hook_does_not_change_execution_state():
+    scenario_fill_and_reject = _run_fill_and_reject_scenario
+    recorder = _RecorderEngine()
+    noop = _NoopHookEngine()
+    scenario_fill_and_reject(recorder)
+    scenario_fill_and_reject(noop)
+
+    assert recorder.rejections, "scenario must produce at least one rejection"
+    assert noop.rejections == []
+    assert recorder.capital == noop.capital
+    assert recorder.positions == noop.positions
+    assert recorder.trades == noop.trades
+    assert recorder.fill_records == noop.fill_records
+
+
+def _run_fill_and_reject_scenario(engine):
+    """Weights that fill on bar 2 (bar 1 is weight 0), plus direct rejections."""
+    dates = pd.date_range("2026-01-02", periods=2)
+    data_map = {"A": pd.DataFrame({"open": [100.0, 100.0], "close": [100.0, 100.0]}, index=dates)}
+    engine._execute_bars(
+        dates,
+        data_map,
+        pd.DataFrame({"A": [100.0, 100.0]}, index=dates),
+        pd.DataFrame({"A": [0.0, 0.5]}, index=dates),
+        ["A"],
+    )
+    frame = _frame()
+    # already_held: A was filled on bar 2 and allow_existing defaults to False.
+    engine._plan_open_order("A", 0.5, frame, _TS, 1_000.0)
+    # no_data and no_bar via direct calls.
+    engine._plan_open_order("B", 0.5, None, _TS, 1_000.0)
+    engine._plan_open_order("B", 0.5, frame, pd.Timestamp("2026-01-03"), 1_000.0)


### PR DESCRIPTION
## Summary

- Add a no-op `_on_plan_rejected(symbol, reason, timestamp)` hook to `BaseEngine`, called at every point where `_plan_open_order` returns `None`.
- Engine subclasses can now tell "nothing to do" apart from "wanted but unfillable" without re-deriving the sizing logic.

## Why

`_plan_open_order` rejects a plan for seven distinct reasons — no target weight, symbol already held, no data frame, no bar at the decision timestamp, market-rule block, invalid price, or a size rounded to zero by lot rules — and callers only see `None`. The zero-size case is the sharpest: for futures engines `round_size` truncates to whole contracts, so a sleeve whose target notional is smaller than one contract trades zero times while the run reports a normal result.

Closes #1235

## Changes

- Split the compound guard in `_plan_open_order` into labelled branches that each pass a machine-readable reason (`no_target_weight`, `already_held`, `no_data`, `no_bar`, `execution_blocked`, `invalid_price`, `zero_size`) to the new `_on_plan_rejected` hook, mirroring the style of `after_position_adjustment`.
- No behavior change: the default hook does nothing and none of the three call sites (`_execute_bars`, `_rebalance`, `_execute_target_rebalance`) are modified.

## Test Plan

- [ ] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [ ] New tests added (`agent/tests/test_plan_rejected.py` — per-cause reason pinning for all 7 causes, reason distinctness, no hook call on a successful plan, default no-op side-effect check, futures whole-contract truncation, recorder-vs-no-op execution-state equality)
- [ ] Tested manually

## Checklist

- [ ] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`)
- [ ] No hardcoded values (API keys, file paths, magic numbers)
- [ ] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] Documentation updated (docstring documents the hook contract and all reason strings; no user-facing docs change)