### PR TITLE
fix(backtest): enforce India T+1 and price-limit bands in composite runs

### DIFF
--- a/agent/backtest/engines/china_a.py
+++ b/agent/backtest/engines/china_a.py
@@ -48,30 +48,15 @@ class ChinaAEngine(BaseEngine):
         Returns:
             True if the trade is allowed.
         """
-        # 1. No short selling
-        if direction == -1:
-            return False
-
-        # 2. T+1: can't sell shares bought today
-        if direction == 0:
-            pos = self.positions.get(symbol)
-            if pos is not None:
-                bar_date = _bar_date(bar)
-                entry_date = pos.entry_time.date() if hasattr(pos.entry_time, "date") else None
-                if bar_date is not None and entry_date is not None and bar_date == entry_date:
-                    return False
-
-        # 3. Price limits, tested at execution time (see _blocked_by_limit).
-        if _blocked_by_limit(self, symbol, direction, bar, _price_limit(symbol)):
-            return False
-
-        return True
+        return china_a_can_execute(self, self, symbol, direction, bar)
 
     def round_size(self, raw_size: float, price: float) -> float:
         """Round down to 100-share lots."""
         return max(int(raw_size / 100) * 100, 0)
 
-    def calc_commission(self, size: float, price: float, _direction: int, is_open: bool) -> float:
+    def calc_commission(
+        self, size: float, price: float, _direction: int, is_open: bool
+    ) -> float:
         """A-share fee structure: commission + stamp tax (sell) + transfer fee.
 
         ``_direction`` is unused today — reserved for future asymmetric
@@ -190,3 +175,76 @@ def _price_limit(symbol: str) -> float:
         return 0.30
     # Main board: ±10%
     return 0.10
+
+
+def _blocked_with_state(
+    state,
+    rules,
+    symbol: str,
+    direction: int,
+    bar: pd.Series,
+    limit: float,
+) -> bool:
+    """Limit check reading base price from *state* and slippage from *rules*."""
+
+    band = state.limit_band(symbol, bar, limit)
+    if band is None:
+        return False
+    lower, upper = band
+    pos = state.positions.get(symbol) if direction == 0 else None
+    pos_dir = pos.direction if pos is not None else None
+    fill_direction = -(pos_dir or 1) if direction == 0 else direction
+    raw = bar.get("open", bar.get("close"))
+    if raw is None or pd.isna(raw):
+        return False
+    price = float(raw)
+    if price <= 0 and not getattr(rules, "allow_nonpositive_prices", False):
+        return False
+    fill = rules.apply_slippage(price, fill_direction)
+    if fill is None or pd.isna(fill):
+        return False
+    tol = 1e-9 * max(abs(lower), abs(upper), 1.0)
+    buying = direction == 1 or (direction == 0 and pos_dir == -1)
+    if buying:
+        return fill >= upper - tol
+    return fill <= lower + tol
+
+
+def china_a_can_execute(
+    state, rules, symbol: str, direction: int, bar: pd.Series
+) -> bool:
+    """A-share rules reading state from *state* and parameters from *rules*.
+
+    Splitting the two lets :class:`CompositeEngine` enforce the same market
+    rules in a cross-market run: the composite owns the shared positions and
+    close panel, while the A-share sub-engine supplies only the tick/limit
+    parameters. A single-market run passes the same engine as both arguments.
+
+    Args:
+        state: Engine owning positions, close panel and bar cursor.
+        rules: A-share engine supplying slippage and limit parameters.
+        symbol: Stock code.
+        direction: 1 (buy), -1 (short), 0 (sell/close).
+        bar: Current bar.
+
+    Returns:
+        True if the trade is allowed.
+    """
+    if direction == -1:
+        return False
+    if direction == 0:
+        pos = state.positions.get(symbol)
+        if pos is not None:
+            bar_date = _bar_date(bar)
+            entry_date = (
+                pos.entry_time.date() if hasattr(pos.entry_time, "date") else None
+            )
+            if (
+                bar_date is not None
+                and entry_date is not None
+                and bar_date == entry_date
+            ):
+                return False
+    if _blocked_with_state(state, rules, symbol, direction, bar, _price_limit(symbol)):
+        return False
+    return True

--- a/agent/backtest/engines/composite.py
+++ b/agent/backtest/engines/composite.py
@@ -31,41 +31,53 @@ def _build_rule_engines(config: dict, codes: List[str]) -> Dict[str, BaseEngine]
     for market in markets:
         if market == "a_share":
             from backtest.engines.china_a import ChinaAEngine
+
             engines["a_share"] = ChinaAEngine(config)
         elif market == "us_equity":
             from backtest.engines.global_equity import GlobalEquityEngine
+
             engines["us_equity"] = GlobalEquityEngine(config, market="us")
         elif market == "hk_equity":
             from backtest.engines.global_equity import GlobalEquityEngine
+
             engines["hk_equity"] = GlobalEquityEngine(config, market="hk")
         elif market == "india_equity":
             from backtest.engines.india_equity import IndiaEquityEngine
+
             engines["india_equity"] = IndiaEquityEngine(config)
         elif market == "kr_equity":
             from backtest.engines.korea_equity import KoreaEquityEngine
+
             engines["kr_equity"] = KoreaEquityEngine(config)
         elif market == "vietnam_equity":
             from backtest.engines.vietnam_equity import VietnamEquityEngine
+
             engines["vietnam_equity"] = VietnamEquityEngine(config)
         elif market == "ca_equity":
             from backtest.engines.global_equity import GlobalEquityEngine
+
             engines["ca_equity"] = GlobalEquityEngine(config, market="ca")
         elif market == "uk_equity":
             from backtest.engines.global_equity import GlobalEquityEngine
+
             engines["uk_equity"] = GlobalEquityEngine(config, market="uk")
         elif market == "crypto":
             from backtest.engines.crypto import CryptoEngine
+
             engines["crypto"] = CryptoEngine(config)
         elif market == "forex":
             from backtest.engines.forex import ForexEngine
+
             engines["forex"] = ForexEngine(config)
         elif market == "futures":
             futures_codes = [c for c in codes if _detect_market(c) == "futures"]
             if any(_is_china_futures(c) for c in futures_codes):
                 from backtest.engines.china_futures import ChinaFuturesEngine
+
                 engines["china_futures"] = ChinaFuturesEngine(config)
             if any(not _is_china_futures(c) for c in futures_codes):
                 from backtest.engines.global_futures import GlobalFuturesEngine
+
                 engines["global_futures"] = GlobalFuturesEngine(config)
 
     return engines
@@ -167,15 +179,14 @@ class CompositeEngine(BaseEngine):
     # ── Stateless method dispatch ──
 
     def can_execute(self, symbol: str, direction: int, bar: pd.Series) -> bool:
-        """Market-rule check with settlement interceptors for A-shares and HOSE."""
+        """Market-rule check delegating through state/parameter split helpers."""
         market = self._symbol_market.get(symbol, "a_share")
 
-        # HOSE: both the T+2 hold and the ±7% band read run state — positions
-        # and the fill ledger for the hold, the close panel for the reference
-        # price — that a stateless rule book does not have. Delegating them
-        # would pass every sell and skip every band check, so the rules are
-        # evaluated against this engine's state using the Vietnam engine's own
-        # implementation, with the sub-engine supplying only the parameters.
+        # HOSE, A-share and India all need composite-owned state: HOSE reads
+        # positions + fill ledger + close panel, A-share/India read positions
+        # for T+1 and the close panel for limit bands. Each uses a module-level
+        # helper that takes (state, rules) so the composite supplies the shared
+        # state while the sub-engine supplies only the market parameters.
         if market == "vietnam_equity":
             sub = self._rule_engines.get("vietnam_equity")
             if sub is not None:
@@ -183,20 +194,19 @@ class CompositeEngine(BaseEngine):
 
                 return hose_can_execute(self, sub, symbol, direction, bar)
 
-        # T+1: intercept here because sub-engine has no access to shared positions
-        if market == "a_share" and direction == 0:
-            pos = self.positions.get(symbol)
-            if pos is not None:
-                bar_date = None
-                if hasattr(bar, "name") and hasattr(bar.name, "date"):
-                    bar_date = bar.name.date()
-                entry_date = (
-                    pos.entry_time.date()
-                    if hasattr(pos.entry_time, "date")
-                    else None
-                )
-                if bar_date and entry_date and bar_date == entry_date:
-                    return False
+        if market == "a_share":
+            sub = self._rule_engines.get("a_share")
+            if sub is not None:
+                from backtest.engines.china_a import china_a_can_execute
+
+                return china_a_can_execute(self, sub, symbol, direction, bar)
+
+        if market == "india_equity":
+            sub = self._rule_engines.get("india_equity")
+            if sub is not None:
+                from backtest.engines.india_equity import india_can_execute
+
+                return india_can_execute(self, sub, symbol, direction, bar)
 
         # Delegate remaining checks (price limits, short-sell block, etc.)
         return self._rule_for(symbol).can_execute(symbol, direction, bar)
@@ -206,11 +216,18 @@ class CompositeEngine(BaseEngine):
         return self._rule_for(self._active_symbol).round_size(raw_size, price)
 
     def calc_commission(
-        self, size: float, price: float, direction: int, is_open: bool,
+        self,
+        size: float,
+        price: float,
+        direction: int,
+        is_open: bool,
     ) -> float:
         """Delegate to active symbol's sub-engine."""
         return self._rule_for(self._active_symbol).calc_commission(
-            size, price, direction, is_open,
+            size,
+            price,
+            direction,
+            is_open,
         )
 
     def apply_slippage(self, price: float, direction: int) -> float:
@@ -223,20 +240,35 @@ class CompositeEngine(BaseEngine):
     # ── PnL / margin dispatch (route by symbol, not _active_symbol) ──
 
     def _calc_pnl(
-        self, symbol: str, direction: int, size: float,
-        entry_price: float, exit_price: float,
+        self,
+        symbol: str,
+        direction: int,
+        size: float,
+        entry_price: float,
+        exit_price: float,
     ) -> float:
         return self._rule_for(symbol)._calc_pnl(
-            symbol, direction, size, entry_price, exit_price,
+            symbol,
+            direction,
+            size,
+            entry_price,
+            exit_price,
         )
 
     def _calc_margin(
-        self, symbol: str, size: float, price: float, leverage: float,
+        self,
+        symbol: str,
+        size: float,
+        price: float,
+        leverage: float,
     ) -> float:
         return self._rule_for(symbol)._calc_margin(symbol, size, price, leverage)
 
     def _calc_raw_size(
-        self, symbol: str, target_notional: float, price: float,
+        self,
+        symbol: str,
+        target_notional: float,
+        price: float,
     ) -> float:
         return self._rule_for(symbol)._calc_raw_size(symbol, target_notional, price)
 
@@ -252,9 +284,13 @@ class CompositeEngine(BaseEngine):
         if market == "crypto":
             crypto_sub = self._rule_engines["crypto"]
             fee = calc_crypto_funding_fee(
-                symbol, bar, timestamp, self.positions,
+                symbol,
+                bar,
+                timestamp,
+                self.positions,
                 crypto_sub.funding_rate,
-                self._funding_applied, self._funding_daily_done,
+                self._funding_applied,
+                self._funding_daily_done,
             )
             self.capital -= fee
 
@@ -269,7 +305,10 @@ class CompositeEngine(BaseEngine):
             forex_sub = self._rule_engines["forex"]
             if forex_sub.swap_enabled:
                 swap = calc_forex_swap(
-                    symbol, timestamp, self.positions,
-                    forex_sub.lot_size, self._last_swap_dates,
+                    symbol,
+                    timestamp,
+                    self.positions,
+                    forex_sub.lot_size,
+                    self._last_swap_dates,
                 )
                 self.capital += swap

--- a/agent/backtest/engines/india_equity.py
+++ b/agent/backtest/engines/india_equity.py
@@ -32,7 +32,6 @@ from __future__ import annotations
 import pandas as pd
 
 from backtest.engines.base import BaseEngine
-from backtest.engines.china_a import _blocked_by_limit
 
 
 class IndiaEquityEngine(BaseEngine):
@@ -73,32 +72,15 @@ class IndiaEquityEngine(BaseEngine):
         Returns:
             True if the trade is allowed.
         """
-        # 1. Short selling: blocked unless explicitly modelling intraday (MIS).
-        if direction == -1 and not self.allow_short:
-            return False
-
-        # 2. T+1: can't sell shares bought today (delivery).
-        if direction == 0:
-            pos = self.positions.get(symbol)
-            if pos is not None:
-                bar_date = _bar_date(bar)
-                entry_date = pos.entry_time.date() if hasattr(pos.entry_time, "date") else None
-                if bar_date is not None and entry_date is not None and bar_date == entry_date:
-                    return False
-
-        # 3. Circuit bands, tested at execution time (see _blocked_by_limit).
-        if self.price_limit and _blocked_by_limit(
-            self, symbol, direction, bar, float(self.price_limit)
-        ):
-            return False
-
-        return True
+        return india_can_execute(self, self, symbol, direction, bar)
 
     def round_size(self, raw_size: float, price: float) -> float:
         """Cash equity trades in 1-share lots."""
         return float(max(int(raw_size), 0))
 
-    def calc_commission(self, size: float, price: float, _direction: int, is_open: bool) -> float:
+    def calc_commission(
+        self, size: float, price: float, _direction: int, is_open: bool
+    ) -> float:
         """India delivery cost stack (see module docstring).
 
         ``_direction`` is unused — reserved for future asymmetric long/short
@@ -106,15 +88,15 @@ class IndiaEquityEngine(BaseEngine):
         """
         notional = size * price
         brokerage = notional * self.in_brokerage
-        exchange_txn = notional * self.in_exchange_txn        # bilateral
-        sebi_fee = notional * self.in_sebi_fee                # bilateral
+        exchange_txn = notional * self.in_exchange_txn  # bilateral
+        sebi_fee = notional * self.in_sebi_fee  # bilateral
         gst = (brokerage + exchange_txn + sebi_fee) * self.in_gst
-        stt = notional * self.in_stt                          # bilateral (delivery)
+        stt = notional * self.in_stt  # bilateral (delivery)
         comm = brokerage + exchange_txn + sebi_fee + gst + stt
         if is_open:
-            comm += notional * self.in_stamp_duty             # stamp duty: buy-only
+            comm += notional * self.in_stamp_duty  # stamp duty: buy-only
         else:
-            comm += self.in_dp_charge                         # DP charge: sell-only, flat
+            comm += self.in_dp_charge  # DP charge: sell-only, flat
         return comm
 
     def apply_slippage(self, price: float, direction: int) -> float:
@@ -139,3 +121,75 @@ def _bar_date(bar: pd.Series):
     if hasattr(bar, "name") and hasattr(bar.name, "date"):
         return bar.name.date()
     return None
+
+
+def _blocked_with_state(
+    state, rules, symbol: str, direction: int, bar: pd.Series, limit: float
+) -> bool:
+    """Limit check reading base price from *state* and slippage from *rules*."""
+
+    band = state.limit_band(symbol, bar, limit)
+    if band is None:
+        return False
+    lower, upper = band
+    pos = state.positions.get(symbol) if direction == 0 else None
+    pos_dir = pos.direction if pos is not None else None
+    fill_direction = -(pos_dir or 1) if direction == 0 else direction
+    raw = bar.get("open", bar.get("close"))
+    if raw is None or pd.isna(raw):
+        return False
+    price = float(raw)
+    if price <= 0 and not getattr(rules, "allow_nonpositive_prices", False):
+        return False
+    fill = rules.apply_slippage(price, fill_direction)
+    if fill is None or pd.isna(fill):
+        return False
+    tol = 1e-9 * max(abs(lower), abs(upper), 1.0)
+    buying = direction == 1 or (direction == 0 and pos_dir == -1)
+    if buying:
+        return fill >= upper - tol
+    return fill <= lower + tol
+
+
+def india_can_execute(
+    state, rules, symbol: str, direction: int, bar: pd.Series
+) -> bool:
+    """India delivery rules reading state from *state* and params from *rules*.
+
+    Splitting the two lets :class:`CompositeEngine` enforce the same rules in
+    a cross-market run: the composite owns the shared positions and close
+    panel, while the India sub-engine supplies ``allow_short``/``price_limit``
+    and slippage. A single-market run passes the same engine as both arguments.
+
+    Args:
+        state: Engine owning positions, close panel and bar cursor.
+        rules: India engine supplying ``allow_short``, ``price_limit`` and
+            slippage.
+        symbol: NSE/BSE symbol.
+        direction: 1 (buy), -1 (short), 0 (sell/close).
+        bar: Current bar.
+
+    Returns:
+        True if the trade is allowed.
+    """
+    if direction == -1 and not getattr(rules, "allow_short", False):
+        return False
+    if direction == 0:
+        pos = state.positions.get(symbol)
+        if pos is not None:
+            bar_date = _bar_date(bar)
+            entry_date = (
+                pos.entry_time.date() if hasattr(pos.entry_time, "date") else None
+            )
+            if (
+                bar_date is not None
+                and entry_date is not None
+                and bar_date == entry_date
+            ):
+                return False
+    limit = getattr(rules, "price_limit", 0.20)
+    if limit and _blocked_with_state(
+        state, rules, symbol, direction, bar, float(limit)
+    ):
+        return False
+    return True

--- a/agent/tests/test_composite_india_backtest.py
+++ b/agent/tests/test_composite_india_backtest.py
@@ -1,0 +1,127 @@
+"""India T+1 and price-limit bands under the composite engine.
+
+Composite runs previously delegated to stateless sub-engines whose
+positions dict was always empty and whose close panel was absent, so
+india_equity.can_execute never blocked a T+1 sell and every
+_blocked_by_limit returned None (fails open). This pins the uniform
+state/parameter helper used for china_a and india_equity, mirroring the
+existing HOSE interception.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from backtest.engines.china_a import ChinaAEngine
+from backtest.engines.composite import CompositeEngine
+from backtest.engines.india_equity import IndiaEquityEngine
+from backtest.models import Position
+
+
+INDIA_CODE = "RELIANCE.NS"
+A_SHARE_CODE = "000001.SZ"
+
+
+def _india_only_composite(**overrides) -> CompositeEngine:
+    codes = [INDIA_CODE, "TCS.NS"]
+    config = {"initial_cash": 1_000_000, "codes": codes, **overrides}
+    return CompositeEngine(config, codes)
+
+
+def _a_share_composite(**overrides) -> CompositeEngine:
+    codes = [A_SHARE_CODE, "600000.SH"]
+    config = {"initial_cash": 1_000_000, "codes": codes, **overrides}
+    return CompositeEngine(config, codes)
+
+
+class TestCompositeIndiaT1:
+    def test_blocks_in_day_sell_against_shared_positions(self):
+        engine = _india_only_composite()
+        ts = pd.Timestamp("2024-04-01")
+        engine.positions[INDIA_CODE] = Position(
+            symbol=INDIA_CODE,
+            direction=1,
+            size=10,
+            entry_price=100,
+            entry_time=ts,
+        )
+        bar = pd.Series({"close": 100, "open": 100})
+        bar.name = ts
+        assert engine.can_execute(INDIA_CODE, 0, bar) is False
+
+    def test_allows_next_day_sell(self):
+        engine = _india_only_composite()
+        engine.positions[INDIA_CODE] = Position(
+            symbol=INDIA_CODE,
+            direction=1,
+            size=10,
+            entry_price=100,
+            entry_time=pd.Timestamp("2024-04-01"),
+        )
+        bar = pd.Series({"close": 100, "open": 100})
+        bar.name = pd.Timestamp("2024-04-02")
+        assert engine.can_execute(INDIA_CODE, 0, bar) is True
+
+    def test_single_market_india_still_blocks(self):
+        eng = IndiaEquityEngine({"initial_cash": 1_000_000})
+        ts = pd.Timestamp("2024-04-01")
+        eng.positions[INDIA_CODE] = Position(
+            symbol=INDIA_CODE,
+            direction=1,
+            size=10,
+            entry_price=100,
+            entry_time=ts,
+        )
+        bar = pd.Series({"close": 100, "open": 100})
+        bar.name = ts
+        assert eng.can_execute(INDIA_CODE, 0, bar) is False
+
+
+class TestCompositeLimitBands:
+    def test_a_share_composite_blocks_limit_up_via_panel(self):
+        engine = _a_share_composite()
+        engine._close_arr = np.array([[10.0, 10.0], [10.0, 10.0]], dtype=float)
+        engine._code_to_col = {A_SHARE_CODE: 0, "600000.SH": 1}
+        engine._bar_idx = 1
+        # base 10, limit 10% -> upper 11. Open at limit should be blocked even without pre_close
+        bar = pd.Series({"open": 11.0})
+        assert engine.can_execute(A_SHARE_CODE, 1, bar) is False
+
+    def test_a_share_composite_allows_inside_band(self):
+        engine = _a_share_composite()
+        engine._close_arr = np.array([[10.0, 10.0], [10.0, 10.0]], dtype=float)
+        engine._code_to_col = {A_SHARE_CODE: 0, "600000.SH": 1}
+        engine._bar_idx = 1
+        bar = pd.Series({"open": 10.5})
+        assert engine.can_execute(A_SHARE_CODE, 1, bar) is True
+
+    def test_india_composite_blocks_limit_up_via_panel(self):
+        engine = _india_only_composite(price_limit=0.20)
+        engine._close_arr = np.array([[100.0, 100.0], [100.0, 100.0]], dtype=float)
+        engine._code_to_col = {INDIA_CODE: 0, "TCS.NS": 1}
+        engine._bar_idx = 1
+        bar = pd.Series({"open": 120.0})
+        assert engine.can_execute(INDIA_CODE, 1, bar) is False
+
+    def test_india_composite_allows_inside_band(self):
+        engine = _india_only_composite(price_limit=0.20)
+        engine._close_arr = np.array([[100.0, 100.0], [100.0, 100.0]], dtype=float)
+        engine._code_to_col = {INDIA_CODE: 0, "TCS.NS": 1}
+        engine._bar_idx = 1
+        bar = pd.Series({"open": 110.0})
+        assert engine.can_execute(INDIA_CODE, 1, bar) is True
+
+    def test_band_inactive_without_any_reference(self):
+        engine = _a_share_composite()
+        engine._bar_idx = 0
+        engine._close_arr = None
+        assert engine.can_execute(A_SHARE_CODE, 1, pd.Series({"open": 11.0})) is True
+
+    def test_single_market_a_share_unchanged(self):
+        eng = ChinaAEngine({"initial_cash": 1_000_000})
+        eng._close_arr = np.array([[10.0], [10.0]], dtype=float)
+        eng._code_to_col = {A_SHARE_CODE: 0}
+        eng._bar_idx = 1
+        assert eng.can_execute(A_SHARE_CODE, 1, pd.Series({"open": 11.0})) is False
+        assert eng.can_execute(A_SHARE_CODE, 1, pd.Series({"open": 10.5})) is True


### PR DESCRIPTION
## Summary

- Fix composite backtests silently dropping India T+1 and all price-limit bands
- Generalize the HOSE interceptor to a uniform state/parameter split for `china_a` and `india_equity`
- Keep single-market and HOSE behavior unchanged

## Why

Composite sub-engines are stateless rule books: `positions` is always empty and no close panel exists, so `india_equity.can_execute` never blocks an in-day sell and `_blocked_by_limit` returns `None` (fails open). The A-share T+1 special-case in `CompositeEngine` also left price bands unhandled.

Closes #1292

## Changes

- `agent/backtest/engines/composite.py`: route `a_share` and `india_equity` through `china_a_can_execute` / `india_can_execute` helpers that receive `(state, rules, ...)`
- `agent/backtest/engines/china_a.py`: extract `china_a_can_execute` + `_blocked_with_state` reading base price from state and slippage from rules; `ChinaAEngine.can_execute` delegates to it
- `agent/backtest/engines/india_equity.py`: extract `india_can_execute` + `_blocked_with_state` with same split; `IndiaEquityEngine.can_execute` delegates to it
- `agent/tests/test_composite_india_backtest.py`: regression covering composite India T+1 and both markets' limit bands

## Test Plan

- [ ] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q` narrow run on composite + market engines)
- [ ] New tests added (`agent/tests/test_composite_india_backtest.py`)
- [ ] Tested manually: composite India blocks in-day sell, composite A-share/India block limit-up opens, next-day sells and inside-band buys remain allowed, single-market unchanged, HOSE path unchanged

## Checklist

- [ ] No changes to protected areas without prior discussion
- [ ] No hardcoded values
- [ ] Code follows CONTRIBUTING.md guidelines
- [ ] Documentation updated (if user-facing change)