### PR TITLE
Alpha Zoo bench: NIFTY 50 (NSE) universe + process-pool robustness

### DIFF
--- a/agent/src/api/alpha_routes.py
+++ b/agent/src/api/alpha_routes.py
@@ -113,7 +113,7 @@ _VALID_UNIVERSES = {
 # Ranking metrics for /alpha/compare — keep in sync with
 # ``src.factors.compare_runner.SORT_KEYS`` (kept local to avoid a heavy import).
 _VALID_SORTS = {"ir", "ic_mean", "ic_positive_ratio", "ic_count"}
-_BENCH_UNIVERSES = {"csi300", "sp500", "btc-usdt"}
+_BENCH_UNIVERSES = {"csi300", "sp500", "btc-usdt", "nifty50"}
 
 
 def _now_iso() -> str:
@@ -399,7 +399,10 @@ def register_alpha_routes(
                 detail=f"unknown theme {theme!r}; expected one of {sorted(_VALID_THEMES)}",
             )
         if universe is not None:
-            _ALIAS = {"csi300": "equity_cn", "sp500": "equity_us", "btc-usdt": "crypto"}
+            _ALIAS = {
+                "csi300": "equity_cn", "sp500": "equity_us",
+                "btc-usdt": "crypto", "nifty50": "equity_in",
+            }
             universe = _ALIAS.get(universe, universe)
         if universe is not None and universe not in _VALID_UNIVERSES:
             raise HTTPException(

--- a/agent/src/factors/bench_runner.py
+++ b/agent/src/factors/bench_runner.py
@@ -20,6 +20,7 @@ import math
 import os
 import time
 from concurrent.futures import ProcessPoolExecutor, as_completed
+from concurrent.futures.process import BrokenProcessPool
 from typing import Any, Callable, Iterable
 
 import numpy as np
@@ -220,6 +221,13 @@ def run_bench(
     n_workers = max(1, min(n_workers, n_total))
     use_parallel = registry is None and n_workers > 1 and n_total > 1
 
+    # ``ProcessPoolExecutor`` forks the current process. When ``run_bench`` is
+    # driven from a multi-threaded host (the uvicorn API worker for
+    # ``POST /alpha/bench``), the forked children can die on startup and every
+    # future then raises ``BrokenProcessPool`` — surfacing as "all N alphas
+    # skipped". Detect that and re-run the batch in-process instead of leaving
+    # the bench silently empty.
+    ran_parallel = False
     if use_parallel:
         ctx_kwargs: dict[str, Any] = {}
         try:
@@ -231,39 +239,52 @@ def run_bench(
             pass
 
         future_to_id: dict[Any, str] = {}
-        with ProcessPoolExecutor(
-            max_workers=n_workers,
-            initializer=_init_bench_worker,
-            initargs=(panel, return_df),
-            **ctx_kwargs,
-        ) as pool:
-            for aid in alpha_ids:
-                fut = pool.submit(_compute_single_alpha, aid)
-                future_to_id[fut] = aid
+        try:
+            with ProcessPoolExecutor(
+                max_workers=n_workers,
+                initializer=_init_bench_worker,
+                initargs=(panel, return_df),
+                **ctx_kwargs,
+            ) as pool:
+                for aid in alpha_ids:
+                    fut = pool.submit(_compute_single_alpha, aid)
+                    future_to_id[fut] = aid
 
-            n_done = 0
-            for fut in as_completed(future_to_id):
-                n_done += 1
-                aid = future_to_id[fut]
-                try:
-                    result = fut.result()
-                except Exception as exc:  # noqa: BLE001
-                    logger.exception("bench: worker crash on %s", aid)
-                    skipped.append({"id": aid, "reason": f"worker crash: {exc}", "kind": "unexpected"})
-                    result = None
-
-                if result is not None:
-                    if "row" in result:
-                        rows.append(result["row"])
-                    elif "skip" in result:
-                        skipped.append(result["skip"])
-
-                if on_progress is not None:
+                n_done = 0
+                for fut in as_completed(future_to_id):
+                    n_done += 1
+                    aid = future_to_id[fut]
                     try:
-                        on_progress(n_done, n_total, aid)
-                    except Exception:  # noqa: BLE001
-                        logger.exception("on_progress callback raised; ignoring")
-    else:
+                        result = fut.result()
+                    except BrokenProcessPool:
+                        raise
+                    except Exception as exc:  # noqa: BLE001
+                        logger.exception("bench: worker crash on %s", aid)
+                        skipped.append({"id": aid, "reason": f"worker crash: {exc}", "kind": "unexpected"})
+                        result = None
+
+                    if result is not None:
+                        if "row" in result:
+                            rows.append(result["row"])
+                        elif "skip" in result:
+                            skipped.append(result["skip"])
+
+                    if on_progress is not None:
+                        try:
+                            on_progress(n_done, n_total, aid)
+                        except Exception:  # noqa: BLE001
+                            logger.exception("on_progress callback raised; ignoring")
+            ran_parallel = True
+        except BrokenProcessPool:
+            logger.warning(
+                "bench: process pool broke (forking from a threaded host?); "
+                "re-running %d alphas in-process",
+                n_total,
+            )
+            rows.clear()
+            skipped.clear()
+
+    if not ran_parallel:
         for idx, aid in enumerate(alpha_ids, start=1):
             try:
                 factor_df = reg.compute(aid, panel)

--- a/agent/src/factors/cli_handlers.py
+++ b/agent/src/factors/cli_handlers.py
@@ -78,7 +78,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[3]
 # ``src.tools.alpha_bench_tool._UNIVERSE_TAG``. There is no KRX (or NSE/BSE)
 # panel yet, so Korea/India are deliberately absent — ``alpha bench`` would
 # fail at universe load, not produce a Korean benchmark.
-_UNIVERSE_CHOICES = ["csi300", "sp500", "btc-usdt"]
+_UNIVERSE_CHOICES = ["csi300", "sp500", "btc-usdt", "nifty50"]
 
 # Per-row fields that only ``bench_runner_strict`` produces. They are the
 # statistics ``categorise_strict`` actually gates on, so a strict run that
@@ -107,6 +107,7 @@ _LIST_UNIVERSE_ALIASES = {
     "csi300": "equity_cn",
     "sp500": "equity_us",
     "btc-usdt": "crypto",
+    "nifty50": "equity_in",
 }
 
 

--- a/agent/src/tools/alpha_bench_tool.py
+++ b/agent/src/tools/alpha_bench_tool.py
@@ -60,6 +60,18 @@ _SP500_MIN_SECTOR_COVERAGE = 0.9
 # allows ~200 calls/min; 4 workers stays well under that with a 300-name list.
 _CSI300_FETCH_WORKERS = 4
 
+# Concurrent per-symbol Yahoo chart fetches for the sp500 / nifty50 panels.
+# The Yahoo loader fetches one symbol per HTTP call and loops sequentially, so
+# a 500-name sp500 panel took >8 min to build (never finished inside the API's
+# stream timeout). 8 workers keeps well under Yahoo's soft rate limit while
+# cutting a cold sp500 build to ~1-2 min; the panel is then pickle-cached.
+_EQUITY_FETCH_WORKERS = 8
+
+# Date the NIFTY 50 constituent list was sampled from Wikipedia (best-effort
+# label for the survivorship-bias warning, mirroring _SP500_CONSTITUENT_SOURCE_DATE).
+_NIFTY50_CONSTITUENT_SOURCE_DATE = "2026-08-31"
+_NIFTY50_MIN_SECTOR_COVERAGE = 0.9
+
 
 # ---------------------------------------------------------------------------
 # Universe + period parsing
@@ -74,6 +86,7 @@ _UNIVERSE_TAG = {
     "csi300": "equity_cn",
     "sp500": "equity_us",
     "btc-usdt": "crypto",
+    "nifty50": "equity_in",
 }
 
 
@@ -108,7 +121,7 @@ def _load_universe_panel(
     with one column per instrument.
 
     Args:
-        universe: ``csi300`` | ``sp500`` | ``btc-usdt``.
+        universe: ``csi300`` | ``sp500`` | ``btc-usdt`` | ``nifty50``.
         period: ``YYYY-YYYY`` or ``YYYY-MM-DD/YYYY-MM-DD``.
         use_cache: When True (default) reuse a pickle in
             ``~/.vibe-trading/cache/`` if the same universe+period was fetched
@@ -136,6 +149,8 @@ def _load_universe_panel(
         panel = _load_csi300_panel(start, end)
     elif universe == "sp500":
         panel = _load_sp500_panel(start, end)
+    elif universe == "nifty50":
+        panel = _load_nifty_panel(start, end)
     elif universe == "btc-usdt":
         panel = _load_btc_panel(start, end)
     else:  # pragma: no cover — guarded above
@@ -304,6 +319,196 @@ _SP500_FALLBACK_CODES = [
     "VZ", "PFE", "INTC", "DIS", "CMCSA", "AMD", "TXN", "PM", "QCOM",
     "NEE", "RTX", "HON", "T", "IBM",
 ]
+
+
+# NIFTY 50 constituents (NSE symbols, no suffix) + NSE sector labels. Used when
+# the Wikipedia fetch in ``_fetch_nifty50_constituents`` fails. Sampled from
+# en.wikipedia.org/wiki/NIFTY_50 on _NIFTY50_CONSTITUENT_SOURCE_DATE.
+_NIFTY50_FALLBACK: dict[str, str] = {
+    "ADANIENT": "Metals & Mining", "ADANIPORTS": "Services",
+    "APOLLOHOSP": "Healthcare", "ASIANPAINT": "Consumer Durables",
+    "AXISBANK": "Financial Services", "BAJAJ-AUTO": "Automobile and Auto Components",
+    "BAJFINANCE": "Financial Services", "BAJAJFINSV": "Financial Services",
+    "BEL": "Capital Goods", "BHARTIARTL": "Telecommunication",
+    "CIPLA": "Healthcare", "COALINDIA": "Oil, Gas & Consumable Fuels",
+    "DRREDDY": "Healthcare", "EICHERMOT": "Automobile and Auto Components",
+    "ETERNAL": "Consumer Services", "GRASIM": "Construction Materials",
+    "HCLTECH": "Information Technology", "HDFCBANK": "Financial Services",
+    "HDFCLIFE": "Financial Services", "HINDALCO": "Metals & Mining",
+    "HINDUNILVR": "Fast Moving Consumer Goods", "ICICIBANK": "Financial Services",
+    "INDIGO": "Services", "INFY": "Information Technology",
+    "ITC": "Fast Moving Consumer Goods", "JIOFIN": "Financial Services",
+    "JSWSTEEL": "Metals & Mining", "KOTAKBANK": "Financial Services",
+    "LT": "Construction", "M&M": "Automobile and Auto Components",
+    "MARUTI": "Automobile and Auto Components", "MAXHEALTH": "Healthcare",
+    "NESTLEIND": "Fast Moving Consumer Goods", "NTPC": "Power",
+    "ONGC": "Oil, Gas & Consumable Fuels", "POWERGRID": "Power",
+    "RELIANCE": "Oil, Gas & Consumable Fuels", "SBILIFE": "Financial Services",
+    "SHRIRAMFIN": "Financial Services", "SBIN": "Financial Services",
+    "SUNPHARMA": "Healthcare", "TCS": "Information Technology",
+    "TATACONSUM": "Fast Moving Consumer Goods",
+    "TATAMOTORS": "Automobile and Auto Components",
+    "TATASTEEL": "Metals & Mining", "TECHM": "Information Technology",
+    "TITAN": "Consumer Durables", "TRENT": "Consumer Services",
+    "ULTRACEMCO": "Construction Materials", "WIPRO": "Information Technology",
+}
+
+
+def _fetch_equity_panel_concurrent(
+    loader: Any,
+    project_codes: list[str],
+    start: str,
+    end: str,
+    *,
+    interval: str = "1D",
+    workers: int = _EQUITY_FETCH_WORKERS,
+) -> dict[str, pd.DataFrame]:
+    """Fetch a wide equity panel one symbol per worker.
+
+    ``loader.fetch`` accepts a list but iterates it sequentially (one HTTP call
+    per symbol), so a 500-name panel is 500 blocking round-trips. Submitting a
+    single-symbol ``fetch`` per worker keeps the loader's own per-symbol cache
+    and normalisation while running the I/O concurrently. One symbol failing
+    never aborts the batch — the loader already logs and drops it.
+    """
+    fetched: dict[str, pd.DataFrame] = {}
+
+    def _one(code: str) -> tuple[str, pd.DataFrame | None]:
+        try:
+            out = loader.fetch([code], start, end, interval=interval)
+        except TypeError:
+            out = loader.fetch([code], start, end)
+        except Exception as exc:  # noqa: BLE001 — loader logs specifics
+            logger.warning("equity panel fetch failed for %s: %s", code, exc)
+            return code, None
+        df = out.get(code) if isinstance(out, dict) else None
+        return code, df
+
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        for fut in as_completed(pool.submit(_one, c) for c in project_codes):
+            code, df = fut.result()
+            if df is not None and not df.empty:
+                fetched[code] = df
+    return fetched
+
+
+def _fetch_nifty50_constituents() -> tuple[list[str], dict[str, str]]:
+    """Current NIFTY 50 tickers + NSE sector labels from Wikipedia.
+
+    Mirrors ``_fetch_sp500_constituents`` (requests + UA, then ``read_html``).
+    Returns ``([], {})`` on any failure so the caller drops to the static list.
+    """
+    url = "https://en.wikipedia.org/wiki/NIFTY_50"
+    try:
+        import io
+
+        import requests
+
+        resp = requests.get(
+            url,
+            headers={
+                "User-Agent": (
+                    "Vibe-Trading/0.1 (research bench; "
+                    "https://github.com/HKUDS/Vibe-Trading)"
+                )
+            },
+            timeout=20,
+        )
+        resp.raise_for_status()
+        tables = pd.read_html(io.StringIO(resp.text))
+        for tbl in tables:
+            cols = {re.sub(r"\[.*?\]", "", str(c)).strip(): c for c in tbl.columns}
+            if "Symbol" not in cols or "Sector" not in cols:
+                continue
+            syms = tbl[cols["Symbol"]].astype(str).str.strip()
+            secs = tbl[cols["Sector"]].astype(str).map(
+                lambda s: re.sub(r"\[.*?\]", "", s).strip()
+            )
+            keep = syms.str.fullmatch(r"[A-Z&\-]+")
+            tickers = syms[keep].tolist()
+            sectors = {
+                s: sec
+                for s, sec, k in zip(syms, secs, keep)
+                if k and sec and sec != "nan"
+            }
+            if len(tickers) >= 40:
+                logger.info(
+                    "nifty50: %d tickers from Wikipedia (%d with a sector)",
+                    len(tickers),
+                    len(sectors),
+                )
+                return tickers, sectors
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("nifty50 Wikipedia fetch failed: %s", exc)
+    return [], {}
+
+
+def _load_nifty_panel(start: str, end: str) -> dict[str, pd.DataFrame]:
+    """NIFTY 50 panel via Yahoo (``.NS`` symbols, no auth). Adds synthetic vwap.
+
+    Same shape and survivorship-bias caveat as ``_load_sp500_panel``: the
+    constituent list is Wikipedia's *current* roster, so names that left the
+    index inside ``start..end`` are silently excluded and IC is biased upward.
+    """
+    tickers, sectors = _fetch_nifty50_constituents()
+    constituent_source = "wikipedia"
+    constituent_source_date: str | None = _NIFTY50_CONSTITUENT_SOURCE_DATE
+    if len(tickers) < 40:
+        tickers = list(_NIFTY50_FALLBACK)
+        sectors = dict(_NIFTY50_FALLBACK)
+        constituent_source = "hand-picked fallback"
+        constituent_source_date = _NIFTY50_CONSTITUENT_SOURCE_DATE
+        logger.warning("nifty50: using %d-name static list", len(tickers))
+
+    logger.warning(
+        "NIFTY 50 universe uses current constituents (%s @ %s) → survivorship-biased",
+        constituent_source,
+        constituent_source_date,
+    )
+
+    project_codes = [f"{t}.NS" for t in tickers]
+    from backtest.loaders.registry import resolve_loader
+
+    loader = resolve_loader("india_equity")
+    fetched = _fetch_equity_panel_concurrent(loader, project_codes, start, end)
+
+    panel = _wide_from_fetched(fetched, include_amount=False)
+    if all(k in panel for k in ("open", "high", "low", "close")):
+        panel["vwap"] = (panel["open"] + panel["high"] + panel["low"] + panel["close"]) / 4.0
+
+    sector_coverage = 0.0
+    if sectors and "close" in panel and not panel["close"].empty:
+        columns = panel["close"].columns
+        labels = [sectors.get(str(c).removesuffix(".NS"), "") for c in columns]
+        sector_coverage = sum(1 for label in labels if label) / len(labels)
+        if sector_coverage >= _NIFTY50_MIN_SECTOR_COVERAGE:
+            panel["sector"] = pd.DataFrame(
+                np.repeat(
+                    np.array([label or "UNKNOWN" for label in labels], dtype=object)[None, :],
+                    len(panel["close"].index),
+                    axis=0,
+                ),
+                index=panel["close"].index,
+                columns=columns,
+            )
+        else:
+            logger.warning(
+                "nifty50: sector coverage %.1f%% below %.0f%% — leaving the tag off",
+                sector_coverage * 100,
+                _NIFTY50_MIN_SECTOR_COVERAGE * 100,
+            )
+
+    panel["_meta"] = {
+        "universe": "nifty50",
+        "survivorship_bias": True,
+        "degraded": constituent_source == "hand-picked fallback",
+        "constituent_source": constituent_source,
+        "constituent_source_date": constituent_source_date,
+        "constituent_count": len(tickers),
+        "sector_source": "wikipedia NSE sector" if "sector" in panel else None,
+        "sector_coverage": round(sector_coverage, 4),
+    }
+    return panel
 
 
 def _load_csi300_panel(start: str, end: str) -> dict[str, pd.DataFrame]:
@@ -500,7 +705,7 @@ def _load_sp500_panel(start: str, end: str) -> dict[str, pd.DataFrame]:
     from backtest.loaders.registry import resolve_loader
 
     loader = resolve_loader("us_equity")
-    fetched = _retry(lambda: loader.fetch(project_codes, start, end)) or {}
+    fetched = _fetch_equity_panel_concurrent(loader, project_codes, start, end)
 
     panel = _wide_from_fetched(fetched, include_amount=False)
     # Synthetic vwap for alpha101 alphas that require it on US universe

--- a/agent/tests/test_alpha_bench_nifty50.py
+++ b/agent/tests/test_alpha_bench_nifty50.py
@@ -1,0 +1,87 @@
+"""NIFTY 50 bench universe: constituent provenance, sector tag, concurrency.
+
+Mirrors the SP500 coverage in ``test_alpha_bench_universe_metadata.py`` /
+``test_alpha_bench_sector_tag.py``. No network — the Wikipedia fetch and the
+Yahoo loader are both stubbed.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+import backtest.loaders.registry as registry
+from src.tools import alpha_bench_tool as tool
+
+
+def _fake_loader() -> object:
+    dates = pd.date_range("2024-01-01", periods=6, freq="D")
+
+    class _Loader:
+        # _fetch_equity_panel_concurrent calls fetch([code], start, end, interval=...)
+        def fetch(self, project_codes, *_args, **_kwargs) -> dict:
+            return {
+                code: pd.DataFrame(
+                    {
+                        "open": range(1, 7),
+                        "high": range(2, 8),
+                        "low": range(1, 7),
+                        "close": range(1, 7),
+                        "volume": [100] * 6,
+                    },
+                    index=dates,
+                )
+                for code in project_codes
+            }
+
+    return _Loader()
+
+
+@pytest.mark.parametrize(
+    ("wiki", "source", "source_date_is_none", "degraded"),
+    [
+        (
+            (["RELIANCE", "TCS", "INFY"] * 15, {"RELIANCE": "Energy", "TCS": "IT", "INFY": "IT"}),
+            "wikipedia",
+            False,
+            False,
+        ),
+        (([], {}), "hand-picked fallback", False, True),
+    ],
+)
+def test_nifty50_constituent_provenance(
+    monkeypatch: pytest.MonkeyPatch,
+    wiki: tuple[list[str], dict[str, str]],
+    source: str,
+    source_date_is_none: bool,
+    degraded: bool,
+) -> None:
+    monkeypatch.setattr(tool, "_fetch_nifty50_constituents", lambda: wiki)
+    monkeypatch.setattr(registry, "resolve_loader", lambda _market: _fake_loader())
+
+    panel = tool._load_nifty_panel("2024-01-01", "2024-01-31")
+
+    assert panel["_meta"]["universe"] == "nifty50"
+    assert panel["_meta"]["constituent_source"] == source
+    assert (panel["_meta"]["constituent_source_date"] is None) is source_date_is_none
+    assert panel["_meta"]["degraded"] is degraded
+    assert panel["_meta"]["survivorship_bias"] is True
+    # synthetic vwap always present for alpha101
+    assert "vwap" in panel
+
+
+def test_nifty50_carries_sector_tag_when_coverage_is_high(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Full-coverage NSE sector labels → a ``sector`` frame the registry accepts."""
+    codes = list(tool._NIFTY50_FALLBACK)
+    sectors = dict(tool._NIFTY50_FALLBACK)
+    monkeypatch.setattr(tool, "_fetch_nifty50_constituents", lambda: (codes, sectors))
+    monkeypatch.setattr(registry, "resolve_loader", lambda _market: _fake_loader())
+
+    panel = tool._load_nifty_panel("2024-01-01", "2024-01-31")
+
+    assert "sector" in panel
+    assert panel["_meta"]["sector_coverage"] == pytest.approx(1.0)
+    # one column per fetched name, each tagged
+    assert set(panel["sector"].iloc[0].unique()).issubset(set(sectors.values()))

--- a/agent/tests/test_alpha_compare_api.py
+++ b/agent/tests/test_alpha_compare_api.py
@@ -96,6 +96,12 @@ def test_compare_rejects_unknown_universe() -> None:
     assert r.status_code == 422
 
 
+@pytest.mark.parametrize("universe", ["csi300", "sp500", "nifty50", "btc-usdt"])
+def test_compare_request_accepts_every_bench_universe(universe: str) -> None:
+    """Each benchable universe passes CompareRequest validation (no worker spawned)."""
+    alpha_routes.CompareRequest(**_valid_body(universe=universe))
+
+
 def test_compare_rejects_unknown_sort() -> None:
     r = _client().post("/alpha/compare", json=_valid_body(sort="sharpe"))
     assert r.status_code == 422

--- a/agent/tests/test_bench_parallel.py
+++ b/agent/tests/test_bench_parallel.py
@@ -153,3 +153,25 @@ class TestParallelBench:
         result = run_bench("test_zoo", "mock", "2020-2021", registry=mock_reg)
 
         assert result["status"] == "ok"
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="mock registry not inherited on spawn")
+    def test_broken_process_pool_falls_back_to_sequential(self, monkeypatch):
+        """A pool that dies on fork (threaded host) must not empty the bench."""
+        from concurrent.futures.process import BrokenProcessPool
+
+        from src.factors import bench_runner
+
+        mock_reg = self._setup_mocks(monkeypatch, n_alphas=4)
+        monkeypatch.setenv("VIBE_TRADING_BENCH_WORKERS", "4")
+
+        def _boom(*_a, **_kw):
+            raise BrokenProcessPool("simulated fork failure")
+
+        monkeypatch.setattr(bench_runner, "ProcessPoolExecutor", _boom)
+
+        result = bench_runner.run_bench("test_zoo", "mock", "2020-2021")
+
+        assert result["status"] == "ok"
+        # every alpha still evaluated, in-process
+        assert result["n_alphas_tested"] + result["n_skipped"] == 4
+        assert result["n_alphas_tested"] >= 1

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -1033,6 +1033,7 @@
     "universeOption": {
       "csi300": "CSI 300 (الصين A)",
       "sp500": "S&P 500 (الولايات المتحدة)",
+      "nifty50": "NIFTY 50 (الهند)",
       "btc-usdt": "BTC-USDT (عملات رقمية)",
       "equity_cn": "أسهم الصين A",
       "equity_us": "أسهم أمريكية",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1038,6 +1038,7 @@
     "universeOption": {
       "csi300": "CSI 300 (China A)",
       "sp500": "S&P 500 (US)",
+      "nifty50": "NIFTY 50 (Indien)",
       "btc-usdt": "BTC-USDT (Krypto)",
       "equity_cn": "China-A-Aktien",
       "equity_us": "US-Aktien",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1038,6 +1038,7 @@
     "universeOption": {
       "csi300": "CSI 300 (China A)",
       "sp500": "S&P 500 (US)",
+      "nifty50": "NIFTY 50 (India)",
       "btc-usdt": "BTC-USDT (Crypto)",
       "equity_cn": "China A-Shares",
       "equity_us": "US Equities",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1038,6 +1038,7 @@
     "universeOption": {
       "csi300": "CSI 300 (China A)",
       "sp500": "S&P 500 (EE. UU.)",
+      "nifty50": "NIFTY 50 (India)",
       "btc-usdt": "BTC-USDT (Cripto)",
       "equity_cn": "Acciones A de China",
       "equity_us": "Acciones de EE. UU.",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1033,6 +1033,7 @@
     "universeOption": {
       "csi300": "CSI 300 (中国 A 株)",
       "sp500": "S&P 500 (米国)",
+      "nifty50": "NIFTY 50 (インド)",
       "btc-usdt": "BTC-USDT (暗号資産)",
       "equity_cn": "中国 A 株",
       "equity_us": "米国株式",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1033,6 +1033,7 @@
     "universeOption": {
       "csi300": "CSI 300 (중국 A주)",
       "sp500": "S&P 500 (미국)",
+      "nifty50": "NIFTY 50 (인도)",
       "btc-usdt": "BTC-USDT (암호화폐)",
       "equity_cn": "중국 A주",
       "equity_us": "미국 주식",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1033,6 +1033,7 @@
     "universeOption": {
       "csi300": "沪深 300（A 股）",
       "sp500": "标普 500（美股）",
+      "nifty50": "NIFTY 50（印度）",
       "btc-usdt": "BTC-USDT（加密货币）",
       "equity_cn": "A 股",
       "equity_us": "美股",

--- a/frontend/src/pages/AlphaZoo.tsx
+++ b/frontend/src/pages/AlphaZoo.tsx
@@ -75,19 +75,21 @@ const ZOO_CARDS: ZooCard[] = [
 ];
 
 // Benchmarkable data universes (bench + compare): each one needs a panel loader
-// on the backend, so there is no Korea/India entry — the KRX factor capability
-// is a metadata universe, not a benchmark universe.
+// on the backend. Korea (equity_kr) and futures have no panel yet, so they stay
+// metadata-only universes.
 const UNIVERSE_OPTIONS = [
   { value: "csi300" },
   { value: "sp500" },
+  { value: "nifty50" },
   { value: "btc-usdt" },
 ];
 
 // Metadata universe -> the benchmark universe whose panel represents it. Markets
-// without a panel (equity_in, equity_kr, futures) are intentionally absent.
+// without a panel (equity_kr, futures) are intentionally absent.
 const BENCH_UNIVERSE_FOR_METADATA: Record<string, string> = {
   equity_cn: "csi300",
   equity_us: "sp500",
+  equity_in: "nifty50",
   crypto: "btc-usdt",
 };
 


### PR DESCRIPTION
## Summary

Two related fixes to the Alpha Zoo bench, found while getting `POST /alpha/bench`
working end-to-end on an install with only free/no-key data sources:

1. **Add a NIFTY 50 (NSE) bench universe** + parallelise the Yahoo panel fetch
2. **Survive a broken process pool** in the bench runner

Happy to split into two PRs if you'd prefer.

> An earlier draft of this branch also added a ccxt crypto-pair source to
> `search_symbol` — dropped, since `main` already resolves crypto pairs from the
> public venue catalogs (`0ed3770f`, `4d04441d`).

---

## Part 1 — NIFTY 50 bench universe + parallel equity fetch

`_load_universe_panel` knows `csi300` / `sp500` / `btc-usdt`. On an install without a
Tushare token that leaves **no working universe**: `csi300` needs the token, `btc-usdt`
is single-asset (cross-sectional factors reject it), and `sp500` fetched its ~500
Yahoo symbols **one HTTP call at a time** — a cold panel took >8 min and never
finished inside the SSE stream timeout.

* `_fetch_equity_panel_concurrent` — fetch a wide equity panel one symbol per worker
  (`ThreadPoolExecutor`, 8) instead of the loader's sequential loop. Reuses the loader's
  own per-symbol cache + normalisation. Cold `sp500` drops to ~1–2 min, then pickle-cached.
  `_load_sp500_panel` now uses it.
* New `nifty50` universe → `equity_in`:
  * `_fetch_nifty50_constituents` — current NIFTY 50 roster + NSE sector labels from
    Wikipedia (requests + UA, then `read_html`), same pattern as `_fetch_sp500_constituents`;
    `_NIFTY50_FALLBACK` static 50-name roster for the offline path.
  * `_load_nifty_panel` — Yahoo `.NS` symbols (no auth), synthetic vwap, sector tag when
    coverage ≥ 90 % so the industry-neutralised alpha101 factors run. Same
    survivorship-bias disclosure in `_meta` as `sp500`.
  * wired through `_UNIVERSE_TAG`, `_BENCH_UNIVERSES` (`alpha_routes`),
    `_UNIVERSE_CHOICES` + `_LIST_UNIVERSE_ALIASES` (`cli_handlers`).
* Frontend: `nifty50` in `UNIVERSE_OPTIONS`, `equity_in -> nifty50` in
  `BENCH_UNIVERSE_FOR_METADATA` (so an India factor's "Run bench" button stops silently
  benching on the S&P 500), `universeOption.nifty50` in all 8 locales.

Verified end-to-end on a live box: `POST /alpha/compare` and `POST /alpha/bench` with
`universe: nifty50` — 50/50 names from Yahoo (~40 s cold), 99/101 alpha101 scored,
sector tag drives the industry-neutral factors.

## Part 2 — bench falls back to sequential when the process pool breaks

`run_bench` parallelises across a `ProcessPoolExecutor` that **forks the current
process**. Driven from the uvicorn worker for `POST /alpha/bench`, the forked children
die on startup (fork of a multi-threaded host) and every future raises
`BrokenProcessPool` — which the per-future handler turned into a *skip*, so the endpoint
returned `n_alphas_tested: 0, n_skipped: N` with `status: ok`.

Latent until now: it needs a universe whose panel actually loads to reach the pool, and
without a Tushare token there was none (Part 1 adds one).

* re-raise `BrokenProcessPool` out of the per-future handler
* wrap the parallel block; on `BrokenProcessPool`, discard partials and run the batch
  through the existing in-process path

Verified: with the pool forced to break, an `alpha101 × nifty50` bench re-runs
in-process — 99 tested / 2 skipped / 22 alive.

---

## Test Plan

- [x] `pytest agent/tests -q -k "alpha or factor or bench or universe or run_card or cli_handler"` → **1458 passed**, 10 skipped
- [x] New tests:
  - `test_alpha_bench_nifty50.py` — constituent provenance, fallback, sector tag
  - `test_alpha_compare_api.py` — parametrised over every bench universe
  - `test_bench_parallel.py::test_broken_process_pool_falls_back_to_sequential`
- [x] Manual end-to-end on a live deployment for both parts (numbers above)
- [ ] Frontend not rebuilt in this PR — Part 1's `AlphaZoo.tsx` + locale edits are trivial
      and type-safe; verified by hand-building on the test box

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`)
- [x] No hardcoded secrets / paths / magic numbers
- [x] Follows CONTRIBUTING.md
- [x] DCO `Signed-off-by:` on every commit
