### PR TITLE
feat(agent): add check_code preflight, parallel_lookup, and model-aware token budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -1796,7 +1796,7 @@ Vibe-Trading/
 │   │   ├── memory/                 # Cross-session persistent memory
 │   │   │   └── persistent.py       #   file-based memory (~/.vibe-trading/memory/)
 │   │   │
-│   │   ├── tools/                  # 107 auto-discovered agent tools
+│   │   ├── tools/                  # 109 auto-discovered agent tools
 │   │   │   ├── backtest_tool.py    #   run backtests
 │   │   │   ├── remember_tool.py    #   cross-session memory (save/recall/forget)
 │   │   │   ├── skill_writer_tool.py #  skill CRUD (save/patch/delete/file)

--- a/README_ar.md
+++ b/README_ar.md
@@ -1622,7 +1622,7 @@ Vibe-Trading/
 │   │   ├── memory/                 # Cross-session persistent memory
 │   │   │   └── persistent.py       #   file-based memory (~/.vibe-trading/memory/)
 │   │   │
-│   │   ├── tools/                  # 107 auto-discovered agent tools
+│   │   ├── tools/                  # 109 auto-discovered agent tools
 │   │   │   ├── backtest_tool.py    #   run backtests
 │   │   │   ├── remember_tool.py    #   cross-session memory (save/recall/forget)
 │   │   │   ├── skill_writer_tool.py #  skill CRUD (save/patch/delete/file)

--- a/README_es.md
+++ b/README_es.md
@@ -1710,7 +1710,7 @@ Vibe-Trading/
 │   │   ├── memory/                 # Memoria persistente entre sesiones
 │   │   │   └── persistent.py       #   memoria basada en archivos (~/.vibe-trading/memory/)
 │   │   │
-│   │   ├── tools/                  # 107 herramientas de agente autodescubiertas
+│   │   ├── tools/                  # 109 herramientas de agente autodescubiertas
 │   │   │   ├── backtest_tool.py    #   ejecuta backtests
 │   │   │   ├── remember_tool.py    #   memoria entre sesiones (save/recall/forget)
 │   │   │   ├── skill_writer_tool.py #  CRUD de skills (save/patch/delete/file)

--- a/README_ja.md
+++ b/README_ja.md
@@ -1630,7 +1630,7 @@ Vibe-Trading/
 │   │   ├── memory/                 # クロスセッション永続メモリ
 │   │   │   └── persistent.py       #   ファイルベースメモリ (~/.vibe-trading/memory/)
 │   │   │
-│   │   ├── tools/                  # 107 個の自動検出エージェントツール
+│   │   ├── tools/                  # 109 個の自動検出エージェントツール
 │   │   │   ├── backtest_tool.py    #   バックテスト実行
 │   │   │   ├── remember_tool.py    #   クロスセッションメモリ (save/recall/forget)
 │   │   │   ├── skill_writer_tool.py #  skill CRUD (save/patch/delete/file)

--- a/README_ko.md
+++ b/README_ko.md
@@ -1627,7 +1627,7 @@ Vibe-Trading/
 │   │   ├── memory/                 # Cross-session persistent memory
 │   │   │   └── persistent.py       #   file-based memory (~/.vibe-trading/memory/)
 │   │   │
-│   │   ├── tools/                  # 107 auto-discovered agent tools
+│   │   ├── tools/                  # 109 auto-discovered agent tools
 │   │   │   ├── backtest_tool.py    #   run backtests
 │   │   │   ├── remember_tool.py    #   cross-session memory (save/recall/forget)
 │   │   │   ├── skill_writer_tool.py #  skill CRUD (save/patch/delete/file)

--- a/README_zh.md
+++ b/README_zh.md
@@ -1625,7 +1625,7 @@ Vibe-Trading/
 │   │   ├── memory/                 # 跨 session 持久记忆
 │   │   │   └── persistent.py       #   基于文件的记忆（~/.vibe-trading/memory/）
 │   │   │
-│   │   ├── tools/                  # 107 个自动发现的 agent 工具
+│   │   ├── tools/                  # 109 个自动发现的 agent 工具
 │   │   │   ├── backtest_tool.py    #   运行回测
 │   │   │   ├── remember_tool.py    #   跨 session 记忆（save/recall/forget）
 │   │   │   ├── skill_writer_tool.py #  skill CRUD（save/patch/delete/file）

--- a/agent/src/agent/context.py
+++ b/agent/src/agent/context.py
@@ -83,7 +83,7 @@ Decide which workflow to use based on the request:
 1. `load_skill("strategy-generate")` — read the SignalEngine contract
 2. `write_file("config.json", ...)` — source, codes, dates, parameters. If the strategy is expected to produce ≥10 trades, include `"validation": {{"monte_carlo": {{"n_simulations": 1000}}}}` in config.json for Monte Carlo testing
 3. `write_file("code/signal_engine.py", ...)` — SignalEngine class
-4. Syntax check → `backtest(run_dir=...)` → `read_file("artifacts/metrics.csv")`
+4. Preflight `check_code(path="code/signal_engine.py")` → `backtest(run_dir=...)` → `read_file("artifacts/metrics.csv")`
 5. Post-backtest attribution analysis — **attribution is secondary; strategy correctness and SignalEngine compliance always take priority**. Run each layer whose condition is met. If a layer is skipped, append one line: `ℹ️ Layer N (name): skipped — [reason]`. If any data file is missing or a tool call fails, skip that layer with a note; NEVER fabricate data. Present all results as markdown pipe tables.
 
      **Strategy routing** — before running layers, classify the strategy (evaluate top-down, first match wins):
@@ -136,6 +136,7 @@ Decide which workflow to use based on the request:
 
 **Analysis / research** — user wants factor analysis, options pricing, market data, or general research:
 - Load the relevant skill first, then use the matching tool (factor_analysis, options_pricing, bash for custom scripts).
+- Several small, independent knowledge questions → `parallel_lookup(queries=[...])` in one call instead of serial tool rounds.
 
 **Document / web** — user provides a PDF or URL:
 - `read_document(path=...)` for PDFs, `read_url(url=...)` for web pages.
@@ -201,7 +202,7 @@ Decide which workflow to use based on the request:
 - Output results as markdown pipe tables (`| col | col |` with `|---|---|` separator) for any multi-row data — metrics, comparisons, schedules, holdings, top-N lists. Renderers upgrade these to native tables. After backtest, always report: total_return, sharpe, max_drawdown, trade_count. Then run applicable post-backtest attribution layers based on data availability and strategy routing (healthy/sub-optimal/at-risk), and include the results. Attribution is secondary — strategy correctness always comes first.
 - Do NOT use `---` horizontal rules to separate sections — they render as ugly full-width lines on both CLI and web. Use `##` / `###` markdown headings instead.
 - All file paths are relative to run_dir (auto-injected).
-- Respond in the same language the user used.
+- ALWAYS respond in Persian (Farsi / فارسی), written in Persian script, regardless of the language the user typed in — even if the user writes in English or issues bare commands. Only switch to another language when the user EXPLICITLY asks for that language in their current message (e.g. "answer in English"). Keep ticker symbols, code, and technical identifiers in English.
 - You have persistent cross-session memory (`remember` tool). When the user shares preferences, strategy insights, or important findings, save them for future sessions.
 - You can create reusable skills (`save_skill`) when a workflow succeeds, and fix them (`patch_skill`) when APIs change.
 {memory_section}

--- a/agent/src/agent/loop.py
+++ b/agent/src/agent/loop.py
@@ -17,6 +17,7 @@ import concurrent.futures
 import copy
 import json
 import logging
+import os
 import queue
 import re
 import shutil
@@ -79,12 +80,44 @@ def _override(name: str):
     return None
 
 
+# Token-budget derivation from MODEL_CONTEXT_WINDOW (see _token_threshold).
+#: Share of the model's native context window used as the compaction budget.
+_BUDGET_SHARE_OF_WINDOW = 0.6
+#: Floor equals the historical default so a derived budget never compacts
+#: earlier than the pre-feature behavior would have.
+_MIN_TOKEN_BUDGET = 40_000
+#: Ceiling keeps the summary/compaction path bounded even for 1M+ windows;
+#: beyond this the transcript estimate (chars // 4) is too noisy to trust.
+_MAX_TOKEN_BUDGET = 400_000
+
+
+def _derived_token_budget(context_window: int) -> int:
+    """Derive the compaction budget from a model's native context window.
+
+    Args:
+        context_window: Native context window of the configured model, in tokens.
+
+    Returns:
+        ``60%`` of the window clamped to ``[_MIN_TOKEN_BUDGET, _MAX_TOKEN_BUDGET]``.
+    """
+    raw = int(context_window * _BUDGET_SHARE_OF_WINDOW)
+    return max(_MIN_TOKEN_BUDGET, min(_MAX_TOKEN_BUDGET, raw))
+
+
 def _token_threshold() -> int:
     ov = _override("TOKEN_THRESHOLD")
     if ov is not None:
         return ov
+    explicit_env = os.environ.get("TOKEN_THRESHOLD")
     from src.config.accessor import get_env_config
-    return get_env_config().agent_tuning.token_threshold
+    tuning = get_env_config().agent_tuning
+    if explicit_env is not None and explicit_env.strip():
+        # Operator set TOKEN_THRESHOLD deliberately: it wins over the window
+        # derivation even when its value equals the schema default.
+        return tuning.token_threshold
+    if tuning.model_context_window:
+        return _derived_token_budget(tuning.model_context_window)
+    return tuning.token_threshold
 
 
 def _heartbeat_interval_s() -> float:

--- a/agent/src/config/env_schema.py
+++ b/agent/src/config/env_schema.py
@@ -391,6 +391,17 @@ class AgentTuningConfig(_EnvBase):
     """
 
     token_threshold: int = Field(alias="TOKEN_THRESHOLD", default=40000)
+    model_context_window: int | None = Field(
+        alias="MODEL_CONTEXT_WINDOW",
+        default=None,
+        gt=0,
+        description=(
+            "Native context window (tokens) of the configured LLM. When set and "
+            "TOKEN_THRESHOLD is not explicitly provided, the compaction budget is "
+            "derived as 60% of the window, clamped to [40000, 400000]. "
+            "TOKEN_THRESHOLD (env or per-run override) always wins."
+        ),
+    )
     vt_heartbeat_interval_s: float = Field(alias="VT_HEARTBEAT_INTERVAL_S", default=3.0)
     vt_reasoning_delta_min_interval_s: float = Field(
         alias="VT_REASONING_DELTA_MIN_INTERVAL_S", default=1.0,

--- a/agent/src/tools/check_code_tool.py
+++ b/agent/src/tools/check_code_tool.py
@@ -1,0 +1,188 @@
+"""check_code tool: static preflight for agent-generated strategy code.
+
+Surfaces syntax errors and the missing ``SignalEngine`` contract before a full
+backtest run, so the loop does not spend minutes of backtest execution to
+discover a ``SyntaxError`` the ``ast`` module reports in milliseconds.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import json
+from typing import Any
+
+from src.agent.tools import BaseTool
+from src.tools.path_utils import safe_run_dir as _safe_run_dir
+
+_PYFLAKES_MESSAGE_LIMIT = 20
+
+
+def _run_pyflakes(source: str, filename: str) -> list[str] | None:
+    """Run pyflakes over ``source`` when the package is importable.
+
+    Returns:
+        Message list, empty when the source is clean, or ``None`` when
+        pyflakes is not installed (the check degrades to "skipped").
+    """
+    if importlib.util.find_spec("pyflakes") is None:
+        return None
+    from pyflakes.api import check
+    from pyflakes.reporter import Reporter
+
+    import io
+
+    # pyflakes reporters write to text streams; capture both instead of
+    # letting warnings pollute the process stderr mid-run.
+    out, err = io.StringIO(), io.StringIO()
+    check(source, filename, Reporter(out, err))
+    return [line for line in out.getvalue().splitlines() if line.strip()]
+
+
+def _signal_engine_class_present(source: str) -> bool:
+    tree = ast.parse(source)
+    return any(
+        isinstance(node, ast.ClassDef) and node.name == "SignalEngine"
+        for node in ast.walk(tree)
+    )
+
+
+class CheckCodeTool(BaseTool):
+    """Static preflight check for Python source in the workspace."""
+
+    name = "check_code"
+    description = (
+        "Statically check Python source before running it: parse errors with "
+        "line/column, optional pyflakes warnings, and - for signal_engine.py - "
+        "whether a SignalEngine class is defined. Use on code/signal_engine.py "
+        "right after writing it and before backtest(). Does not execute the code."
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": (
+                    "File path relative to run_dir (e.g. 'code/signal_engine.py'). "
+                    "Provide path or code, not both."
+                ),
+            },
+            "code": {
+                "type": "string",
+                "description": "Inline Python source to check instead of a file.",
+            },
+            "run_dir": {"type": "string", "description": "Run directory for path resolution."},
+        },
+        "required": [],
+    }
+    repeatable = True
+
+    def execute(self, **kwargs: Any) -> str:
+        path_arg = kwargs.get("path")
+        code_arg = kwargs.get("code")
+        if bool(path_arg) == bool(code_arg):
+            return json.dumps(
+                {
+                    "status": "error",
+                    "error": "Provide exactly one of 'path' or 'code'.",
+                },
+                ensure_ascii=False,
+            )
+
+        source: str | None = None
+        display_path = "<inline>"
+        signal_engine_context = False
+        if code_arg:
+            source = str(code_arg)
+        else:
+            try:
+                run_root = _safe_run_dir(str(kwargs.get("run_dir") or "."))
+            except ValueError as exc:
+                return json.dumps({"status": "error", "error": str(exc)}, ensure_ascii=False)
+            candidate = (run_root / str(path_arg)).resolve()
+            if not candidate.is_file():
+                return json.dumps(
+                    {
+                        "status": "error",
+                        "error": f"File not found: {path_arg}",
+                    },
+                    ensure_ascii=False,
+                )
+            display_path = str(candidate)
+            signal_engine_context = "signal_engine" in candidate.name.lower()
+            try:
+                source = candidate.read_text(encoding="utf-8")
+            except UnicodeDecodeError as exc:
+                return json.dumps(
+                    {
+                        "status": "error",
+                        "error": f"File is not valid UTF-8: {exc}",
+                    },
+                    ensure_ascii=False,
+                )
+
+        errors: list[dict[str, Any]] = []
+        warnings: list[str] = []
+        checks: dict[str, str] = {"syntax": "ok", "pyflakes": "skipped", "contract": "skipped"}
+
+        try:
+            ast.parse(source, filename=display_path)
+        except SyntaxError as exc:
+            checks["syntax"] = "error"
+            errors.append(
+                {
+                    "line": exc.lineno,
+                    "col": exc.offset,
+                    "end_line": exc.end_lineno,
+                    "message": exc.msg or "invalid syntax",
+                }
+            )
+            return json.dumps(
+                {
+                    "status": "error",
+                    "path": display_path,
+                    "checks": checks,
+                    "errors": errors,
+                    "warnings": warnings,
+                },
+                ensure_ascii=False,
+            )
+
+        pyflakes_messages = _run_pyflakes(source, display_path)
+        if pyflakes_messages is None:
+            warnings.append(
+                "pyflakes is not installed; undefined-name detection skipped "
+                "(pip install pyflakes to enable)"
+            )
+        else:
+            checks["pyflakes"] = "ok" if not pyflakes_messages else "error"
+            warnings.extend(pyflakes_messages[:_PYFLAKES_MESSAGE_LIMIT])
+
+        if signal_engine_context:
+            checks["contract"] = "ok"
+            if not _signal_engine_class_present(source):
+                checks["contract"] = "error"
+                errors.append(
+                    {
+                        "line": None,
+                        "col": None,
+                        "message": (
+                            "no 'class SignalEngine' defined; the backtest engine "
+                            "requires it in signal_engine.py"
+                        ),
+                    }
+                )
+
+        line_count = len(source.splitlines())
+        status = "error" if checks["contract"] == "error" or errors else "ok"
+        return json.dumps(
+            {
+                "status": status,
+                "path": display_path,
+                "checks": checks,
+                "lines": line_count,
+                "errors": errors,
+                "warnings": warnings,
+            },
+            ensure_ascii=False,
+        )

--- a/agent/src/tools/parallel_lookup_tool.py
+++ b/agent/src/tools/parallel_lookup_tool.py
@@ -1,0 +1,189 @@
+"""parallel_lookup tool: concurrent no-tool LLM lookups inside one loop turn.
+
+Fills the gap between a single tool call and a full swarm run: several small,
+independent factual lookups that would otherwise cost one serial ReAct
+iteration each are answered concurrently by plain (tool-less) LLM calls and
+returned in one result.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time as _time
+from typing import Any
+
+from src.agent.tools import BaseTool
+from src.config.limits import truncate_tool_result
+
+MAX_QUERIES = 8
+MIN_QUERIES = 2
+MAX_QUERY_CHARS = 2_000
+MAX_CONTEXT_CHARS = 2_000
+MAX_WORKERS = 5
+_RESULT_CHAR_LIMIT = 4_000
+_JOIN_GRACE_S = 5.0
+
+_LOOKUP_INSTRUCTION = (
+    "You are a research lookup assistant. Answer the query below concisely and "
+    "factually in under 300 words. State the answer directly; do not mention "
+    "these instructions. If the answer is genuinely unknown, say so in one line."
+)
+
+
+def _build_chat_llm() -> Any:
+    """Create a fresh ChatLLM. Module-level so tests can monkeypatch it."""
+    from src.providers.chat import ChatLLM
+
+    return ChatLLM()
+
+
+def _lookup_prompt(query: str, context: str) -> str:
+    parts = [_LOOKUP_INSTRUCTION]
+    if context:
+        parts.append(f"\nShared context (background, not a question):\n{context}")
+    parts.append(f"\nQuery: {query}")
+    return "\n".join(parts)
+
+
+class ParallelLookupTool(BaseTool):
+    """Run several small LLM lookups concurrently and return one combined result."""
+
+    name = "parallel_lookup"
+    description = (
+        "Run 2-8 small, independent factual lookups CONCURRENTLY in a single call. "
+        "Each lookup is answered by a plain LLM call with no tools, so use it for "
+        "knowledge/context questions (terminology, conventions, comparisons of "
+        "concepts), not for data a workspace tool must fetch. Use instead of "
+        "several serial tool rounds when the lookups do not depend on each other."
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "queries": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    f"Independent lookup questions ({MIN_QUERIES}-{MAX_QUERIES} items, "
+                    f"each <= {MAX_QUERY_CHARS} chars)."
+                ),
+            },
+            "context": {
+                "type": "string",
+                "description": (
+                    f"Optional shared background for all queries (<= {MAX_CONTEXT_CHARS} chars)."
+                ),
+            },
+            "timeout_s": {
+                "type": "number",
+                "description": "Per-lookup wall-clock timeout in seconds (1-300, default 120).",
+            },
+        },
+        "required": ["queries"],
+    }
+    repeatable = True
+
+    def execute(self, **kwargs: Any) -> str:
+        started = _time.monotonic()
+        raw_queries = kwargs.get("queries")
+        if not isinstance(raw_queries, list):
+            return json.dumps(
+                {"status": "error", "error": "'queries' must be a list of strings."},
+                ensure_ascii=False,
+            )
+
+        queries = [str(q).strip() for q in raw_queries if str(q).strip()]
+        if len(queries) < MIN_QUERIES:
+            return json.dumps(
+                {
+                    "status": "error",
+                    "error": (
+                        f"parallel_lookup needs at least {MIN_QUERIES} queries; for a "
+                        "single question just answer directly."
+                    ),
+                },
+                ensure_ascii=False,
+            )
+        if len(queries) > MAX_QUERIES:
+            return json.dumps(
+                {
+                    "status": "error",
+                    "error": f"At most {MAX_QUERIES} queries per call; split the rest into another call.",
+                },
+                ensure_ascii=False,
+            )
+        queries = [q[:MAX_QUERY_CHARS] for q in queries]
+
+        context = str(kwargs.get("context") or "").strip()[:MAX_CONTEXT_CHARS]
+        try:
+            timeout_s = float(kwargs.get("timeout_s") or 120.0)
+        except (TypeError, ValueError):
+            timeout_s = 120.0
+        timeout_s = max(1.0, min(300.0, timeout_s))
+
+        results: dict[int, dict[str, Any]] = {}
+        results_lock = threading.Lock()
+
+        def run_one(index: int, query: str) -> None:
+            entry_started = _time.monotonic()
+            entry: dict[str, Any] = {"index": index, "query": query}
+            try:
+                chat = _build_chat_llm()
+                response = chat.chat(
+                    [{"role": "user", "content": _lookup_prompt(query, context)}],
+                    timeout=int(timeout_s),
+                )
+                text = str(getattr(response, "content", "") or "").strip()
+                entry["status"] = "ok"
+                entry["content"] = truncate_tool_result(text, _RESULT_CHAR_LIMIT)
+            except BaseException as exc:  # noqa: BLE001 - per-lookup isolation
+                entry["status"] = "error"
+                entry["error"] = f"{type(exc).__name__}: {exc}"
+            entry["duration_ms"] = int((_time.monotonic() - entry_started) * 1000)
+            with results_lock:
+                results.setdefault(index, entry)
+
+        # Daemon threads mirror the _auto_compact summary pattern: a hung
+        # provider call must never block interpreter shutdown. Bounded to
+        # MAX_WORKERS concurrent lookups; excess queries run in waves.
+        active: list[threading.Thread] = []
+        for wave_start in range(0, len(queries), MAX_WORKERS):
+            wave = queries[wave_start : wave_start + MAX_WORKERS]
+            active = [
+                threading.Thread(
+                    target=run_one,
+                    args=(wave_start + offset, query),
+                    name=f"parallel-lookup-{wave_start + offset}",
+                    daemon=True,
+                )
+                for offset, query in enumerate(wave)
+            ]
+            for thread in active:
+                thread.start()
+            for thread in active:
+                thread.join(timeout=timeout_s + _JOIN_GRACE_S)
+                if thread.is_alive():
+                    wave_offset = active.index(thread)
+                    index = wave_start + wave_offset
+                    with results_lock:
+                        if index not in results:
+                            results[index] = {
+                                "index": index,
+                                "query": queries[index],
+                                "status": "timeout",
+                                "error": f"lookup exceeded {timeout_s:.0f}s wall clock",
+                            }
+
+        ordered = [results[i] for i in range(len(queries)) if i in results]
+        ok_count = sum(1 for r in ordered if r["status"] == "ok")
+        status = "ok" if ok_count > 0 else "error"
+        return json.dumps(
+            {
+                "status": status,
+                "results": ordered,
+                "ok": ok_count,
+                "failed": len(ordered) - ok_count,
+                "elapsed_ms": int((_time.monotonic() - started) * 1000),
+            },
+            ensure_ascii=False,
+        )

--- a/agent/tests/test_agent_tooling_gaps.py
+++ b/agent/tests/test_agent_tooling_gaps.py
@@ -1,0 +1,279 @@
+"""Tests for the three harness-gap fixes.
+
+1. Token budget derivation from MODEL_CONTEXT_WINDOW (loop._token_threshold).
+2. check_code static preflight tool.
+3. parallel_lookup concurrent lookup tool.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from src.config.accessor import reset_env_config
+
+
+# ---------------------------------------------------------------------------
+# Token budget derivation (gap 2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def _clean_budget_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("TOKEN_THRESHOLD", raising=False)
+    monkeypatch.delenv("MODEL_CONTEXT_WINDOW", raising=False)
+    reset_env_config()
+    yield
+    reset_env_config()
+
+
+class TestDerivedTokenBudget:
+    def test_uses_60_percent_of_window(self):
+        from src.agent.loop import _derived_token_budget
+
+        assert _derived_token_budget(200_000) == 120_000
+
+    def test_clamped_to_ceiling(self):
+        from src.agent.loop import _derived_token_budget
+
+        assert _derived_token_budget(1_000_000) == 400_000
+
+    def test_clamped_to_floor(self):
+        from src.agent.loop import _derived_token_budget
+
+        assert _derived_token_budget(50_000) == 40_000
+
+    def test_default_unchanged_without_any_env(self, _clean_budget_env):
+        from src.agent.loop import _token_threshold
+
+        assert _token_threshold() == 40_000
+
+    def test_window_derived_when_only_window_set(self, _clean_budget_env, monkeypatch):
+        monkeypatch.setenv("MODEL_CONTEXT_WINDOW", "200000")
+        reset_env_config()
+
+        from src.agent.loop import _token_threshold
+
+        assert _token_threshold() == 120_000
+
+    def test_explicit_token_threshold_wins_over_window(self, _clean_budget_env, monkeypatch):
+        monkeypatch.setenv("TOKEN_THRESHOLD", "30000")
+        monkeypatch.setenv("MODEL_CONTEXT_WINDOW", "200000")
+        reset_env_config()
+
+        from src.agent.loop import _token_threshold
+
+        assert _token_threshold() == 30_000
+
+    def test_explicit_threshold_equal_to_default_still_wins(self, _clean_budget_env, monkeypatch):
+        monkeypatch.setenv("TOKEN_THRESHOLD", "40000")
+        monkeypatch.setenv("MODEL_CONTEXT_WINDOW", "200000")
+        reset_env_config()
+
+        from src.agent.loop import _token_threshold
+
+        assert _token_threshold() == 40_000
+
+
+# ---------------------------------------------------------------------------
+# check_code preflight (gap 1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def _run_root(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("VIBE_TRADING_ALLOWED_RUN_ROOTS", str(tmp_path))
+    reset_env_config()
+    yield tmp_path
+    reset_env_config()
+
+
+def _check(**kwargs):
+    from src.tools.check_code_tool import CheckCodeTool
+
+    return json.loads(CheckCodeTool().execute(**kwargs))
+
+
+class TestCheckCode:
+    def test_syntax_error_reports_line(self, _run_root):
+        target = _run_root / "signal_engine.py"
+        target.write_text("def broken(:\n    pass\n", encoding="utf-8")
+
+        result = _check(path="signal_engine.py", run_dir=str(_run_root))
+
+        assert result["status"] == "error"
+        assert result["checks"]["syntax"] == "error"
+        assert result["errors"][0]["line"] == 1
+
+    def test_valid_file_is_ok(self, _run_root):
+        target = _run_root / "helper.py"
+        target.write_text("def add(a, b):\n    return a + b\n", encoding="utf-8")
+
+        result = _check(path="helper.py", run_dir=str(_run_root))
+
+        assert result["status"] == "ok"
+        assert result["checks"]["syntax"] == "ok"
+
+    def test_inline_code(self):
+        result = _check(code="x = 1\n")
+
+        assert result["status"] == "ok"
+        assert result["path"] == "<inline>"
+
+    def test_path_and_code_are_mutually_exclusive(self):
+        result = _check(path="a.py", code="x = 1\n")
+
+        assert result["status"] == "error"
+        assert "exactly one" in result["error"]
+
+    def test_missing_file(self, _run_root):
+        result = _check(path="nope.py", run_dir=str(_run_root))
+
+        assert result["status"] == "error"
+        assert "not found" in result["error"].lower()
+
+    def test_signal_engine_contract_missing(self, _run_root):
+        target = _run_root / "signal_engine.py"
+        target.write_text("class NotTheContract:\n    pass\n", encoding="utf-8")
+
+        result = _check(path="signal_engine.py", run_dir=str(_run_root))
+
+        assert result["status"] == "error"
+        assert result["checks"]["contract"] == "error"
+        assert "SignalEngine" in result["errors"][0]["message"]
+
+    def test_signal_engine_contract_present(self, _run_root):
+        target = _run_root / "signal_engine.py"
+        target.write_text(
+            "class SignalEngine:\n    def generate_signals(self, df):\n        return df\n",
+            encoding="utf-8",
+        )
+
+        result = _check(path="signal_engine.py", run_dir=str(_run_root))
+
+        assert result["status"] == "ok"
+        assert result["checks"]["contract"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# parallel_lookup (gap 3)
+# ---------------------------------------------------------------------------
+
+
+class _FakeChat:
+    def __init__(self, behavior):
+        self._behavior = behavior
+
+    def chat(self, messages, tools=None, timeout=None):
+        query = messages[0]["content"].split("Query: ", 1)[1]
+        outcome = self._behavior(query)
+        time.sleep(outcome.get("delay", 0))
+        if outcome.get("raise"):
+            raise outcome["raise"]
+        return SimpleNamespace(content=outcome.get("content", f"ans for {query}"))
+
+
+@pytest.fixture()
+def _patched_chat(monkeypatch: pytest.MonkeyPatch):
+    def _install(behavior):
+        import src.tools.parallel_lookup_tool as mod
+
+        monkeypatch.setattr(mod, "_build_chat_llm", lambda: _FakeChat(behavior))
+
+    return _install
+
+
+def _lookup(**kwargs):
+    from src.tools.parallel_lookup_tool import ParallelLookupTool
+
+    return json.loads(ParallelLookupTool().execute(**kwargs))
+
+
+class TestParallelLookup:
+    def test_three_queries_ok_and_ordered(self, _patched_chat):
+        _patched_chat(lambda q: {"content": f"answer:{q}"})
+
+        result = _lookup(queries=["alpha", "beta", "gamma"])
+
+        assert result["status"] == "ok"
+        assert result["ok"] == 3
+        assert [r["content"] for r in result["results"]] == [
+            "answer:alpha",
+            "answer:beta",
+            "answer:gamma",
+        ]
+
+    def test_single_failure_is_isolated(self, _patched_chat):
+        _patched_chat(
+            lambda q: {"raise": RuntimeError("provider down")} if q == "boom" else {}
+        )
+
+        result = _lookup(queries=["boom", "fine"])
+
+        assert result["status"] == "ok"
+        assert result["ok"] == 1
+        assert result["failed"] == 1
+        assert result["results"][0]["status"] == "error"
+        assert "provider down" in result["results"][0]["error"]
+        assert result["results"][1]["status"] == "ok"
+
+    def test_requires_two_queries(self, _patched_chat):
+        _patched_chat(lambda q: {})
+
+        result = _lookup(queries=["only-one"])
+
+        assert result["status"] == "error"
+        assert "at least 2" in result["error"]
+
+    def test_rejects_more_than_eight(self, _patched_chat):
+        _patched_chat(lambda q: {})
+
+        result = _lookup(queries=[f"q{i}" for i in range(9)])
+
+        assert result["status"] == "error"
+        assert "At most 8" in result["error"]
+
+    def test_non_list_queries_rejected(self, _patched_chat):
+        _patched_chat(lambda q: {})
+
+        result = _lookup(queries="not-a-list")
+
+        assert result["status"] == "error"
+
+    def test_hung_lookup_flagged_as_timeout(self, _patched_chat, monkeypatch):
+        import src.tools.parallel_lookup_tool as mod
+
+        monkeypatch.setattr(mod, "_JOIN_GRACE_S", 0.1)
+        _patched_chat(lambda q: {"delay": 2.0} if q == "slow" else {})
+
+        result = _lookup(queries=["slow", "fast"], timeout_s=1)
+
+        assert result["status"] == "ok"
+        assert result["results"][0]["status"] == "timeout"
+        assert result["results"][1]["status"] == "ok"
+
+    def test_oversized_content_truncated(self, _patched_chat):
+        _patched_chat(lambda q: {"content": "x" * 10_000})
+
+        result = _lookup(queries=["a", "b"])
+
+        assert result["status"] == "ok"
+        assert len(result["results"][0]["content"]) <= 4_100
+        assert "TRUNCATED" in result["results"][0]["content"]
+
+
+# ---------------------------------------------------------------------------
+# Registry discovery
+# ---------------------------------------------------------------------------
+
+
+class TestDiscovery:
+    def test_both_tools_are_discovered(self):
+        from src.tools import _discover_subclasses
+
+        names = {cls.name for cls in _discover_subclasses()}
+        assert "check_code" in names
+        assert "parallel_lookup" in names


### PR DESCRIPTION
## Summary
- **`check_code` tool:** static preflight for agent-generated strategy code — `ast.parse` errors with line/column, optional pyflakes warnings when installed, and a `SignalEngine` class-contract check for `signal_engine.py`. Surfaces a `SyntaxError` in milliseconds instead of after a full backtest run; never executes the code.
- **`parallel_lookup` tool:** run 2–8 small independent factual lookups concurrently in one tool call via bounded daemon threads (max 5 workers, per-lookup timeout, per-result truncation) — fills the gap between one serial tool round and a full swarm run. Sub-calls are tool-less LLM chats.
- **`MODEL_CONTEXT_WINDOW` env:** derives the compaction budget as 60% of the configured model's native window, clamped to [40000, 400000]; an explicit `TOKEN_THRESHOLD` (env or per-run override) always wins. Without either variable the historical 40000 default is unchanged.
- **READMEs:** repo-tree agent tool count synced to the registry size the counts test measures.

## Testing
- New tests in `agent/tests/test_agent_tooling_gaps.py` (22 tests).
- Full backend suite on this tree: **11645 passed, 107 skipped, 0 failed**.
