### PR TITLE
fix(frontend): point non-backtest runs to Studio instead of a blank dashboard

### DIFF
--- a/frontend/src/components/charts/StrategyResearchDashboard.tsx
+++ b/frontend/src/components/charts/StrategyResearchDashboard.tsx
@@ -133,7 +133,9 @@ export function StrategyResearchDashboard({ run }: { run: RunData }) {
       drawdown: String(row.drawdown ?? ""),
     }));
   }, [run.artifacts_equity_csv, run.equity_curve]);
-  const trades = run.artifacts_trades_csv || run.trade_log || [];
+  const trades = run.artifacts_trades_csv?.length
+    ? run.artifacts_trades_csv
+    : run.trade_log || [];
   const identity = useMemo(() => getStrategyReportIdentity(run), [run]);
 
   useEffect(() => {

--- a/frontend/src/components/charts/StrategyResearchDashboard.tsx
+++ b/frontend/src/components/charts/StrategyResearchDashboard.tsx
@@ -207,6 +207,21 @@ export function StrategyResearchDashboard({ run }: { run: RunData }) {
     };
   }, [dark, equityRows, trades]);
 
+  // This dashboard is built around a classic equity-curve backtest. A
+  // portfolio-construction / risk-snapshot run (risk_xray, rebalance_notes)
+  // has neither, so every KPI and chart here would silently render as
+  // dashes/blank -- which reads as "broken", not "different run type". Point
+  // to the Studio tab instead, which actually renders that run's data.
+  if (equityRows.length === 0 && trades.length === 0 && (run.risk_xray || run.rebalance_notes)) {
+    return (
+      <div className="mx-auto max-w-[640px] rounded-xl border border-[#dfe2e7] bg-card p-8 text-center shadow-sm">
+        <FlaskConical className="mx-auto h-8 w-8 text-muted-foreground" aria-hidden="true" />
+        <p className="mt-3 text-sm font-medium text-foreground">{t("runDashboard.noBacktestData")}</p>
+        <p className="mt-1 text-sm text-muted-foreground">{t("runDashboard.noBacktestDataStudioHint")}</p>
+      </div>
+    );
+  }
+
   const metrics: Record<string, number> = run.metrics || {};
   const kpis = [
     [t("runDashboard.kpiTotalReturn"), pct(metrics.total_return), BLUE],

--- a/frontend/src/components/charts/__tests__/StrategyResearchDashboard.test.tsx
+++ b/frontend/src/components/charts/__tests__/StrategyResearchDashboard.test.tsx
@@ -68,4 +68,23 @@ describe("StrategyResearchDashboard empty state", () => {
     expect(screen.queryByText("This run has no backtest data to chart")).not.toBeInTheDocument();
     expect(screen.getByText("Sharpe")).toBeInTheDocument();
   });
+
+  it("falls back to trade_log when the artifact trade array is empty", () => {
+    render(<StrategyResearchDashboard run={makeRun({
+      risk_xray: { concentration: { hhi: 0.018 } },
+      artifacts_trades_csv: [],
+      trade_log: [{
+        timestamp: "2026-01-02",
+        code: "AAPL",
+        side: "sell",
+        price: "101",
+        qty: "1",
+        pnl: "1",
+        reason: "exit signal",
+      }],
+    })} />);
+
+    expect(screen.queryByText("This run has no backtest data to chart")).not.toBeInTheDocument();
+    expect(screen.getByText("exit signal")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/charts/__tests__/StrategyResearchDashboard.test.tsx
+++ b/frontend/src/components/charts/__tests__/StrategyResearchDashboard.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import type { RunData } from "@/lib/api";
+import { StrategyResearchDashboard } from "../StrategyResearchDashboard";
+import { echarts } from "@/lib/echarts";
+
+// Regression test for: a portfolio-construction / risk-snapshot run (only
+// risk_xray / rebalance_notes, no equity curve or trades) rendered the full
+// backtest dashboard shell with every KPI and chart silently blank/dashed --
+// indistinguishable from a broken page. It should instead point to the
+// Studio tab, which is where that run's actual numbers render.
+
+vi.mock("@/lib/echarts", () => ({
+  echarts: { init: vi.fn() },
+}));
+
+function makeRun(overrides: Partial<RunData> = {}): RunData {
+  return {
+    status: "success",
+    run_id: "run-riskxray",
+    ...overrides,
+  };
+}
+
+describe("StrategyResearchDashboard empty state", () => {
+  beforeEach(() => {
+    vi.mocked(echarts.init).mockImplementation((() => ({
+      setOption: vi.fn(),
+      resize: vi.fn(),
+      dispose: vi.fn(),
+      group: "",
+    })) as unknown as typeof echarts.init);
+  });
+
+  it("points to Studio instead of a blank KPI shell for a risk_xray-only run", () => {
+    render(<StrategyResearchDashboard run={makeRun({ risk_xray: { concentration: { hhi: 0.018 } } })} />);
+
+    expect(screen.getByText("This run has no backtest data to chart")).toBeInTheDocument();
+    expect(screen.getByText(/Studio tab/)).toBeInTheDocument();
+    expect(screen.queryByText("Sharpe")).not.toBeInTheDocument();
+  });
+
+  it("also applies for a rebalance_notes-only run", () => {
+    render(<StrategyResearchDashboard run={makeRun({
+      rebalance_notes: { summary: { rebalance_count: 3, turnover_total: 0.3, turnover_mean: 0.1, turnover_max: 0.15 } },
+    })} />);
+
+    expect(screen.getByText("This run has no backtest data to chart")).toBeInTheDocument();
+  });
+
+  it("renders the normal dashboard when equity/trade data is present, even alongside risk_xray", () => {
+    render(<StrategyResearchDashboard run={makeRun({
+      risk_xray: { concentration: { hhi: 0.018 } },
+      equity_curve: [
+        { time: "2026-01-01", equity: 100, drawdown: 0 },
+        { time: "2026-01-02", equity: 101, drawdown: 0 },
+      ],
+      metrics: {
+        final_value: 1_010_000,
+        total_return: 0.01,
+        annual_return: 0.01,
+        max_drawdown: -0.01,
+        sharpe: 1.2,
+        win_rate: 0.5,
+        trade_count: 2,
+      },
+    })} />);
+
+    expect(screen.queryByText("This run has no backtest data to chart")).not.toBeInTheDocument();
+    expect(screen.getByText("Sharpe")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -1399,6 +1399,8 @@
   },
   "runDashboard": {
     "eyebrow": "بحث كمّي · اختبار رجعي",
+    "noBacktestData": "لا توجد بيانات اختبار رجعي لعرضها في هذا التشغيل",
+    "noBacktestDataStudioHint": "يبدو أنه تحليل محفظة/مخاطر بدلاً من ذلك — راجع أرقامه في تبويب Studio.",
     "engine": "محرك",
     "portfolio": "محفظة",
     "systematicStrategy": "استراتيجية منهجية",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1399,6 +1399,8 @@
   },
   "runDashboard": {
     "eyebrow": "Quantitative Forschung · Backtest",
+    "noBacktestData": "Für diesen Run gibt es keine Backtest-Daten zum Anzeigen",
+    "noBacktestDataStudioHint": "Das sieht eher nach einer Portfolio-/Risikoanalyse aus — die Zahlen dazu finden Sie im Studio-Tab.",
     "engine": "Engine",
     "portfolio": "Portfolio",
     "systematicStrategy": "Systematische Strategie",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1399,6 +1399,8 @@
   },
   "runDashboard": {
     "eyebrow": "Quantitative research · Backtest",
+    "noBacktestData": "This run has no backtest data to chart",
+    "noBacktestDataStudioHint": "It looks like a portfolio/risk analysis instead — check the Studio tab for its numbers.",
     "engine": "engine",
     "portfolio": "Portfolio",
     "systematicStrategy": "Systematic strategy",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1399,6 +1399,8 @@
   },
   "runDashboard": {
     "eyebrow": "Investigación cuantitativa · Backtest",
+    "noBacktestData": "Este run no tiene datos de backtest que graficar",
+    "noBacktestDataStudioHint": "Parece un análisis de cartera/riesgo — consulta sus números en la pestaña Studio.",
     "engine": "motor",
     "portfolio": "Cartera",
     "systematicStrategy": "Estrategia sistemática",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1399,6 +1399,8 @@
   },
   "runDashboard": {
     "eyebrow": "定量リサーチ · バックテスト",
+    "noBacktestData": "このRunにはグラフ化できるバックテストデータがありません",
+    "noBacktestDataStudioHint": "ポートフォリオ/リスク分析のようです — 数値はStudioタブで確認してください。",
     "engine": "エンジン",
     "portfolio": "ポートフォリオ",
     "systematicStrategy": "システマティック戦略",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1399,6 +1399,8 @@
   },
   "runDashboard": {
     "eyebrow": "계량 리서치 · 백테스트",
+    "noBacktestData": "이 실행에는 표시할 백테스트 데이터가 없습니다",
+    "noBacktestDataStudioHint": "포트폴리오/리스크 분석으로 보입니다 — 수치는 Studio 탭에서 확인하세요.",
     "engine": "엔진",
     "portfolio": "포트폴리오",
     "systematicStrategy": "시스테매틱 전략",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1399,6 +1399,8 @@
   },
   "runDashboard": {
     "eyebrow": "量化研究 · 策略回测",
+    "noBacktestData": "该次运行没有可供绘图的回测数据",
+    "noBacktestDataStudioHint": "这看起来是一次投资组合/风险分析——请在 Studio 标签页查看具体数值。",
     "engine": "回测引擎",
     "portfolio": "投资组合",
     "systematicStrategy": "系统化交易策略",


### PR DESCRIPTION
## Summary

- The "Dashboard" tab (`StrategyResearchDashboard`) is always shown regardless of run type, and is built entirely around a classic equity-curve backtest (KPIs from `run.metrics`, nav/drawdown/trade charts).
- A portfolio-construction / risk-snapshot run — `risk_xray` + `rebalance_notes`, no equity curve, no trades — has none of that data. Every KPI silently rendered as a dash and every chart stayed empty, with nothing telling you this run is simply a different type. It just looked broken.

## Why

Found while investigating a user report of "the numbers I used to see are gone, just dashes now" on a specific run. The run's backend data (`risk_xray.json`) was verified complete and correct on disk — the issue is purely that the Dashboard tab has no data of the shape it expects for this run type. The correct data was rendering fine all along on the "Studio" tab (`RunDetail.tsx`'s `hasStudio` / `StudioTab`), just not the one the user had open.

## Changes

- `StrategyResearchDashboard.tsx`: early-return an empty-state card (short message + pointer to Studio) when there's no `equity_curve`/`trade_log`/`artifacts_equity_csv`/`artifacts_trades_csv` data but the run does have `risk_xray` or `rebalance_notes`. Runs with real backtest data render exactly as before, unconditionally, regardless of whether `risk_xray` also happens to be present.
- New i18n keys `runDashboard.noBacktestData` / `runDashboard.noBacktestDataStudioHint` across all 7 locales.
- New test file `StrategyResearchDashboard.test.tsx`: covers the `risk_xray`-only case, the `rebalance_notes`-only case, and confirms the normal dashboard still renders when equity/trade data is present alongside `risk_xray`.

## Out of scope

- Not changing which tab is auto-selected on load, or hiding the Dashboard tab itself for these runs — this only fixes what renders inside it. A "default to the right tab per run type" change would be a separate, more invasive UX decision.

## Test Plan

- [x] New test: `npx vitest run src/components/charts/__tests__/StrategyResearchDashboard.test.tsx` — 3/3 passing.
- [x] `npx tsc -b` — clean.
- [x] All 7 locale JSON files validated to still parse.
- [ ] Not tested against a live browser session manually; verified via the unit tests instead.

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`)
- [x] No hardcoded values
- [x] Follows CONTRIBUTING.md (DCO sign-off on the commit)
- [x] No user-facing docs needed — pure bugfix, no new config/flags/behavior to document