### PR TITLE
fix(desktop): correctly handle EPERM in updater shutdown checks

### DIFF
--- a/desktop/electron/src/backend-manager.ts
+++ b/desktop/electron/src/backend-manager.ts
@@ -481,7 +481,10 @@ function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;
-  } catch {
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException)?.code;
+    if (code === "EPERM") return true;
+    if (code === "ESRCH") return false;
     return false;
   }
 }

--- a/desktop/electron/src/backend-watchdog.ts
+++ b/desktop/electron/src/backend-watchdog.ts
@@ -129,7 +129,10 @@ function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;
-  } catch {
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException)?.code;
+    if (code === "EPERM") return true;
+    if (code === "ESRCH") return false;
     return false;
   }
 }


### PR DESCRIPTION
## Summary
- Fix shutdown liveness check to distinguish EPERM (alive) from ESRCH (not alive) in dormant updater handoff.

## Why
Refs #1016.

`isProcessAlive` treated every `process.kill` error as not alive, so a PID that exists but lacks permission was misreported as exited and the handoff gate could succeed while the backend still held the listener.

## Changes
- `desktop/electron/src/backend-manager.ts`: return true for EPERM, false for ESRCH.
- `desktop/electron/src/backend-watchdog.ts`: same fix.

## Test Plan
- [ ] Existing tests pass (`npm run build` and `npm run test:update-safety`)
- [ ] New tests added (if applicable)
- [ ] Tested manually (describe below)

## Checklist
- [ ] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [ ] No hardcoded values (API keys, file paths, magic numbers)
- [ ] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] Documentation updated (if user-facing change)