### PR TITLE
fix(backtest): scale target-rebalance basket when 100% weight plus commission exceeds capital

### DIFF
--- a/agent/backtest/engines/base.py
+++ b/agent/backtest/engines/base.py
@@ -1617,6 +1617,103 @@ class BaseEngine(ABC):
             elif self.can_execute(symbol, 0, bar):
                 reductions.append(self._plan_reduction(before, target_size, price))
 
+        def _plans(scale: float) -> tuple[list[_ReductionOrder], list[_OpenOrder]]:
+            reds: list[_ReductionOrder] = []
+            ops: list[_OpenOrder] = []
+            for sym in sorted(codes):
+                tw = target_weights.get(sym)
+                if tw is None:
+                    continue
+                self._validate_rebalance_values(tw)
+                scaled_w = tw * scale
+                self._active_symbol = sym
+                before = self.positions.get(sym)
+                target_direction = 1 if scaled_w > 1e-9 else (-1 if scaled_w < -1e-9 else 0)
+                frame = data_map.get(sym)
+                if frame is None or ts not in frame.index:
+                    continue
+                bar = frame.loc[ts]
+                if before is None or target_direction != before.direction:
+                    if before is not None:
+                        if not self.can_execute(sym, 0, bar):
+                            continue
+                        raw_price = self.execution_open(bar)
+                        self._validate_rebalance_values(raw_price, positive=True)
+                        price = self.apply_slippage(raw_price, -before.direction)
+                        self._validate_rebalance_values(price, positive=True)
+                        reds.append(self._plan_reduction(before, 0.0, price))
+                        if target_direction == 0:
+                            continue
+                    order = self._plan_open_order(
+                        sym,
+                        scaled_w,
+                        frame,
+                        ts,
+                        equity,
+                        allow_existing=before is not None,
+                        require_positive_price=True,
+                    )
+                    if order is not None:
+                        self._validate_rebalance_values(
+                            order.price, order.leverage, order.size, order.margin, order.commission
+                        )
+                        ops.append(order)
+                    continue
+                raw_price = self.execution_open(bar)
+                self._validate_rebalance_values(raw_price, positive=True)
+                leverage = self._leverage_for_symbol(sym)
+                self._validate_rebalance_values(raw_price, before.leverage, leverage)
+                target_notional = abs(scaled_w) * equity * before.leverage
+                prices = (
+                    self.apply_slippage(raw_price, before.direction),
+                    self.apply_slippage(raw_price, -before.direction),
+                )
+                self._validate_rebalance_values(*prices, positive=True)
+                sizes = tuple(
+                    self.round_size(
+                        self._calc_raw_size(sym, target_notional, price), price
+                    )
+                    for price in prices
+                )
+                self._validate_rebalance_values(*prices, *sizes)
+                if self.rebalance_tolerance > 0.0:
+                    reference_size = self.round_size(
+                        self._calc_raw_size(sym, target_notional, raw_price), raw_price
+                    )
+                    if abs(before.size - reference_size) <= self.rebalance_tolerance * abs(
+                        reference_size
+                    ):
+                        continue
+                increase = sizes[0] > before.size + 1e-9
+                reduction = sizes[1] < before.size - 1e-9
+                if increase == reduction:
+                    continue
+                target_size, price = (sizes[0], prices[0]) if increase else (sizes[1], prices[1])
+                if not math.isclose(leverage, before.leverage, rel_tol=1e-9, abs_tol=1e-9):
+                    raise ValueError("cannot rebalance a position with changed leverage")
+                if increase:
+                    if not self.can_execute(sym, target_direction, bar):
+                        continue
+                    size = target_size - before.size
+                    order = _OpenOrder(
+                        symbol=sym,
+                        direction=before.direction,
+                        price=price,
+                        size=size,
+                        leverage=leverage,
+                        margin=self._calc_margin(sym, size, price, leverage),
+                        commission=self.calc_commission(
+                            size, price, before.direction, is_open=True
+                        ),
+                    )
+                    self._validate_rebalance_values(
+                        order.price, order.leverage, order.size, order.margin, order.commission
+                    )
+                    ops.append(order)
+                elif self.can_execute(sym, 0, bar):
+                    reds.append(self._plan_reduction(before, target_size, price))
+            return reds, ops
+
         projected_capital = (
             self.capital
             + sum(order.capital_credit for order in reductions)
@@ -1624,7 +1721,25 @@ class BaseEngine(ABC):
         )
         self._validate_rebalance_values(projected_capital)
         if projected_capital < -1e-9:
-            raise ValueError("insufficient capital for position rebalance")
+            low, high = 0.0, 1.0
+            best: tuple[list[_ReductionOrder], list[_OpenOrder]] | None = None
+            for _ in range(50):
+                mid = (low + high) / 2.0
+                cand_reds, cand_ops = _plans(mid)
+                cand_projected = (
+                    self.capital
+                    + sum(r.capital_credit for r in cand_reds)
+                    - sum(o.cost for o in cand_ops)
+                )
+                self._validate_rebalance_values(cand_projected)
+                if cand_projected >= -1e-9:
+                    low = mid
+                    best = (cand_reds, cand_ops)
+                else:
+                    high = mid
+            if best is None:
+                raise ValueError("insufficient capital for position rebalance")
+            reductions, opens = best
 
         for order in reductions:
             if order.target_size <= 1e-9:

--- a/agent/tests/test_base_engine.py
+++ b/agent/tests/test_base_engine.py
@@ -311,22 +311,53 @@ def test_existing_rebalance_does_not_churn_inside_slippage_band(direction):
 
 def test_rebalance_insufficient_capital_is_atomic():
     engine = _AdjustmentEngine(fee_rate=0.10)
+    _run_adjustments(engine, {"A": [1.0]})
+    # 100% target with 10% commission now scales instead of aborting:
+    # ratio preserved, total cost fits capital
+    assert engine.bar_positions[0]["A"].size == pytest.approx(9.090909, rel=1e-5)
+    assert engine.bar_capitals[0] == pytest.approx(0.0, abs=1e-4)
+    assert sum(f.fee + f.margin for f in engine.fill_records if f.action == "open") <= 1_000.0 + 1e-9
+
+
+def test_rebalance_100_percent_plus_commission_scales_and_preserves_ratio():
+    engine = _AdjustmentEngine(fee_rate=0.001)
+    _run_adjustments(engine, {"A": [0.60], "B": [0.40]})
+    sizes = _sizes(engine.bar_positions[0])
+    assert sizes["A"] / sizes["B"] == pytest.approx(1.5, rel=1e-5)
+    total_cost = sum(f.fee + f.margin for f in engine.fill_records if f.action == "open")
+    assert total_cost <= 1_000.0 + 1e-9
+    assert engine.bar_capitals[0] >= -1e-9
+
+
+def test_rebalance_scaling_is_independent_of_code_order():
+    weights = {"A": [0.60], "B": [0.40]}
+    first, second = _run_both_code_orders(lambda: _AdjustmentEngine(fee_rate=0.001), weights)
+    assert _sizes(first.bar_positions[0]) == pytest.approx(_sizes(second.bar_positions[0]))
+    assert first.bar_capitals == pytest.approx(second.bar_capitals)
+
+
+def test_rebalance_irrecoverably_infeasible_is_atomic():
+    # High exit commission makes even a small reduction infeasible:
+    # capital + credit stays negative, so no scaled basket can fit.
+    engine = _AdjustmentEngine(fee_rate=2.0)
+    # First bar scales to ~3.33, second bar tries to reduce but credit is negative
     with pytest.raises(ValueError, match="insufficient capital"):
-        _run_adjustments(engine, {"A": [1.0]})
-    _assert_unchanged(engine)
+        _run_adjustments(engine, {"A": [0.50, 0.90]})
+    # Atomic: second bar never committed
+    assert len(engine.bar_positions) == 1
+    assert engine.capital == engine.bar_capitals[0]
 
 
 def test_existing_multi_symbol_rebalance_failure_is_atomic():
     engine = _AdjustmentEngine(fee_rate=0.01)
-
-    with pytest.raises(ValueError, match="insufficient capital"):
-        _run_adjustments(engine, {"A": [0.25, 0.10], "B": [0.25, 0.90]})
-
-    assert engine.capital == engine.bar_capitals[0] == 495.0
-    assert engine.positions == engine.bar_positions[0]
-    assert engine.trades == []
-    assert engine.adjustment_events == []
-    assert len(engine.bar_positions) == 1
+    _run_adjustments(engine, {"A": [0.25, 0.10], "B": [0.25, 0.90]})
+    # Previously aborted; now scales with common factor preserving ratio
+    assert len(engine.bar_positions) == 2
+    # After second bar, weights preserve ratio and cost fits
+    assert engine.bar_capitals[1] >= -1e-9
+    # Order independence for this basket as well
+    first, second = _run_both_code_orders(lambda: _AdjustmentEngine(fee_rate=0.01), {"A": [0.25, 0.10], "B": [0.25, 0.90]})
+    assert _sizes(first.bar_positions[1]) == pytest.approx(_sizes(second.bar_positions[1]))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Scale the rebalance basket with a common factor when target weights sum to 100% and commission pushes total cost above available capital, instead of raising `ValueError`
- Preserve portfolio proportions and code-order independence by mirroring the fairness scaling already used in the normal open basket path
- Keep atomic failure for irrecoverably infeasible baskets

## Why

In `position_adjustment=rebalance` mode a basket with weights summing to 100% plus nonzero commission aborted with `ValueError: insufficient capital for position rebalance`. Expected behavior is to apply one common scale factor to every sleeve after reductions and before committing increases/opens, as the hold-mode open basket already does (`agent/backtest/engines/base.py:1136`).

Closes #1274

## Changes

- `agent/backtest/engines/base.py`: add `_plans(scale)` helper inside `_execute_target_rebalance` and 50-iteration binary search to find the largest feasible scale when projected capital is negative; fall back to `ValueError` only when no scale fits
- `agent/tests/test_base_engine.py`: update pinned abort contract to assert scaling (ratio preservation, cost fits capital, order independence) and keep atomic failure for a high-fee reduction case

## Test Plan

- [x] Existing tests pass (`pytest agent/tests/test_base_engine.py --tb=short -q` — 91 passed, 2 pre-existing unrelated failures)
- [x] New tests added
- [x] Tested manually: 60/40 basket with 0.1% commission scales preserving 1.5 ratio and fits capital; single 100% with 10% commission scales to ~0.909; order independence verified; irrecoverably infeasible (high exit commission) still fails atomically

## Checklist

- [x] No changes to protected areas without prior discussion
- [x] No hardcoded values
- [x] Code follows CONTRIBUTING.md guidelines
- [x] Documentation updated (if user-facing change)