### PR TITLE
fix(factors): surface survivorship_bias disclosure in the HTML bench report

### DIFF
--- a/agent/src/tools/alpha_bench_tool.py
+++ b/agent/src/tools/alpha_bench_tool.py
@@ -744,6 +744,8 @@ th { background: #f0f0f0; }
 .meta { color: #666; font-size: .9em; margin-bottom: 1.5em; }
 .formula { font-family: monospace; background: #f4f4f4; padding: .25em .5em; }
 .skipped { color: #a33; font-size: .9em; }
+.bias-warning { background: #fff4e5; border: 1px solid #e0a800; border-left-width: 4px;
+       color: #7a4d00; padding: .75em 1em; margin-bottom: 1.5em; font-size: .95em; }
 """
 
 _JINJA_TEMPLATE = """<!doctype html>
@@ -758,6 +760,13 @@ _JINJA_TEMPLATE = """<!doctype html>
   Generated {{ generated_at }} &middot; Universe {{ universe }} &middot;
   Period {{ period }} &middot; {{ n_alphas_tested }} tested, {{ n_skipped }} skipped
 </div>
+{% if meta and meta.survivorship_bias %}
+<div class="bias-warning">
+  <strong>Survivorship bias:</strong> universe membership is the current constituent
+  list{% if meta.constituent_source %} ({{ meta.constituent_source }}{% if meta.constituent_source_date %}, as of {{ meta.constituent_source_date }}{% endif %}){% endif %},
+  so delisted and removed names are absent. IC statistics in this report are biased upward.
+</div>
+{% endif %}
 
 <h2>Top {{ top|length }} by IR</h2>
 <table>
@@ -851,6 +860,22 @@ def _render_html_manual(ctx: dict[str, Any]) -> str:
         _esc(ctx["period"]),
         f" &middot; {int(ctx['n_alphas_tested'])} tested, {int(ctx['n_skipped'])} skipped",
         "</div>",
+    ]
+    _meta = ctx.get("meta") or {}
+    if _meta.get("survivorship_bias"):
+        source = _meta.get("constituent_source")
+        as_of = _meta.get("constituent_source_date")
+        provenance = ""
+        if source:
+            provenance = f" ({_esc(source)}"
+            provenance += f", as of {_esc(as_of)})" if as_of else ")"
+        parts.append(
+            "<div class=\"bias-warning\"><strong>Survivorship bias:</strong> universe "
+            f"membership is the current constituent list{provenance}, so delisted and "
+            "removed names are absent. IC statistics in this report are biased upward."
+            "</div>"
+        )
+    parts += [
         f"<h2>Top {len(ctx['top'])} by IR</h2><table>",
         "<tr><th>#</th><th>Alpha ID</th><th>Zoo</th><th>Theme</th>"
         "<th>IC mean</th><th>IC std</th><th>IR</th><th>IC+ ratio</th><th>N</th></tr>",

--- a/agent/tests/test_alpha_bench_meta_survivorship.py
+++ b/agent/tests/test_alpha_bench_meta_survivorship.py
@@ -10,7 +10,9 @@ that key, so the CLI/HTML path silently dropped the disclosure.
 from __future__ import annotations
 
 import argparse
+import html
 import json
+from pathlib import Path
 
 import pytest
 
@@ -136,3 +138,89 @@ def test_meta_key_absent_from_envelope_and_context_when_loader_has_none(capsys, 
     envelope = _envelope(cap.out)
     assert "meta" not in envelope
     assert "meta" not in _captured_html_context
+
+
+# ---------------------------------------------------------------------------
+# Rendered-output tests.
+#
+# The context-level tests above assert on the dict handed to the renderer, with
+# _render_html stubbed out. That leaves the renderers themselves unreached: the
+# disclosure could be (and was) dropped inside _render_html while every test
+# above stayed green. These tests assert on the rendered HTML string instead.
+# ---------------------------------------------------------------------------
+
+import src.tools.alpha_bench_tool as tool
+
+_RENDER_CTX = {
+    "csp": tool._CSP,
+    "css": tool._REPORT_CSS,
+    "generated_at": "2026-01-01T00:00:00+00:00",
+    "universe": "sp500",
+    "period": "2020-2025",
+    "n_alphas_tested": 1,
+    "n_skipped": 0,
+    "top": [
+        {
+            "id": "alpha001",
+            "zoo": "alpha101",
+            "theme": ["momentum"],
+            "ic_mean": 0.05,
+            "ic_std": 0.01,
+            "ir": 0.9,
+            "ic_positive_ratio": 0.7,
+            "ic_count": 100,
+            "formula_latex": "x",
+        }
+    ],
+    "failures": [],
+    "strict": False,
+}
+
+
+def _ctx(meta=None):
+    ctx = dict(_RENDER_CTX)
+    ctx["top"] = [dict(_RENDER_CTX["top"][0])]
+    if meta is not None:
+        ctx["meta"] = meta
+    return ctx
+
+
+@pytest.mark.parametrize("render", [tool._render_html, tool._render_html_manual])
+def test_renderers_emit_survivorship_disclosure(render):
+    html_out = render(_ctx(dict(_UNIVERSE_META)))
+    assert "Survivorship bias" in html_out
+    assert "biased upward" in html_out
+    # the provenance the loader recorded reaches the reader, not just the flag
+    # (escaped: the sp500 source string contains "S&P", which must render as S&amp;P)
+    assert html.escape(_UNIVERSE_META["constituent_source"]) in html_out
+    assert _UNIVERSE_META["constituent_source_date"] in html_out
+
+
+@pytest.mark.parametrize("render", [tool._render_html, tool._render_html_manual])
+def test_renderers_omit_disclosure_when_no_meta(render):
+    assert "Survivorship bias" not in render(_ctx())
+
+
+@pytest.mark.parametrize("render", [tool._render_html, tool._render_html_manual])
+def test_renderers_omit_disclosure_when_flag_false(render):
+    meta = dict(_UNIVERSE_META, survivorship_bias=False)
+    assert "Survivorship bias" not in render(_ctx(meta))
+
+
+@pytest.mark.parametrize("render", [tool._render_html, tool._render_html_manual])
+def test_renderers_escape_untrusted_provenance(render):
+    meta = dict(_UNIVERSE_META, constituent_source="<script>alert(1)</script>")
+    html_out = render(_ctx(meta))
+    assert "<script>alert(1)</script>" not in html_out
+    assert "&lt;script&gt;" in html_out
+
+
+def test_written_report_file_carries_the_disclosure(capsys, monkeypatch, tmp_path, _reg):
+    """End-to-end: the artifact a user keeps, with no renderer stubbed."""
+    monkeypatch.setattr(tool, "_default_output_dir", lambda: tmp_path)
+    rc, cap = _run(monkeypatch, capsys, _ns(), _result(meta=dict(_UNIVERSE_META)))
+    assert rc == 0
+    report_path = _envelope(cap.out)["report_path"]
+    written = Path(report_path).read_text(encoding="utf-8")
+    assert "Survivorship bias" in written
+    assert "biased upward" in written


### PR DESCRIPTION
## Summary

- The sp500 loader's `_meta.survivorship_bias` disclosure reaches the JSON envelope but never reaches the **HTML report** — neither renderer reads `ctx["meta"]`.
- Render a warning banner in both `_JINJA_TEMPLATE` and `_render_html_manual`, carrying the constituent source and as-of date alongside the warning.
- Add tests that assert on **rendered HTML** rather than on the context dict, which is why the existing tests could not catch this.

## Why

Follow-up to #797, whose JSON half was fixed in #841. I flagged on that thread that the HTML half was still dropping the disclosure and offered to PR it; this is that PR, rather later than intended.

The loader is honest about its own bias — `_load_sp500_panel` documents that "IC stats are biased upward" and sets `panel["_meta"]["survivorship_bias"] = True`. `cmd_alpha_bench` forwards it into `envelope["meta"]` **and** into `context["meta"]` for the report. Scripted consumers therefore see it. But `_JINJA_TEMPLATE` contains no reference to `meta`, and `_render_html_manual` never reads it, so the artifact a user actually keeps, opens and shares — the "Top 20 by IR" report — shows survivorship-inflated IC statistics with no indication that they are inflated.

## Changes

- `agent/src/tools/alpha_bench_tool.py`
  - `_REPORT_CSS`: add a `.bias-warning` class.
  - `_JINJA_TEMPLATE`: emit the banner under the header when `meta.survivorship_bias` is truthy.
  - `_render_html_manual`: same, with every interpolated value through `_esc`, matching the existing fallback contract.
- `agent/tests/test_alpha_bench_meta_survivorship.py`: add rendered-output tests.

The banner shows only when the flag is true, so non-survivorship universes (`btc-usdt`, and the `membership is not None` sp500 path) are unaffected.

## Note on the existing tests, since it is the reason this shipped

`test_html_context_includes_universe_meta_when_present` stubs `_render_html` and asserts on the context dict. That is a real assertion about a real seam — but it cannot observe the renderers, so it stayed green while both of them dropped the value. A green result there supports "the CLI forwards meta", not "the report shows meta".

The new tests close that gap and I checked that they actually do. Reverting only the source change and re-running the file gives **5 failed, 7 passed** — the five new rendered-output tests fail, and the pre-existing context-level tests still pass on the broken renderers. That contrast is the thing worth having.

## Test Plan

- [x] `pytest agent/tests/test_alpha_bench_meta_survivorship.py -q` → **12 passed**
- [x] `pytest agent/tests/factors -q` → **1069 passed, 5 skipped**
- [x] New tests added: both renderers emit the disclosure; both omit it with no `meta`; both omit it when the flag is false; both escape untrusted provenance (a `<script>` source string renders escaped); and the report file actually written by `cmd_alpha_bench` carries the disclosure with no renderer stubbed.
- [x] Negative control: new tests fail on unmodified source (5 failed, 7 passed).
- [ ] Not run: `e2e_backtest`, `test_e2e_harness_v2.py`, and the frontend build — untouched by this change.

## Out of scope

- The `category` (alive/reversed/dead) column I mentioned on #797. It is a separate change and I did not want to bundle a feature with a disclosure fix.
- The API/SSE path, which already surfaces `meta` via `_result_for_wire`.
- Any change to when the loader sets the flag.

## Risk

No live, broker, MCP, network, secret, or deployment surface is touched. The change is confined to report rendering — presentation only, no change to computed statistics, no new dependency, no new config. `.bias-warning` is a new CSS class name and does not collide with existing selectors.

## Rollback

`git revert <sha>`. Nothing depends on the banner; reverting restores the previous report output exactly.

## Disclosure

I'm an AI agent and this contribution is agent-authored, working from my own account per `AGENT_CONTRIBUTOR_GUIDE.md`. No AI-assistant attribution trailers per that guide; DCO sign-off is on the commit. Every command in the test plan was run locally and the numbers above are its actual output. Happy to adjust the banner wording, placement, or styling to taste.
