### PR TITLE
fix(providers): self-heal temperature rejection on the OpenAI-compatible path

### DIFF
--- a/agent/src/providers/llm.py
+++ b/agent/src/providers/llm.py
@@ -524,13 +524,60 @@ if ChatOpenAI is not None:
                 self._capture(choice["message"], gen.message)
             return result
 
+        def _generate(self, *args: Any, **kwargs: Any) -> Any:
+            try:
+                return super()._generate(*args, **kwargs)
+            except Exception as exc:  # noqa: BLE001 - retried or re-raised below
+                if not self._remember_temperature_unsupported(exc):
+                    raise
+                return super()._generate(*args, **kwargs)
+
+        async def _agenerate(self, *args: Any, **kwargs: Any) -> Any:
+            try:
+                return await super()._agenerate(*args, **kwargs)
+            except Exception as exc:  # noqa: BLE001 - retried or re-raised below
+                if not self._remember_temperature_unsupported(exc):
+                    raise
+                return await super()._agenerate(*args, **kwargs)
+
+        def _remember_temperature_unsupported(self, exc: BaseException) -> bool:
+            """Record a temperature-unsupported error and report a one-shot retry.
+
+            Mirrors the native Anthropic path for the generic OpenAI-compatible
+            branch: next-generation Claude models served through
+            ``OPENAI_BASE_URL`` return HTTP 400 when `temperature` is sent
+            (issue #1223). The model is remembered in
+            ``_ANTHROPIC_TEMPERATURE_UNSUPPORTED`` so later requests omit it up
+            front.
+            """
+            if not _is_anthropic_temperature_unsupported_error(exc):
+                return False
+            model = str(self.model_name)
+            if model not in _ANTHROPIC_TEMPERATURE_UNSUPPORTED:
+                logger.info(
+                    "Model %s rejects `temperature`; retrying without it "
+                    "and omitting it for subsequent calls.",
+                    model,
+                )
+                _ANTHROPIC_TEMPERATURE_UNSUPPORTED.add(model)
+            return True
+
         def _stream(self, *args: Any, **kwargs: Any) -> Iterator[Any]:
             """Route Responses streams through the mapping-compatible adapter."""
             if self._use_responses_api({**kwargs, **self.model_kwargs}):
                 cloned = copy(self)
                 cloned.root_client = _ResponsesSyncClient(self.root_client)
-                return super(ChatOpenAIWithReasoning, cloned)._stream(*args, **kwargs)
-            return self._stream_with_usage_fallback(*args, **kwargs)
+                inner = super(ChatOpenAIWithReasoning, cloned)._stream(*args, **kwargs)
+            else:
+                inner = self._stream_with_usage_fallback(*args, **kwargs)
+            # The temperature-unsupported error is raised before the first chunk is
+            # produced, so retrying the whole stream cannot duplicate output.
+            try:
+                yield from inner
+            except Exception as exc:  # noqa: BLE001 - retried or re-raised below
+                if not self._remember_temperature_unsupported(exc):
+                    raise
+                yield from self._stream(*args, **kwargs)
 
         def _stream_with_usage_fallback(self, *args: Any, **kwargs: Any) -> Iterator[Any]:
             # stream_usage=True is set at build time so streamed calls report
@@ -553,19 +600,17 @@ if ChatOpenAI is not None:
             _STREAM_USAGE_UNSUPPORTED.add(model)
             yield from super()._stream(*args, stream_usage=False, **kwargs)
 
-        async def _astream(self, *args: Any, **kwargs: Any) -> AsyncIterator[Any]:
-            """Async route matching ``_stream`` for Responses compatibility."""
-            if self._use_responses_api({**kwargs, **self.model_kwargs}):
-                cloned = copy(self)
-                cloned.root_async_client = _ResponsesAsyncClient(self.root_async_client)
-                async for chunk in super(ChatOpenAIWithReasoning, cloned)._astream(
-                    *args, **kwargs
-                ):
-                    yield chunk
-                return
+        async def _astream_with_usage_fallback(
+            self, *args: Any, **kwargs: Any
+        ) -> AsyncIterator[Any]:
+            # stream_usage=True is set at build time so streamed calls report
+            # real token counts (issue #1224); an endpoint that rejects
+            # stream_options is remembered and retried without it.
             model = str(self.model_name)
             if model in _STREAM_USAGE_UNSUPPORTED:
-                async for chunk in super()._astream(*args, stream_usage=False, **kwargs):
+                async for chunk in super()._astream(
+                    *args, stream_usage=False, **kwargs
+                ):
                     yield chunk
                 return
             try:
@@ -582,6 +627,25 @@ if ChatOpenAI is not None:
             _STREAM_USAGE_UNSUPPORTED.add(model)
             async for chunk in super()._astream(*args, stream_usage=False, **kwargs):
                 yield chunk
+
+        async def _astream(self, *args: Any, **kwargs: Any) -> AsyncIterator[Any]:
+            """Async route matching ``_stream`` for Responses compatibility."""
+            if self._use_responses_api({**kwargs, **self.model_kwargs}):
+                cloned = copy(self)
+                cloned.root_async_client = _ResponsesAsyncClient(self.root_async_client)
+                inner = super(ChatOpenAIWithReasoning, cloned)._astream(*args, **kwargs)
+            else:
+                inner = self._astream_with_usage_fallback(*args, **kwargs)
+            # The temperature-unsupported error is raised before the first chunk is
+            # produced, so retrying the whole stream cannot duplicate output.
+            try:
+                async for chunk in inner:
+                    yield chunk
+            except Exception as exc:  # noqa: BLE001 - retried or re-raised below
+                if not self._remember_temperature_unsupported(exc):
+                    raise
+                async for chunk in self._astream(*args, **kwargs):
+                    yield chunk
 
         def _convert_chunk_to_generation_chunk(  # type: ignore[override]
             self,
@@ -614,6 +678,9 @@ if ChatOpenAI is not None:
             is absent, breaking ReAct continuations after a tool call (#39).
             """
             payload = super()._get_request_payload(input_, stop=stop, **kwargs)
+            # Models that rejected `temperature` before omit it up front (#1223).
+            if str(self.model_name) in _ANTHROPIC_TEMPERATURE_UNSUPPORTED:
+                payload.pop("temperature", None)
             if "messages" in payload:
                 messages = super()._convert_input(input_).to_messages()
                 caps = self._capabilities()

--- a/agent/tests/test_llm.py
+++ b/agent/tests/test_llm.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
 import os
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import httpx
 import pytest
 
 from src.providers.capabilities import (
@@ -13,7 +16,7 @@ from src.providers.capabilities import (
     get_provider_capabilities,
     provider_env_names,
 )
-from src.providers.llm import _sync_provider_env, build_llm
+from src.providers.llm import ChatOpenAIWithReasoning, _sync_provider_env, build_llm
 
 
 class TestProviderCapabilityAliases:
@@ -459,6 +462,225 @@ def test_is_anthropic_temperature_unsupported_error_matching() -> None:
     assert not _is_anthropic_temperature_unsupported_error(
         RuntimeError("rate limit exceeded")
     )
+
+
+# ---------------------------------------------------------------------------
+# OpenAI-compatible branch temperature self-heal (issue #1223)
+# ---------------------------------------------------------------------------
+
+
+_ANTHROPIC_OPENAI_COMPAT_TEMPERATURE_ERROR = {
+    "error": {
+        "code": "invalid_request_error",
+        "message": "`temperature` is deprecated for this model.",
+        "type": "invalid_request_error",
+        "param": None,
+    }
+}
+
+
+def _openai_compat_completion_body(model: str) -> dict:
+    return {
+        "id": "chatcmpl-temperature-test",
+        "object": "chat.completion",
+        "created": 0,
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "ok"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+
+
+def _openai_compat_sse(text: str, model: str) -> bytes:
+    chunk = {
+        "id": "chatcmpl-temperature-test",
+        "object": "chat.completion.chunk",
+        "created": 0,
+        "model": model,
+        "choices": [{"index": 0, "delta": {"content": text}, "finish_reason": "stop"}],
+    }
+    return (f"data: {json.dumps(chunk)}\n\ndata: [DONE]\n\n").encode("utf-8")
+
+
+@pytest.mark.skipif(
+    ChatOpenAIWithReasoning is None,
+    reason="langchain-openai is not installed",
+)
+def test_openai_compat_temperature_self_heal_drops_and_retries() -> None:
+    """A 400 on `temperature` gets one retry without it, remembered for later calls."""
+    import src.providers.llm as llm_mod
+
+    calls: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        calls.append(body)
+        if "temperature" in body:
+            return httpx.Response(400, json=_ANTHROPIC_OPENAI_COMPAT_TEMPERATURE_ERROR)
+        return httpx.Response(200, json=_openai_compat_completion_body(model))
+
+    model = "claude-opus-4-8"
+    llm_mod._ANTHROPIC_TEMPERATURE_UNSUPPORTED.discard(model)
+    try:
+        with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+            llm = ChatOpenAIWithReasoning(
+                model=model,
+                api_key="sk-test",
+                base_url="https://api.anthropic.invalid/v1/",
+                temperature=0.0,
+                http_client=client,
+                vibe_provider="openai",
+                vibe_api_key="sk-test",
+            )
+            result = llm.invoke("hello")
+            assert result.content == "ok"
+            # First attempt carried temperature and failed; the retry dropped it.
+            assert len(calls) == 2
+            assert "temperature" in calls[0]
+            assert calls[0]["temperature"] == 0.0
+            assert "temperature" not in calls[1]
+            assert model in llm_mod._ANTHROPIC_TEMPERATURE_UNSUPPORTED
+
+            # Remembered: the second invoke skips the doomed attempt entirely.
+            llm.invoke("hello again")
+            assert len(calls) == 3
+            assert "temperature" not in calls[2]
+    finally:
+        llm_mod._ANTHROPIC_TEMPERATURE_UNSUPPORTED.discard(model)
+
+
+@pytest.mark.skipif(
+    ChatOpenAIWithReasoning is None,
+    reason="langchain-openai is not installed",
+)
+def test_openai_compat_temperature_preserved_for_supported_model() -> None:
+    """Models that accept `temperature` keep it; nothing is remembered."""
+    import src.providers.llm as llm_mod
+
+    calls: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        calls.append(body)
+        return httpx.Response(200, json=_openai_compat_completion_body(model))
+
+    model = "claude-sonnet-4-5"
+    llm_mod._ANTHROPIC_TEMPERATURE_UNSUPPORTED.discard(model)
+    try:
+        with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+            llm = ChatOpenAIWithReasoning(
+                model=model,
+                api_key="sk-test",
+                base_url="https://api.anthropic.invalid/v1/",
+                temperature=0.0,
+                http_client=client,
+                vibe_provider="openai",
+                vibe_api_key="sk-test",
+            )
+            result = llm.invoke("hello")
+
+        assert result.content == "ok"
+        assert len(calls) == 1
+        assert calls[0]["temperature"] == 0.0
+        assert model not in llm_mod._ANTHROPIC_TEMPERATURE_UNSUPPORTED
+    finally:
+        llm_mod._ANTHROPIC_TEMPERATURE_UNSUPPORTED.discard(model)
+
+
+@pytest.mark.skipif(
+    ChatOpenAIWithReasoning is None,
+    reason="langchain-openai is not installed",
+)
+def test_openai_compat_stream_temperature_self_heals_and_is_remembered() -> None:
+    """A streaming 400 on `temperature` retries without it; later streams skip it."""
+    import src.providers.llm as llm_mod
+
+    calls: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        calls.append(body)
+        if "temperature" in body:
+            return httpx.Response(400, json=_ANTHROPIC_OPENAI_COMPAT_TEMPERATURE_ERROR)
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=_openai_compat_sse("ok", model),
+        )
+
+    model = "claude-opus-4-8"
+    llm_mod._ANTHROPIC_TEMPERATURE_UNSUPPORTED.discard(model)
+    try:
+        with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+            llm = ChatOpenAIWithReasoning(
+                model=model,
+                api_key="sk-test",
+                base_url="https://api.anthropic.invalid/v1/",
+                temperature=0.0,
+                http_client=client,
+                vibe_provider="openai",
+                vibe_api_key="sk-test",
+            )
+            first = "".join(chunk.content for chunk in llm.stream("hello"))
+
+        assert first == "ok"
+        # The temperature-unsupported error surfaces before the first chunk, so
+        # the retry cannot duplicate output.
+        assert len(calls) == 2
+        assert "temperature" in calls[0]
+        assert "temperature" not in calls[1]
+        assert model in llm_mod._ANTHROPIC_TEMPERATURE_UNSUPPORTED
+    finally:
+        llm_mod._ANTHROPIC_TEMPERATURE_UNSUPPORTED.discard(model)
+
+
+@pytest.mark.skipif(
+    ChatOpenAIWithReasoning is None,
+    reason="langchain-openai is not installed",
+)
+def test_openai_compat_agenerate_temperature_self_heals() -> None:
+    """The async generate path mirrors the sync temperature self-heal."""
+    import src.providers.llm as llm_mod
+
+    calls: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        calls.append(body)
+        if "temperature" in body:
+            return httpx.Response(400, json=_ANTHROPIC_OPENAI_COMPAT_TEMPERATURE_ERROR)
+        return httpx.Response(200, json=_openai_compat_completion_body(model))
+
+    async def run():
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            llm = ChatOpenAIWithReasoning(
+                model=model,
+                api_key="sk-test",
+                base_url="https://api.anthropic.invalid/v1/",
+                temperature=0.0,
+                http_async_client=client,
+                vibe_provider="openai",
+                vibe_api_key="sk-test",
+            )
+            return await llm.ainvoke("hello")
+
+    model = "claude-opus-4-8"
+    llm_mod._ANTHROPIC_TEMPERATURE_UNSUPPORTED.discard(model)
+    try:
+        result = asyncio.run(run())
+
+        assert result.content == "ok"
+        assert len(calls) == 2
+        assert "temperature" in calls[0]
+        assert "temperature" not in calls[1]
+        assert model in llm_mod._ANTHROPIC_TEMPERATURE_UNSUPPORTED
+    finally:
+        llm_mod._ANTHROPIC_TEMPERATURE_UNSUPPORTED.discard(model)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Extend the Anthropic temperature self-heal (classify the 400, retry once, remember the model) to the generic OpenAI-compatible branch (`ChatOpenAIWithReasoning`), so requests to Anthropic models through `OPENAI_BASE_URL` recover from "`temperature` is deprecated for this model." automatically.
- No change for models that accept `temperature` — the configured value keeps being sent.

## Why

Next-generation Claude models (claude-opus-4-8, claude-sonnet-5, ...) reject any request carrying `temperature` with HTTP 400. At v0.1.14 the native Anthropic Messages path detects the error, retries without the field and remembers the model, but the generic OpenAI-compatible branch still sends `temperature` unconditionally, so running `LANGCHAIN_PROVIDER=openai` with `OPENAI_BASE_URL=https://api.anthropic.com/v1/` fails on every call.

Closes #1223

## Changes

- `ChatOpenAIWithReasoning._remember_temperature_unsupported` classifies the 400 with the existing `_is_anthropic_temperature_unsupported_error` detector, logs once, and records the model in `_ANTHROPIC_TEMPERATURE_UNSUPPORTED` — the same set the native path uses.
- `_generate` / `_agenerate` retry once without the field; `_stream` / `_astream` do the same (the 400 is raised before the first chunk, so the retry cannot duplicate output). The async stream_usage fallback moves to a named `_astream_with_usage_fallback` to mirror the sync `_stream` layering — no behavior change.
- `_get_request_payload` omits `temperature` up front for remembered models, so later calls skip the doomed request.

## Test Plan

- [ ] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q` — verified for the touched components: `agent/tests/test_llm.py`, `agent/tests/test_provider_header_isolation.py`, `agent/tests/test_env_schema.py`)
- [ ] New tests added: mocked-error regression tests in `agent/tests/test_llm.py` covering invoke self-heal and the remembered-model fast path, supported-model preservation, stream self-heal, and async invoke; all fail on the pre-fix code with the verbatim 400
- [ ] Tested manually (provider-dependent behavior verified with mocked 400/SSE responses via `httpx.MockTransport`, no live credentials)

## Checklist

- [ ] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion — direction raised and left open in #1223; follows the self-heal precedent from #1224 on the same file
- [ ] No hardcoded values (API keys, file paths, magic numbers)
- [ ] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] Documentation updated (if user-facing change) — no doc change needed; behavior now matches the native path