### PR TITLE
feat(market): add UK equities (LSE .L) support

### DIFF
--- a/agent/backtest/engines/_market_hooks.py
+++ b/agent/backtest/engines/_market_hooks.py
@@ -35,6 +35,9 @@ _MARKET_PATTERNS = [
     # Canada equities: Toronto Stock Exchange (TD.TO) and TSX Venture
     # (PNG.V). Yahoo carries both suffixes verbatim.
     (re.compile(r"^[A-Z0-9&.\-]+\.(TO|V)$", re.I), "ca_equity"),
+    # UK equities: London Stock Exchange (VOD.L, SHEL.L, HSBA.L). Yahoo
+    # carries the .L suffix verbatim (parity with Canada handling).
+    (re.compile(r"^[A-Z0-9&.\-]+\.L$", re.I), "uk_equity"),
     # Vietnam equities: HOSE (VIC.VN). Tickers are three letters in practice;
     # the class stays broad to admit fund certificates and ETF codes.
     (re.compile(r"^[A-Z0-9]+\.VN$", re.I), "vietnam_equity"),
@@ -74,6 +77,7 @@ _MARKET_CURRENCY = {
     "india_equity": "INR",
     "kr_equity": "KRW",
     "ca_equity": "CAD",
+    "uk_equity": "GBP",
     "vietnam_equity": "VND",
     # Every crypto pattern in _MARKET_PATTERNS is USDT-quoted, and USDT is
     # carried at its USD peg. This is the one approximation in the table: a

--- a/agent/backtest/loaders/registry.py
+++ b/agent/backtest/loaders/registry.py
@@ -151,6 +151,8 @@ FALLBACK_CHAINS: dict[str, list[str]] = {
     "kr_equity":   ["pykrx", "yahoo", "yfinance", "local"],
     # TSX (.TO) / TSX Venture (.V): direct Yahoo first, SDK fallback second.
     "ca_equity":   ["yahoo", "yfinance", "local"],
+    # LSE (.L): London Stock Exchange — same Yahoo-then-SDK chain as Canada.
+    "uk_equity":   ["yahoo", "yfinance", "local"],
     # Vietnam (.VN): Yahoo lists HOSE only — HNX and UPCOM are unsupported,
     # so those two are reachable only through the user's local files.
     "vietnam_equity": ["yahoo", "yfinance", "local"],

--- a/agent/backtest/loaders/yahoo_loader.py
+++ b/agent/backtest/loaders/yahoo_loader.py
@@ -54,7 +54,7 @@ def _is_supported(code: str) -> bool:
     """
     upper = code.strip().upper()
     return upper.endswith(
-        (".US", ".HK", ".NS", ".BO", ".KS", ".KQ", ".TO", ".V", ".VN", "=F", "=X")
+        (".US", ".HK", ".NS", ".BO", ".KS", ".KQ", ".TO", ".V", ".VN", ".L", ".IL", "=F", "=X")
     )
 
 
@@ -180,7 +180,7 @@ class DataLoader:
     name = "yahoo"
     markets = {
         "us_equity", "hk_equity", "india_equity", "kr_equity", "ca_equity",
-        "vietnam_equity",
+        "vietnam_equity", "uk_equity",
     }
     # Yahoo chart volume is single shares for US/HK equities
     # (HKUDS/Vibe-Trading#1062; HK verified 2026-08-11, 00700.HK ratio 1.00

--- a/agent/backtest/runner.py
+++ b/agent/backtest/runner.py
@@ -824,6 +824,7 @@ _MARKET_TO_SOURCE = {
     "india_equity": "yahoo",
     "kr_equity": "pykrx",
     "ca_equity": "yahoo",
+    "uk_equity": "yahoo",
     "vietnam_equity": "yahoo",
     "crypto": "okx",
     "futures": "tushare",

--- a/agent/src/market_data.py
+++ b/agent/src/market_data.py
@@ -28,6 +28,9 @@ _SOURCE_PATTERNS = [
     (re.compile(r"^[A-Z0-9&.\-]+\.(NS|BO)$", re.I), "yahoo"),
     # Canada: Toronto Stock Exchange (TD.TO) / TSX Venture (PNG.V).
     (re.compile(r"^[A-Z0-9&.\-]+\.(TO|V)$", re.I), "yahoo"),
+    # UK: London Stock Exchange (VOD.L, SHEL.L). Served by Yahoo's public
+    # chart endpoint verbatim (parity with Canada .TO/.V handling).
+    (re.compile(r"^[A-Z0-9&.\-]+\.L$", re.I), "yahoo"),
     # Yahoo futures (GC=F, CL=F) and forex (EURUSD=X) suffix conventions —
     # served verbatim by Yahoo's public chart endpoint (#718). Without these,
     # such symbols fell through to the ``tushare`` default and were routed to

--- a/agent/tests/test_registry.py
+++ b/agent/tests/test_registry.py
@@ -134,7 +134,7 @@ class TestFallbackChains:
     def test_all_expected_markets_present(self) -> None:
         expected = {
             "a_share", "us_equity", "hk_equity", "india_equity", "kr_equity",
-            "ca_equity", "vietnam_equity", "crypto", "futures", "fund", "macro",
+            "ca_equity", "uk_equity", "vietnam_equity", "crypto", "futures", "fund", "macro",
             "forex",
         }
         assert expected == set(FALLBACK_CHAINS.keys())

--- a/agent/tests/test_settings_api.py
+++ b/agent/tests/test_settings_api.py
@@ -665,7 +665,7 @@ def test_get_data_source_settings_lists_default_source_orders(
     orders = {entry["market"]: entry for entry in entries}
     assert set(orders) == {
         "a_share", "us_equity", "hk_equity", "india_equity", "kr_equity",
-        "ca_equity", "vietnam_equity", "crypto", "futures", "fund", "macro",
+        "ca_equity", "uk_equity", "vietnam_equity", "crypto", "futures", "fund", "macro",
         "forex",
     }
     a_share = orders["a_share"]

--- a/agent/tests/test_yahoo_loader.py
+++ b/agent/tests/test_yahoo_loader.py
@@ -314,7 +314,7 @@ class TestLoaderMetadata:
         assert loader.name == "yahoo"
         assert loader.markets == {
             "us_equity", "hk_equity", "india_equity", "kr_equity", "ca_equity",
-            "vietnam_equity",
+            "uk_equity", "vietnam_equity",
         }
         assert loader.requires_auth is False
         assert loader.is_available() is True


### PR DESCRIPTION
Fixes #1205

## Summary

- UK LSE `.L` symbols now route to Yahoo with `source=auto` instead of returning `_unresolved`.

## Why

`VOD.L` with `source=auto` was classified as an A-share and never tried Yahoo, while explicit `source=yahoo` succeeded.

## Changes

- Add `uk_equity` market (GBP) with Yahoo-first fallback and `.L`/`.IL` Yahoo gate.

## Test Plan

- [ ] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [ ] New tests added (if applicable)
- [ ] Tested manually (describe below)

## Checklist

- [ ] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [ ] No hardcoded values (API keys, file paths, magic numbers)
- [ ] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] Documentation updated (if user-facing change)

Reviewers: @warren618, @QCYTSN