### PR TITLE
fix(agent): make tool invocation policy argument-aware

### DIFF
--- a/agent/src/agent/loop.py
+++ b/agent/src/agent/loop.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import concurrent.futures
 import copy
+import hashlib
 import json
 import logging
 import queue
@@ -25,13 +26,13 @@ import threading
 import time as _time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Mapping, Optional
 
 from src.agent.context import ContextBuilder
 from src.agent.grounding import GroundingLedger
 from src.agent.memory import WorkspaceMemory
 from src.agent.progress import HeartbeatTimer, ProgressEvent, _set_emitter
-from src.agent.tools import ToolRegistry
+from src.agent.tools import InvocationPolicy, ToolRegistry
 from src.agent.trace import TraceWriter
 from src.core.state import RunStateStore
 from src.goal.context import (
@@ -936,7 +937,8 @@ class AgentLoop:
         self.memory = memory or WorkspaceMemory()
         self._event_callback = event_callback
         self.max_iterations = max_iterations
-        self._called_ok: set[str] = set()
+        self._once_per_run_completed: set[str] = set()
+        self._once_per_run_reserved: set[str] = set()
         self._cancel_event = threading.Event()
         self._previous_summary: str = ""
         self._persistent_memory = persistent_memory
@@ -1041,7 +1043,8 @@ class AgentLoop:
             self._cancel_event.clear()
         else:
             self._has_run = True
-        self._called_ok = set()
+        self._once_per_run_completed = set()
+        self._once_per_run_reserved = set()
         self._previous_summary = ""
         self._released_fallback = False
         self._released_fallback_reason = None
@@ -1929,15 +1932,6 @@ class AgentLoop:
                 continue
 
             tool_def = self.registry.get(tc.name)
-            is_repeatable = tool_def.repeatable if tool_def else False
-            if tc.name in self._called_ok and not is_repeatable:
-                logger.warning(f"Blocked duplicate call: {tc.name} (already succeeded)")
-                skip_msg = json.dumps({"skipped": True, "reason": f"{tc.name} already completed successfully. Use the previous result."})
-                messages.append(context.format_tool_result(tc.id, tc.name, skip_msg))
-                trace.write({"type": "tool_skipped", "iter": iteration, "tool": tc.name})
-                react_trace.append({"type": "tool_skipped", "tool": tc.name})
-                continue
-
             if self._grounding is not None:
                 authorization = self._grounding.authorize_tool_call(
                     tc.name,
@@ -1958,14 +1952,34 @@ class AgentLoop:
                     )
                     continue
 
+            policy = self._invocation_policy(tool_def)
+            call_key = self._identical_call_key(tc.name, tc.arguments)
+            if policy == InvocationPolicy.ONCE_PER_RUN:
+                if (
+                    tc.name in self._once_per_run_completed
+                    or tc.name in self._once_per_run_reserved
+                ):
+                    self._record_invocation_skip(
+                        tc,
+                        policy=policy,
+                        call_key=call_key,
+                        context=context,
+                        messages=messages,
+                        trace=trace,
+                        react_trace=react_trace,
+                        iteration=iteration,
+                    )
+                    continue
+                self._once_per_run_reserved.add(tc.name)
+
             # Deterministic tools (e.g. financial_rigor calc) return the same
             # result for the same args. Checked AFTER authorization above so a
             # cached repeat can never bypass the identity gate. After auto-compact cleared earlier
             # tool outputs, the model used to re-run identical expressions
             # 5-9x each (2026-08-20 INTC run) to re-verify numbers it could
             # no longer see. Serve an identical prior call from cache instead.
-            if tool_def is not None and getattr(tool_def, "deterministic", False):
-                cache_key = self._identical_call_key(tc.name, tc.arguments)
+            if policy == InvocationPolicy.CACHE_IDENTICAL:
+                cache_key = call_key
                 if cache_key is not None and cache_key in self._called_identical:
                     cached = self._called_identical[cache_key]
                     messages.append(context.format_tool_result(tc.id, tc.name, cached))
@@ -1974,8 +1988,15 @@ class AgentLoop:
                         "iter": iteration,
                         "tool": tc.name,
                         "call_id": tc.id,
+                        "invocation_policy": policy.value,
+                        "invocation_key": self._call_key_hash(cache_key),
                     })
-                    react_trace.append({"type": "tool_result_cached", "tool": tc.name})
+                    react_trace.append({
+                        "type": "tool_result_cached",
+                        "tool": tc.name,
+                        "invocation_policy": policy.value,
+                        "invocation_key": self._call_key_hash(cache_key),
+                    })
                     self._emit(
                         "tool_result",
                         {
@@ -1985,6 +2006,8 @@ class AgentLoop:
                             "preview": cached[:200],
                             "call_id": tc.id,
                             "cached": True,
+                            "invocation_policy": policy.value,
+                            "invocation_key": self._call_key_hash(cache_key),
                         },
                     )
                     continue
@@ -2508,6 +2531,88 @@ class AgentLoop:
             return None
         return (tool_name, canonical)
 
+    @staticmethod
+    def _invocation_policy(tool_def: Any) -> InvocationPolicy:
+        """Return a registered tool's effective invocation policy."""
+        if tool_def is None:
+            return InvocationPolicy.ALLOW
+        resolver = getattr(tool_def, "effective_invocation_policy", None)
+        if callable(resolver):
+            return resolver()
+        if getattr(tool_def, "deterministic", False):
+            return InvocationPolicy.CACHE_IDENTICAL
+        if getattr(tool_def, "is_readonly", False) or getattr(
+            tool_def, "repeatable", False
+        ):
+            return InvocationPolicy.ALLOW
+        return InvocationPolicy.ONCE_PER_RUN
+
+    @staticmethod
+    def _call_key_hash(call_key: tuple[str, str] | None) -> str | None:
+        """Return a short non-reversible identifier for trace correlation."""
+        if call_key is None:
+            return None
+        material = f"{call_key[0]}\0{call_key[1]}".encode("utf-8")
+        return hashlib.sha256(material).hexdigest()[:16]
+
+    def _record_invocation_skip(
+        self,
+        tc: Any,
+        *,
+        policy: InvocationPolicy,
+        call_key: tuple[str, str] | None,
+        context: ContextBuilder,
+        messages: list,
+        trace: TraceWriter,
+        react_trace: list,
+        iteration: int,
+    ) -> None:
+        """Return and trace a once-per-run skip without invoking the tool."""
+        reason = (
+            f"{tc.name} is limited to one successful or in-flight invocation "
+            "per run"
+        )
+        key_hash = self._call_key_hash(call_key)
+        args = _normalize_tool_run_dir(tc.arguments, self.memory.run_dir)
+        redacted_args = redact_payload(args)
+        logger.warning("Skipped tool call %s under %s", tc.name, policy.value)
+        messages.append(
+            context.format_tool_result(
+                tc.id,
+                tc.name,
+                json.dumps(
+                    {
+                        "skipped": True,
+                        "reason": reason,
+                        "invocation_policy": policy.value,
+                        "invocation_key": key_hash,
+                    },
+                    ensure_ascii=False,
+                ),
+            )
+        )
+        trace.write(
+            {
+                "type": "tool_skipped",
+                "iter": iteration,
+                "tool": tc.name,
+                "call_id": tc.id,
+                "args": redacted_args,
+                "invocation_policy": policy.value,
+                "invocation_key": key_hash,
+                "reason": reason,
+            }
+        )
+        react_trace.append(
+            {
+                "type": "tool_skipped",
+                "tool": tc.name,
+                "invocation_policy": policy.value,
+                "invocation_key": key_hash,
+                "reason": reason,
+            }
+        )
+
     def _finalize_tool_result(
         self,
         tc: Any,
@@ -2541,8 +2646,19 @@ class AgentLoop:
         self._last_activity_wall = _time.time()
 
         success = _is_tool_success(result)
+        try:
+            tool_def = self.registry.get(tc.name)
+        except Exception:  # noqa: BLE001
+            tool_def = None
+        policy = self._invocation_policy(tool_def)
+        call_key = self._identical_call_key(tc.name, tc.arguments)
+
+        if policy == InvocationPolicy.ONCE_PER_RUN:
+            self._once_per_run_reserved.discard(tc.name)
+
         if success:
-            self._called_ok.add(tc.name)
+            if policy == InvocationPolicy.ONCE_PER_RUN:
+                self._once_per_run_completed.add(tc.name)
             if tc.name == "backtest":
                 try:
                     _archive_backtest_result(result, self.memory.run_dir)
@@ -2572,15 +2688,12 @@ class AgentLoop:
         # Cache successful deterministic results so an identical later call is
         # served without re-execution (regression: repeated financial_rigor
         # calcs after compaction, 2026-08-20 INTC run).
-        if success:
-            try:
-                tool_def = self.registry.get(tc.name)
-            except Exception:  # noqa: BLE001
-                tool_def = None
-            if tool_def is not None and getattr(tool_def, "deterministic", False):
-                cache_key = self._identical_call_key(tc.name, tc.arguments)
-                if cache_key is not None:
-                    self._called_identical[cache_key] = result
+        if (
+            success
+            and policy == InvocationPolicy.CACHE_IDENTICAL
+            and call_key is not None
+        ):
+            self._called_identical[call_key] = result
 
         status = "ok" if success else "error"
         truncated = truncate_tool_result(result)

--- a/agent/src/agent/tools.py
+++ b/agent/src/agent/tools.py
@@ -5,9 +5,18 @@ from __future__ import annotations
 import json
 import logging
 from abc import ABC, abstractmethod
+from enum import Enum
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
-from typing import Any, Dict, List, Optional
+
+
+class InvocationPolicy(str, Enum):
+    """Host-side execution policy for repeated tool invocations."""
+
+    ALLOW = "allow"
+    CACHE_IDENTICAL = "cache_identical"
+    ONCE_PER_RUN = "once_per_run"
 
 
 class BaseTool(ABC):
@@ -17,18 +26,34 @@ class BaseTool(ABC):
         name: Unique tool identifier.
         description: Tool description shown to the LLM.
         parameters: Parameter definition in JSON Schema format.
-        repeatable: Whether the tool may be called more than once.
+        invocation_policy: Explicit host-side repeat/caching policy.
+        repeatable: Legacy compatibility flag used when no policy is set.
     """
 
     name: str = ""
     description: str = ""
     parameters: Dict[str, Any] = {}
+    invocation_policy: InvocationPolicy | None = None
     repeatable: bool = False
     is_readonly: bool = True
     # Pure, side-effect-free computation: identical args always produce the
     # same result, so the loop may serve repeated identical calls from cache
     # instead of re-executing them (financial_rigor calc/verify, etc.).
     deterministic: bool = False
+
+    def effective_invocation_policy(self) -> InvocationPolicy:
+        """Return the explicit policy or a backward-compatible default.
+
+        Returns:
+            Effective invocation policy for this tool instance.
+        """
+        if self.invocation_policy is not None:
+            return InvocationPolicy(self.invocation_policy)
+        if self.deterministic:
+            return InvocationPolicy.CACHE_IDENTICAL
+        if self.is_readonly or self.repeatable:
+            return InvocationPolicy.ALLOW
+        return InvocationPolicy.ONCE_PER_RUN
 
     @classmethod
     def check_available(cls) -> bool:

--- a/agent/tests/test_agent_loop_invocation_policy.py
+++ b/agent/tests/test_agent_loop_invocation_policy.py
@@ -1,0 +1,120 @@
+"""Regression coverage for host-side tool invocation policies."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from src.agent.context import ContextBuilder
+from src.agent.loop import AgentLoop
+from src.agent.tools import BaseTool, InvocationPolicy, ToolRegistry
+from src.agent.trace import TraceWriter
+
+
+class _RecordingTool(BaseTool):
+    """Configurable tool that records every implementation invocation."""
+
+    name = "recording_tool"
+    description = "test invocation policy"
+    parameters: dict = {"type": "object", "properties": {}}
+
+    def __init__(
+        self,
+        *,
+        is_readonly: bool,
+        statuses: list[str] | None = None,
+    ) -> None:
+        self.is_readonly = is_readonly
+        self.statuses = list(statuses or ["ok"])
+        self.calls: list[dict] = []
+
+    def execute(self, **kwargs: object) -> str:
+        """Record arguments and return the configured status."""
+        self.calls.append(kwargs)
+        index = min(len(self.calls) - 1, len(self.statuses) - 1)
+        return json.dumps({"status": self.statuses[index]})
+
+
+def _drive(
+    tool: BaseTool,
+    run_dir: Path,
+    batches: list[list[dict]],
+) -> tuple[list[dict], list[dict]]:
+    """Send argument batches through the real tool scheduling path."""
+    registry = ToolRegistry()
+    registry.register(tool)
+    agent = AgentLoop(registry=registry, llm=SimpleNamespace(), max_iterations=4)
+    run_dir.mkdir()
+    agent.memory.run_dir = str(run_dir)
+    trace = TraceWriter(run_dir)
+    messages: list[dict] = []
+    react_trace: list[dict] = []
+    call_number = 0
+    for iteration, batch in enumerate(batches, start=1):
+        tool_calls = []
+        for arguments in batch:
+            call_number += 1
+            tool_calls.append(
+                SimpleNamespace(
+                    id=f"call_{call_number}",
+                    name=tool.name,
+                    arguments=arguments,
+                )
+            )
+        agent._process_tool_calls(
+            tool_calls,
+            ContextBuilder,
+            messages,
+            trace,
+            react_trace,
+            iteration,
+        )
+    trace.close()
+    return messages, list(TraceWriter.read(run_dir))
+
+
+def test_legacy_metadata_maps_to_explicit_policies() -> None:
+    """Legacy tool flags retain safe behavior under the new policy API."""
+    readonly = _RecordingTool(is_readonly=True)
+    mutation = _RecordingTool(is_readonly=False)
+    readonly.deterministic = True
+
+    assert readonly.effective_invocation_policy() == (InvocationPolicy.CACHE_IDENTICAL)
+    readonly.deterministic = False
+    assert readonly.effective_invocation_policy() == InvocationPolicy.ALLOW
+    assert mutation.effective_invocation_policy() == InvocationPolicy.ONCE_PER_RUN
+
+
+def test_once_per_run_mutation_blocks_same_batch_duplicate(tmp_path: Path) -> None:
+    """A non-repeatable mutation is reserved before batch execution."""
+    tool = _RecordingTool(is_readonly=False)
+
+    messages, records = _drive(
+        tool,
+        tmp_path / "mutation",
+        [[{"value": 1}, {"value": 2, "token": "secret-value"}]],
+    )
+
+    assert len(tool.calls) == 1
+    assert len(messages) == 2
+    skipped = [record for record in records if record["type"] == "tool_skipped"]
+    assert len(skipped) == 1
+    assert skipped[0]["invocation_policy"] == "once_per_run"
+    assert skipped[0]["invocation_key"]
+    assert skipped[0]["args"]["token"] == "[redacted]"
+
+
+def test_once_per_run_failure_can_retry_next_iteration(tmp_path: Path) -> None:
+    """Only a successful mutation closes the once-per-run policy."""
+    tool = _RecordingTool(is_readonly=False, statuses=["error", "ok"])
+
+    messages, records = _drive(
+        tool,
+        tmp_path / "retry",
+        [[{"value": 1}], [{"value": 1}]],
+    )
+
+    assert len(tool.calls) == 2
+    assert len(messages) == 2
+    assert not [record for record in records if record["type"] == "tool_skipped"]

--- a/agent/tests/test_agent_loop_repeatable_tools.py
+++ b/agent/tests/test_agent_loop_repeatable_tools.py
@@ -67,6 +67,12 @@ from src.tools.symbol_search_tool import SymbolSearchTool
             {"code": "600276.SH", "statement": "indicators"},
             {"code": "601899.SH", "statement": "indicators"},
         ),
+        pytest.param(
+            FinancialStatementsTool,
+            {"code": "ATRC.US", "statement": "income"},
+            {"code": "ATRC.US", "statement": "income", "offset": 13},
+            id="financial-statements-paging",
+        ),
         (
             SectorInfoTool,
             {"code": "600276.SH", "mode": "membership"},
@@ -86,7 +92,7 @@ def test_readonly_query_executes_again_with_different_arguments(
     first_args: dict[str, object],
     second_args: dict[str, object],
 ) -> None:
-    """A successful query must not suppress the next iteration's symbol."""
+    """A successful query must not suppress the next argument-dependent call."""
     calls: list[dict[str, object]] = []
     tool = tool_cls()
 

--- a/agent/tests/test_agent_loop_repeatable_tools.py
+++ b/agent/tests/test_agent_loop_repeatable_tools.py
@@ -12,9 +12,12 @@ from src.agent.context import ContextBuilder
 from src.agent.loop import AgentLoop
 from src.agent.tools import ToolRegistry
 from src.agent.trace import TraceWriter
+from src.tools.financial_statements_tool import FinancialStatementsTool
 from src.tools.get_fundamentals_tool import GetFundamentalsTool
 from src.tools.market_data_tool import MarketDataTool
 from src.tools.market_screener_tool import MarketScreenerTool
+from src.tools.sector_tool import SectorInfoTool
+from src.tools.stock_news_tool import StockNewsTool
 from src.tools.symbol_search_tool import SymbolSearchTool
 
 
@@ -59,9 +62,24 @@ from src.tools.symbol_search_tool import SymbolSearchTool
             {"query": "Apple", "limit": 5},
             {"query": "Microsoft", "limit": 5},
         ),
+        (
+            FinancialStatementsTool,
+            {"code": "600276.SH", "statement": "indicators"},
+            {"code": "601899.SH", "statement": "indicators"},
+        ),
+        (
+            SectorInfoTool,
+            {"code": "600276.SH", "mode": "membership"},
+            {"code": "601899.SH", "mode": "membership"},
+        ),
+        (
+            StockNewsTool,
+            {"code": "600276.SH", "scope": "stock", "limit": 5},
+            {"code": "601899.SH", "scope": "stock", "limit": 5},
+        ),
     ],
 )
-def test_repeatable_query_executes_again_with_different_arguments(
+def test_readonly_query_executes_again_with_different_arguments(
     monkeypatch,
     tmp_path: Path,
     tool_cls: type,


### PR DESCRIPTION
## Problem

`AgentLoop` currently records only the name of a successful non-repeatable tool. A later call with different arguments is therefore skipped before the tool implementation runs. This breaks parameter-dependent read-only research: after fetching one company's financial statements, sector membership, news, fund flow, or reports, the same tool cannot fetch the next company in a later iteration.

On current `main`, a two-symbol `get_financial_statements` reproduction executes only `600276.SH`; `601899.SH` is emitted as `tool_skipped`.

## Change

- Add an explicit `InvocationPolicy` with backward-compatible defaults:
  - deterministic tools cache identical logical calls;
  - read-only or legacy repeatable tools allow subsequent calls;
  - legacy non-repeatable mutations remain once-per-run.
- Evaluate Grounding authorization before cache or once-per-run decisions.
- Reserve once-per-run mutations before batch execution so duplicates in one assistant response cannot both run.
- Add redacted arguments, invocation policy, hashed call key, and reason to skip/cache traces.

## Behavior

Before:

```text
get_financial_statements(600276.SH) -> executed
get_financial_statements(601899.SH) -> tool_skipped
```

After:

```text
get_financial_statements(600276.SH) -> executed
get_financial_statements(601899.SH) -> executed
```

Existing order and external-write tools with `repeatable=False` and `is_readonly=False` continue to map to once-per-run.

## Out of scope

- Query rewriting or structured request contracts
- Symbol identity/context resolution
- Dynamic capability routing
- Failure circuit breaking and explicit business-idempotency policies
- Prompt changes or new data sources
- Changes to broker, mandate, MCP, credential, or deployment configuration

## Validation

- Baseline reproduction on `origin/main`: 1 implementation call, 1 false `tool_skipped` for two different symbols.
- Fixed-branch reproduction: 2 implementation calls, 0 `tool_skipped`.
- `pytest agent/tests/test_agent_loop_invocation_policy.py agent/tests/test_agent_loop_repeatable_tools.py agent/tests/test_agent_loop_deterministic_cache.py -q` — 15 passed.
- `pytest agent/tests/test_mandate_enforcement.py agent/tests/test_killswitch_blocks_orders.py agent/tests/test_readonly_default.py agent/tests/test_agent_loop_trace.py -q` — 40 passed.
- `pytest --ignore=agent/tests/e2e_backtest --ignore=agent/tests/test_e2e_harness_v2.py --tb=short -q` — 11,659 passed, 93 skipped.
- `ruff check` on all changed Python files — passed.
- `git diff --check` — passed.

No live broker action or external network data call was run.

## Rollback

Revert the single commit to restore the prior name-level behavior. The patch adds no migration, dependency, configuration, or persisted-state format.
