### PR TITLE
fix(backtest): fill options signals on the next bar, not the signal date (#1293)

### DIFF
--- a/agent/backtest/engines/options_portfolio.py
+++ b/agent/backtest/engines/options_portfolio.py
@@ -233,13 +233,15 @@ def run_options_backtest(
     all_dates = set()
     for df in data_map.values():
         all_dates.update(df.index)
-    dates = sorted(all_dates)
+    full_dates = sorted(all_dates)
 
     # Warm-up bars primed the signal engine above; from here they do not exist,
-    # so nothing they contain reaches a fill, the equity curve or a metric.
-    warmup_end = evaluation_start_index(config, pd.DatetimeIndex(dates))
-    if warmup_end:
-        dates = dates[warmup_end:]
+    # so nothing they contain reaches a fill, the equity curve or a metric. The
+    # full range stays available for the previous-bar lookup, so a signal dated
+    # the last warm-up bar fills on the first evaluated bar -- the equity
+    # engines' convention (the warm-up cut is applied after the signal shift).
+    warmup_end = evaluation_start_index(config, pd.DatetimeIndex(full_dates))
+    dates = full_dates[warmup_end:]
 
     # Index signals by date
     signal_by_date: Dict[str, List[Dict[str, Any]]] = {}
@@ -255,17 +257,21 @@ def run_options_backtest(
     equity_records: List[Dict[str, Any]] = []
 
     for idx, current_date in enumerate(dates):
+        full_idx = idx + warmup_end
         ts = pd.Timestamp(current_date)
         date_str = str(ts.date()) if hasattr(ts, "date") else str(ts)
         # Signals are dated the bar they were computed on and priced/filled on
-        # the next bar -- the framework convention the equity engines follow
-        # (#1293). A signal dated before the first evaluation bar is never
-        # executed, matching how warm-up-dated signals behaved before. Set
-        # options_config.same_day_fill to price a signal on its own date.
+        # the next bar's close, executed end-of-day on the bar after the
+        # decision (#1293). Equity engines fill the next bar's open; the
+        # options engine deliberately fills the next close because signals are
+        # computed on end-of-day data. A signal dated the last warm-up bar
+        # fills on the first evaluated bar, matching the equity convention;
+        # only signals dated before the very first loaded bar can never fill.
+        # Set options_config.same_day_fill to price a signal on its own date.
         if same_day_fill:
             signal_date = date_str
-        elif idx > 0:
-            prev = pd.Timestamp(dates[idx - 1])
+        elif full_idx > 0:
+            prev = pd.Timestamp(full_dates[full_idx - 1])
             signal_date = str(prev.date()) if hasattr(prev, "date") else str(prev)
         else:
             signal_date = None
@@ -318,32 +324,6 @@ def run_options_backtest(
                         "entry_date": pos.entry_date,
                     })
                     positions.remove(pos)
-
-        # 2b. Handle expiry
-        expired = [p for p in positions if p.is_expired(ts)]
-        for pos in expired:
-            spot = spot_prices.get(pos.underlying_code, 0.0)
-            intrinsic = pos.intrinsic_value(spot)
-
-            # Expiry: recover intrinsic value (entry_price already deducted at open)
-            settlement = intrinsic * pos.qty * contract_multiplier
-            cash += settlement
-            pnl = (intrinsic - pos.entry_price) * pos.qty * contract_multiplier
-
-            side = "exercise" if intrinsic > 0 else "expire"
-            trade_records.append({
-                "timestamp": date_str,
-                "code": pos.underlying_code,
-                "option_type": pos.option_type,
-                "strike": pos.strike,
-                "expiry": str(pos.expiry.date()),
-                "side": side,
-                "price": round(intrinsic, 4),
-                "qty": pos.qty,
-                "pnl": round(pnl, 4),
-                "entry_date": pos.entry_date,
-            })
-            positions.remove(pos)
 
         # 3. Execute the prior bar's signals at today's prices
         day_signals = signal_by_date.get(signal_date, []) if signal_date else []
@@ -456,7 +436,35 @@ def run_options_backtest(
                                 underlying_code=matched.underlying_code,
                             )
 
-        # 4. Compute portfolio mark-to-market value and Greeks
+        # 4. Handle expiry. Runs after signal execution so a fill dated the
+        # bar before expiry settles on the expiry bar itself: an option is
+        # never carried past its expiry and never settled a bar late (#1293).
+        expired = [p for p in positions if p.is_expired(ts)]
+        for pos in expired:
+            spot = spot_prices.get(pos.underlying_code, 0.0)
+            intrinsic = pos.intrinsic_value(spot)
+
+            # Expiry: recover intrinsic value (entry_price already deducted at open)
+            settlement = intrinsic * pos.qty * contract_multiplier
+            cash += settlement
+            pnl = (intrinsic - pos.entry_price) * pos.qty * contract_multiplier
+
+            side = "exercise" if intrinsic > 0 else "expire"
+            trade_records.append({
+                "timestamp": date_str,
+                "code": pos.underlying_code,
+                "option_type": pos.option_type,
+                "strike": pos.strike,
+                "expiry": str(pos.expiry.date()),
+                "side": side,
+                "price": round(intrinsic, 4),
+                "qty": pos.qty,
+                "pnl": round(pnl, 4),
+                "entry_date": pos.entry_date,
+            })
+            positions.remove(pos)
+
+        # 5. Compute portfolio mark-to-market value and Greeks
         portfolio_value = cash
         total_delta = 0.0
         total_gamma = 0.0

--- a/agent/backtest/engines/options_portfolio.py
+++ b/agent/backtest/engines/options_portfolio.py
@@ -213,6 +213,7 @@ def run_options_backtest(
     exercise_style = options_cfg.get("exercise_style", "european")  # v2: "european" or "american"
     iv_skew = options_cfg.get("iv_skew", 0.0)         # v2: smile skew param (0 = flat)
     iv_curvature = options_cfg.get("iv_curvature", 0.0)  # v2: smile curvature
+    same_day_fill = options_cfg.get("same_day_fill", False)
 
     # Load underlying data
     data_map = loader.fetch(codes, start_date, end_date)
@@ -253,9 +254,21 @@ def run_options_backtest(
     greeks_records: List[Dict[str, Any]] = []
     equity_records: List[Dict[str, Any]] = []
 
-    for current_date in dates:
+    for idx, current_date in enumerate(dates):
         ts = pd.Timestamp(current_date)
         date_str = str(ts.date()) if hasattr(ts, "date") else str(ts)
+        # Signals are dated the bar they were computed on and priced/filled on
+        # the next bar -- the framework convention the equity engines follow
+        # (#1293). A signal dated before the first evaluation bar is never
+        # executed, matching how warm-up-dated signals behaved before. Set
+        # options_config.same_day_fill to price a signal on its own date.
+        if same_day_fill:
+            signal_date = date_str
+        elif idx > 0:
+            prev = pd.Timestamp(dates[idx - 1])
+            signal_date = str(prev.date()) if hasattr(prev, "date") else str(prev)
+        else:
+            signal_date = None
 
         # 1. Get underlying price and IV for the current day
         spot_prices: Dict[str, float] = {}
@@ -332,8 +345,8 @@ def run_options_backtest(
             })
             positions.remove(pos)
 
-        # 3. Execute today's signals
-        day_signals = signal_by_date.get(date_str, [])
+        # 3. Execute the prior bar's signals at today's prices
+        day_signals = signal_by_date.get(signal_date, []) if signal_date else []
         for sig in day_signals:
             action = sig.get("action", "")
             legs = sig.get("legs", [])

--- a/agent/src/skills/options-strategy/SKILL.md
+++ b/agent/src/skills/options-strategy/SKILL.md
@@ -90,7 +90,8 @@ Iron Condor opening signal:
     "options_config": {
         "risk_free_rate": 0.05,
         "iv_source": "historical",
-        "contract_multiplier": 1.0
+        "contract_multiplier": 1.0,
+        "same_day_fill": false
     }
 }
 ```
@@ -100,6 +101,7 @@ Key fields:
 - `options_config.risk_free_rate`: risk-free rate, default `0.05`
 - `options_config.iv_source`: volatility source, currently supports `"historical"` (30-day rolling historical volatility computed from underlying closes)
 - `options_config.contract_multiplier`: contract multiplier, default `1.0`
+- `options_config.same_day_fill`: `false` (default) fills a signal dated T on the next bar's close; `true` restores the legacy same-date fill (signal and fill share T's close and IV)
 
 ## BS Model Principles
 

--- a/agent/tests/test_options_next_bar_fill.py
+++ b/agent/tests/test_options_next_bar_fill.py
@@ -42,7 +42,7 @@ class _FlatLoader:
         return {"SPY": _BARS.copy()}
 
 
-def _signal(date: str):
+def _signal(date: str, expiry: str = _EXPIRY):
     class _Engine:
         def generate(self, data_map):  # noqa: ANN001
             return [
@@ -50,7 +50,7 @@ def _signal(date: str):
                     "date": date,
                     "action": "open",
                     "underlying": "SPY",
-                    "legs": [{"type": "call", "strike": _STRIKE, "expiry": _EXPIRY, "qty": _QTY}],
+                    "legs": [{"type": "call", "strike": _STRIKE, "expiry": expiry, "qty": _QTY}],
                 }
             ]
 
@@ -62,7 +62,14 @@ def _fill_price(day: pd.Timestamp, iv: float) -> float:
     return bs_price(_BARS.at[day, "close"], _STRIKE, t, 0.0, iv, "call")
 
 
-def _run(tmp_path: Path, *, date: str, same_day: bool = False):
+def _run(
+    tmp_path: Path,
+    *,
+    date: str,
+    same_day: bool = False,
+    warmup_bars: int = 0,
+    expiry: str = _EXPIRY,
+):
     run_options_backtest(
         {
             "codes": ["SPY"],
@@ -72,6 +79,7 @@ def _run(tmp_path: Path, *, date: str, same_day: bool = False):
             "engine": "options",
             "initial_cash": 100_000.0,
             "commission": 0.0,
+            **({"warmup_bars": warmup_bars} if warmup_bars else {}),
             "options_config": {
                 "risk_free_rate": 0.0,
                 "contract_multiplier": 1.0,
@@ -79,7 +87,7 @@ def _run(tmp_path: Path, *, date: str, same_day: bool = False):
             },
         },
         _FlatLoader(),
-        _signal(date),
+        _signal(date, expiry=expiry),
         tmp_path,
     )
     return pd.read_csv(tmp_path / "artifacts" / "trades.csv")
@@ -121,3 +129,24 @@ def test_signal_dated_before_first_bar_never_executes(tmp_path: Path) -> None:
 def test_signal_on_last_bar_has_no_next_bar_to_fill(tmp_path: Path) -> None:
     trades = _run(tmp_path, date="2025-01-06")
     assert len(trades) == 0
+
+
+def test_last_warmup_bar_signal_fills_on_first_eval_bar(tmp_path: Path) -> None:
+    """Equity parity: the warm-up cut applies after the signal shift, so a
+    signal dated the last warm-up bar fills on the first evaluated bar."""
+    trades = _run(tmp_path, date="2025-01-01", warmup_bars=1)
+
+    assert len(trades) == 1
+    assert trades.iloc[0]["timestamp"] == "2025-01-02"
+
+
+def test_fill_on_expiry_bar_settles_same_bar_never_a_bar_late(tmp_path: Path) -> None:
+    """Signal dated 2025-01-02 fills 2025-01-03 == expiry: settlement must
+    happen on that bar (entry T floored at 0.001, intrinsic at expiry spot),
+    not on the next bar at the next bar's spot."""
+    trades = _run(tmp_path, date="2025-01-02", expiry="2025-01-03")
+
+    assert list(trades["timestamp"]) == ["2025-01-03", "2025-01-03"]
+    assert trades.iloc[0]["side"] == "buy"
+    assert trades.iloc[1]["side"] == "expire"  # K=100 vs close 90: OTM
+    assert trades.iloc[1]["price"] == pytest.approx(0.0)

--- a/agent/tests/test_options_next_bar_fill.py
+++ b/agent/tests/test_options_next_bar_fill.py
@@ -1,0 +1,123 @@
+"""Regression: options signals must fill on the next bar, not the signal date.
+
+The options engine priced and filled a signal dated T with T's own close and
+IV, so a signal computed on T's close embeded the information it was computed
+from -- a full day of underlying move times delta on every options backtest.
+The equity engines in the same framework execute the next bar; this pins the
+options engine to the same convention. ``same_day_fill: True`` restores the
+legacy same-date fill for strategies that want it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from backtest.engines.options_portfolio import bs_price, run_options_backtest
+
+_DATES = pd.bdate_range("2025-01-01", periods=4)
+_CLOSES = [100.0, 110.0, 90.0, 120.0]
+_BARS = pd.DataFrame(
+    {
+        "open": _CLOSES,
+        "high": [c + 1.0 for c in _CLOSES],
+        "low": [c - 1.0 for c in _CLOSES],
+        "close": _CLOSES,
+        "volume": [1000, 1000, 1000, 1000],
+    },
+    index=_DATES,
+)
+
+_EXPIRY = "2025-02-21"
+_STRIKE = 100.0
+_QTY = 10
+
+
+class _FlatLoader:
+    name = "yfinance"
+
+    def fetch(self, codes, start_date, end_date):  # noqa: ANN001
+        return {"SPY": _BARS.copy()}
+
+
+def _signal(date: str):
+    class _Engine:
+        def generate(self, data_map):  # noqa: ANN001
+            return [
+                {
+                    "date": date,
+                    "action": "open",
+                    "underlying": "SPY",
+                    "legs": [{"type": "call", "strike": _STRIKE, "expiry": _EXPIRY, "qty": _QTY}],
+                }
+            ]
+
+    return _Engine()
+
+
+def _fill_price(day: pd.Timestamp, iv: float) -> float:
+    t = max((pd.Timestamp(_EXPIRY) - day).days / 365.0, 0.001)
+    return bs_price(_BARS.at[day, "close"], _STRIKE, t, 0.0, iv, "call")
+
+
+def _run(tmp_path: Path, *, date: str, same_day: bool = False):
+    run_options_backtest(
+        {
+            "codes": ["SPY"],
+            "start_date": "2025-01-01",
+            "end_date": "2025-01-07",
+            "source": "yfinance",
+            "engine": "options",
+            "initial_cash": 100_000.0,
+            "commission": 0.0,
+            "options_config": {
+                "risk_free_rate": 0.0,
+                "contract_multiplier": 1.0,
+                **({"same_day_fill": True} if same_day else {}),
+            },
+        },
+        _FlatLoader(),
+        _signal(date),
+        tmp_path,
+    )
+    return pd.read_csv(tmp_path / "artifacts" / "trades.csv")
+
+
+def test_signal_dated_t_fills_on_the_next_bar(tmp_path: Path) -> None:
+    trades = _run(tmp_path, date="2025-01-02")
+
+    assert len(trades) == 1
+    assert trades.iloc[0]["timestamp"] == "2025-01-03"
+    assert trades.iloc[0]["price"] == pytest.approx(
+        _fill_price(pd.Timestamp("2025-01-03"), 0.3), abs=1e-4
+    )
+
+
+def test_fill_price_uses_next_bar_spot_not_signal_date_spot(tmp_path: Path) -> None:
+    """Pricing at 90 (2025-01-03) with an expiry 49 days out differs from 110."""
+    trades = _run(tmp_path, date="2025-01-02")
+
+    price_on_02 = bs_price(110.0, _STRIKE, max((pd.Timestamp(_EXPIRY) - pd.Timestamp("2025-01-02")).days / 365.0, 0.001), 0.0, 0.3, "call")
+    assert trades.iloc[0]["price"] != pytest.approx(price_on_02)
+
+
+def test_same_day_fill_flag_preserves_legacy_behavior(tmp_path: Path) -> None:
+    trades = _run(tmp_path, date="2025-01-02", same_day=True)
+
+    assert len(trades) == 1
+    assert trades.iloc[0]["timestamp"] == "2025-01-02"
+    assert trades.iloc[0]["price"] == pytest.approx(
+        _fill_price(pd.Timestamp("2025-01-02"), 0.3), abs=1e-4
+    )
+
+
+def test_signal_dated_before_first_bar_never_executes(tmp_path: Path) -> None:
+    trades = _run(tmp_path, date="2024-12-31")
+    assert len(trades) == 0
+
+
+def test_signal_on_last_bar_has_no_next_bar_to_fill(tmp_path: Path) -> None:
+    trades = _run(tmp_path, date="2025-01-06")
+    assert len(trades) == 0

--- a/agent/tests/test_options_smile_consistency.py
+++ b/agent/tests/test_options_smile_consistency.py
@@ -165,10 +165,14 @@ class TestGreeksUseTheLegVol:
 
         smile_vol = leg_iv(100.0, 110.0, _BASE_IV, -0.15, 0.05)
         expiry = pd.Timestamp("2025-02-21")
-        time_to_expiry = max((expiry - _DATES[0]).days / 365.0, 0.001)
+        # The signal dated 2025-01-01 fills on the next bar at the same 100.0
+        # spot, so the first greeks row is zero and the position's greeks
+        # appear on the fill bar (2025-01-02).
+        fill_day = _DATES[1]
+        time_to_expiry = max((expiry - fill_day).days / 365.0, 0.001)
         expected = bs_greeks(100.0, 110.0, time_to_expiry, 0.0, smile_vol, "call")
 
-        assert float(greeks.iloc[0]["delta"]) == pytest.approx(
+        assert float(greeks.iloc[1]["delta"]) == pytest.approx(
             expected["delta"] * 10, rel=1e-6
         )
 


### PR DESCRIPTION
## Summary

The options day loop (`engines/options_portfolio.py`, section "3. Execute today's signals") priced and filled a signal dated T with T's own close and IV, so a signal computed on T's close embedded exactly the information it was computed from — a full day of underlying move times delta, on every options backtest. The equity engines in the same framework execute the next bar; this PR brings the options engine to the same convention (#1293, part 1).

## Changes

- **Fill shift** — signals dated T now execute on the next bar, priced at T+1's close and IV (the loop's existing carry-forward for missing dates is unchanged). Signals dated before the first evaluation bar are never executed, matching prior warm-up-date behavior.
- **Opt-out** — `options_config.same_day_fill: true` restores the legacy same-date fill for strategies that want it.
- **Tests** — `test_options_next_bar_fill.py`: signal dated T fills at T+1's price; fill price differs from the signal-date price; same-day flag preserves legacy behavior; signal dated before the first bar and signals with no next bar never execute. Updated `test_greeks_are_reported_at_the_smile_vol` to assert Greeks on the fill bar instead of the signal bar.

> Note: the issue's second, independent leak (HV warm-up backfills the first valid window into bars before it) is a separate one-change PR — `fix/options-hv-warmup` — referencing this issue.

## Test Plan

- `pytest agent/tests/test_options_next_bar_fill.py agent/tests/test_options_smile_consistency.py agent/tests/test_options_partial_close.py agent/tests/test_warmup_window.py agent/tests/test_run_card.py agent/tests/test_run_card_content_filter.py -q` → **51 passed**

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`)
- [x] No hardcoded values
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Documentation updated (loop comments)

Part of #1293 (fill leak); the HV/warm-up leak is tracked separately as part 2.
