### PR TITLE
fix(grounding): keep full-width brackets out of clause split

### DIFF
--- a/agent/src/agent/grounding.py
+++ b/agent/src/agent/grounding.py
@@ -449,10 +449,12 @@ _PROSPECTIVE_LEVEL_RE = re.compile(
     r")",
     re.IGNORECASE,
 )
-# Full-width brackets and enumeration commas delimit prose clauses. ASCII
+# Enumeration commas and clause terminators delimit prose clauses. ASCII
 # parentheses are deliberately not separators: an explicit derivation such as
-# "(8.5 - 7.9) / 2" must stay in one segment for the formula check.
-_CLAUSE_SEPARATOR_RE = re.compile(r"[,，;；。、\n（）【】]")
+# "(8.5 - 7.9) / 2" must stay in one segment for the formula check. Full-width
+# brackets （）【】 are grouping characters for the same reason and must also
+# stay in one segment so "公司名（代码）价格" keeps the symbol and figure together.
+_CLAUSE_SEPARATOR_RE = re.compile(r"[,，;；。、\n]")
 
 
 # The ASCII comma both separates clauses and groups thousands, and the clause


### PR DESCRIPTION
## Summary

- Fix full-width brackets being treated as clause separators so `unsourced_symbol_figures` detects figures wrapped in （）【】

## Why

Full-width brackets split `公司名（代码）价格` into separate clauses, separating the symbol from its figure and causing a false negative while half-width `()` worked correctly. Fixes #1260.

## Changes

- Keep full-width brackets out of the clause separator so both bracket forms stay in one segment

## Test Plan

- [ ] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [ ] New tests added (if applicable)
- [ ] Tested manually (describe below)

## Checklist

- [ ] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [ ] No hardcoded values (API keys, file paths, magic numbers)
- [ ] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] Documentation updated (if user-facing change)