### PR TITLE
fix(backtest): use configured default IV for HV warm-up bars (#1293)

### DIFF
--- a/agent/backtest/engines/options_portfolio.py
+++ b/agent/backtest/engines/options_portfolio.py
@@ -19,6 +19,7 @@ the per-leg vol every pricing site must agree on.
 """
 
 import json
+import math
 import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -42,9 +43,10 @@ def historical_volatility(
     Args:
         close: Close price Series.
         window: Rolling window in days.
-        default_iv: Volatility used for bars without a full window. Backfilling
-            the first computed window here would price bars before it with
-            information from the window's own end (#1293).
+        default_iv: Volatility used for any bar without a full rolling window
+            (the leading warm-up and NaN gaps). Backfilling the first computed
+            window here would price bars before it with information from the
+            window's own end (#1293).
 
     Returns:
         Annualised historical volatility Series.
@@ -219,6 +221,8 @@ def run_options_backtest(
     iv_skew = options_cfg.get("iv_skew", 0.0)         # v2: smile skew param (0 = flat)
     iv_curvature = options_cfg.get("iv_curvature", 0.0)  # v2: smile curvature
     default_iv = options_cfg.get("default_iv", 0.3)
+    if not math.isfinite(default_iv) or default_iv <= 0.0:
+        raise ValueError("options_config.default_iv must be a finite, positive float")
 
     # Load underlying data
     data_map = loader.fetch(codes, start_date, end_date)

--- a/agent/backtest/engines/options_portfolio.py
+++ b/agent/backtest/engines/options_portfolio.py
@@ -34,19 +34,24 @@ from src.quantlib.options import bs_greeks, bs_price, normalise_option_type
 # --- Historical volatility ---
 
 
-def historical_volatility(close: pd.Series, window: int = 30) -> pd.Series:
+def historical_volatility(
+    close: pd.Series, window: int = 30, default_iv: float = 0.3
+) -> pd.Series:
     """Calculate annualised historical volatility from a close price series.
 
     Args:
         close: Close price Series.
         window: Rolling window in days.
+        default_iv: Volatility used for bars without a full window. Backfilling
+            the first computed window here would price bars before it with
+            information from the window's own end (#1293).
 
     Returns:
         Annualised historical volatility Series.
     """
     log_ret = np.log(close / close.shift(1))
     hv = log_ret.rolling(window=window).std() * np.sqrt(252)
-    return hv.fillna(hv.dropna().iloc[0] if len(hv.dropna()) > 0 else 0.3)
+    return hv.fillna(default_iv)
 
 
 # --- IV Smile model (v2) ---
@@ -213,6 +218,7 @@ def run_options_backtest(
     exercise_style = options_cfg.get("exercise_style", "european")  # v2: "european" or "american"
     iv_skew = options_cfg.get("iv_skew", 0.0)         # v2: smile skew param (0 = flat)
     iv_curvature = options_cfg.get("iv_curvature", 0.0)  # v2: smile curvature
+    default_iv = options_cfg.get("default_iv", 0.3)
 
     # Load underlying data
     data_map = loader.fetch(codes, start_date, end_date)
@@ -223,7 +229,7 @@ def run_options_backtest(
     # Compute implied volatility (approximated by historical volatility)
     iv_map: Dict[str, pd.Series] = {}
     for code, df in data_map.items():
-        iv_map[code] = historical_volatility(df["close"])
+        iv_map[code] = historical_volatility(df["close"], default_iv=default_iv)
 
     # Generate trade signals
     signals = engine.generate(data_map)
@@ -263,14 +269,22 @@ def run_options_backtest(
         for code, df in data_map.items():
             if ts in df.index:
                 spot_prices[code] = float(df.at[ts, "close"])
-                ivs[code] = float(iv_map[code].at[ts]) if ts in iv_map[code].index else 0.3
+                ivs[code] = (
+                    float(iv_map[code].at[ts])
+                    if ts in iv_map[code].index
+                    else default_iv
+                )
             else:
                 # Use the last available price
                 before = df.index[df.index <= ts]
                 if len(before) > 0:
                     last = before[-1]
                     spot_prices[code] = float(df.at[last, "close"])
-                    ivs[code] = float(iv_map[code].at[last]) if last in iv_map[code].index else 0.3
+                    ivs[code] = (
+                        float(iv_map[code].at[last])
+                        if last in iv_map[code].index
+                        else default_iv
+                    )
 
         # 2a. American early exercise (v2): exercise if intrinsic > continuation
         if exercise_style == "american":
@@ -278,7 +292,7 @@ def run_options_backtest(
                 if pos.is_expired(ts):
                     continue  # handled below
                 spot = spot_prices.get(pos.underlying_code, 0.0)
-                iv_val_ex = ivs.get(pos.underlying_code, 0.3)
+                iv_val_ex = ivs.get(pos.underlying_code, default_iv)
                 T_ex = pos.time_to_expiry(ts)
                 if T_ex <= 0:
                     continue
@@ -340,7 +354,7 @@ def run_options_backtest(
             underlying = sig.get("underlying", codes[0] if codes else "")
 
             spot = spot_prices.get(underlying, 0.0)
-            iv_val = ivs.get(underlying, 0.3)
+            iv_val = ivs.get(underlying, default_iv)
 
             for leg in legs:
                 # Fold before it is priced, matched and recorded: config comes
@@ -453,7 +467,7 @@ def run_options_backtest(
 
         for pos in positions:
             spot = spot_prices.get(pos.underlying_code, 0.0)
-            iv_val = ivs.get(pos.underlying_code, 0.3)
+            iv_val = ivs.get(pos.underlying_code, default_iv)
             T = pos.time_to_expiry(ts)
 
             mark_iv = leg_iv(spot, pos.strike, iv_val, iv_skew, iv_curvature)

--- a/agent/src/skills/options-strategy/SKILL.md
+++ b/agent/src/skills/options-strategy/SKILL.md
@@ -90,7 +90,8 @@ Iron Condor opening signal:
     "options_config": {
         "risk_free_rate": 0.05,
         "iv_source": "historical",
-        "contract_multiplier": 1.0
+        "contract_multiplier": 1.0,
+        "default_iv": 0.3
     }
 }
 ```
@@ -100,6 +101,7 @@ Key fields:
 - `options_config.risk_free_rate`: risk-free rate, default `0.05`
 - `options_config.iv_source`: volatility source, currently supports `"historical"` (30-day rolling historical volatility computed from underlying closes)
 - `options_config.contract_multiplier`: contract multiplier, default `1.0`
+- `options_config.default_iv`: volatility used for bars without a full rolling window (warm-up and NaN gaps), default `0.3`; must be finite and positive
 
 ## BS Model Principles
 

--- a/agent/tests/test_options_hv_warmup.py
+++ b/agent/tests/test_options_hv_warmup.py
@@ -1,0 +1,44 @@
+"""Regression: the HV warm-up must not backfill the first computed window.
+
+``historical_volatility`` filled the orphan bars of the 30-day rolling window
+with the first valid value -- the volatility computed over bars 1..30, so bars
+1..29 were priced with information from bar 30. Warm-up bars now use the
+configured default IV instead; bars with a full window keep the real rolling
+volatility. (#1293, part 2.)
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from backtest.engines.options_portfolio import historical_volatility
+
+
+def test_warmup_bars_use_default_iv_not_the_first_computed_window() -> None:
+    close = pd.Series([100.0] * 40)
+    hv = historical_volatility(close)
+
+    # Constant closes: the only rolling volatility anywhere is zero, so the old
+    # backfill would plant 0.0 over the warm-up. The first 30 bars must be the
+    # default IV instead, the rest the real (zero) rolling volatility.
+    assert hv.iloc[:30].eq(0.3).all()
+    assert hv.iloc[30:].eq(0.0).all()
+
+
+def test_default_iv_is_configurable() -> None:
+    close = pd.Series([100.0] * 40)
+    hv = historical_volatility(close, default_iv=0.5)
+
+    assert hv.iloc[:30].eq(0.5).all()
+    assert hv.iloc[30:].eq(0.0).all()
+
+
+def test_full_window_bars_are_unchanged_by_the_warmup_fix() -> None:
+    """A trend keeps its real rolling vol everywhere past the warm-up."""
+    close = pd.Series(np.linspace(100.0, 200.0, 60))
+    hv = historical_volatility(close)
+
+    log_ret = np.log(close / close.shift(1))
+    expected = log_ret.rolling(30).std() * np.sqrt(252)
+    pd.testing.assert_series_equal(hv.iloc[30:], expected.iloc[30:].fillna(0.0))

--- a/agent/tests/test_options_hv_warmup.py
+++ b/agent/tests/test_options_hv_warmup.py
@@ -9,10 +9,13 @@ volatility. (#1293, part 2.)
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
+import pytest
 
-from backtest.engines.options_portfolio import historical_volatility
+from backtest.engines.options_portfolio import historical_volatility, run_options_backtest
 
 
 def test_warmup_bars_use_default_iv_not_the_first_computed_window() -> None:
@@ -42,3 +45,39 @@ def test_full_window_bars_are_unchanged_by_the_warmup_fix() -> None:
     log_ret = np.log(close / close.shift(1))
     expected = log_ret.rolling(30).std() * np.sqrt(252)
     pd.testing.assert_series_equal(hv.iloc[30:], expected.iloc[30:].fillna(0.0))
+
+
+@pytest.mark.parametrize("bad_iv", [0.0, -0.5, float("nan"), float("inf")])
+def test_default_iv_must_be_positive_and_finite(bad_iv: float) -> None:
+    """NaN/zero/negative config would silently break pricing or crash on dump."""
+
+    class _FlatLoader:
+        name = "yfinance"
+
+        def fetch(self, codes, start_date, end_date):  # noqa: ANN001
+            return {
+                "SPY": pd.DataFrame(
+                    {"close": [100.0, 101.0], "open": [100.0, 100.5]},
+                    index=pd.to_datetime(["2025-01-01", "2025-01-02"]),
+                )
+            }
+
+    class _NoSignals:
+        def generate(self, data_map):  # noqa: ANN001
+            return []
+
+    with pytest.raises(ValueError, match="default_iv"):
+        run_options_backtest(
+            {
+                "codes": ["SPY"],
+                "start_date": "2025-01-01",
+                "end_date": "2025-01-02",
+                "source": "yfinance",
+                "engine": "options",
+                "initial_cash": 100_000.0,
+                "options_config": {"default_iv": bad_iv},
+            },
+            _FlatLoader(),
+            _NoSignals(),
+            Path("/tmp/opts_guard"),
+        )


### PR DESCRIPTION
## Summary

`historical_volatility` (`engines/options_portfolio.py`) filled the orphan bars of the 30-day rolling window with the first computed value — the vol over bars 1..30 — so bars 1..29 were priced with information from bar 30: a small lookahead leak on every options backtest that uses historical vol (#1293, part 2).

## Changes

- **Warm-up bars use the default IV** — `historical_volatility(close, window=30, default_iv=0.3)` returns `hv.fillna(default_iv)` instead of backfilling the first valid window. Bars with a full window keep the real rolling volatility.
- **Config threaded through** — new `options_config.default_iv` (default `0.3`) feeds the warm-up fill and replaces the engine's other hardcoded `0.3` IV fallbacks, so one config governs every "no IV available" case.
- **Tests** — `test_options_hv_warmup.py`: constant closes prove the warm-up is the default IV and not the (zero) first window; configurable default; full-window bars unchanged vs the raw rolling volatility.

> Independent, one-change PR split from #1293 — the fill-shift half is #1299.

## Test Plan

- `pytest agent/tests/test_options_hv_warmup.py agent/tests/test_options_smile_consistency.py agent/tests/test_options_partial_close.py agent/tests/test_warmup_window.py -q` → **32 passed**

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`)
- [x] No hardcoded values
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Documentation updated (function docstring)

Part of #1293 (HV warm-up leak); the fill leak is #1299.
