### PR TITLE
fix(backtest): correct Monte Carlo Sharpe annualisation in validation.json

### DIFF
--- a/agent/backtest/run_card.py
+++ b/agent/backtest/run_card.py
@@ -75,6 +75,18 @@ def write_run_card(
         card["artifact_refs"] = normalized_refs
     if "validation" in metrics:
         card["validation"] = metrics["validation"]
+    else:
+        # The standalone validator (``python -m backtest.validation <run_dir>``)
+        # writes artifacts/validation.json without going through ``metrics``.
+        # Surface it so the card never says "Not present" while the file exists.
+        validation_file = run_dir / "artifacts" / "validation.json"
+        if validation_file.exists():
+            try:
+                card["validation"] = json.loads(
+                    validation_file.read_text(encoding="utf-8")
+                )
+            except (json.JSONDecodeError, OSError):
+                pass
 
     card = _json_safe(card)
     json_path = run_dir / "run_card.json"
@@ -178,6 +190,57 @@ def _normalize_artifact_refs(artifact_refs: Sequence[Mapping[str, Any]] | None) 
     return refs
 
 
+def _render_validation(validation: Any) -> list[str]:
+    """Compact Markdown for the validation block.
+
+    ``artifacts/validation.json`` nests ``monte_carlo`` / ``bootstrap`` /
+    ``walk_forward`` and carries raw sample arrays and equity-path matrices —
+    dumping those verbatim (the old behaviour) bloats the card with thousands
+    of numbers on one line. Summarise the headline fields; the full data
+    stays in ``run_card.json`` and ``artifacts/validation.json``.
+    """
+    if not isinstance(validation, Mapping):
+        return [f"- {validation}"]
+
+    summary_keys = {
+        "monte_carlo": (
+            "actual_sharpe", "p_value_sharpe", "actual_max_dd", "p_value_max_dd",
+            "simulated_sharpe_mean", "simulated_sharpe_p5", "simulated_sharpe_p95",
+            "n_trades", "trades_per_year", "n_simulations", "basis", "error",
+        ),
+        "bootstrap": (
+            "observed_sharpe", "ci_lower", "ci_upper", "median_sharpe",
+            "prob_positive", "n_bootstrap", "error",
+        ),
+        "walk_forward": (
+            "n_windows", "profitable_windows", "consistency_rate",
+            "return_mean", "sharpe_mean", "sharpe_std", "error",
+        ),
+    }
+    lines: list[str] = []
+    handled = False
+    for section, keys in summary_keys.items():
+        block = validation.get(section)
+        if not isinstance(block, Mapping):
+            continue
+        handled = True
+        shown = ", ".join(f"{k}={block[k]}" for k in keys if k in block)
+        lines.append(f"- {section}: {shown}")
+    if handled:
+        return lines
+
+    # Unknown shape (e.g. the legacy flat dict): key/value, but never dump
+    # long arrays or nested dicts inline.
+    for key, value in validation.items():
+        if isinstance(value, (list, tuple)) and len(value) > 8:
+            lines.append(f"- {key}: [{len(value)} values]")
+        elif isinstance(value, Mapping):
+            lines.append(f"- {key}: {{{len(value)} fields}}")
+        else:
+            lines.append(f"- {key}: {value}")
+    return lines or ["- Present but empty."]
+
+
 def _render_markdown(card: Mapping[str, Any]) -> str:
     lines = [
         "# Backtest Run Card",
@@ -210,11 +273,7 @@ def _render_markdown(card: Mapping[str, Any]) -> str:
 
     lines.extend(["", "## Validation"])
     if "validation" in card:
-        validation = card["validation"]
-        if isinstance(validation, Mapping):
-            lines.extend(f"- {key}: {value}" for key, value in validation.items())
-        else:
-            lines.append(f"- {validation}")
+        lines.extend(_render_validation(card["validation"]))
     else:
         lines.append("- Not present.")
 

--- a/agent/backtest/validation.py
+++ b/agent/backtest/validation.py
@@ -37,6 +37,21 @@ def monte_carlo_test(
     Null hypothesis: the observed Sharpe / max-drawdown is no better than
     a random ordering of the same trades.
 
+    All Sharpe figures here are computed on the *per-trade* realised-PnL
+    sequence (one observation per closed trade), then annualised by the
+    strategy's realised trade frequency — ``sqrt(trades_per_year)``, derived
+    from the first entry and last exit timestamp. The previous implementation
+    hard-coded ``sqrt(252)`` as if each trade were one trading day, which
+    inflated the reported Sharpe by ``sqrt(252 / trades_per_year)`` (roughly
+    8x for a ~12-trade multi-year backtest). The p-values are unchanged by
+    this: a constant factor applied to both the actual and every simulated
+    Sharpe cannot change their ordering.
+
+    ``actual_max_dd`` is the drawdown of the realised-PnL path (visible only
+    at trade-exit granularity); it is deliberately *not* the mark-to-market
+    daily max drawdown reported on the run card, because the permutation test
+    is about trade ordering, not intraday marks.
+
     Args:
         trades: Completed round-trip trades from backtest.
         initial_capital: Starting capital.
@@ -45,7 +60,8 @@ def monte_carlo_test(
 
     Returns:
         Dict with actual_sharpe, p_value_sharpe, actual_max_dd,
-        p_value_max_dd, simulated_sharpes (percentiles).
+        p_value_max_dd, simulated_sharpe percentiles, plus ``basis``,
+        ``trades_per_year`` and ``annualization_factor``.
     """
     if isinstance(n_simulations, bool) or not isinstance(n_simulations, Integral) or n_simulations < 1:
         return {
@@ -58,7 +74,8 @@ def monte_carlo_test(
         return {"error": "need at least 3 trades", "p_value_sharpe": 1.0}
 
     pnls = np.array([t.pnl for t in trades])
-    actual = _path_metrics(pnls, initial_capital)
+    ann_factor, trades_per_year = _trade_annualization(trades)
+    actual = _path_metrics(pnls, initial_capital, ann_factor)
 
     rng = np.random.default_rng(seed)
     sharpe_count = 0
@@ -73,7 +90,7 @@ def monte_carlo_test(
         shuffled = rng.permutation(pnls)
         if sim_equities is not None:
             sim_equities[i] = initial_capital + np.cumsum(shuffled)
-        sim = _path_metrics(shuffled, initial_capital)
+        sim = _path_metrics(shuffled, initial_capital, ann_factor)
         sim_sharpes.append(sim["sharpe"])
         if sim["sharpe"] >= actual["sharpe"]:
             sharpe_count += 1
@@ -92,6 +109,12 @@ def monte_carlo_test(
         "simulated_sharpe_p95": round(float(np.percentile(sim_arr, 95)), 4),
         "n_simulations": n_simulations,
         "n_trades": len(trades),
+        "trades_per_year": round(trades_per_year, 2) if trades_per_year else None,
+        "annualization_factor": round(ann_factor, 4),
+        "basis": (
+            "per-trade realised PnL sequence; Sharpe annualised by realised "
+            "trade frequency (sqrt(trades_per_year)), not sqrt(252)"
+        ),
         "sharpe_samples": [round(float(s), 4) for s in sim_sharpes],
     }
     if sim_equities is not None:
@@ -113,8 +136,15 @@ def monte_carlo_test(
     return result
 
 
-def _path_metrics(pnls: np.ndarray, initial_capital: float) -> Dict[str, float]:
-    """Compute Sharpe and max drawdown from a PnL sequence."""
+def _path_metrics(
+    pnls: np.ndarray, initial_capital: float, ann_factor: float = 1.0
+) -> Dict[str, float]:
+    """Sharpe and max drawdown from a per-trade PnL sequence.
+
+    ``ann_factor`` scales the raw per-trade Sharpe to an annual figure; it is
+    ``sqrt(trades_per_year)`` (see :func:`_trade_annualization`). Pass ``1.0``
+    to get the un-annualised per-trade Sharpe.
+    """
     equity = initial_capital + np.cumsum(pnls)
     if len(equity) > 1:
         prev = equity[:-1]
@@ -123,11 +153,30 @@ def _path_metrics(pnls: np.ndarray, initial_capital: float) -> Dict[str, float]:
     else:
         returns = np.array([0.0])
     std = returns.std()
-    sharpe = float(returns.mean() / (std + 1e-10) * np.sqrt(252))
+    sharpe = float(returns.mean() / (std + 1e-10) * ann_factor)
     peak = np.maximum.accumulate(equity)
     dd = (equity - peak) / np.where(peak > 0, peak, 1.0)
     max_dd = float(dd.min())
     return {"sharpe": sharpe, "max_dd": max_dd}
+
+
+def _trade_annualization(trades: List[TradeRecord]) -> tuple[float, float | None]:
+    """Return ``(sqrt(trades_per_year), trades_per_year)`` from the realised
+    trade cadence — first entry to last exit. Falls back to ``(1.0, None)``
+    (no annualisation) when the timestamps are missing or span no time, so a
+    Sharpe is never silently annualised on a wrong basis.
+    """
+    try:
+        stamps = [pd.Timestamp(t.entry_time) for t in trades]
+        stamps += [pd.Timestamp(t.exit_time) for t in trades]
+        stamps = [s for s in stamps if not pd.isna(s)]
+        span_days = (max(stamps) - min(stamps)).total_seconds() / 86_400.0
+    except (ValueError, TypeError, AttributeError):
+        return 1.0, None
+    if span_days <= 0 or len(trades) == 0:
+        return 1.0, None
+    trades_per_year = len(trades) / (span_days / 365.25)
+    return math.sqrt(trades_per_year), trades_per_year
 
 
 # ─── Bootstrap Sharpe CI ───
@@ -368,28 +417,45 @@ def _load_trades(run_dir: Path) -> List[TradeRecord]:
     if df.empty:
         return []
 
-    # trades.csv has entry+exit row pairs; extract exit rows (they have pnl != 0)
-    trades = []
-    exit_rows = df[df["pnl"] != 0].reset_index(drop=True)
-    for _, row in exit_rows.iterrows():
-        hold = pd.to_numeric(row.get("holding_bars"), errors="coerce")
-        if pd.isna(hold):
-            hold = pd.to_numeric(row.get("holding_days", 0), errors="coerce")
-        holding_bars = 0.0 if pd.isna(hold) else float(hold)
+    # trades.csv is time-ordered entry/exit rows. An entry row carries no
+    # realised numbers (pnl / holding / return_pct all zero); an exit row
+    # carries at least one. Pair each exit with the most recent open entry of
+    # the same code so entry_time / entry_price are real — the old code keyed
+    # only on ``pnl != 0`` (dropping zero-PnL exits) and stamped entry_time
+    # with the exit timestamp (breaking walk-forward bucketing).
+    def _num(row: pd.Series, col: str) -> float:
+        val = pd.to_numeric(row.get(col), errors="coerce")
+        return 0.0 if pd.isna(val) else float(val)
+
+    df = df.sort_values("timestamp").reset_index(drop=True)
+    open_entries: Dict[str, pd.Series] = {}
+    trades: List[TradeRecord] = []
+    for _, row in df.iterrows():
+        code = str(row.get("code", ""))
+        realised = _num(row, "pnl") or _num(row, "return_pct") or max(
+            _num(row, "holding_bars"), _num(row, "holding_days")
+        )
+        if not realised and code not in open_entries:
+            open_entries[code] = row
+            continue
+        entry = open_entries.pop(code, None)
+        hold = _num(row, "holding_bars") or _num(row, "holding_days")
         trades.append(
             TradeRecord(
-                symbol=str(row.get("code", "")),
+                symbol=code,
                 direction=1 if row.get("side") == "sell" else -1,
-                entry_price=0.0,
-                exit_price=float(row.get("price", 0)),
-                entry_time=pd.Timestamp(row.get("timestamp", "2000-01-01")),
+                entry_price=_num(entry, "price") if entry is not None else 0.0,
+                exit_price=_num(row, "price"),
+                entry_time=pd.Timestamp(
+                    (entry if entry is not None else row).get("timestamp", "2000-01-01")
+                ),
                 exit_time=pd.Timestamp(row.get("timestamp", "2000-01-01")),
-                size=float(row.get("qty", 0)),
+                size=_num(row, "qty"),
                 leverage=1.0,
-                pnl=float(row.get("pnl", 0)),
-                pnl_pct=float(row.get("return_pct", 0)),
+                pnl=_num(row, "pnl"),
+                pnl_pct=_num(row, "return_pct"),
                 exit_reason=str(row.get("reason", "signal")),
-                holding_bars=holding_bars,
+                holding_bars=hold,
                 commission=0.0,
             )
         )


### PR DESCRIPTION
## Summary

- Fix an ~8x inflation of every Sharpe figure in `artifacts/validation.json`'s `monte_carlo` block
- Fix trade miscounting and wrong `entry_time` in the standalone validator's `_load_trades`
- Make the run card surface `validation.json` when it was produced by the standalone validator, and render it compactly

## Why

Running the built-in validation on a multi-year daily backtest produces a `monte_carlo` block whose numbers are not usable:

```
"actual_sharpe": 6.994,
"simulated_sharpe_mean": 6.0596,
```

against a backtest whose reported Sharpe is ~0.7.

Root cause: `backtest/validation.py::_path_metrics` annualises the **per-trade** realised-PnL return series with a hard-coded `* np.sqrt(252)`, i.e. as if each closed trade were one trading day. For a strategy that trades ~4–5 times a year that scales the Sharpe by `sqrt(252 / trades_per_year)` ≈ 8x. The p-values are unaffected (a constant factor applied to both the actual and every simulated Sharpe cannot change their ordering), but `actual_sharpe`, `simulated_sharpe_mean/std/p5/p95` and `sharpe_samples` are all on a meaningless scale, and the frontend `ValidationPanel` renders them verbatim.

Two smaller issues in the same file's standalone CLI path (`python -m backtest.validation <run_dir>`):

- `_load_trades` selects exit rows with `df["pnl"] != 0`, which drops genuine break-even exits and, on some `trades.csv` shapes, miscounts (`n_trades` came out as 13 for a 12-trade run).
- It sets both `entry_time` and `exit_time` to the exit row's timestamp, so `walk_forward_analysis` buckets every trade by its exit date.

And `run_card.py` only emits a `## Validation` section when the runner passes validation results through `metrics`; a `validation.json` written by the standalone CLI is ignored, so the card says "Validation: Not present" next to a populated file.

## Changes

`backtest/validation.py`
- `_path_metrics(pnls, initial_capital, ann_factor=1.0)` — take the annualisation factor as an argument instead of hard-coding `sqrt(252)`.
- New `_trade_annualization(trades)` — derive `sqrt(trades_per_year)` from the first-entry→last-exit span; fall back to `1.0` (no annualisation) when timestamps are missing or span no time, so a Sharpe is never silently annualised on a wrong basis.
- `monte_carlo_test` now also emits `basis`, `trades_per_year`, `annualization_factor`. Existing keys and their meaning are unchanged; `actual_max_dd` is still the realised-PnL-path drawdown (that is what the trade-permutation test is about) and is now documented as deliberately distinct from the run card's daily max-DD.
- `_load_trades` rewritten to pair entry/exit rows in time order, so `entry_time` / `entry_price` are real and break-even exits are counted.

`backtest/run_card.py`
- When `metrics` carries no `"validation"`, fall back to reading `artifacts/validation.json`.
- New `_render_validation()` — compact Markdown summary of the `monte_carlo` / `bootstrap` / `walk_forward` blocks instead of dumping `sharpe_samples` / `equity_paths` inline. Full data stays in `run_card.json`.

### Before / after (real 12-trade BTC-USDT daily run)

| field | before | after |
|---|--:|--:|
| `actual_sharpe` | 6.994 | 0.916 |
| `simulated_sharpe_mean` | 6.060 | 0.698 |
| `n_trades` | 13 | 12 |
| `p_value_sharpe` | 0.213 | 0.093 |

(`p_value_sharpe` moves only because the trade count was wrong before.)

## Test Plan

- [x] Existing tests pass — `pytest agent/tests -q -k "validation or run_card"` → 243 passed, 7 skipped
- [ ] New tests added — existing `test_validation.py` / `test_validation_cli.py` / `test_run_card*.py` cover the changed code; happy to add a regression test asserting `actual_sharpe` is within an order of magnitude of the daily Sharpe if you'd like one
- [x] Tested manually — regenerated `validation.json` and `run_card.md` for a real run; numbers above

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) — changes are in `agent/backtest/`
- [x] No hardcoded values
- [x] Follows CONTRIBUTING.md
- [x] DCO sign-off present on the commit
