### PR TITLE
fix(frontend): clear stale streamingSessionId on session reopen

### DIFF
--- a/frontend/src/pages/Agent.tsx
+++ b/frontend/src/pages/Agent.tsx
@@ -602,6 +602,22 @@ export function Agent() {
         }
       }
       if (genRef.current !== gen) return;
+      // A background session's SSE stream disconnects the moment you navigate
+      // away (doDisconnect() in the session-switch effect), so the
+      // session_completed event that would normally clear streamingSessionId
+      // never arrives -- the sidebar's "thinking" spinner for that session
+      // sticks around for the rest of the tab's life, even long after the
+      // turn actually finished. Reopening the session re-fetches its
+      // committed history right here; if the newest stored message is
+      // already the assistant's reply, the turn is done, so release the
+      // stale marker instead of leaving it dangling.
+      if (
+        act().streamingSessionId === sid
+        && msgs.length > 0
+        && msgs[msgs.length - 1].role === "assistant"
+      ) {
+        act().clearStreamingSession(sid);
+      }
       act().loadHistory(agentMsgs);
       act().setSessionLoading(false);
       act().cacheSession(sid, agentMsgs);

--- a/frontend/src/pages/__tests__/AgentBackgroundStreamCompletion.test.tsx
+++ b/frontend/src/pages/__tests__/AgentBackgroundStreamCompletion.test.tsx
@@ -1,0 +1,139 @@
+import { act, render, waitFor } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { Agent } from "../Agent";
+import { useAgentStore } from "@/stores/agent";
+
+// Regression test for: a session's sidebar "thinking" spinner (driven by
+// streamingSessionId) never clears once you navigate away from it mid-turn,
+// even long after that turn actually finishes. The SSE stream for a
+// backgrounded session is torn down the moment you switch away
+// (doDisconnect() in the session-switch effect), so the session_completed
+// event that would normally clear streamingSessionId never arrives. Reopening
+// that session must reconcile the marker against its now-committed history
+// instead of leaving it stuck for the rest of the tab's life.
+
+const apiMock = vi.hoisted(() => ({
+  getGoal: vi.fn(),
+  getLLMSettings: vi.fn(),
+  getRun: vi.fn(),
+  getSessionMessages: vi.fn(),
+  sseUrl: vi.fn((sid: string) => `/sessions/${sid}/events`),
+}));
+
+const sseMock = vi.hoisted(() => ({
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+  onStatusChange: vi.fn(),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, api: apiMock };
+});
+
+vi.mock("@/hooks/useSSE", () => ({
+  useSSE: () => sseMock,
+}));
+
+function storedReply(sessionId: string) {
+  return {
+    message_id: `${sessionId}-reply`,
+    session_id: sessionId,
+    role: "assistant" as const,
+    content: "done",
+    created_at: "2026-08-01T00:00:00Z",
+    linked_attempt_id: `${sessionId}-attempt`,
+    tool_trail: [],
+    metadata: {},
+  };
+}
+
+function storedPrompt(sessionId: string) {
+  return {
+    message_id: `${sessionId}-prompt`,
+    session_id: sessionId,
+    role: "user" as const,
+    content: "still working on it",
+    created_at: "2026-08-01T00:00:00Z",
+    linked_attempt_id: null,
+    tool_trail: [],
+    metadata: null,
+  };
+}
+
+describe("Agent background stream completion reconciliation", () => {
+  beforeEach(() => {
+    useAgentStore.getState().reset();
+    apiMock.getGoal.mockResolvedValue(null);
+    apiMock.getLLMSettings.mockResolvedValue({
+      provider: "deepseek",
+      model_name: "deepseek-v4-pro",
+      base_url: "https://api.deepseek.com/v1",
+      api_key_configured: true,
+      api_key_required: true,
+      temperature: 0,
+      timeout_seconds: 120,
+      max_retries: 2,
+      reasoning_effort: "low",
+      sse_timeout_seconds: 90,
+      env_path: "agent/.env",
+      providers: [],
+    });
+    Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+      configurable: true,
+      value: vi.fn(),
+    });
+  });
+
+  it("clears a background session's stale streamingSessionId once its reply is committed", async () => {
+    apiMock.getSessionMessages.mockImplementation((sid: string) => (
+      sid === "session-bg" ? Promise.resolve([storedReply(sid)]) : Promise.resolve([])
+    ));
+
+    const router = createMemoryRouter(
+      [{ path: "/", element: <Agent /> }],
+      { initialEntries: ["/?session=session-one"] },
+    );
+    render(<RouterProvider router={router} />);
+    await waitFor(() => expect(apiMock.getSessionMessages).toHaveBeenCalledWith("session-one"));
+
+    // Simulate: session-bg was mid-turn when the user navigated away from it earlier.
+    act(() => {
+      useAgentStore.setState({ streamingSessionId: "session-bg" });
+    });
+
+    await act(async () => {
+      await router.navigate("/?session=session-bg");
+    });
+
+    await waitFor(() => {
+      expect(useAgentStore.getState().streamingSessionId).toBeNull();
+    });
+  });
+
+  it("leaves streamingSessionId alone when the background session genuinely has no reply yet", async () => {
+    apiMock.getSessionMessages.mockImplementation((sid: string) => (
+      sid === "session-bg" ? Promise.resolve([storedPrompt(sid)]) : Promise.resolve([])
+    ));
+
+    const router = createMemoryRouter(
+      [{ path: "/", element: <Agent /> }],
+      { initialEntries: ["/?session=session-one"] },
+    );
+    render(<RouterProvider router={router} />);
+    await waitFor(() => expect(apiMock.getSessionMessages).toHaveBeenCalledWith("session-one"));
+
+    act(() => {
+      useAgentStore.setState({ streamingSessionId: "session-bg" });
+    });
+
+    await act(async () => {
+      await router.navigate("/?session=session-bg");
+    });
+
+    await waitFor(() => {
+      expect(apiMock.getSessionMessages).toHaveBeenCalledWith("session-bg");
+    });
+    expect(useAgentStore.getState().streamingSessionId).toBe("session-bg");
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes the sidebar "thinking" spinner for a session getting permanently stuck once you navigate away from it mid-turn, even long after that turn actually finishes.

## Why

Closes #1256.

`streamingSessionId` (the store field the sidebar spinner reads) is deliberately *preserved* when you switch sessions, so it can keep showing progress for a session you've left. But the same session-switch effect also tears down that session's SSE connection (`doDisconnect()`), so the `session_completed` event that would normally clear the marker never arrives. Reopening the session later doesn't help either — `/events?replay=active` only replays buffered events for a still-`running` attempt, so there's nothing to reconcile against once it has already completed. The one function that does this reconciliation (`syncCompletedAttempt`) is only ever invoked right after the local client sends a message, never on session (re)open.

Net effect: leave a streaming session, and its sidebar spinner is wrong forever, until a full page reload.

## Changes

- `frontend/src/pages/Agent.tsx`: in `loadSessionMessages` (already called on every session open/reopen, and already fetching that session's full committed history), if the session being loaded is the one marked as `streamingSessionId` and its newest stored message is already the assistant's reply, clear the stale marker via `clearStreamingSession`. No extra network request — reuses data already fetched for this call.
- `frontend/src/pages/__tests__/AgentBackgroundStreamCompletion.test.tsx`: new regression test covering both the fix (stale marker clears once the reply is committed) and the negative case (marker is left alone when the background session genuinely has no reply yet, i.e. still running).

## Test Plan

- [x] New test added: `npx vitest run src/pages/__tests__/AgentBackgroundStreamCompletion.test.tsx` — 2/2 passing.
- [x] Full frontend suite: `npx vitest run --pool=threads` — 596/598 passing; the 2 failures (`options.test.ts` `ivLabel` decimal-separator formatting, `tearsheet.test.ts` UTC-5 timezone-offset assumption) are pre-existing and locale/timezone-environment-dependent, unrelated to this change (reproduce identically on `main` without this diff).
- [x] `npx tsc -b` — clean.
- [ ] Not tested against a live browser session manually; verified via the unit test's simulated navigation instead.

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`)
- [x] No hardcoded values
- [x] Follows CONTRIBUTING.md (DCO sign-off on the commit)
- [x] No user-facing docs needed — pure bugfix, no new config/flags/behavior to document