### PR TITLE
feat(backtest): add USD-M tolerance calibration from recorded comparisons

### DIFF
--- a/agent/backtest/binance_tolerance_calibration.py
+++ b/agent/backtest/binance_tolerance_calibration.py
@@ -1,0 +1,158 @@
+"""Deterministic tolerance calibration from recorded reconciliation comparisons.
+
+This module is deliberately offline.  It derives a versioned
+ReconciliationTolerance from recorded local-versus-exchange comparison
+samples and verifies that a tolerance bounds a recorded sample set.  A
+calibrated tolerance is evidence about recorded observations only; it never
+relaxes validation or touches accounting state.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+import re
+from typing import Sequence
+
+from backtest.binance_account_reconciliation import ReconciliationTolerance
+
+
+_CANONICAL_USDM_SYMBOL = re.compile(r"^[A-Z0-9]+-USDT-PERP$")
+
+
+def _require_finite(name: str, value: float, *, non_negative: bool = False) -> None:
+    if not math.isfinite(value):
+        raise ValueError(f"{name} must be finite")
+    if non_negative and value < 0:
+        raise ValueError(f"{name} must be non-negative")
+
+
+@dataclass(frozen=True)
+class CalibrationSample:
+    """One recorded local-versus-exchange comparison sample."""
+
+    field: str
+    local_value: float
+    exchange_value: float
+    symbol: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.field:
+            raise ValueError("field must not be empty")
+        _require_finite("local_value", self.local_value)
+        _require_finite("exchange_value", self.exchange_value)
+        if self.symbol is not None and not _CANONICAL_USDM_SYMBOL.fullmatch(self.symbol):
+            raise ValueError("symbol must use canonical *-USDT-PERP form")
+
+    @property
+    def absolute_delta(self) -> float:
+        return abs(self.local_value - self.exchange_value)
+
+
+@dataclass(frozen=True)
+class CalibratedField:
+    """Per-field calibration statistics over one recorded field."""
+
+    field: str
+    sample_count: int
+    max_absolute_delta: float
+    proposed_absolute: float
+    proposed_relative: float
+
+
+@dataclass(frozen=True)
+class ToleranceCalibration:
+    """Versioned calibration outcome over one recorded sample set."""
+
+    version: str
+    sample_count: int
+    fields: tuple[CalibratedField, ...]
+    tolerance: ReconciliationTolerance
+
+
+def _max_relative_delta(samples: Sequence[CalibrationSample]) -> float:
+    return max(
+        (
+            sample.absolute_delta / max(abs(sample.local_value), abs(sample.exchange_value))
+            if sample.absolute_delta != 0
+            else 0.0
+        )
+        for sample in samples
+    )
+
+
+def calibrate_tolerance(
+    samples: Sequence[CalibrationSample],
+    *,
+    version: str,
+    min_samples_per_field: int = 4,
+    safety_factor: float = 2.0,
+    absolute_floor: float = 1e-8,
+    relative_floor: float = 1e-8,
+) -> ToleranceCalibration:
+    """Derive a versioned tolerance that bounds the recorded sample set.
+
+    Raises:
+        ValueError: If inputs are invalid or any field group holds fewer than
+            ``min_samples_per_field`` samples.
+    """
+    if not samples:
+        raise ValueError("samples must not be empty")
+    if not version:
+        raise ValueError("version must not be empty")
+    if min_samples_per_field < 1:
+        raise ValueError("min_samples_per_field must be at least one")
+    _require_finite("safety_factor", safety_factor, non_negative=True)
+    if safety_factor < 1.0:
+        raise ValueError("safety_factor must be at least 1.0")
+    _require_finite("absolute_floor", absolute_floor, non_negative=True)
+    _require_finite("relative_floor", relative_floor, non_negative=True)
+
+    grouped: dict[str, list[CalibrationSample]] = {}
+    for sample in samples:
+        grouped.setdefault(sample.field, []).append(sample)
+    undercounted = sorted(field for field, group in grouped.items() if len(group) < min_samples_per_field)
+    if undercounted:
+        raise ValueError(f"fields below min_samples_per_field: {undercounted}")
+
+    calibrated = []
+    for field in sorted(grouped):
+        group = grouped[field]
+        max_absolute_delta = max(sample.absolute_delta for sample in group)
+        calibrated.append(
+            CalibratedField(
+                field=field,
+                sample_count=len(group),
+                max_absolute_delta=max_absolute_delta,
+                proposed_absolute=max(absolute_floor, safety_factor * max_absolute_delta),
+                proposed_relative=max(relative_floor, safety_factor * _max_relative_delta(group)),
+            )
+        )
+    tolerance = ReconciliationTolerance(
+        absolute=max(item.proposed_absolute for item in calibrated),
+        relative=max(item.proposed_relative for item in calibrated),
+        max_timestamp_skew_seconds=0.0,
+        version=version,
+    )
+    return ToleranceCalibration(
+        version=version,
+        sample_count=len(samples),
+        fields=tuple(calibrated),
+        tolerance=tolerance,
+    )
+
+
+def verify_tolerance_covers(
+    tolerance: ReconciliationTolerance,
+    samples: Sequence[CalibrationSample],
+) -> tuple[CalibrationSample, ...]:
+    """Return the recorded samples the tolerance does not bound."""
+    uncovered = []
+    for sample in samples:
+        allowed_delta = max(
+            tolerance.absolute,
+            tolerance.relative * max(abs(sample.local_value), abs(sample.exchange_value)),
+        )
+        if sample.absolute_delta > allowed_delta:
+            uncovered.append(sample)
+    return tuple(uncovered)

--- a/agent/tests/test_binance_tolerance_calibration.py
+++ b/agent/tests/test_binance_tolerance_calibration.py
@@ -1,0 +1,233 @@
+"""Deterministic tolerance calibration from recorded reconciliation samples."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from backtest.binance_account_reconciliation import (
+    BinanceAccountSnapshot,
+    BinancePositionSnapshot,
+    ReconciliationTolerance,
+    reconcile_binance_account,
+)
+from backtest.binance_tolerance_calibration import (
+    CalibrationSample,
+    calibrate_tolerance,
+    verify_tolerance_covers,
+)
+from backtest.perpetual_risk import (
+    AccountState,
+    PositionRisk,
+    PositionState,
+    RiskSnapshot,
+)
+
+
+OBSERVED_AT = pd.Timestamp("2026-08-27T08:00:00Z")
+
+
+def _samples() -> list[CalibrationSample]:
+    return [
+        CalibrationSample("entry_price", 60_000.0, 60_001.0, "BTC-USDT-PERP"),
+        CalibrationSample("entry_price", 60_000.0, 60_000.5, "BTC-USDT-PERP"),
+        CalibrationSample("entry_price", 60_000.0, 59_999.0, "BTC-USDT-PERP"),
+        CalibrationSample("entry_price", 60_000.0, 60_000.25, "BTC-USDT-PERP"),
+        CalibrationSample("quantity", 0.1, 0.1003, "BTC-USDT-PERP"),
+        CalibrationSample("quantity", 0.1, 0.1001, "BTC-USDT-PERP"),
+        CalibrationSample("quantity", 0.1, 0.0999, "BTC-USDT-PERP"),
+        CalibrationSample("quantity", 0.1, 0.1002, "BTC-USDT-PERP"),
+        CalibrationSample("wallet_balance", 1_000.0, 1_000.4),
+        CalibrationSample("wallet_balance", 1_000.0, 1_000.2),
+        CalibrationSample("wallet_balance", 1_000.0, 999.7),
+        CalibrationSample("wallet_balance", 1_000.0, 1_000.1),
+    ]
+
+
+def _exchange_cross(**changes: object) -> BinanceAccountSnapshot:
+    values: dict[str, object] = {
+        "schema_version": "binance-usdm-account-observation-v1",
+        "observed_at": OBSERVED_AT,
+        "source": "binance-usdm",
+        "source_profile": "binance-live-sdk-readonly",
+        "configuration_hash": "a" * 64,
+        "data_status": "complete",
+        "wallet_balance": 1_000.0,
+        "margin_balance": 1_100.0,
+        "available_balance": 490.0,
+        "total_unrealized_pnl": 100.0,
+        "total_initial_margin": 610.0,
+        "total_maintenance_margin": 24.4,
+        "positions": (
+            BinancePositionSnapshot(
+                "BTC-USDT-PERP",
+                0.1,
+                60_000.0,
+                10.0,
+                "cross",
+                None,
+                100.0,
+                610.0,
+                24.4,
+            ),
+        ),
+        "fidelity_flags": (
+            "client_observation_time",
+            "sequential_signed_reads",
+        ),
+    }
+    values.update(changes)
+    return BinanceAccountSnapshot(**values)  # type: ignore[arg-type]
+
+
+def test_calibration_covers_recorded_samples() -> None:
+    samples = _samples()
+
+    calibration = calibrate_tolerance(samples, version="calibration-v1")
+
+    assert isinstance(calibration.tolerance, ReconciliationTolerance)
+    assert verify_tolerance_covers(calibration.tolerance, samples) == ()
+
+
+def test_zero_drift_samples_get_positive_floors() -> None:
+    samples = [CalibrationSample("quantity", 0.1, 0.1, "BTC-USDT-PERP") for _ in range(5)]
+
+    calibration = calibrate_tolerance(samples, version="calibration-v1", absolute_floor=1e-6)
+
+    field = calibration.fields[0]
+    assert field.max_absolute_delta == 0.0
+    assert field.proposed_absolute == 1e-6
+    assert field.proposed_relative == 1e-8
+    assert calibration.tolerance.absolute == 1e-6 > 0
+    assert verify_tolerance_covers(calibration.tolerance, samples) == ()
+
+
+def test_field_stats_and_ordering() -> None:
+    samples = [
+        CalibrationSample("available_balance", 500.0, 500.25),
+        CalibrationSample("available_balance", 500.0, 499.5),
+        CalibrationSample("available_balance", 500.0, 500.0),
+        CalibrationSample("available_balance", 500.0, 500.1),
+        CalibrationSample("wallet_balance", 1_000.0, 1_001.0),
+        CalibrationSample("wallet_balance", 1_000.0, 1_000.5),
+        CalibrationSample("wallet_balance", 1_000.0, 1_000.25),
+        CalibrationSample("wallet_balance", 1_000.0, 1_000.1),
+    ]
+
+    calibration = calibrate_tolerance(samples, version="calibration-v1")
+
+    assert calibration.version == "calibration-v1"
+    assert calibration.sample_count == 8
+    assert [item.field for item in calibration.fields] == ["available_balance", "wallet_balance"]
+    available = calibration.fields[0]
+    assert available.sample_count == 4
+    assert available.max_absolute_delta == 0.5
+    assert available.proposed_absolute == pytest.approx(1.0)
+    assert available.proposed_relative == pytest.approx(0.002)
+    wallet = calibration.fields[1]
+    assert wallet.sample_count == 4
+    assert wallet.max_absolute_delta == 1.0
+    assert wallet.proposed_absolute == pytest.approx(2.0)
+    assert wallet.proposed_relative == pytest.approx(2.0 / 1_001.0)
+    assert calibration.tolerance.absolute == pytest.approx(2.0)
+    assert calibration.tolerance.relative == pytest.approx(0.002)
+    assert calibration.tolerance.max_timestamp_skew_seconds == 0.0
+    assert calibration.tolerance.version == "calibration-v1"
+
+
+def test_calibration_accepted_by_reconciler() -> None:
+    position = PositionState("BTC-USDT-PERP", 0.1, 60_000.0, 10.0, 3.0, None)
+    account = AccountState(1_000.0, (position,), "cross")
+    risk = PositionRisk("BTC-USDT-PERP", 61_000.0, 6_100.0, 100.0, 610.0, 24.4, None)
+    snapshot = RiskSnapshot(
+        1_100.0,
+        610.0,
+        24.4,
+        490.0,
+        (risk,),
+        "healthy",
+        (),
+        ("conservative_intrabar_assumption",),
+    )
+    exchange = _exchange_cross(wallet_balance=1_000.4)
+    samples = [
+        CalibrationSample("wallet_balance", 1_000.0, 1_000.4),
+        CalibrationSample("wallet_balance", 1_000.0, 1_000.3),
+        CalibrationSample("wallet_balance", 1_000.0, 1_000.2),
+        CalibrationSample("wallet_balance", 1_000.0, 1_000.1),
+    ]
+
+    calibration = calibrate_tolerance(samples, version="calibration-v1")
+
+    assert verify_tolerance_covers(calibration.tolerance, samples) == ()
+    report = reconcile_binance_account(
+        account,
+        snapshot,
+        exchange,
+        expected_timestamp=OBSERVED_AT,
+        tolerance=calibration.tolerance,
+    )
+    assert report.has_drift is False
+
+
+@pytest.mark.parametrize(
+    "calibrate",
+    [
+        lambda: calibrate_tolerance([], version="calibration-v1"),
+        lambda: calibrate_tolerance(_samples(), version=""),
+        lambda: calibrate_tolerance(_samples(), version="calibration-v1", safety_factor=0.5),
+        lambda: calibrate_tolerance(_samples(), version="calibration-v1", min_samples_per_field=5),
+        lambda: calibrate_tolerance(_samples(), version="calibration-v1", absolute_floor=-1.0),
+        lambda: calibrate_tolerance(_samples(), version="calibration-v1", relative_floor=-1.0),
+        lambda: calibrate_tolerance(_samples(), version="calibration-v1", absolute_floor=float("nan")),
+        lambda: calibrate_tolerance(_samples(), version="calibration-v1", min_samples_per_field=0),
+    ],
+)
+def test_calibration_fails_closed(calibrate) -> None:
+    with pytest.raises(ValueError):
+        calibrate()
+
+
+@pytest.mark.parametrize(
+    "build_sample",
+    [
+        lambda: CalibrationSample("wallet_balance", float("nan"), 1_000.0),
+        lambda: CalibrationSample("wallet_balance", 1_000.0, float("inf")),
+        lambda: CalibrationSample("", 1_000.0, 1_000.0),
+        lambda: CalibrationSample("quantity", 1.0, 1.0, "BTCUSDT"),
+        lambda: CalibrationSample("quantity", 1.0, 1.0, "btc-usdt-perp"),
+    ],
+)
+def test_sample_fails_closed(build_sample) -> None:
+    with pytest.raises(ValueError):
+        build_sample()
+
+
+def test_infinite_safety_factor_rejected() -> None:
+    with pytest.raises(ValueError):
+        calibrate_tolerance(_samples(), version="calibration-v1", safety_factor=float("inf"))
+
+
+def test_boundary_delta_is_covered() -> None:
+    tolerance = ReconciliationTolerance(
+        absolute=0.5,
+        relative=0.0,
+        max_timestamp_skew_seconds=0.0,
+        version="reconciliation-tolerance-v1",
+    )
+    boundary = CalibrationSample("wallet_balance", 1.0, 0.5)
+    offending = CalibrationSample("wallet_balance", 1.0, 0.4)
+
+    assert verify_tolerance_covers(tolerance, [boundary]) == ()
+    assert verify_tolerance_covers(tolerance, [boundary, offending]) == (offending,)
+
+
+def test_verify_flags_uncovered_sample() -> None:
+    covered = CalibrationSample("quantity", 0.1, 0.1, "BTC-USDT-PERP")
+    offending = CalibrationSample("quantity", 0.1, 0.2, "BTC-USDT-PERP")
+    tight = ReconciliationTolerance(absolute=1e-3, relative=1e-3, version="tight-v1")
+
+    uncovered = verify_tolerance_covers(tight, [covered, offending])
+
+    assert uncovered == (offending,)
+    assert verify_tolerance_covers(tight, []) == ()


### PR DESCRIPTION
## Summary

- add deterministic tolerance calibration for Binance USD-M reconciliation from recorded comparison samples
- derive a versioned `ReconciliationTolerance` with per-field statistics and a configurable safety factor
- fail closed on empty, malformed, non-finite, or under-sampled input; coverage against the recorded set is deterministically verifiable

## Why

Slices #1106/#1229/#1230 shipped the reconciliation contracts, the read-only observation boundary, and drift evidence artifacts, but every caller must still hand-pick tolerance values. This slice binds tolerance selection to recorded observations: a calibrated tolerance provably bounds the sample set it was derived from, so drift classification stops being an unjustified guess.

Progresses #1030.

## Changes

- add a pure, offline calibration module over the existing `ReconciliationTolerance` contract: `CalibrationSample`, `CalibratedField`, `ToleranceCalibration`
- `calibrate_tolerance` groups recorded samples per field, fails closed below `min_samples_per_field`, and requires a safety factor of at least 1.0 so the result covers every recorded sample; zero-delta fields keep strictly positive floors
- `verify_tolerance_covers` mirrors the reconciler's allowed-delta rule (`max(absolute, relative * max(|local|, |exchange|))`); changes to that formula must be mirrored here
- timestamp-skew calibration is out of scope: `max_timestamp_skew_seconds` stays pinned at 0.0
- no wiring into runs or artifacts yet — calibration is standalone offline tooling; the reconciler and drift-evidence modules are unchanged

## Test Plan

- [ ] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [ ] New tests added (if applicable)
- [ ] Tested manually (describe below)

## Checklist

- [ ] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [ ] No hardcoded values (API keys, file paths, magic numbers)
- [ ] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] Documentation updated (if user-facing change)