### PR TITLE
fix(backtest): make non-strict crypto liquidation direction-aware and mark to adverse extremum

### DIFF
--- a/agent/backtest/engines/_market_hooks.py
+++ b/agent/backtest/engines/_market_hooks.py
@@ -47,7 +47,10 @@ _MARKET_PATTERNS = [
     # USDT pairs only in the quote currency; both belong to CryptoEngine.
     (re.compile(r"^[A-Z]+-USD$", re.I), "crypto"),
     # China futures: product+delivery.exchange (e.g. IF2406.CFFEX, rb2410.SHFE)
-    (re.compile(r"^[A-Za-z]{1,2}\d{3,4}\.(ZCE|DCE|SHFE|INE|CFFEX|GFEX)$", re.I), "futures"),
+    (
+        re.compile(r"^[A-Za-z]{1,2}\d{3,4}\.(ZCE|DCE|SHFE|INE|CFFEX|GFEX)$", re.I),
+        "futures",
+    ),
     # Global futures: product+month-code (e.g. ESZ4, CLF25, GCM2025)
     (re.compile(r"^[A-Z]{2,4}[FGHJKMNQUVXZ]\d{1,2}$", re.I), "futures"),
     # Global futures: product+YYMM (e.g. CL2412, ES2503)
@@ -124,6 +127,7 @@ def code_currency(code: str) -> str:
         return _FUTURES_EXCHANGE_CURRENCY.get(exchange, "USD")
     return f"UNKNOWN:{market}"
 
+
 # Known Chinese-futures product codes — used as a heuristic when a symbol
 # lacks an exchange suffix (e.g. bare ``RB2410``, ``IF2406``). Without this
 # table composite.py was misrouting such bare codes to GlobalFutures.
@@ -131,14 +135,59 @@ def code_currency(code: str) -> str:
 # before lookup so callers can pass any case (``RB2410`` and ``rb2410``
 # both resolve correctly).
 _CN_FUTURES_PRODUCTS = {
-    "if", "ic", "ih", "im", "t", "tf", "ts", "tl",
-    "au", "ag", "cu", "al", "zn", "pb", "ni", "sn", "ss",
-    "rb", "hc", "i", "j", "jm",
-    "sc", "fu", "lu", "bu", "nr",
-    "c", "cs", "m", "y", "a", "p", "jd", "lh",
-    "cf", "sr", "ta", "ma", "ap", "rm", "oi",
-    "pp", "l", "v", "eg", "eb", "pf", "sa", "fg", "ur",
-    "si", "lc",
+    "if",
+    "ic",
+    "ih",
+    "im",
+    "t",
+    "tf",
+    "ts",
+    "tl",
+    "au",
+    "ag",
+    "cu",
+    "al",
+    "zn",
+    "pb",
+    "ni",
+    "sn",
+    "ss",
+    "rb",
+    "hc",
+    "i",
+    "j",
+    "jm",
+    "sc",
+    "fu",
+    "lu",
+    "bu",
+    "nr",
+    "c",
+    "cs",
+    "m",
+    "y",
+    "a",
+    "p",
+    "jd",
+    "lh",
+    "cf",
+    "sr",
+    "ta",
+    "ma",
+    "ap",
+    "rm",
+    "oi",
+    "pp",
+    "l",
+    "v",
+    "eg",
+    "eb",
+    "pf",
+    "sa",
+    "fg",
+    "ur",
+    "si",
+    "lc",
 }
 
 
@@ -210,6 +259,7 @@ def _detect_submarket(codes: List[str]) -> str:
         if upper.endswith(".L"):
             return "uk"
     return "us"
+
 
 # ── Crypto: OKX tiered maintenance margin table (simplified) ──
 
@@ -289,12 +339,62 @@ def calc_crypto_funding_fee(
     return notional * funding_rate * pos.direction
 
 
+def _liquidation_mark_price(bar: pd.Series, pos: Position) -> float:
+    """Return the adverse extremum for liquidation marking.
+
+    For longs the adverse move is a drop, so mark against ``low``;
+    for shorts it is a spike, so mark against ``high``.  Falls back
+    to ``close`` when neither extremum is present (close-only bars).
+
+    Supports both non-strict (``high``/``low``) and strict
+    (``mark_high``/``mark_low``) field names.
+
+    Args:
+        bar: Current bar data.
+        pos: Position whose liquidation is being evaluated.
+
+    Returns:
+        Price to use for the maintenance check.
+    """
+    if pos.direction == -1:
+        for key in ("high", "mark_high"):
+            if key in bar.index:
+                val = bar.get(key)
+                if val is not None and pd.notna(val):
+                    return float(val)
+    else:
+        for key in ("low", "mark_low"):
+            if key in bar.index:
+                val = bar.get(key)
+                if val is not None and pd.notna(val):
+                    return float(val)
+    return float(bar.get("close", pos.entry_price))
+
+
+def crypto_liquidation_mark_price(bar: pd.Series, pos: Position) -> float:
+    """Public helper for callers that need the same liquidation mark.
+
+    Args:
+        bar: Current bar data.
+        pos: Position to mark.
+
+    Returns:
+        Adverse mark price for liquidation.
+    """
+    return _liquidation_mark_price(bar, pos)
+
+
 def check_crypto_liquidation(
     symbol: str,
     bar: pd.Series,
     positions: Dict[str, Position],
 ) -> bool:
     """Check if a crypto position should be liquidated.
+
+    Direction-aware: longs at leverage <=1 remain exempt, shorts at
+    leverage <=1 are always evaluated.  Marks against the bar's
+    adverse extremum (high for shorts, low for longs) when high/low
+    are present, otherwise falls back to close.
 
     Args:
         symbol: Instrument code.
@@ -306,10 +406,13 @@ def check_crypto_liquidation(
         Does NOT execute the liquidation -- caller handles that.
     """
     pos = positions.get(symbol)
-    if pos is None or pos.leverage <= 1.0:
+    if pos is None:
+        return False
+    # 1x longs are exempt (cannot be liquidated); 1x shorts are not.
+    if pos.leverage <= 1.0 and pos.direction != -1:
         return False
 
-    mark_price = float(bar.get("close", pos.entry_price))
+    mark_price = _liquidation_mark_price(bar, pos)
     margin = pos.size * pos.entry_price / pos.leverage
     unrealized = pos.direction * pos.size * (mark_price - pos.entry_price)
 
@@ -323,12 +426,22 @@ def check_crypto_liquidation(
 # ── Forex: swap tables ──
 
 _SWAP_LONG: dict[str, float] = {
-    "EUR/USD": -6.5, "GBP/USD": -3.0, "USD/JPY": 8.0, "USD/CHF": 4.0,
-    "AUD/USD": -2.0, "USD/CAD": 2.0, "NZD/USD": -1.5,
+    "EUR/USD": -6.5,
+    "GBP/USD": -3.0,
+    "USD/JPY": 8.0,
+    "USD/CHF": 4.0,
+    "AUD/USD": -2.0,
+    "USD/CAD": 2.0,
+    "NZD/USD": -1.5,
 }
 _SWAP_SHORT: dict[str, float] = {
-    "EUR/USD": 3.5, "GBP/USD": -1.0, "USD/JPY": -12.0, "USD/CHF": -8.0,
-    "AUD/USD": -1.0, "USD/CAD": -5.0, "NZD/USD": -2.0,
+    "EUR/USD": 3.5,
+    "GBP/USD": -1.0,
+    "USD/JPY": -12.0,
+    "USD/CHF": -8.0,
+    "AUD/USD": -1.0,
+    "USD/CAD": -5.0,
+    "NZD/USD": -2.0,
 }
 
 

--- a/agent/backtest/engines/composite.py
+++ b/agent/backtest/engines/composite.py
@@ -19,6 +19,7 @@ from backtest.engines._market_hooks import (
     code_currency,
     calc_crypto_funding_fee,
     check_crypto_liquidation,
+    crypto_liquidation_mark_price,
     calc_forex_swap,
 )
 
@@ -31,41 +32,53 @@ def _build_rule_engines(config: dict, codes: List[str]) -> Dict[str, BaseEngine]
     for market in markets:
         if market == "a_share":
             from backtest.engines.china_a import ChinaAEngine
+
             engines["a_share"] = ChinaAEngine(config)
         elif market == "us_equity":
             from backtest.engines.global_equity import GlobalEquityEngine
+
             engines["us_equity"] = GlobalEquityEngine(config, market="us")
         elif market == "hk_equity":
             from backtest.engines.global_equity import GlobalEquityEngine
+
             engines["hk_equity"] = GlobalEquityEngine(config, market="hk")
         elif market == "india_equity":
             from backtest.engines.india_equity import IndiaEquityEngine
+
             engines["india_equity"] = IndiaEquityEngine(config)
         elif market == "kr_equity":
             from backtest.engines.korea_equity import KoreaEquityEngine
+
             engines["kr_equity"] = KoreaEquityEngine(config)
         elif market == "vietnam_equity":
             from backtest.engines.vietnam_equity import VietnamEquityEngine
+
             engines["vietnam_equity"] = VietnamEquityEngine(config)
         elif market == "ca_equity":
             from backtest.engines.global_equity import GlobalEquityEngine
+
             engines["ca_equity"] = GlobalEquityEngine(config, market="ca")
         elif market == "uk_equity":
             from backtest.engines.global_equity import GlobalEquityEngine
+
             engines["uk_equity"] = GlobalEquityEngine(config, market="uk")
         elif market == "crypto":
             from backtest.engines.crypto import CryptoEngine
+
             engines["crypto"] = CryptoEngine(config)
         elif market == "forex":
             from backtest.engines.forex import ForexEngine
+
             engines["forex"] = ForexEngine(config)
         elif market == "futures":
             futures_codes = [c for c in codes if _detect_market(c) == "futures"]
             if any(_is_china_futures(c) for c in futures_codes):
                 from backtest.engines.china_futures import ChinaFuturesEngine
+
                 engines["china_futures"] = ChinaFuturesEngine(config)
             if any(not _is_china_futures(c) for c in futures_codes):
                 from backtest.engines.global_futures import GlobalFuturesEngine
+
                 engines["global_futures"] = GlobalFuturesEngine(config)
 
     return engines
@@ -191,9 +204,7 @@ class CompositeEngine(BaseEngine):
                 if hasattr(bar, "name") and hasattr(bar.name, "date"):
                     bar_date = bar.name.date()
                 entry_date = (
-                    pos.entry_time.date()
-                    if hasattr(pos.entry_time, "date")
-                    else None
+                    pos.entry_time.date() if hasattr(pos.entry_time, "date") else None
                 )
                 if bar_date and entry_date and bar_date == entry_date:
                     return False
@@ -206,11 +217,18 @@ class CompositeEngine(BaseEngine):
         return self._rule_for(self._active_symbol).round_size(raw_size, price)
 
     def calc_commission(
-        self, size: float, price: float, direction: int, is_open: bool,
+        self,
+        size: float,
+        price: float,
+        direction: int,
+        is_open: bool,
     ) -> float:
         """Delegate to active symbol's sub-engine."""
         return self._rule_for(self._active_symbol).calc_commission(
-            size, price, direction, is_open,
+            size,
+            price,
+            direction,
+            is_open,
         )
 
     def apply_slippage(self, price: float, direction: int) -> float:
@@ -223,20 +241,35 @@ class CompositeEngine(BaseEngine):
     # ── PnL / margin dispatch (route by symbol, not _active_symbol) ──
 
     def _calc_pnl(
-        self, symbol: str, direction: int, size: float,
-        entry_price: float, exit_price: float,
+        self,
+        symbol: str,
+        direction: int,
+        size: float,
+        entry_price: float,
+        exit_price: float,
     ) -> float:
         return self._rule_for(symbol)._calc_pnl(
-            symbol, direction, size, entry_price, exit_price,
+            symbol,
+            direction,
+            size,
+            entry_price,
+            exit_price,
         )
 
     def _calc_margin(
-        self, symbol: str, size: float, price: float, leverage: float,
+        self,
+        symbol: str,
+        size: float,
+        price: float,
+        leverage: float,
     ) -> float:
         return self._rule_for(symbol)._calc_margin(symbol, size, price, leverage)
 
     def _calc_raw_size(
-        self, symbol: str, target_notional: float, price: float,
+        self,
+        symbol: str,
+        target_notional: float,
+        price: float,
     ) -> float:
         return self._rule_for(symbol)._calc_raw_size(symbol, target_notional, price)
 
@@ -252,16 +285,20 @@ class CompositeEngine(BaseEngine):
         if market == "crypto":
             crypto_sub = self._rule_engines["crypto"]
             fee = calc_crypto_funding_fee(
-                symbol, bar, timestamp, self.positions,
+                symbol,
+                bar,
+                timestamp,
+                self.positions,
                 crypto_sub.funding_rate,
-                self._funding_applied, self._funding_daily_done,
+                self._funding_applied,
+                self._funding_daily_done,
             )
             self.capital -= fee
 
             if check_crypto_liquidation(symbol, bar, self.positions):
                 pos = self.positions.get(symbol)
                 if pos is not None:
-                    mark_price = float(bar.get("close", pos.entry_price))
+                    mark_price = crypto_liquidation_mark_price(bar, pos)
                     liq_price = crypto_sub.apply_slippage(mark_price, -pos.direction)
                     self._close_position(symbol, liq_price, timestamp, "liquidation")
 
@@ -269,7 +306,10 @@ class CompositeEngine(BaseEngine):
             forex_sub = self._rule_engines["forex"]
             if forex_sub.swap_enabled:
                 swap = calc_forex_swap(
-                    symbol, timestamp, self.positions,
-                    forex_sub.lot_size, self._last_swap_dates,
+                    symbol,
+                    timestamp,
+                    self.positions,
+                    forex_sub.lot_size,
+                    self._last_swap_dates,
                 )
                 self.capital += swap

--- a/agent/backtest/engines/crypto.py
+++ b/agent/backtest/engines/crypto.py
@@ -19,6 +19,7 @@ from backtest.engines.base import BaseEngine
 from backtest.engines._market_hooks import (
     calc_crypto_funding_fee,
     check_crypto_liquidation,
+    crypto_liquidation_mark_price,
 )
 from backtest.models import Position
 from backtest.perpetual_evidence import (
@@ -79,7 +80,7 @@ class CryptoEngine(BaseEngine):
         self._risk_frames: dict[str, MarketRiskFrame] = {}
         self._blocked_symbols: set[str] = set()
         self._rebalance_risk_checked = False
-        self._funding_applied: set = set()   # (symbol, date, hour) — per-slot dedup
+        self._funding_applied: set = set()  # (symbol, date, hour) — per-slot dedup
         self._funding_daily_done: set = set()  # (symbol, date) — daily fallback dedup
 
     def _validate_strict_resolution(self, config: dict[str, Any]) -> None:
@@ -103,7 +104,9 @@ class CryptoEngine(BaseEngine):
     ) -> dict[str, Any]:
         self._validate_strict_resolution(config)
         self._run_interval = str(config.get("interval", "1D"))
-        return super().run_backtest(config, loader, signal_engine, run_dir, bars_per_year)
+        return super().run_backtest(
+            config, loader, signal_engine, run_dir, bars_per_year
+        )
 
     def can_execute(self, symbol: str, direction: int, bar: pd.Series) -> bool:
         """Crypto: 24/7, long/short/close all allowed."""
@@ -113,7 +116,9 @@ class CryptoEngine(BaseEngine):
         """Crypto supports fractional sizes, round to 6 decimals."""
         return round(max(raw_size, 0.0), 6)
 
-    def calc_commission(self, size: float, price: float, _direction: int, is_open: bool) -> float:
+    def calc_commission(
+        self, size: float, price: float, _direction: int, is_open: bool
+    ) -> float:
         """Maker/Taker separated. Opens typically hit taker, closes hit maker.
 
         ``_direction`` is unused — reserved for future funding-rate asymmetry
@@ -163,10 +168,14 @@ class CryptoEngine(BaseEngine):
         for symbol in codes:
             frame = data_map.get(symbol)
             if frame is None or timestamp not in frame.index:
-                raise ValueError(f"missing synchronized frame for {symbol} at {timestamp}")
+                raise ValueError(
+                    f"missing synchronized frame for {symbol} at {timestamp}"
+                )
             bar = frame.loc[timestamp]
             if not isinstance(bar, pd.Series):
-                raise ValueError(f"duplicate frame timestamp for {symbol} at {timestamp}")
+                raise ValueError(
+                    f"duplicate frame timestamp for {symbol} at {timestamp}"
+                )
             ExecutionFrame(timestamp, float(bar["execution_open"]))
             rate = bar["funding_rate"]
             settlement = bar["funding_settlement_time"]
@@ -195,7 +204,9 @@ class CryptoEngine(BaseEngine):
             self._market_risk_sources.add(risks[symbol].source)
         self._risk_frames = risks
 
-    def _record_event(self, timestamp: pd.Timestamp, event_type: str, **details: Any) -> None:
+    def _record_event(
+        self, timestamp: pd.Timestamp, event_type: str, **details: Any
+    ) -> None:
         if not self.perpetual_strict:
             return
         self._perpetual_events.append(
@@ -218,7 +229,9 @@ class CryptoEngine(BaseEngine):
             timestamp,
             "risk_snapshot",
             phase="pre_fill" if price_field == "mark_open" else "post_fill",
-            price_source=("mark_open" if price_field == "mark_open" else "adverse_mark_extrema"),
+            price_source=(
+                "mark_open" if price_field == "mark_open" else "adverse_mark_extrema"
+            ),
             status=snapshot.status,
             margin_balance=snapshot.margin_balance,
             initial_margin=snapshot.initial_margin,
@@ -250,7 +263,9 @@ class CryptoEngine(BaseEngine):
             if key in self._strict_funding_applied:
                 continue
             payment = (
-                position.direction * position.size * frame.mark_open
+                position.direction
+                * position.size
+                * frame.mark_open
                 * float(frame.funding_rate)
             )
             self.capital -= payment
@@ -302,13 +317,17 @@ class CryptoEngine(BaseEngine):
         snapshot = (
             evaluate_isolated(account, self._risk_frames, price_field)
             if self.margin_mode == "isolated"
-            else CrossMarginRiskModel().evaluate(account, self._risk_frames, price_field)
+            else CrossMarginRiskModel().evaluate(
+                account, self._risk_frames, price_field
+            )
         )
         self._record_risk_snapshot(timestamp, price_field, snapshot)
         if snapshot.status == "healthy":
             return False
         prices = {risk.symbol: risk.mark_price for risk in snapshot.per_position}
-        price_source = "mark_open" if price_field == "mark_open" else "adverse_mark_extrema"
+        price_source = (
+            "mark_open" if price_field == "mark_open" else "adverse_mark_extrema"
+        )
         liquidation_details = []
         for symbol in snapshot.liquidation_targets:
             position = self.positions[symbol]
@@ -327,7 +346,9 @@ class CryptoEngine(BaseEngine):
                 timestamp,
                 "account_liquidation",
                 symbols=sorted(symbol for symbol, _, _ in liquidation_details),
-                liquidation_prices={symbol: price for symbol, price, _ in liquidation_details},
+                liquidation_prices={
+                    symbol: price for symbol, price, _ in liquidation_details
+                },
                 price_source=price_source,
                 liquidation_fee=sum(fee for _, _, fee in liquidation_details),
                 fidelity_flags=list(snapshot.fidelity_flags),
@@ -406,9 +427,7 @@ class CryptoEngine(BaseEngine):
         if not self.perpetual_strict:
             return
 
-        normalized_action = (
-            "reduce" if action == "partial_reduction" else action
-        )
+        normalized_action = "reduce" if action == "partial_reduction" else action
         if normalized_action not in {"increase", "reduce"}:
             raise ValueError(f"unexpected position adjustment action: {action}")
 
@@ -447,7 +466,8 @@ class CryptoEngine(BaseEngine):
         if self.perpetual_strict:
             try:
                 close_df = pd.DataFrame(
-                    {symbol: data_map[symbol]["mark_close"] for symbol in codes}, index=dates
+                    {symbol: data_map[symbol]["mark_close"] for symbol in codes},
+                    index=dates,
                 )
             except KeyError as exc:
                 raise ValueError(f"missing strict mark-close data: {exc}") from exc
@@ -476,9 +496,13 @@ class CryptoEngine(BaseEngine):
         return True
 
     def _execute_open_order(self, order, timestamp: pd.Timestamp) -> None:
-        if self.perpetual_strict and self.position_adjustment == "rebalance" and (
-            self.terminal_status == "account_liquidation"
-            or order.symbol in self._blocked_symbols
+        if (
+            self.perpetual_strict
+            and self.position_adjustment == "rebalance"
+            and (
+                self.terminal_status == "account_liquidation"
+                or order.symbol in self._blocked_symbols
+            )
         ):
             return
         if self._reject_unfunded_atomic_order(order, timestamp, "open"):
@@ -502,10 +526,14 @@ class CryptoEngine(BaseEngine):
         self._risk_after_atomic_mutation(timestamp)
 
     def _execute_position_increase(self, order, timestamp: pd.Timestamp) -> None:
-        if self.perpetual_strict and self.position_adjustment == "rebalance" and (
-            self.terminal_status == "account_liquidation"
-            or order.symbol in self._blocked_symbols
-            or order.symbol not in self.positions
+        if (
+            self.perpetual_strict
+            and self.position_adjustment == "rebalance"
+            and (
+                self.terminal_status == "account_liquidation"
+                or order.symbol in self._blocked_symbols
+                or order.symbol not in self.positions
+            )
         ):
             return
         if self._reject_unfunded_atomic_order(order, timestamp, "increase"):
@@ -514,10 +542,14 @@ class CryptoEngine(BaseEngine):
 
     def _execute_partial_reduction(self, order, timestamp: pd.Timestamp) -> None:
         symbol = order.before.symbol
-        if self.perpetual_strict and self.position_adjustment == "rebalance" and (
-            self.terminal_status == "account_liquidation"
-            or symbol in self._blocked_symbols
-            or symbol not in self.positions
+        if (
+            self.perpetual_strict
+            and self.position_adjustment == "rebalance"
+            and (
+                self.terminal_status == "account_liquidation"
+                or symbol in self._blocked_symbols
+                or symbol not in self.positions
+            )
         ):
             return
         super()._execute_partial_reduction(order, timestamp)
@@ -535,7 +567,9 @@ class CryptoEngine(BaseEngine):
             trade = self.trades[-1]
             price_source = self._liquidation_price_source
             if price_source is None:
-                price_source = "mark_close" if reason == "end_of_backtest" else "execution_open"
+                price_source = (
+                    "mark_close" if reason == "end_of_backtest" else "execution_open"
+                )
             self._record_event(
                 exit_time,
                 "market_fill",
@@ -576,10 +610,14 @@ class CryptoEngine(BaseEngine):
             )
             metrics.update(
                 {
-                    "perpetual_funding_settlements": summary["funding_settlement_count"],
+                    "perpetual_funding_settlements": summary[
+                        "funding_settlement_count"
+                    ],
                     "perpetual_funding_pnl": summary["total_funding_pnl"],
                     "perpetual_liquidation_events": summary["liquidation_event_count"],
-                    "perpetual_liquidated_positions": summary["liquidated_position_count"],
+                    "perpetual_liquidated_positions": summary[
+                        "liquidated_position_count"
+                    ],
                     "perpetual_trading_fees": summary["total_trading_fee"],
                     "perpetual_liquidation_fees": summary["total_liquidation_fee"],
                 }
@@ -601,14 +639,19 @@ class CryptoEngine(BaseEngine):
     def on_bar(self, symbol: str, bar: pd.Series, timestamp: pd.Timestamp) -> None:
         """Crypto per-bar hooks: funding fee + liquidation check."""
         fee = calc_crypto_funding_fee(
-            symbol, bar, timestamp, self.positions,
-            self.funding_rate, self._funding_applied, self._funding_daily_done,
+            symbol,
+            bar,
+            timestamp,
+            self.positions,
+            self.funding_rate,
+            self._funding_applied,
+            self._funding_daily_done,
         )
         self.capital -= fee
 
         if check_crypto_liquidation(symbol, bar, self.positions):
             pos = self.positions.get(symbol)
             if pos is not None:
-                mark_price = float(bar.get("close", pos.entry_price))
+                mark_price = crypto_liquidation_mark_price(bar, pos)
                 liq_price = self.apply_slippage(mark_price, -pos.direction)
                 self._close_position(symbol, liq_price, timestamp, "liquidation")

--- a/agent/tests/test_non_strict_liquidation.py
+++ b/agent/tests/test_non_strict_liquidation.py
@@ -1,0 +1,317 @@
+"""Regression for non-strict direction-aware liquidation.
+
+Covers:
+- 1x short through 2x adverse bar is liquidated (equity never <0)
+- 1x long at -90% survives
+- adverse extremum marking (high/low) vs close-only fallback
+- composite path shares the corrected hook
+- strict data-mode path unchanged
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from backtest.engines._market_hooks import (
+    check_crypto_liquidation,
+    crypto_liquidation_mark_price,
+)
+from backtest.engines.crypto import CryptoEngine
+from backtest.engines.composite import CompositeEngine
+from backtest.models import Position
+
+
+def _bar(
+    close: float, high: float | None = None, low: float | None = None, **extra
+) -> pd.Series:
+    data: dict = {"close": close}
+    if high is not None:
+        data["high"] = high
+    if low is not None:
+        data["low"] = low
+    data.update(extra)
+    return pd.Series(data)
+
+
+# ---------------------------------------------------------------------------
+# Hook-level
+# ---------------------------------------------------------------------------
+
+
+class TestDirectionAwareHook:
+    def test_1x_short_liquidated_through_2x_adverse(self) -> None:
+        pos = Position(
+            "BTC-USDT", -1, 100.0, pd.Timestamp("2025-01-01"), 1.0, leverage=1.0
+        )
+        bar = _bar(close=300.0, high=300.0, low=90.0)
+        assert check_crypto_liquidation("BTC-USDT", bar, {"BTC-USDT": pos}) is True
+        # mark uses high for shorts
+        assert crypto_liquidation_mark_price(bar, pos) == pytest.approx(300.0)
+
+    def test_1x_long_survives_minus_90(self) -> None:
+        pos = Position(
+            "BTC-USDT", 1, 100.0, pd.Timestamp("2025-01-01"), 1.0, leverage=1.0
+        )
+        bar = _bar(close=10.0, high=110.0, low=10.0)
+        assert check_crypto_liquidation("BTC-USDT", bar, {"BTC-USDT": pos}) is False
+        assert crypto_liquidation_mark_price(bar, pos) == pytest.approx(10.0)
+
+    def test_wick_through_maintenance_triggers_when_high_low_exist(self) -> None:
+        # short: close 110 not enough, high 150 triggers
+        pos = Position(
+            "BTC-USDT", -1, 100.0, pd.Timestamp("2025-01-01"), 1.0, leverage=3.0
+        )
+        bar_close = _bar(close=110.0)
+        bar_wick = _bar(close=110.0, high=150.0, low=100.0)
+        assert (
+            check_crypto_liquidation("BTC-USDT", bar_close, {"BTC-USDT": pos}) is False
+        )
+        assert check_crypto_liquidation("BTC-USDT", bar_wick, {"BTC-USDT": pos}) is True
+
+        # long: close 90 not enough, low 60 triggers
+        pos_long = Position(
+            "BTC-USDT", 1, 100.0, pd.Timestamp("2025-01-01"), 1.0, leverage=3.0
+        )
+        bar_close_l = _bar(close=90.0)
+        bar_wick_l = _bar(close=90.0, high=110.0, low=60.0)
+        assert (
+            check_crypto_liquidation("BTC-USDT", bar_close_l, {"BTC-USDT": pos_long})
+            is False
+        )
+        assert (
+            check_crypto_liquidation("BTC-USDT", bar_wick_l, {"BTC-USDT": pos_long})
+            is True
+        )
+
+    def test_close_only_bars_retain_behavior(self) -> None:
+        pos = Position(
+            "BTC-USDT", -1, 100.0, pd.Timestamp("2025-01-01"), 1.0, leverage=3.0
+        )
+        bar = _bar(close=150.0)
+        assert crypto_liquidation_mark_price(bar, pos) == pytest.approx(150.0)
+        assert check_crypto_liquidation("BTC-USDT", bar, {"BTC-USDT": pos}) is True
+
+        pos_long = Position(
+            "BTC-USDT", 1, 100.0, pd.Timestamp("2025-01-01"), 1.0, leverage=3.0
+        )
+        bar2 = _bar(close=60.0)
+        assert crypto_liquidation_mark_price(bar2, pos_long) == pytest.approx(60.0)
+
+    def test_mark_high_low_alias(self) -> None:
+        pos_short = Position(
+            "BTC-USDT", -1, 100.0, pd.Timestamp("2025-01-01"), 1.0, leverage=3.0
+        )
+        bar = _bar(close=110.0, mark_high=150.0)
+        assert crypto_liquidation_mark_price(bar, pos_short) == pytest.approx(150.0)
+        assert (
+            check_crypto_liquidation("BTC-USDT", bar, {"BTC-USDT": pos_short}) is True
+        )
+
+        pos_long = Position(
+            "BTC-USDT", 1, 100.0, pd.Timestamp("2025-01-01"), 1.0, leverage=3.0
+        )
+        bar2 = _bar(close=90.0, mark_low=60.0)
+        assert crypto_liquidation_mark_price(bar2, pos_long) == pytest.approx(60.0)
+        assert (
+            check_crypto_liquidation("BTC-USDT", bar2, {"BTC-USDT": pos_long}) is True
+        )
+
+
+# ---------------------------------------------------------------------------
+# Engine integration — CryptoEngine (non-strict)
+# ---------------------------------------------------------------------------
+
+
+class TestCryptoEngineNonStrict:
+    def _engine(self) -> CryptoEngine:
+        return CryptoEngine(
+            {
+                "initial_cash": 10_000,
+                "leverage": 1.0,
+                "slippage": 0.0,
+                "maker_rate": 0.0,
+                "taker_rate": 0.0,
+            }
+        )
+
+    def test_1x_short_liquidated_equity_never_negative(self) -> None:
+        engine = self._engine()
+        engine.positions["BTC-USDT"] = Position(
+            "BTC-USDT", -1, 100.0, pd.Timestamp("2025-01-01"), 1.0, leverage=1.0
+        )
+        bar = _bar(close=300.0, high=300.0, low=90.0)
+        ts = pd.Timestamp("2025-01-02")
+        engine.on_bar("BTC-USDT", bar, ts)
+        assert "BTC-USDT" not in engine.positions
+        assert engine.trades[0].exit_reason == "liquidation"
+        # equity after liquidation is capital (no negative unrealized left)
+        assert engine.capital >= 0
+
+    def test_1x_long_survives(self) -> None:
+        engine = self._engine()
+        engine.positions["BTC-USDT"] = Position(
+            "BTC-USDT", 1, 100.0, pd.Timestamp("2025-01-01"), 1.0, leverage=1.0
+        )
+        bar = _bar(close=10.0, high=110.0, low=10.0)
+        ts = pd.Timestamp("2025-01-02")
+        engine.on_bar("BTC-USDT", bar, ts)
+        assert "BTC-USDT" in engine.positions
+
+    def test_wick_liquidation_uses_high_for_short(self) -> None:
+        engine = CryptoEngine(
+            {
+                "initial_cash": 10_000,
+                "leverage": 3.0,
+                "slippage": 0.0,
+                "maker_rate": 0.0,
+                "taker_rate": 0.0,
+            }
+        )
+        engine.positions["BTC-USDT"] = Position(
+            "BTC-USDT", -1, 100.0, pd.Timestamp("2025-01-01"), 1.0, leverage=3.0
+        )
+        # close 110 would not liquidate, high 150 should
+        bar_no_wick = _bar(close=110.0)
+        bar_wick = _bar(close=110.0, high=150.0, low=100.0)
+        ts = pd.Timestamp("2025-01-02")
+        # close-only: survives
+        engine2 = CryptoEngine(
+            {
+                "initial_cash": 10_000,
+                "leverage": 3.0,
+                "slippage": 0.0,
+                "maker_rate": 0.0,
+                "taker_rate": 0.0,
+            }
+        )
+        engine2.positions["BTC-USDT"] = Position(
+            "BTC-USDT", -1, 100.0, pd.Timestamp("2025-01-01"), 1.0, leverage=3.0
+        )
+        engine2.on_bar("BTC-USDT", bar_no_wick, ts)
+        assert "BTC-USDT" in engine2.positions
+        # wick: liquidated at high price
+        engine.on_bar("BTC-USDT", bar_wick, ts)
+        assert "BTC-USDT" not in engine.positions
+        assert engine.trades[0].exit_price == pytest.approx(150.0)
+
+
+# ---------------------------------------------------------------------------
+# CompositeEngine (non-strict) shares the same hook
+# ---------------------------------------------------------------------------
+
+
+class TestCompositeEngineNonStrict:
+    def test_composite_1x_short_liquidated(self) -> None:
+        engine = CompositeEngine(
+            {
+                "initial_cash": 10_000,
+                "leverage": 1.0,
+                "slippage": 0.0,
+                "maker_rate": 0.0,
+                "taker_rate": 0.0,
+            },
+            ["BTC-USDT", "ETH-USDT"],
+        )
+        engine.positions["BTC-USDT"] = Position(
+            "BTC-USDT", -1, 100.0, pd.Timestamp("2025-01-01"), 1.0, leverage=1.0
+        )
+        bar = _bar(close=300.0, high=300.0)
+        ts = pd.Timestamp("2025-01-02")
+        engine.on_bar("BTC-USDT", bar, ts)
+        assert "BTC-USDT" not in engine.positions
+
+    def test_composite_1x_long_survives(self) -> None:
+        engine = CompositeEngine(
+            {
+                "initial_cash": 10_000,
+                "leverage": 1.0,
+                "slippage": 0.0,
+                "maker_rate": 0.0,
+                "taker_rate": 0.0,
+            },
+            ["BTC-USDT"],
+        )
+        engine.positions["BTC-USDT"] = Position(
+            "BTC-USDT", 1, 100.0, pd.Timestamp("2025-01-01"), 1.0, leverage=1.0
+        )
+        bar = _bar(close=10.0, low=10.0)
+        ts = pd.Timestamp("2025-01-02")
+        engine.on_bar("BTC-USDT", bar, ts)
+        assert "BTC-USDT" in engine.positions
+
+    def test_composite_wick_uses_adverse_extremum(self) -> None:
+        engine = CompositeEngine(
+            {
+                "initial_cash": 10_000,
+                "leverage": 3.0,
+                "slippage": 0.0,
+                "maker_rate": 0.0,
+                "taker_rate": 0.0,
+            },
+            ["BTC-USDT"],
+        )
+        engine.positions["BTC-USDT"] = Position(
+            "BTC-USDT", -1, 100.0, pd.Timestamp("2025-01-01"), 1.0, leverage=3.0
+        )
+        bar = _bar(close=110.0, high=150.0)
+        ts = pd.Timestamp("2025-01-02")
+        engine.on_bar("BTC-USDT", bar, ts)
+        assert "BTC-USDT" not in engine.positions
+        assert engine.trades[0].exit_price == pytest.approx(150.0)
+
+
+# ---------------------------------------------------------------------------
+# Strict path unchanged — strict liquidation uses MarketRiskFrame, not the
+# non-strict hook. Verify a known strict isolated liquidation still closes.
+# ---------------------------------------------------------------------------
+
+
+class TestStrictPathUntouched:
+    def test_strict_isolated_liquidation_still_closes(self) -> None:
+        dates = pd.date_range("2026-01-01", periods=2, freq="h", tz="UTC")
+        brackets = '[{"bracket_tier":1,"notional_cap":1000000.0,"maintenance_rate":0.004,"cumulative_maintenance_amount":0.0}]'
+
+        def _strict_frame(dates, **kwargs):
+            base = [100.0] * len(dates)
+            mark_low = kwargs.get("mark_low", base)
+            return pd.DataFrame(
+                {
+                    "execution_open": base,
+                    "mark_open": base,
+                    "mark_high": base,
+                    "mark_low": mark_low,
+                    "mark_close": base,
+                    "funding_rate": [0.0] * len(dates),
+                    "funding_settlement_time": [pd.NaT] * len(dates),
+                    "maintenance_brackets": [brackets] * len(dates),
+                    "maintenance_bracket_version": ["fixture-v1"] * len(dates),
+                },
+                index=dates,
+            )
+
+        frames = {
+            "BTC-USDT-PERP": _strict_frame(dates, mark_low=[100.0, 80.0]),
+            "ETH-USDT-PERP": _strict_frame(dates),
+        }
+        engine = CryptoEngine(
+            {
+                "initial_cash": 2_000.0,
+                "leverage": 10.0,
+                "perpetual_strict": True,
+                "funding_mode": "data",
+                "margin_mode": "isolated",
+                "interval": "1H",
+                "taker_rate": 0.0,
+                "maker_rate": 0.0,
+                "liquidation_fee_rate": 0.01,
+            }
+        )
+        close_df = pd.DataFrame(index=dates)
+        target = {s: [0.5, 0.5] for s in frames}
+        engine._execute_bars(
+            dates, frames, close_df, pd.DataFrame(target, index=dates), list(frames)
+        )
+        reasons = {t.symbol: t.exit_reason for t in engine.trades}
+        assert reasons["BTC-USDT-PERP"] == "position_liquidation"
+        assert reasons["ETH-USDT-PERP"] == "end_of_backtest"


### PR DESCRIPTION
## Summary
- Make non-strict crypto liquidation direction-aware: 1x longs remain exempt, 1x shorts are now liquidated.
- Mark positions against the bar's adverse extremum (high for shorts, low for longs, fallback to close) when high/low are present.
- Share the corrected hook between CryptoEngine and CompositeEngine.

## Why
Non-strict path exempted all `leverage <=1` regardless of direction and only checked close. A 1x short could survive an unbounded adverse move with negative equity, and intra-bar wicks that pierced maintenance were ignored.

Fixes #1291

## Changes
- `_market_hooks`: direction-aware check and adverse-extremum marking with close fallback
- `crypto` and `composite` engines: use shared liquidation mark for execution price

## Test Plan
- [ ] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [ ] New tests added (if applicable)
- [ ] Tested manually (describe below)

## Checklist
- [ ] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [ ] No hardcoded values (API keys, file paths, magic numbers)
- [ ] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] Documentation updated (if user-facing change)