### PR TITLE
fix(backtest): scale target-rebalance basket when it exceeds capital

### DIFF
--- a/agent/backtest/engines/base.py
+++ b/agent/backtest/engines/base.py
@@ -19,7 +19,7 @@ from collections import Counter
 from collections.abc import Iterable
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -1508,123 +1508,161 @@ class BaseEngine(ABC):
         target_weights: Dict[str, Optional[float]], data_map: Dict[str, pd.DataFrame],
         ts: pd.Timestamp, equity: float, codes: List[str],
     ) -> None:
-        """Plan every target delta, preflight capital, then commit the basket."""
-        reductions: list[_ReductionOrder] = []
-        opens: list[_OpenOrder] = []
+        """Plan every target delta, preflight capital, then commit the basket.
 
-        for symbol in sorted(codes):
-            target_weight = target_weights.get(symbol)
-            if target_weight is None:
-                continue
-            self._validate_rebalance_values(target_weight)
+        If the requested basket does not fit after fees/lot rounding, apply
+        one common scale factor to all target weights -- the same fairness
+        mechanism the open basket path uses -- preserving portfolio
+        proportions and code-order independence. A basket that cannot fit
+        even after full closeouts still aborts atomically.
+        """
 
-            self._active_symbol = symbol
-            before = self.positions.get(symbol)
-            target_direction = 1 if target_weight > 1e-9 else (-1 if target_weight < -1e-9 else 0)
-            frame = data_map.get(symbol)
-            if frame is None or ts not in frame.index:
-                continue
-            bar = frame.loc[ts]
+        def _plan_basket(scale: float) -> Tuple[List[_ReductionOrder], List[_OpenOrder]]:
+            reductions: list[_ReductionOrder] = []
+            opens: list[_OpenOrder] = []
 
-            if before is None or target_direction != before.direction:
-                if before is not None:
-                    if not self.can_execute(symbol, 0, bar):
-                        continue
-                    raw_price = self.execution_open(bar)
-                    self._validate_rebalance_values(raw_price, positive=True)
-                    price = self.apply_slippage(raw_price, -before.direction)
-                    self._validate_rebalance_values(price, positive=True)
-                    reductions.append(self._plan_reduction(before, 0.0, price))
-                    if target_direction == 0:
-                        continue
-                order = self._plan_open_order(
-                    symbol,
-                    target_weight,
-                    frame,
-                    ts,
-                    equity,
-                    allow_existing=before is not None,
-                    require_positive_price=True,
+            for symbol in sorted(codes):
+                target_weight = target_weights.get(symbol)
+                if target_weight is None:
+                    continue
+                self._validate_rebalance_values(target_weight)
+                scaled_weight = target_weight * scale
+
+                self._active_symbol = symbol
+                before = self.positions.get(symbol)
+                target_direction = (
+                    1 if scaled_weight > 1e-9 else (-1 if scaled_weight < -1e-9 else 0)
                 )
-                if order is not None:
+                frame = data_map.get(symbol)
+                if frame is None or ts not in frame.index:
+                    continue
+                bar = frame.loc[ts]
+
+                if before is None or target_direction != before.direction:
+                    if before is not None:
+                        if not self.can_execute(symbol, 0, bar):
+                            continue
+                        raw_price = self.execution_open(bar)
+                        self._validate_rebalance_values(raw_price, positive=True)
+                        price = self.apply_slippage(raw_price, -before.direction)
+                        self._validate_rebalance_values(price, positive=True)
+                        reductions.append(self._plan_reduction(before, 0.0, price))
+                        if target_direction == 0:
+                            continue
+                    order = self._plan_open_order(
+                        symbol,
+                        scaled_weight,
+                        frame,
+                        ts,
+                        equity,
+                        allow_existing=before is not None,
+                        require_positive_price=True,
+                    )
+                    if order is not None:
+                        self._validate_rebalance_values(
+                            order.price, order.leverage, order.size, order.margin, order.commission
+                        )
+                        opens.append(order)
+                    continue
+
+                raw_price = self.execution_open(bar)
+                self._validate_rebalance_values(raw_price, positive=True)
+                leverage = self._leverage_for_symbol(symbol)
+                self._validate_rebalance_values(raw_price, before.leverage, leverage)
+                target_notional = abs(scaled_weight) * equity * before.leverage
+                prices = (
+                    self.apply_slippage(raw_price, before.direction),
+                    self.apply_slippage(raw_price, -before.direction),
+                )
+                self._validate_rebalance_values(*prices, positive=True)
+                sizes = tuple(
+                    self.round_size(
+                        self._calc_raw_size(symbol, target_notional, price), price
+                    )
+                    for price in prices
+                )
+                self._validate_rebalance_values(*prices, *sizes)
+                # Tolerance band. The held size is compared against the size the
+                # target implies at the unslipped price -- keeping the slippage side
+                # out of a drift question is the principled choice, though its
+                # practical effect is one slippage width and only reaches the
+                # outcome within that distance of the band edge, which is why no
+                # test pins it: such a test would assert a coincidence.
+                # A changed target moves this reference far past any sane band, so
+                # target changes still execute at every tolerance.
+                if self.rebalance_tolerance > 0.0:
+                    reference_size = self.round_size(
+                        self._calc_raw_size(symbol, target_notional, raw_price), raw_price
+                    )
+                    if abs(before.size - reference_size) <= self.rebalance_tolerance * abs(
+                        reference_size
+                    ):
+                        continue
+
+                increase = sizes[0] > before.size + 1e-9
+                reduction = sizes[1] < before.size - 1e-9
+                # Both or neither means the target lies inside the fill-price band.
+                if increase == reduction:
+                    continue
+                target_size, price = (
+                    (sizes[0], prices[0]) if increase else (sizes[1], prices[1])
+                )
+                if not math.isclose(leverage, before.leverage, rel_tol=1e-9, abs_tol=1e-9):
+                    raise ValueError("cannot rebalance a position with changed leverage")
+                if increase:
+                    if not self.can_execute(symbol, target_direction, bar):
+                        continue
+                    size = target_size - before.size
+                    order = _OpenOrder(
+                        symbol=symbol,
+                        direction=before.direction,
+                        price=price,
+                        size=size,
+                        leverage=leverage,
+                        margin=self._calc_margin(symbol, size, price, leverage),
+                        commission=self.calc_commission(
+                            size, price, before.direction, is_open=True
+                        ),
+                    )
                     self._validate_rebalance_values(
                         order.price, order.leverage, order.size, order.margin, order.commission
                     )
                     opens.append(order)
-                continue
+                elif self.can_execute(symbol, 0, bar):
+                    reductions.append(self._plan_reduction(before, target_size, price))
 
-            raw_price = self.execution_open(bar)
-            self._validate_rebalance_values(raw_price, positive=True)
-            leverage = self._leverage_for_symbol(symbol)
-            self._validate_rebalance_values(raw_price, before.leverage, leverage)
-            target_notional = abs(target_weight) * equity * before.leverage
-            prices = (
-                self.apply_slippage(raw_price, before.direction),
-                self.apply_slippage(raw_price, -before.direction),
+            return reductions, opens
+
+        def _basket_capital(
+            reductions: List[_ReductionOrder], opens: List[_OpenOrder]
+        ) -> float:
+            return (
+                self.capital
+                + sum(order.capital_credit for order in reductions)
+                - sum(order.cost for order in opens)
             )
-            self._validate_rebalance_values(*prices, positive=True)
-            sizes = tuple(
-                self.round_size(
-                    self._calc_raw_size(symbol, target_notional, price), price
-                )
-                for price in prices
-            )
-            self._validate_rebalance_values(*prices, *sizes)
-            # Tolerance band. The held size is compared against the size the
-            # target implies at the unslipped price -- keeping the slippage side
-            # out of a drift question is the principled choice, though its
-            # practical effect is one slippage width and only reaches the
-            # outcome within that distance of the band edge, which is why no
-            # test pins it: such a test would assert a coincidence.
-            # A changed target moves this reference far past any sane band, so
-            # target changes still execute at every tolerance.
-            if self.rebalance_tolerance > 0.0:
-                reference_size = self.round_size(
-                    self._calc_raw_size(symbol, target_notional, raw_price), raw_price
-                )
-                if abs(before.size - reference_size) <= self.rebalance_tolerance * abs(
-                    reference_size
-                ):
-                    continue
 
-            increase = sizes[0] > before.size + 1e-9
-            reduction = sizes[1] < before.size - 1e-9
-            # Both or neither means the target lies inside the fill-price band.
-            if increase == reduction:
-                continue
-            target_size, price = (sizes[0], prices[0]) if increase else (sizes[1], prices[1])
-            if not math.isclose(leverage, before.leverage, rel_tol=1e-9, abs_tol=1e-9):
-                raise ValueError("cannot rebalance a position with changed leverage")
-            if increase:
-                if not self.can_execute(symbol, target_direction, bar):
-                    continue
-                size = target_size - before.size
-                order = _OpenOrder(
-                    symbol=symbol,
-                    direction=before.direction,
-                    price=price,
-                    size=size,
-                    leverage=leverage,
-                    margin=self._calc_margin(symbol, size, price, leverage),
-                    commission=self.calc_commission(
-                        size, price, before.direction, is_open=True
-                    ),
-                )
-                self._validate_rebalance_values(
-                    order.price, order.leverage, order.size, order.margin, order.commission
-                )
-                opens.append(order)
-            elif self.can_execute(symbol, 0, bar):
-                reductions.append(self._plan_reduction(before, target_size, price))
-
-        projected_capital = (
-            self.capital
-            + sum(order.capital_credit for order in reductions)
-            - sum(order.cost for order in opens)
-        )
-        self._validate_rebalance_values(projected_capital)
+        # a. Plan at full scale; commit directly when the basket fits.
+        reductions, opens = _plan_basket(1.0)
+        projected_capital = _basket_capital(reductions, opens)
+        # b. If fees/lot rounding push the basket past capital, shrink every
+        #    sleeve by one common factor, searching the largest scale that
+        #    still fits -- mirroring the fairness contract of the open path.
         if projected_capital < -1e-9:
-            raise ValueError("insufficient capital for position rebalance")
+            low, high = 0.0, 1.0
+            for _ in range(50):
+                mid = (low + high) * 0.5
+                candidate_reductions, candidate_opens = _plan_basket(mid)
+                candidate_capital = _basket_capital(candidate_reductions, candidate_opens)
+                if candidate_capital >= -1e-9:
+                    low = mid
+                    reductions, opens = candidate_reductions, candidate_opens
+                else:
+                    high = mid
+            projected_capital = _basket_capital(reductions, opens)
+            self._validate_rebalance_values(projected_capital)
+            if projected_capital < -1e-9:
+                raise ValueError("insufficient capital for position rebalance")
 
         for order in reductions:
             if order.target_size <= 1e-9:

--- a/agent/tests/test_base_engine.py
+++ b/agent/tests/test_base_engine.py
@@ -309,24 +309,41 @@ def test_existing_rebalance_does_not_churn_inside_slippage_band(direction):
     _assert_unchanged(engine, {"A": before})
 
 
-def test_rebalance_insufficient_capital_is_atomic():
+def test_rebalance_insufficient_capital_scales_basket_to_fit():
     engine = _AdjustmentEngine(fee_rate=0.10)
-    with pytest.raises(ValueError, match="insufficient capital"):
-        _run_adjustments(engine, {"A": [1.0]})
-    _assert_unchanged(engine)
+    _run_adjustments(engine, {"A": [1.0]})
+    # Full cost would be 1100 > 1000 capital; the basket must scale to fit.
+    assert engine.bar_positions[0]["A"].size == pytest.approx(100.0 / 11.0)
+    assert engine.bar_capitals[0] == pytest.approx(0.0, abs=1e-4)
 
 
-def test_existing_multi_symbol_rebalance_failure_is_atomic():
+def test_rebalance_scaled_basket_preserves_weight_ratios():
     engine = _AdjustmentEngine(fee_rate=0.01)
+    _run_adjustments(engine, {"A": [0.25, 0.10], "B": [0.25, 0.90]})
+    a, b = engine.bar_positions[1]["A"].size, engine.bar_positions[1]["B"].size
+    assert a / b == pytest.approx(0.10 / 0.90)
+    assert engine.bar_capitals[1] >= -1e-9
+    assert engine.bar_capitals[1] == pytest.approx(0.0, abs=1e-2)
 
+
+def test_rebalance_scaled_basket_is_independent_of_input_code_order():
+    weights = {"A": [0.60, 0.10], "B": [0.40, 0.90]}
+    first, second = _run_both_code_orders(
+        lambda: _AdjustmentEngine(fee_rate=0.01), weights
+    )
+    assert first.bar_positions == second.bar_positions
+    assert first.bar_capitals == second.bar_capitals
+
+
+def test_rebalance_irrecoverably_infeasible_basket_is_atomic():
+    engine = _AdjustmentEngine(fee_rate=0.10)
+    engine.positions["A"] = _position(direction=-1, size=10.0)
+    before = engine.positions["A"]
+    # Closing the short at 300 destroys 1300 net of margin; even after full
+    # closeout the basket cannot fit capital, so it must still abort.
     with pytest.raises(ValueError, match="insufficient capital"):
-        _run_adjustments(engine, {"A": [0.25, 0.10], "B": [0.25, 0.90]})
-
-    assert engine.capital == engine.bar_capitals[0] == 495.0
-    assert engine.positions == engine.bar_positions[0]
-    assert engine.trades == []
-    assert engine.adjustment_events == []
-    assert len(engine.bar_positions) == 1
+        _run_adjustments(engine, {"A": [0.0]}, execution_prices={"A": [300.0]})
+    _assert_unchanged(engine, positions={"A": before})
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

With `position_adjustment=rebalance`, a target basket whose weights sum to 100% plus nonzero commissions exceeds available capital and previously aborted with `ValueError: insufficient capital for position rebalance`. A recoverable basket (one that fits at some common scale) should scale down instead of failing, just like the open-basket path already does.

## Change

- Refactor the rebalance planner into one scaled closure `_plan_basket(scale)` used for both the full-scale plan and every bisection candidate — no duplicated planning logic that could drift.
- If the full-scale basket does not fit, bisect the common scale factor (50 iterations, largest scale that fits) and apply it to every sleeve: portfolio proportions (weight ratios) and code-order independence are preserved.
- Keep the atomic abort for irrecoverably infeasible baskets: if even full closeouts cannot make the projected capital non-negative, raise `ValueError` with no positions touched.

## Tests

- `test_rebalance_insufficient_capital_scales_basket_to_fit` — 100% weight + 10% fee scales to exactly fit capital.
- `test_rebalance_scaled_basket_preserves_weight_ratios` — 10%/90% ratio kept after scaling.
- `test_rebalance_scaled_basket_is_independent_of_input_code_order` — same outcome for both code orders.
- `test_rebalance_irrecoverably_infeasible_basket_is_atomic` — margin-destroying closeout still aborts unchanged.

Related: #1278 addresses the same issue with a similar bisection; this PR is an alternative implementation (single planner for both paths, plus a defensive final capital check).
