### PR TITLE
fix(live): enforce narrowing semantics for non-numeric and list mandate adjustments

### DIFF
--- a/agent/src/live/mandate/commit.py
+++ b/agent/src/live/mandate/commit.py
@@ -49,6 +49,11 @@ _PROPOSALS_DIRNAME = "proposals"
 _CONSENT_DIRNAME = "consent"
 _PROPOSAL_ID_RE = re.compile(r"^mp_[0-9a-f]{32}$")
 
+def _is_real_number(value: Any) -> bool:
+    """Return whether ``value`` is a non-bool int/float."""
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
 #: Maps every accepted alias of a clamped limit to its CANONICAL name. The
 #: proposal profile, the ceiling snapshot, and the clamp in
 #: ``propose_mandate_tool`` all use slightly different human-vs-schema spellings
@@ -262,12 +267,33 @@ def _resolve_profile(
             if key not in resolved:
                 raise CommitError(f"adjustment {key!r} is not a field of the selected profile")
             current = resolved[key]
-            if isinstance(current, (int, float)) and isinstance(value, (int, float)):
+            if _is_real_number(current):
+                if not _is_real_number(value):
+                    raise CommitError(
+                        f"adjustment {key!r}={value!r} has an invalid type for the rendered limit "
+                        f"{current!r}; numeric narrowing requires an int or float"
+                    )
                 if value > current:
                     raise CommitError(
                         f"adjustment {key!r}={value} widens the rendered limit {current}; "
                         "widening must go through a fresh proposal"
                     )
+            elif isinstance(current, list):
+                if not isinstance(value, list):
+                    raise CommitError(
+                        f"adjustment {key!r}={value!r} has an invalid type for the rendered list "
+                        f"{current!r}; list narrowing requires a list subset"
+                    )
+                if not all(item in current for item in value):
+                    raise CommitError(
+                        f"adjustment {key!r}={value!r} widens the rendered whitelist {current!r}; "
+                        "widening must go through a fresh proposal"
+                    )
+            elif type(value) is not type(current) or value != current:
+                raise CommitError(
+                    f"adjustment {key!r}={value!r} changes the rendered value {current!r}; "
+                    "only narrowing or equivalent adjustments are allowed"
+                )
             resolved[key] = value
     return resolved
 
@@ -299,12 +325,21 @@ def _profile_fits_ceilings(profile: Mapping[str, Any], ceilings: Mapping[str, An
         if key not in prof:
             continue
         prof_value = prof[key]
-        if isinstance(ceiling_value, (int, float)) and isinstance(prof_value, (int, float)):
-            if prof_value > ceiling_value:
-                return False
-        elif key == "leverage":
+        if key == "leverage" and ceiling_value == "none":
             # Cash-only ceiling forbids any leverage other than "none".
-            if ceiling_value == "none" and prof_value not in ("none", None, 1, 1.0):
+            if prof_value is True or prof_value is False or prof_value not in ("none", None, 1, 1.0):
+                return False
+        elif key == "allowed_instruments":
+            # A whitelist may only be narrowed, never widened at commit time.
+            if not isinstance(ceiling_value, list) or not isinstance(prof_value, list):
+                return False
+            if not all(item in ceiling_value for item in prof_value):
+                return False
+        else:
+            # Numeric ceilings fail closed when either side is bool/non-numeric.
+            if not _is_real_number(ceiling_value) or not _is_real_number(prof_value):
+                return False
+            if prof_value > ceiling_value:
                 return False
     return True
 

--- a/agent/tests/test_consent_commit.py
+++ b/agent/tests/test_consent_commit.py
@@ -23,6 +23,7 @@ import src.live.mandate.commit as mandate_commit
 from src.live.mandate.commit import (
     CommitError,
     DEFAULT_MANDATE_LIFETIME_DAYS,
+    _profile_fits_ceilings,
     commit_mandate,
     save_proposal,
 )
@@ -321,6 +322,117 @@ def _save_handcrafted_proposal(
         }
     )
     return proposal_id
+
+
+def _save_h19_proposal(live_runtime: Path) -> str:
+    """Persist the H19 fixture: numeric leverage and a two-item whitelist."""
+    profile = {
+        "ordinal": 1,
+        "label": "h19",
+        "max_order_usd": 100.0,
+        "max_total_exposure_usd": 100.0,
+        "daily_trade_cap": 2,
+        "leverage": 2,
+        "instruments": ["equity", "option"],
+    }
+    ceilings = {
+        "account_funding_usd": 100.0,
+        "max_order_notional_usd": 100.0,
+        "max_total_exposure_usd": 100.0,
+        "max_trades_per_day": 2,
+        "leverage": 2,
+        "allowed_instruments": ["equity", "option"],
+    }
+    return _save_handcrafted_proposal("robinhood", profile, ceilings)
+
+
+def test_adjust_string_numeric_widening_rejected(live_runtime: Path) -> None:
+    """H19: a string "10" cannot widen numeric leverage 2 by type confusion."""
+    proposal_id = _save_h19_proposal(live_runtime)
+    with pytest.raises(CommitError, match="invalid type"):
+        commit_mandate(
+            proposal_id=proposal_id,
+            ordinal=1,
+            adjustments={"leverage": "10"},
+            consent_ack=True,
+            broker="robinhood",
+        )
+    assert load_mandate("robinhood") is None
+
+
+def test_adjust_string_numeric_narrowing_rejected(live_runtime: Path) -> None:
+    """H19 policy: even string numeric narrowing is rejected as an invalid type."""
+    proposal_id = _save_h19_proposal(live_runtime)
+    with pytest.raises(CommitError, match="numeric narrowing requires an int or float"):
+        commit_mandate(
+            proposal_id=proposal_id,
+            ordinal=1,
+            adjustments={"leverage": "1"},
+            consent_ack=True,
+            broker="robinhood",
+        )
+    assert load_mandate("robinhood") is None
+
+
+def test_adjust_bool_numeric_limit_rejected(live_runtime: Path) -> None:
+    """H19: bool is an int subclass, but is never a valid numeric limit value."""
+    proposal_id = _save_h19_proposal(live_runtime)
+    with pytest.raises(CommitError, match="invalid type"):
+        commit_mandate(
+            proposal_id=proposal_id,
+            ordinal=1,
+            adjustments={"leverage": True},
+            consent_ack=True,
+            broker="robinhood",
+        )
+    assert load_mandate("robinhood") is None
+
+
+def test_adjust_instruments_widening_rejected(live_runtime: Path) -> None:
+    """H19: adding an instrument to the rendered whitelist must re-propose."""
+    proposal_id = _save_h19_proposal(live_runtime)
+    with pytest.raises(CommitError, match="widen"):
+        commit_mandate(
+            proposal_id=proposal_id,
+            ordinal=1,
+            adjustments={"instruments": ["equity", "option", "cfd"]},
+            consent_ack=True,
+            broker="robinhood",
+        )
+    assert load_mandate("robinhood") is None
+
+
+def test_adjust_instruments_narrowing_subset_commits(live_runtime: Path) -> None:
+    """H19: a true subset of the rendered whitelist commits as narrowing."""
+    proposal_id = _save_h19_proposal(live_runtime)
+    result = commit_mandate(
+        proposal_id=proposal_id,
+        ordinal=1,
+        adjustments={"instruments": ["equity"]},
+        consent_ack=True,
+        broker="robinhood",
+    )
+    mandate = load_mandate("robinhood")
+    assert result["mandate_id"]
+    assert mandate is not None
+    assert mandate.hard_caps.allowed_instruments == ("equity",)
+
+
+def test_profile_fits_ceilings_rejects_non_numeric_profile_value() -> None:
+    """H19 defense-in-depth: numeric ceilings reject string profile values."""
+    assert not _profile_fits_ceilings({"leverage": "10"}, {"leverage": 2})
+
+
+def test_profile_fits_ceilings_rejects_bool_profile_value() -> None:
+    """H19 defense-in-depth: bool cannot masquerade as a numeric profile value."""
+    assert not _profile_fits_ceilings({"leverage": True}, {"leverage": 2})
+
+
+def test_profile_fits_ceilings_rejects_instrument_widening() -> None:
+    """H19 defense-in-depth: the ceiling whitelist must contain every instrument."""
+    profile = {"instruments": ["equity", "option"]}
+    ceilings = {"allowed_instruments": ["equity"]}
+    assert not _profile_fits_ceilings(profile, ceilings)
 
 
 def test_commit_rejects_profile_over_alias_keyed_order_ceiling(live_runtime: Path) -> None:


### PR DESCRIPTION
## Problem

The commit-time adjustment path only guarded the both-numeric branch, so three narrowing-check bypasses slipped through (roadmap audit #1207, finding 19):

- **Type confusion**: a rendered numeric limit (`leverage: 2`) adjusted with a string (`"10"`) skipped the widening check entirely and committed as-is
- **Bool masquerade**: `True`/`False` are int subclasses in Python and passed the `isinstance(current, (int, float))` guard
- **List fields unguarded**: `instruments` / `allowed_instruments` had no comparison branch at all, so a whitelist could be widened from `["AAPL"]` to `["AAPL","TSLA","SPY"]` at commit time - silently expanding the authorization the user actually saw

The downstream ceiling re-check `_profile_fits_ceilings` had the same both-numeric blind spot, so it never caught what `_resolve_profile` let through.

## Fix

In `agent/src/live/mandate/commit.py`:

- `_resolve_profile`: numeric limits now reject non-numeric adjustment types outright (invalid type, not silent skip); bool is excluded from numeric handling; list limits must be **subsets** of the rendered whitelist; other scalar types must be equivalent - widening always goes back through PROPOSE
- `_profile_fits_ceilings`: fails closed on non-numeric pairs, treats bool as non-numeric, and enforces whitelist containment on `allowed_instruments`

## Verification

All scenarios are covered by new tests in `agent/tests/test_consent_commit.py`:

| Test | Result |
|---|---|
| `test_adjust_string_numeric_widening_rejected` | ✅ |
| `test_adjust_string_numeric_narrowing_rejected` | ✅ |
| `test_adjust_bool_numeric_limit_rejected` | ✅ |
| `test_adjust_instruments_widening_rejected` | ✅ |
| `test_adjust_instruments_narrowing_subset_commits` | ✅ |
| `test_profile_fits_ceilings_rejects_non_numeric_profile_value` | ✅ |
| `test_profile_fits_ceilings_rejects_bool_profile_value` | ✅ |
| `test_profile_fits_ceilings_rejects_instrument_widening` | ✅ |

- Full suite: **33 passed** (25 existing + 8 new)
- Reverse verification: reverting only `commit.py` to main makes exactly the 7 new rejection tests fail, confirming they guard the actual bug
- `git diff` touches exactly two files: the fix + its tests

Fixes part of #1207 (finding 19).
