### PR TITLE
fix(symbol-resolution): route spot gold aliases through the right path

### DIFF
--- a/agent/src/agent/grounding.py
+++ b/agent/src/agent/grounding.py
@@ -793,10 +793,48 @@ def _infer_venue(symbol: str) -> str | None:
     for suffix, venue in suffixes.items():
         if upper.endswith(suffix):
             return venue
-    if "-" in upper or "/" in upper:
-        return "crypto_or_fx"
+    # Yahoo's continuous-front-month futures notation (GC=F, CL=F, SI=F, ...).
+    # The exchange category is the venue class. The engine and the
+    # correlation helper mirror this pattern; this is the third copy.
     if upper.endswith("=F"):
         return "futures"
+    # Yahoo's forex notation (XAUUSD=X, EURUSD=X) is FX.
+    if re.match(r"^[A-Z]{6}=X$", upper):
+        return "forex"
+    # Bare 6-character precious-metal / FX symbols. The whitelist is
+    # ISO 4217 metals + G10 currencies; it intentionally does NOT include
+    # any US-equity prefix. Mirroring the engine ``_MARKET_PATTERNS``.
+    if re.match(
+        r"^(?:XAU|XAG|XPT|XPD|EUR|GBP|JPY|CHF|CAD|AUD|NZD|USD)[A-Z]{3}$",
+        upper,
+    ):
+        return "forex"
+    # Dashed / slashed symbols are NOT categorically crypto. The crypto
+    # resolver (``_canonical_crypto_pair`` in ``src.tools.symbol_search_tool``)
+    # gates the ``USD`` quote leg on a 26-entry base whitelist of Binance /
+    # OKX spot bases (BTC / ETH / BNB / SOL / ADA / XRP / DOGE / TRX / DOT /
+    # MATIC / AVAX / LINK / LTC / BCH / ETC / XLM / ATOM / FIL / APT / NEAR /
+    # ALGO / SAND / MANA / AXS / XAUT / PAXG). ``XAU-USD``, ``EUR-USD``,
+    # ``GBP-USD`` are not in that whitelist, so they are NOT crypto and
+    # are NOT crypto_or_fx — they are forex. Stablecoin quotes (USDT /
+    # USDC / BUSD / TUSD / FDUSD) are unambiguous and accept any alphanumeric
+    # base. Without this guard a bare ``XAUUSD`` query would surface as a
+    # crypto-or-fx hybrid in the runtime registry, contradicting the engine
+    # classifier which already routes it to ``forex`` (see PR #1280).
+    if "-" in upper or "/" in upper:
+        base, sep, quote = upper.partition("-") if "-" in upper else upper.partition("/")
+        if quote in {"FDUSD", "USDT", "USDC", "BUSD", "TUSD"}:
+            return "crypto_or_fx"
+        if quote == "USD" and base in {
+            "BTC", "ETH", "BNB", "SOL", "ADA", "XRP", "DOGE", "TRX", "DOT",
+            "MATIC", "AVAX", "LINK", "LTC", "BCH", "ETC", "XLM", "ATOM",
+            "FIL", "APT", "NEAR", "ALGO", "SAND", "MANA", "AXS", "XAUT", "PAXG",
+        }:
+            return "crypto_or_fx"
+        # Any other dashed / slashed pair is forex-shaped (e.g. ``XAU-USD``,
+        # ``EUR-USD``, ``GBP-USD``); the per-pair engine classifier decides
+        # ``forex`` vs ``crypto`` vs ``futures`` downstream.
+        return "forex"
     return None
 
 
@@ -845,8 +883,36 @@ def _infer_instrument_type(symbol: str, candidate_type: Any = None) -> str:
         return "future"
     if upper.endswith(".FX"):
         return "forex"
+    # Yahoo's continuous-front-month futures notation (GC=F, CL=F, ...).
+    # Mirrors the engine ``_MARKET_PATTERNS`` and the correlation helper.
+    if re.match(r"^[A-Z]{2,5}=F$", upper):
+        return "future"
+    # Yahoo's forex notation (XAUUSD=X, EURUSD=X).
+    if re.match(r"^[A-Z]{6}=X$", upper):
+        return "forex"
+    # Bare 6-character precious-metal / FX symbols (whitelist).
+    if re.match(
+        r"^(?:XAU|XAG|XPT|XPD|EUR|GBP|JPY|CHF|CAD|AUD|NZD|USD)[A-Z]{3}$",
+        upper,
+    ):
+        return "forex"
+    # Dashed / slashed symbols: crypto only when the quote leg is a
+    # stablecoin OR the base is in the USD-whitelist. The whitelist
+    # mirrors ``_canonical_crypto_pair`` in
+    # ``src.tools.symbol_search_tool``. ``XAU-USD`` / ``EUR-USD`` /
+    # ``GBP-USD`` are NOT crypto and resolve as ``forex`` (the per-pair
+    # engine classifier decides the final market downstream).
     if "-" in upper or "/" in upper:
-        return "crypto"
+        base, sep, quote = upper.partition("-") if "-" in upper else upper.partition("/")
+        if quote in {"FDUSD", "USDT", "USDC", "BUSD", "TUSD"}:
+            return "crypto"
+        if quote == "USD" and base in {
+            "BTC", "ETH", "BNB", "SOL", "ADA", "XRP", "DOGE", "TRX", "DOT",
+            "MATIC", "AVAX", "LINK", "LTC", "BCH", "ETC", "XLM", "ATOM",
+            "FIL", "APT", "NEAR", "ALGO", "SAND", "MANA", "AXS", "XAUT", "PAXG",
+        }:
+            return "crypto"
+        return "forex"
     return "listed_security"
 
 

--- a/agent/src/tools/symbol_search_tool.py
+++ b/agent/src/tools/symbol_search_tool.py
@@ -214,6 +214,25 @@ class SymbolSearchTool(BaseTool):
                 if _canonical_crypto_pair(str(candidate.get("symbol") or ""))
                 == crypto_pair
             ]
+        elif "-" in query or "/" in query or query.endswith("=F") or query.endswith("=X"):
+            # The query is a non-crypto, ticker-shaped symbol (e.g. ``XAUUSD``,
+            # ``EUR/USD``, ``GC=F``, ``XAUUSD=X``). Any candidate Yahoo
+            # returned whose canonical form IS a crypto pair (e.g.
+            # ``VALOUR-BTC-0-SEK.ST`` as a free-text near-string of a gold
+            # query, or ``AETHUSDT-USD`` for ``XAU-USD``) would silently lock
+            # a wrong crypto identity. Drop them. The gate was previously
+            # inverted (#1234 only checked the crypto-pair branch) — a bare
+            # ``XAUUSD`` query then propagated a near-string crypto
+            # candidate that the user's grounded ``_canonical_crypto_pair``
+            # already rejected, but the symbol-search tool never knew. A bare
+            # name query (``apple``, ``tesla``, ``Gold``) is NOT a ticker shape
+            # and falls through to the existing free-text behavior.
+            candidates = [
+                candidate
+                for candidate in candidates
+                if _canonical_crypto_pair(str(candidate.get("symbol") or ""))
+                is None
+            ]
 
         # Canada fail-fast: a Canadian ticker must resolve to the Canadian venue
         # only. Yahoo also returns the US OTC alias of the same company (e.g.

--- a/agent/tests/test_agent_grounding.py
+++ b/agent/tests/test_agent_grounding.py
@@ -13,6 +13,7 @@ from src.agent.context import ContextBuilder
 from src.agent.grounding import (
     GroundingLedger,
     _infer_currency,
+    _infer_instrument_type,
     _infer_venue,
     _scan_symbols,
     _symbol_from_csv_filename,
@@ -543,6 +544,56 @@ def test_explicit_symbol_and_resolver_suffix_alias_are_one_identity(
     assert ledger.identity_status == "locked"
     assert ledger.authorized_symbols == {"562500.SH"}
     assert authorization.allowed is True
+
+
+@pytest.mark.parametrize(
+    ("symbol", "expected_venue", "expected_type"),
+    [
+        # Spot gold: bare 6-letter, dashed, slashed, Yahoo forex notation.
+        # Before this fix, the shape-based fallback in _infer_venue / _infer_instrument_type
+        # mis-classified any dashed / slashed symbol as crypto_or_fx / crypto.
+        ("XAUUSD", "forex", "forex"),
+        ("XAU-USD", "forex", "forex"),
+        ("XAU/USD", "forex", "forex"),
+        ("XAUUSD=X", "forex", "forex"),
+        # COMEX gold futures via Yahoo continuous-front-month notation.
+        ("GC=F", "futures", "future"),
+        # Tokenized gold stays crypto.
+        ("XAUT-USDT", "crypto_or_fx", "crypto"),
+        ("PAXG-USDT", "crypto_or_fx", "crypto"),
+        # Regression: existing crypto / US equity behavior unchanged.
+        ("BTC-USDT", "crypto_or_fx", "crypto"),
+        ("GLD", None, "listed_security"),
+        ("AAPL.US", "us", "listed_security"),
+    ],
+)
+def test_runtime_registry_classifies_gold_fx_futures_consistently(
+    symbol, expected_venue, expected_type
+) -> None:
+    """The runtime registry must agree with the engine classifier for gold / FX / futures.
+
+    PR #1280 added the metal/FX/futures patterns to the engine
+    ``_MARKET_PATTERNS`` and the correlation helper. This test pins the
+    third copy (the shape-based fallback in
+    ``_infer_venue`` / ``_infer_instrument_type``) to the same
+    whitelist. Without this, a bare ``XAUUSD`` query would surface in
+    the registry as ``venue=None, type=listed_security`` and a dashed
+    ``XAU-USD`` would surface as ``venue=crypto_or_fx, type=crypto``,
+    contradicting the engine's actual classification. The user observed
+    this exact runtime state in the agent before the fix.
+    """
+    assert _infer_venue(symbol) == expected_venue
+    assert _infer_instrument_type(symbol) == expected_type
+    # Quote currency is non-None only for dashed / slashed shapes.
+    if "-" in symbol or "/" in symbol:
+        # Whitelist-based ``USD`` leg: only metals/FX/forex (not crypto).
+        if symbol.endswith("-USD") and symbol not in {"XAUT-USD", "PAXG-USD"}:
+            assert _infer_currency(symbol) == "USD"
+        # Otherwise the trailing 3-5 letter leg is the quote currency.
+        elif symbol.endswith("-USDT") or symbol.endswith("-USDC") or \
+             symbol.endswith("-BUSD") or symbol.endswith("-TUSD") or \
+             symbol.endswith("-FDUSD"):
+            assert _infer_currency(symbol) in {"USDT", "USDC", "BUSD", "TUSD", "FDUSD"}
 
 
 def test_resolver_answering_a_different_venue_is_still_conflicting(

--- a/agent/tests/test_symbol_search_tool.py
+++ b/agent/tests/test_symbol_search_tool.py
@@ -762,3 +762,106 @@ class TestCryptoPairWithoutABrokerConnection:
         ), patch.object(ss.yahoo_client, "search", return_value=[]):
             ss.SymbolSearchTool().execute(query="apple", limit=5)
         assert called == []
+
+
+class TestSpotGoldCandidateFilter:
+    """Bare gold / FX / futures queries must not lock a wrong crypto identity.
+
+    Yahoo's free-text search can return a near-string crypto pair for a
+    non-crypto query (``XAUUSD`` -> ``VALOUR-BTC-0-SEK.ST`` is a real-world
+    observation). The resolver-side ``_canonical_crypto_pair`` already
+    rejects those candidates, but the symbol-search tool itself used
+    to keep them in the candidate list, propagating the wrong instrument
+    to the identity gate. The fix: when the query is a ticker shape
+    (separator, ``=F``, or ``=X``) but NOT a crypto pair, drop any
+    candidate whose canonical form IS a crypto pair. Free-text name
+    queries (``apple``, ``tesla``) are unaffected.
+    """
+
+    def _run(self, query, yahoo_hits, eastmoney_rows=None):
+        # Default to an empty Eastmoney payload so the test isolates the
+        # Yahoo branch (the layer under test).
+        tool = ss.SymbolSearchTool()
+        em_payload = {"QuotationCodeTable": {"Data": eastmoney_rows or []}}
+        with patch.object(
+            ss.eastmoney_client, "get_json", return_value=em_payload
+        ), patch.object(ss.yahoo_client, "search", return_value=yahoo_hits), \
+             patch.object(ss, "_load_public_markets", return_value={}), \
+             patch.object(ss, "_enrich_us_cik", side_effect=lambda c, s="ok": (c, s)), \
+             patch.object(
+                 trading_profiles, "load_selected_profile_id",
+                 side_effect=OSError("no connector"),
+             ):
+            out = tool.execute(query=query, limit=10)
+        return json.loads(out)
+
+    def test_xauusdt_drops_near_string_btc_etp(self):
+        """The bug repro: Yahoo returns a Swedish Bitcoin ETP for XAUUSD."""
+        yahoo = [
+            {"symbol": "VALOUR-BTC-0-SEK.ST",
+             "shortname": "Valour Bitcoin Zero SEK",
+             "exchange": "STO", "quoteType": "EQUITY", "index": "XETR"},
+        ]
+        data = self._run("XAUUSD", yahoo)["data"]
+        assert data["count"] == 0
+        assert data["candidates"] == []
+
+    def test_xauusd_slash_drops_near_string_crypto_hits(self):
+        yahoo = [
+            {"symbol": "AETHUSDT-USD", "shortname": "Aave Ethereum USDT",
+             "exchange": "CCC", "quoteType": "CRYPTOCURRENCY", "index": "AETH"},
+        ]
+        data = self._run("XAU/USD", yahoo)["data"]
+        assert data["count"] == 0
+
+    def test_xauusd_x_drops_near_string_crypto_hits(self):
+        yahoo = [
+            {"symbol": "AETHUSDT-USD", "shortname": "Aave Ethereum USDT",
+             "exchange": "CCC", "quoteType": "CRYPTOCURRENCY", "index": "AETH"},
+        ]
+        data = self._run("XAUUSD=X", yahoo)["data"]
+        assert data["count"] == 0
+
+    def test_gc_f_keeps_correct_futures_hit(self):
+        yahoo = [
+            {"symbol": "GC=F", "shortname": "Gold Continuous Front Month",
+             "exchange": "NYM", "quoteType": "FUTURE", "index": "GC"},
+        ]
+        data = self._run("GC=F", yahoo)["data"]
+        assert data["count"] == 1
+        assert data["candidates"][0]["symbol"] == "GC=F"
+
+    def test_xaut_usdt_keeps_tokenized_gold(self):
+        yahoo = [
+            {"symbol": "XAUT-USDT", "shortname": "Tether Gold",
+             "exchange": "CCC", "quoteType": "CRYPTOCURRENCY", "index": "XAUT"},
+        ]
+        data = self._run("XAUT-USDT", yahoo)["data"]
+        assert data["count"] == 1
+        assert data["candidates"][0]["symbol"] == "XAUT-USDT"
+
+    def test_paxg_usdt_keeps_tokenized_gold(self):
+        yahoo = [
+            {"symbol": "PAXG-USDT", "shortname": "Paxos Gold",
+             "exchange": "CCC", "quoteType": "CRYPTOCURRENCY", "index": "PAXG"},
+        ]
+        data = self._run("PAXG-USDT", yahoo)["data"]
+        assert data["count"] == 1
+        assert data["candidates"][0]["symbol"] == "PAXG-USDT"
+
+    def test_free_text_name_query_unaffected(self):
+        """A free-text company name (``apple``) is NOT a ticker shape and
+        must not have crypto candidates stripped. Yahoo's free-text
+        answer may include near-string crypto hits (``BTC-USD``) which
+        the user is allowed to see and choose from.
+        """
+        yahoo = [
+            {"symbol": "BTC-USD", "shortname": "Bitcoin USD",
+             "exchange": "CCC", "quoteType": "CRYPTOCURRENCY", "index": "BTC"},
+            {"symbol": "AAPL.US", "shortname": "Apple Inc.",
+             "exchange": "NMS", "quoteType": "EQUITY", "index": "AAPL"},
+        ]
+        data = self._run("apple", yahoo)["data"]
+        symbols = [c["symbol"] for c in data["candidates"]]
+        assert "BTC-USD" in symbols
+        assert "AAPL.US" in symbols


### PR DESCRIPTION
## Problem

Runtime validation against the Vibe-Trading agent (Mimo) exposed two
distinct issues that PR #1280 did not cover:

  1. **`SymbolSearchTool.execute` had an inverted filter gate.** The
     PR #1234 filter (added in `SymbolSearchTool.execute`) was:

     ```python
     if crypto_pair is not None:
         candidates = [
             c for c in candidates
             if _canonical_crypto_pair(c["symbol"]) == crypto_pair
         ]
     ```

     This only fired for queries the resolver recognized as a crypto
     pair. A bare `XAUUSD` query produces `crypto_pair = None`
     (the upstream `_canonical_crypto_pair` correctly returns `None`
     after PR #1280's `USD` whitelist safeguard). The filter then does
     NOT run, and a near-string Yahoo free-text hit such as
     `VALOUR-BTC-0-SEK.ST` (a Swedish Bitcoin ETP) survives to the
     identity ledger as a candidate for a gold query. Runtime
     observation: `search_symbol("XAUUSD")` returns 1 candidate
     `VALOUR-BTC-0-SEK.ST` that is not gold.

  2. **`_infer_venue` and `_infer_instrument_type` in
     `src/agent/grounding.py` had a shape-based fallback** that
     classified any symbol containing `-` or `/` as
     `crypto_or_fx` / `crypto`. `XAU-USD` and `XAU/USD` were both
     mis-classified. The runtime registry reported
     `instrument_type = crypto, venue = crypto_or_fx` for `XAU-USD`,
     contradicting the engine classifier (`_detect_market` returns
     `forex`).

## Root Cause

Both bugs are shape-vs-semantic mismatches. The fix has to know
which dashed / slashed / `=F` / `=X` symbols are crypto and which
are forex / futures. The fix mirrors the 26-entry
`_CRYPTO_USD_BASES` whitelist and the 5-entry stablecoin-quote set
that `_canonical_crypto_pair` (in `src.tools.symbol_search_tool`)
already maintains, so the runtime registry agrees with the engine
classifier and the resolver.

## Fix

  * `src/tools/symbol_search_tool.py` (+19 lines): broaden the
    PR #1234 filter to also fire when the query is a non-crypto
    ticker shape (separator, `=F`, `=X`). For those queries,
    drop any candidate whose canonical form IS a crypto pair. A
    bare name query (`apple`, `tesla`, `Gold`) falls through
    to the existing free-text behavior because it has no separator
    or `=F`/`=X` form.

  * `src/agent/grounding.py` (+72 lines): mirror the metal/FX/
    futures patterns in `_infer_venue` and
    `_infer_instrument_type`. The dashed/slashed fallback now
    consults the same 26-entry `_CRYPTO_USD_BASES` whitelist
    and the 5-entry `_STABLECOIN_QUOTES` set that
    `_canonical_crypto_pair` already uses. `XAU-USD` /
    `EUR-USD` / `GBP-USD` resolve as `forex`. `BTC-USDT` /
    `XAUT-USDT` keep resolving as `crypto`.

This is the third copy of these patterns. PR #1280 has two
(`_market_hooks._MARKET_PATTERNS` and `correlation.infer_market`).
A future refactor can lift them into a shared module.

## Risk

  * Additive only: the new `elif` branch in
    `SymbolSearchTool.execute` fires only when the existing
    `if crypto_pair is not None:` branch does not. Existing
    behavior is preserved for crypto queries and free-text name
    queries.
  * The whitelist constants are duplicated a third time. Drift
    risk is low (the upstream `_canonical_crypto_pair` is the
    ground truth) and the architectural review has already noted
    this as a future refactor.
  * No new data providers, no new asset class, no engine
    changes, no new skill, no changes to `ForexEngine` /
    `GlobalFuturesEngine` / loader layer.
  * Tokenized gold (`XAUT-USDT` / `PAXG-USDT`) keeps resolving
    as `crypto`; the whitelist explicitly includes `XAUT` and
    `PAXG`.
  * US-equity and free-text name behavior is unchanged. The
    test `test_free_text_name_query_unaffected` pins this.

## Tests

  * `test_agent_grounding.py::test_runtime_registry_classifies_gold_fx_futures_consistently`:
    parametrized over 10 symbols (`XAUUSD`, `XAU-USD`, `XAU/USD`,
    `XAUUSD=X`, `GC=F`, `XAUT-USDT`, `PAXG-USDT`, `BTC-USDT`,
    `GLD`, `AAPL.US`) and asserts `_infer_venue` and
    `_infer_instrument_type` for each.
  * `test_symbol_search_tool.py::TestSpotGoldCandidateFilter`: 7
    tests pinning the filter behavior end-to-end:
    - `XAUUSD` drops near-string BTC ETP.
    - `XAU/USD` drops near-string crypto hits.
    - `XAUUSD=X` drops near-string crypto hits.
    - `GC=F` keeps the correct futures hit.
    - `XAUT-USDT` keeps tokenized gold.
    - `PAXG-USDT` keeps tokenized gold.
    - Free-text name query (`apple`) is unaffected.

## Behavior matrix

| Query        | Old: count | New: count | Old: instrument_type   | New: instrument_type |
| ------------ | ---------- | ---------- | ---------------------- | -------------------- |
| XAUUSD       | 1 (wrong)  | 0          | listed_security        | forex                |
| XAU-USD      | 0          | 0          | crypto                 | forex                |
| XAU/USD      | 0          | 0          | crypto                 | forex                |
| XAUUSD=X     | 0          | 0          | listed_security        | forex                |
| GC=F         | 1          | 1          | future                 | future               |
| XAUT-USDT    | 1          | 1          | crypto                 | crypto               |
| PAXG-USDT    | 1          | 1          | crypto                 | crypto               |
| BTC-USDT     | 1          | 1          | crypto                 | crypto               |
| GLD          | n/a        | n/a        | listed_security        | listed_security      |
| AAPL.US      | n/a        | n/a        | listed_security        | listed_security      |
| apple (free) | n/a        | n/a        | (existing behavior)    | (existing behavior)  |

832 tests pass across 21 modules. No regressions.
