### PR TITLE
fix(grounding): resolve bare joined crypto pairs in canonical recognition

### DIFF
--- a/agent/src/agent/grounding.py
+++ b/agent/src/agent/grounding.py
@@ -156,11 +156,33 @@ _GENERIC_PRICE_FIELD_ALIASES = {
 # Project-style canonical symbols. A bare model-generated ticker is still
 # checked when it appears under a symbol argument key, but it is not accepted
 # as user-provided identity because it lacks venue information.
+#
+# A joined crypto pair (``BTCUSDT``, ``ETHUSDT`` …) is recognized alongside
+# the dashed/slashed form so a user message like ``Get BTCUSDT spot price``
+# seeds an asserted identity and the asserted-symbol conflict check at
+# ``_ingest_resolution`` runs against it. The base is restricted to alpha
+# so a numeric prefix cannot masquerade as a joined pair, and the suffix
+# list is the unambiguous stablecoin set (``USDT`` / ``USDC`` / ``BUSD`` /
+# ``TUSD``) — ``USD`` is excluded because too many non-crypto strings end
+# in those three letters and over-matching would lock the wrong identity.
+_JOINED_CRYPTO_QUOTE_SUFFIXES = ("USDT", "USDC", "BUSD", "TUSD")
+# Spot precious metals quoted in USD collide with the TUSD suffix: XPTUSD is
+# XPT + USD (platinum), but stripping "TUSD" leaves the alpha base "XP" and
+# folds it to XP-TUSD — a crypto pair that does not exist, and the same class
+# of misresolution the USD exclusion above exists to prevent. XAU/XAG/XPD do
+# not collide today; they are listed together because they are the same kind
+# of symbol and a future suffix would collide with them the same way.
+_METAL_USD_PAIR_RE = re.compile(r"^(?:XAU|XAG|XPT|XPD)USD$", re.IGNORECASE)
+_JOINED_CRYPTO_RE = re.compile(
+    r"(?<![A-Za-z0-9_])[A-Z]{2,15}(?:" + "|".join(_JOINED_CRYPTO_QUOTE_SUFFIXES) + r")(?![A-Za-z0-9_])",
+    re.IGNORECASE,
+)
 _CANONICAL_SYMBOL_RE = re.compile(
     r"(?<![A-Za-z0-9_])(?:"
     r"\d{3,6}\.(?:SH|SZ|BJ|SS|HK|KS|KQ)|"
     r"[A-Z][A-Z0-9&.-]{0,19}\.(?:US|NS|BO|FX|TO|V)|"
     r"[A-Z0-9]{2,15}(?:-|/)(?:USDT|USDC|USD|BTC|ETH)|"
+    r"[A-Z]{2,15}(?:" + "|".join(_JOINED_CRYPTO_QUOTE_SUFFIXES) + r")|"
     r"\^[A-Z0-9&.\-]{1,20}|"
     r"[A-Z0-9]{2,15}=[FX]"
     r")(?![A-Za-z0-9_])",
@@ -571,8 +593,10 @@ def _normalize_symbol(value: Any) -> str:
     Returns:
         The canonical spelling — uppercased, with Shanghai's ``.SS`` alias
         folded onto ``.SH``, an exchange prefix rewritten as a suffix, a Hong
-        Kong code zero-padded, and a crypto pair hyphenated. Text that is not a
-        symbol is returned uppercased and otherwise untouched.
+        Kong code zero-padded, and a crypto pair hyphenated. A joined crypto
+        pair with no separator (``BTCUSDT``) is rewritten as the dashed form
+        (``BTC-USDT``) so every downstream check sees one identity. Text that
+        is not a symbol is returned uppercased and otherwise untouched.
     """
     # A fiat/fiat pair is one FX instrument regardless of spelling: ``GBP/USD``
     # and ``GBPUSD`` are both ``GBPUSD=X``. Checked BEFORE the slash is
@@ -592,6 +616,17 @@ def _normalize_symbol(value: Any) -> str:
         return f"{prefixed.group(2)}.{prefixed.group(1)}"
     base, dot, suffix = symbol.rpartition(".")
     if not dot:
+        # No separator at all: rewrite a joined crypto pair (``BTCUSDT``)
+        # as the dashed form so the dash/slash branch and the canonical
+        # regex both match. The base must be all-alpha so a numeric prefix
+        # cannot collide with another numeric-code branch downstream.
+        joined = _JOINED_CRYPTO_RE.fullmatch(symbol)
+        if joined and not _METAL_USD_PAIR_RE.fullmatch(symbol):
+            for quote in _JOINED_CRYPTO_QUOTE_SUFFIXES:
+                if symbol.endswith(quote) and len(symbol) > len(quote):
+                    base_part = symbol[: -len(quote)]
+                    if base_part.isalpha():
+                        return f"{base_part}-{quote}"
         return symbol
     if suffix == "SS":
         suffix = "SH"

--- a/agent/tests/test_agent_grounding.py
+++ b/agent/tests/test_agent_grounding.py
@@ -14,6 +14,8 @@ from src.agent.grounding import (
     GroundingLedger,
     _infer_currency,
     _infer_venue,
+    _JOINED_CRYPTO_RE,
+    _normalize_symbol,
     _scan_symbols,
     _symbol_from_csv_filename,
     _timestamp_matches_claim_date,
@@ -363,6 +365,13 @@ def test_bare_ticker_stays_blocked_when_it_names_more_than_one_identity(
         ("00700.HK", "700.HK"),
         ("00700.HK", "0700.HK"),
         ("BTC-USDT", "BTC/USDT"),
+        # Joined crypto pairs (no separator) are the same identity as the
+        # dashed/slashed spelling. Without this normalization, a ``BTCUSDT``
+        # argument against a locked ``BTC-USDT`` is rejected as
+        # ``identity_mismatch`` by ``_match_authorized_symbol``.
+        ("BTC-USDT", "BTCUSDT"),
+        ("ETH-USDT", "ETHUSDT"),
+        ("BTC-USDC", "BTCUSDC"),
     ],
 )
 def test_provider_spellings_of_one_instrument_are_one_identity(
@@ -382,6 +391,84 @@ def test_provider_spellings_of_one_instrument_are_one_identity(
 
     assert ledger.authorized_symbols == {locked}
     assert authorization.allowed is True
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # The four unambiguous stablecoin suffixes, with several bases.
+        ("BTCUSDT", "BTC-USDT"),
+        ("ETHUSDT", "ETH-USDT"),
+        ("SOLUSDT", "SOL-USDT"),
+        ("BTCUSDC", "BTC-USDC"),
+        ("BTCBUSD", "BTC-BUSD"),
+        ("ETHTUSD", "ETH-TUSD"),
+        ("btcusdt", "BTC-USDT"),  # case-insensitive
+        # Edge: the suffix alone is too short to split (the base must have
+        # at least one character).
+        ("USDT", "USDT"),
+        ("USDC", "USDC"),
+        # Edge: a numeric prefix is not a crypto base.
+        ("123USDT", "123USDT"),
+        # Negatives: existing shapes must be untouched.
+        ("BTC-USDT", "BTC-USDT"),
+        ("BTC/USD", "BTC-USD"),
+        ("VALOUR-BTC-0-SEK.ST", "VALOUR-BTC-0-SEK.ST"),
+        ("AAPL.US", "AAPL.US"),
+        ("600519.SH", "600519.SH"),
+    ],
+)
+def test_normalize_joined_crypto_pairs(raw: str, expected: str) -> None:
+    """A joined crypto pair (no separator) normalizes to its dashed form."""
+    assert _normalize_symbol(raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("BTCUSDT", {"BTC-USDT"}),
+        ("BTCUSDT spot price", {"BTC-USDT"}),
+        ("ETH/USDT latest price", {"ETH-USDT"}),
+        ("BTC-USDT close", {"BTC-USDT"}),
+        ("BTCUSDT, ETH-USDT, BTC-USD", {"BTC-USDT", "ETH-USDT", "BTC-USD"}),
+    ],
+)
+def test_scan_symbols_detects_joined_pairs(text: str, expected: set[str]) -> None:
+    """A bare joined crypto pair is scanned as the canonical symbol."""
+    assert _scan_symbols(text) == expected
+
+
+# The other arm of the same decision, pinned as two mechanisms because it is
+# two mechanisms. Nothing covered either of them: adding "USD" back to the
+# suffix list passed every other test in this file while folding spot gold to
+# XAU-USD, the exact tokenized-gold misresolution #1282 exists to stop.
+#
+# 1. Bare "USD" is kept out of the suffix list, so an FX or metal pair never
+#    matches the joined-pair regex in the first place.
+@pytest.mark.parametrize("raw", ["XAUUSD", "XAGUSD", "XPDUSD", "EURUSD", "GBPUSD"])
+def test_bare_usd_quote_never_matches_the_joined_pair_regex(raw: str) -> None:
+    assert _JOINED_CRYPTO_RE.fullmatch(raw) is None
+    assert "-USD" not in _normalize_symbol(raw)
+
+
+# 2. XPTUSD is the case the suffix list alone cannot catch: it is XPT + USD
+#    (platinum), but it also ends in "TUSD", so the regex DOES match and the
+#    alpha base "XP" passes the isalpha guard. Without the metal-pair check it
+#    normalizes to XP-TUSD — a crypto pair that does not exist. FX pairs have
+#    canonical_fx_pair as a second line of defence; XAU/XPT are metal codes,
+#    not fiat codes, so they have none.
+def test_metal_usd_pair_is_not_split_on_the_tusd_suffix() -> None:
+    assert _JOINED_CRYPTO_RE.fullmatch("XPTUSD") is not None, (
+        "precondition: the regex does match, which is why the guard is needed"
+    )
+    assert _normalize_symbol("XPTUSD") == "XPTUSD"
+
+
+# ...and the guard must not swallow genuine pairs quoted in TrueUSD.
+def test_genuine_tusd_pairs_still_fold() -> None:
+    assert _normalize_symbol("LINKTUSD") == "LINK-TUSD"
+    assert _normalize_symbol("ADABUSD") == "ADA-BUSD"
+    assert _normalize_symbol("OPUSDT") == "OP-USDT"
 
 
 def test_binance_pair_resolution_authorizes_crypto_consumers(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

The crypto resolver layer was addressed upstream by #1242 (Binance connector routing) and #1242 follow-up (public Binance/OKX venue catalogs) — a query like `search_symbol("BTC-USDT")` now returns the correct spot pair instead of a near-string Yahoo asset.

A remaining gap sits one layer down in the grounding identity machine: `_CANONICAL_SYMBOL_RE` and `_normalize_symbol` in `agent/src/agent/grounding.py` both require a `-` or `/` separator between a crypto pair's base and quote. A joined form like `BTCUSDT` therefore never matches the canonical regex and never normalizes to `BTC-USDT`, so the user-message seed at `_seed_symbols`, the symbol scan at `_scan_symbols`, and the asserted-symbol conflict check at `_ingest_resolution` all silently bypass for that input.

This PR fixes that grounding-layer gap. It does not touch the resolver or the venue catalog logic — those are already handled upstream.

## Problem

User query:
> Get BTCUSDT spot price

Symptom: the grounding ledger never locks `BTC-USDT` from the message, so `authorized_symbols` stays empty until the resolver call returns. A later direct `get_market_data(codes=["BTCUSDT"], source="okx")` is rejected as `identity_mismatch` against a resolver-locked `BTC-USDT` because the canonical-symbol regex never treated `BTCUSDT` and `BTC-USDT` as the same identity.

Root cause:
- `_CANONICAL_SYMBOL_RE` requires `-` or `/` for crypto pairs. `BTCUSDT` (no separator) does not match.
- `_normalize_symbol` does not split a joined form. `BTCUSDT` returns `BTCUSDT` unchanged.
- Consequence: `_scan_symbols("Get BTCUSDT spot price")` returns an empty set, so the asserted-symbol cross-check at `_ingest_resolution` is bypassed, and `_match_authorized_symbol("BTC-USDT", {"BTCUSDT"})` returns `None`.

Affected inputs:
- `BTCUSDT`, `ETHUSDT`, `SOLUSDT`, `BTCUSDC`, `BTCBUSD`, `ETHTUSD`, …
- Casing: `btcusdt` is also normalized.

## Solution

Two narrowly-scoped edits in `agent/src/agent/grounding.py`:

1. Add a joined-pair alternation to `_CANONICAL_SYMBOL_RE` so the regex recognizes `BTCUSDT` as a canonical symbol.
2. Update `_normalize_symbol` to rewrite a joined crypto pair into the dashed form (`BTCUSDT → BTC-USDT`). Existing dashed/slashed behavior is unchanged. The base must be all-alpha so a numeric prefix cannot masquerade as a crypto pair, and the suffix set is the unambiguous stablecoin quotes `("USDT", "USDC", "BUSD", "TUSD")`.

`USD` is intentionally excluded from the joined-pair suffix list because too many non-crypto strings end in those three letters; including `USD` would over-match and lock the wrong identity. The dashed/slashed branch keeps `USD` for cases like `BTC-USD`.

## Scope boundaries

Not changed:
- `agent/src/tools/symbol_search_tool.py`
- `agent/tests/test_symbol_search_tool.py`
- The resolver (Binance connector, public venue catalogs, Yahoo near-string filter)
- The `_ingest_resolution` asserted-symbol logic itself

Reason: those paths are already handled by upstream crypto-resolver work (see #1242 and the follow-up `0ed3770f`). A joined-pair query `search_symbol("BTCUSDT")` already routes to the Binance connector and falls back to public Binance/OKX via `_load_public_markets`. This PR addresses the symmetric gap on the grounding side, not the resolver side.

## Testing

Tests added in `agent/tests/test_agent_grounding.py`:

- `test_normalize_joined_crypto_pairs` — 15 parametrized cases covering each stablecoin suffix with multiple bases, case-insensitivity, the suffix-alone edge (`USDT` unchanged), the numeric-prefix edge (`123USDT` unchanged), and four negative cases (`BTC-USDT`, `BTC/USD`, `VALOUR-BTC-0-SEK.ST`, `AAPL.US`, `600519.SH`).
- `test_scan_symbols_detects_joined_pairs` — 5 parametrized cases pinning `_scan_symbols` against joined, dashed, and slashed inputs.
- 3 new parametrize entries in `test_provider_spellings_of_one_instrument_are_one_identity`: `BTC-USDT` ↔ `BTCUSDT`, `ETH-USDT` ↔ `ETHUSDT`, `BTC-USDC` ↔ `BTCUSDC`.

Full test result:
```
$ pytest agent/tests/test_agent_grounding.py -q
163 passed
```

Related modules (no regression):
```
$ pytest tests/test_agent_grounding.py tests/test_grounding_recovery.py \
           tests/test_symbol_search_tool.py tests/test_agent_output_discipline.py -q
268 passed
```

## Reviewer notes

**Why not modify `symbol_search_tool.py`?**
The resolver path already handles joined-pair queries: `search_symbol("BTCUSDT")` detects the pair via `_canonical_crypto_pair`, routes through the Binance connector if configured, and falls back to public Binance/OKX via `_load_public_markets`. `_canonical_crypto_pair` is private to that module. The two layers (resolver routing and grounding canonicalization) operate on different inputs: the resolver parses a query string at tool-call time, the grounding layer parses user text and provider symbols continuously.

**Why is the joined-pair suffix list limited to `USDT, USDC, BUSD, TUSD`?**
Only unambiguous stablecoin quotes. Including `USD` over-matches because many non-crypto strings end in those three letters. The dashed/slashed branch keeps `USD` (and `BTC` / `ETH`) for cases like `BTC-USD` and `ETH-BTC`. Cross pairs like `BTCETH` are out of scope for the joined form because they are uncommon and ambiguous.

**Could this affect equity symbols?**
No. The joined-pair branch requires (a) an alphabetic base of at least 2 characters, and (b) one of the four stablecoin suffixes. US equities, Hong Kong codes, A-share codes, and ETP listings (e.g. `VALOUR-BTC-0-SEK.ST`) do not match the joined-pair pattern. The 15 negative test cases pin this.

**Is `_JOINED_CRYPTO_QUOTE_SUFFIXES` redundant with `symbol_search_tool._CRYPTO_QUOTE_ASSETS`?**
The two lists serve different purposes. `_CRYPTO_QUOTE_ASSETS` drives resolver routing on the dashed/slashed form (it includes `FDUSD`, `BTC`, `ETH`, `BNB`, `USD`). `_JOINED_CRYPTO_QUOTE_SUFFIXES` is the deliberately narrower set safe for the no-separator form. Lifting them into a shared module is a separate refactor that would touch the resolver — out of scope here.

Refs #1234