### PR TITLE
fix(live): size buy-limit orders at the worse of quote and limit

### DIFF
--- a/agent/src/live/enforcement.py
+++ b/agent/src/live/enforcement.py
@@ -132,6 +132,9 @@ class OrderIntent:
     quantity: float | None
     instrument_type: InstrumentType
     asset_class: AssetClass | None = None
+    # Buy-limit worst-case fill price for notional math (#18); None on market
+    # orders and on connectors that do not pass one through.
+    limit_price: float | None = None
 
 
 @dataclass(frozen=True)

--- a/agent/src/live/order_guard.py
+++ b/agent/src/live/order_guard.py
@@ -258,6 +258,7 @@ class LiveOrderGuardTool(MCPRemoteTool):
             notional_usd=enforced,
             quantity=intent.quantity,
             instrument_type=intent.instrument_type,
+            limit_price=intent.limit_price,
         )
 
     def _quote_price(self, intent: OrderIntent) -> float | None:

--- a/agent/src/live/sdk_order_gate.py
+++ b/agent/src/live/sdk_order_gate.py
@@ -943,6 +943,16 @@ def _implied_notional(intent: OrderIntent, connector_module: Any, config: Any) -
             return None
         return float(value)
     price = _quote_price(intent, connector_module, config)
+    # A buy limit is fillable anywhere up to its limit, so the cap must be
+    # sized for the worse of the two (#18): pricing it at the quote alone
+    # would let a limit at 2x the market fill at twice the authorized amount.
+    # Sell limits do not create exposure, so the quote stands there.
+    if (
+        intent.side == "buy"
+        and intent.limit_price is not None
+        and price is not None
+    ):
+        price = max(price, intent.limit_price)
     if price is None:
         return None
     return intent.quantity * price

--- a/agent/src/trading/service.py
+++ b/agent/src/trading/service.py
@@ -700,6 +700,7 @@ def place_order(
         quantity=float(quantity) if quantity is not None else None,
         instrument_type=instrument_type,
         asset_class=asset_class,
+        limit_price=float(limit_price) if limit_price is not None else None,
     )
     result = execute_live_order(
         broker=profile.connector,

--- a/agent/tests/test_limit_price_notional.py
+++ b/agent/tests/test_limit_price_notional.py
@@ -1,0 +1,65 @@
+"""Buy-limit notional must be sized at the worse of quote and limit (#18).
+
+A buy limit at 2x the market used to be priced at the quote alone, so it
+passed a cap sized for the quote while being fillable at twice the
+authorized amount. Sell limits do not create exposure, so the quote stands
+there.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import src.live.sdk_order_gate as sdk_order_gate
+from src.live.enforcement import OrderIntent
+from src.live.mandate.model import AssetClass, InstrumentType
+
+
+def _connector(last: float):
+    return SimpleNamespace(get_quote=lambda symbol, config=None: {"quote": {"last": last}})
+
+
+def _intent(limit_price: float | None, side: str = "buy") -> OrderIntent:
+    return OrderIntent(
+        symbol="AAPL",
+        side=side,
+        notional_usd=None,
+        quantity=10.0,
+        instrument_type=InstrumentType.EQUITY,
+        asset_class=AssetClass.US_EQUITY,
+        limit_price=limit_price,
+    )
+
+
+def test_buy_limit_above_quote_is_priced_at_the_limit() -> None:
+    intent = sdk_order_gate._normalize_notional(
+        _intent(limit_price=200.0), _connector(last=100.0), config=None
+    )
+    assert intent is not None
+    assert intent.notional_usd == pytest.approx(2000.0)
+
+
+def test_buy_limit_below_quote_keeps_the_quote() -> None:
+    intent = sdk_order_gate._normalize_notional(
+        _intent(limit_price=80.0), _connector(last=100.0), config=None
+    )
+    assert intent is not None
+    assert intent.notional_usd == pytest.approx(1000.0)
+
+
+def test_market_order_ignores_the_limit_path() -> None:
+    intent = sdk_order_gate._normalize_notional(
+        _intent(limit_price=None), _connector(last=100.0), config=None
+    )
+    assert intent is not None
+    assert intent.notional_usd == pytest.approx(1000.0)
+
+
+def test_sell_limit_keeps_the_quote() -> None:
+    intent = sdk_order_gate._normalize_notional(
+        _intent(limit_price=200.0, side="sell"), _connector(last=100.0), config=None
+    )
+    assert intent is not None
+    assert intent.notional_usd == pytest.approx(1000.0)


### PR DESCRIPTION
Fixes #18 from the trust-layer roadmap (#1207)

## What

A buy-limit order's notional is now sized at the worse of the live quote and the limit price, instead of the quote alone. Previously a buy limit at 2x the market passed a notional cap sized for the quote while being fillable at twice the authorized amount. The limit price now rides the `OrderIntent` from the service entry point through the gate, and the sizing rule applies only on the buy side: a sell limit creates no new exposure, so the quote stands there. The order_guard normalize path preserves the field instead of dropping it.

## Tests

New `agent/tests/test_limit_price_notional.py`: a buy limit above the quote is priced at the limit, a buy limit below the quote keeps the quote, a market order ignores the path, and a sell limit keeps the quote. The cap case is red on current main and green here; the existing gate/mandate/kill-switch suites pass (95 tests).

## Risk / rollback

Buy-limit orders that used to sneak past `max_order_notional_usd` are now correctly denied, which is the intended hardening of the mandate gate. No broker API or order-shape changes. Rollback: revert this commit.

Prepared with AI assistance (Kimi K3); the defect was validated on current main before the fix.
