### PR TITLE
fix(backtest): perpetual funding settles 3x/day on daily bars

### DIFF
--- a/agent/backtest/engines/_market_hooks.py
+++ b/agent/backtest/engines/_market_hooks.py
@@ -225,6 +225,36 @@ _TIER_TABLE = [
 FUNDING_HOURS = {0, 8, 16}
 
 
+def _interval_hours(interval: str) -> float:
+    """Convert interval token to span hours.
+
+    Supports project intervals like 1m/5m/15m/30m/1H/4H/1D/1W/1M.
+    """
+    token = str(interval).strip()
+    if not token:
+        return 24.0
+    # normalize: allow e.g. "1D", "1d", "4H"
+    import re as _re
+
+    m = _re.match(r"^\s*(\d+(?:\.\d+)?)\s*([a-zA-Z]+)\s*$", token)
+    if not m:
+        return 24.0
+    value = float(m.group(1))
+    unit = m.group(2).lower()
+    if unit in {"m", "min", "mins", "minute", "minutes"}:
+        return value / 60.0
+    if unit in {"h", "hour", "hours"}:
+        return value
+    if unit in {"d", "day", "days"}:
+        return value * 24.0
+    if unit in {"w", "week", "weeks"}:
+        return value * 24.0 * 7
+    if unit in {"mo", "mth", "month", "months"}:
+        return value * 24.0 * 30
+    # fallback: treat as hours
+    return value
+
+
 def _maintenance_rate(notional_usd: float) -> float:
     """Look up tiered maintenance margin rate."""
     for tier_max, rate in _TIER_TABLE:
@@ -241,6 +271,7 @@ def calc_crypto_funding_fee(
     funding_rate: float,
     applied_set: set,
     daily_done_set: set,
+    interval: str | None = None,
 ) -> float:
     """Calculate crypto funding fee for one symbol.
 
@@ -253,6 +284,10 @@ def calc_crypto_funding_fee(
             carries no historical ``funding_rate`` column.
         applied_set: (symbol, date, hour) dedup set — mutated.
         daily_done_set: (symbol, date) dedup set — mutated.
+        interval: Bar interval token (e.g. "1D", "4H", "1H", "15m").
+            When span >= 8h, settlement count is ``max(1, span_hours // 8)``
+            per bar so daily bars settle 3x/day, 12h 1x/bar (2/day), weekly 21x.
+            Intraday spans (<8h) keep the slot logic on 0/8/16 UTC.
 
     Returns:
         Fee amount (positive = longs pay, negative = longs receive).
@@ -262,6 +297,46 @@ def calc_crypto_funding_fee(
 
     current_date = timestamp.date()
     hour = timestamp.hour if hasattr(timestamp, "hour") else 0
+
+    # Span-based settlement for daily+ bars: count is per-bar, not per-slot
+    if interval is not None:
+        try:
+            span_hours = _interval_hours(interval)
+        except Exception:
+            span_hours = None
+        if span_hours is not None and span_hours >= 8:
+            settlements = max(1, int(span_hours // 8))
+            key = (symbol, current_date, hour)
+            if key in applied_set:
+                return 0.0
+            applied_set.add(key)
+            pos = positions.get(symbol)
+            if pos is None:
+                return 0.0
+            mark_price = float(bar.get("close", pos.entry_price))
+            notional = pos.size * mark_price
+            hist = bar.get("funding_rate")
+            if hist is not None and pd.notna(hist):
+                funding_rate = float(hist)
+            return notional * funding_rate * pos.direction * settlements
+        # Intraday (<8h): only settlement-hour slots, no daily fallback
+        if span_hours is not None and span_hours < 8:
+            if hour in FUNDING_HOURS:
+                key = (symbol, current_date, hour)
+                if key in applied_set:
+                    return 0.0
+                applied_set.add(key)
+            else:
+                return 0.0
+            pos = positions.get(symbol)
+            if pos is None:
+                return 0.0
+            mark_price = float(bar.get("close", pos.entry_price))
+            notional = pos.size * mark_price
+            hist = bar.get("funding_rate")
+            if hist is not None and pd.notna(hist):
+                funding_rate = float(hist)
+            return notional * funding_rate * pos.direction
 
     if hour in FUNDING_HOURS:
         key = (symbol, current_date, hour)

--- a/agent/backtest/engines/composite.py
+++ b/agent/backtest/engines/composite.py
@@ -132,6 +132,8 @@ class CompositeEngine(BaseEngine):
         # Forex dedup state
         self._last_swap_dates: dict = {}
 
+        self._run_interval = str(config.get("interval", "1D"))
+
     def run_backtest(self, config: dict, *args, **kwargs):
         """Run the pipeline, refusing a code set that spans currencies.
 
@@ -150,6 +152,7 @@ class CompositeEngine(BaseEngine):
             ValueError: If the codes span more than one settlement currency.
         """
         _reject_mixed_currency(config.get("codes") or list(self._symbol_market))
+        self._run_interval = str(config.get("interval", "1D"))
         return super().run_backtest(config, *args, **kwargs)
 
     def _rule_for(self, symbol: str) -> BaseEngine:
@@ -255,6 +258,7 @@ class CompositeEngine(BaseEngine):
                 symbol, bar, timestamp, self.positions,
                 crypto_sub.funding_rate,
                 self._funding_applied, self._funding_daily_done,
+                self._run_interval,
             )
             self.capital -= fee
 

--- a/agent/backtest/engines/crypto.py
+++ b/agent/backtest/engines/crypto.py
@@ -603,6 +603,7 @@ class CryptoEngine(BaseEngine):
         fee = calc_crypto_funding_fee(
             symbol, bar, timestamp, self.positions,
             self.funding_rate, self._funding_applied, self._funding_daily_done,
+            self._run_interval,
         )
         self.capital -= fee
 

--- a/agent/tests/test_crypto_engine.py
+++ b/agent/tests/test_crypto_engine.py
@@ -261,7 +261,7 @@ class TestSlippage:
 
 class TestFundingFee:
     def test_funding_deducted_at_settlement_hour(self) -> None:
-        engine = _make_engine(funding_rate=0.0001)
+        engine = _make_engine(funding_rate=0.0001, interval="1H")
         engine.positions["BTC-USDT"] = Position(
             "BTC-USDT", 1, 60000.0, pd.Timestamp("2025-01-01"), 1.0, leverage=10.0,
         )
@@ -269,11 +269,11 @@ class TestFundingFee:
         bar = _make_bar(close=60000.0)
         ts = pd.Timestamp("2025-01-01 08:00:00")  # settlement hour
         engine.on_bar("BTC-USDT", bar, ts)
-        # Long pays: 1.0 × 60000 × 0.0001 × 1(long) = $6
+        # Long pays: 1.0 × 60000 × 0.0001 × 1(long) = $6 (intraday slot)
         assert engine.capital == pytest.approx(initial_capital - 6.0)
 
     def test_non_settlement_hour_applies_daily_fallback(self) -> None:
-        """Non-settlement hour still applies funding once per day (daily bar support)."""
+        """Daily interval settles 3x per day regardless of bar hour (span-based)."""
         engine = _make_engine(funding_rate=0.0001)
         engine.positions["BTC-USDT"] = Position(
             "BTC-USDT", 1, 60000.0, pd.Timestamp("2025-01-01"), 1.0, leverage=10.0,
@@ -282,8 +282,8 @@ class TestFundingFee:
         bar = _make_bar(close=60000.0)
         ts = pd.Timestamp("2025-01-01 05:00:00")  # not settlement hour
         engine.on_bar("BTC-USDT", bar, ts)
-        # Daily fallback: applies once even at non-settlement hour
-        assert engine.capital == pytest.approx(initial_capital - 6.0)
+        # Daily bars: 1D -> 3 settlements per bar (span_hours // 8)
+        assert engine.capital == pytest.approx(initial_capital - 18.0)
 
     def test_short_receives_funding(self) -> None:
         engine = _make_engine(funding_rate=0.0001)
@@ -319,7 +319,7 @@ class TestFundingFee:
         assert engine.capital == initial_capital
 
     def test_daily_bars_apply_each_day(self) -> None:
-        """Regression: daily bars (all hour=0) must apply funding every day, not just day 1."""
+        """Regression: daily bars (all hour=0) must apply 3x funding every day."""
         engine = _make_engine(funding_rate=0.0001)
         engine.positions["BTC-USDT"] = Position(
             "BTC-USDT", 1, 60000.0, pd.Timestamp("2025-01-01"), 1.0, leverage=10.0,
@@ -342,12 +342,12 @@ class TestFundingFee:
         after_day3 = engine.capital
         assert after_day3 < after_day2  # fee deducted again
 
-        # Each day: 1 × 60000 × 0.0001 = $6
-        assert initial - after_day3 == pytest.approx(18.0)
+        # Each day: 3 × 60000 × 0.0001 = $18; 3 days = $54
+        assert initial - after_day3 == pytest.approx(54.0)
 
     def test_multi_symbol_funding(self) -> None:
         """Each symbol gets independent funding settlement."""
-        engine = _make_engine(funding_rate=0.0001)
+        engine = _make_engine(funding_rate=0.0001, interval="1H")
         engine.positions["BTC-USDT"] = Position(
             "BTC-USDT", 1, 60000.0, pd.Timestamp("2025-01-01"), 1.0, leverage=10.0,
         )
@@ -463,7 +463,7 @@ class TestHistoricalFundingRate:
     def test_bar_funding_rate_overrides_fixed_rate(self) -> None:
         """A bar carrying a historical ``funding_rate`` column (USD-M perp
         data) must be charged at that rate, not the fixed config rate."""
-        engine = _make_engine(funding_rate=0.0001)
+        engine = _make_engine(funding_rate=0.0001, interval="1H")
         engine.positions["BTC-USDT-PERP"] = Position(
             "BTC-USDT-PERP", 1, 60000.0, pd.Timestamp("2025-01-01"), 1.0, leverage=10.0,
         )
@@ -475,7 +475,7 @@ class TestHistoricalFundingRate:
         assert engine.capital == pytest.approx(initial_capital - 30.0)
 
     def test_negative_historical_funding_pays_longs(self) -> None:
-        engine = _make_engine(funding_rate=0.0001)
+        engine = _make_engine(funding_rate=0.0001, interval="1H")
         engine.positions["BTC-USDT-PERP"] = Position(
             "BTC-USDT-PERP", 1, 60000.0, pd.Timestamp("2025-01-01"), 1.0, leverage=10.0,
         )
@@ -489,7 +489,7 @@ class TestHistoricalFundingRate:
     def test_nan_funding_rate_falls_back_to_fixed(self) -> None:
         """Non-settlement bars carry NaN funding_rate — must fall back to
         the fixed config rate (daily-fallback path), not charge NaN."""
-        engine = _make_engine(funding_rate=0.0001)
+        engine = _make_engine(funding_rate=0.0001, interval="1H")
         engine.positions["BTC-USDT-PERP"] = Position(
             "BTC-USDT-PERP", 1, 60000.0, pd.Timestamp("2025-01-01"), 1.0, leverage=10.0,
         )


### PR DESCRIPTION
## Summary

- Fix non-strict perpetual funding on daily bars to settle 3x/day (span_hours // 8) instead of 1x/day. Intraday bars keep 0/8/16 slot logic.

## Why

`calc_crypto_funding_fee` settled on `FUNDING_HOURS = {0,8,16}` with per-slot dedup. Daily bars all carry `hour=0`, so only one settlement fired per day (0.01% * 365 vs engine model 0.01% * 3 * 365). Tracked in roadmap #1207 Phase 2 item 8. Closes #1290.

## Changes

- Make settlement count span-based: `max(1, span_hours // 8)` per bar for span >= 8h (1D -> 3/day, 12H -> 1/bar, 1W -> 21/week); intraday (<8h) keeps slot logic without daily fallback.

## Test Plan

- [ ] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [ ] New tests added (if applicable)
- [ ] Tested manually (describe below)

Tested: `pytest agent/tests/test_crypto_engine.py -q` 60 passed; manual reproduction daily 3 days 54.0, 1H at 08:00 6.0, funding_rate=0 0, composite 1D 18.0; intraday 4H 00/08 6 each, 04 0.

## Checklist

- [ ] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [ ] No hardcoded values (API keys, file paths, magic numbers)
- [ ] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] Documentation updated (if user-facing change)