### PR TITLE
fix(deps): cap fastmcp below 4.0.0 until the constructor/snapshot adaptation lands

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,10 @@ dependencies = [
     "pydantic>=2.0.0",
     "python-multipart>=0.0.18",
     "sse-starlette>=1.6.0",
-    "fastmcp>=2.14.0",
+    # 4.0.0 changed MCPError's constructor (message is now separate) and the
+    # session snapshot shape; tests construct it the 2.x way. Cap until the
+    # adaptation lands.
+    "fastmcp>=2.14.0,<4.0.0",
     "ddgs>=6.0.0",
     "jinja2>=3.1.0",
     "matplotlib>=3.7.0",


### PR DESCRIPTION
## What

fastmcp 4.0.0 (released today) changed `MCPError`'s constructor (message is now a separate argument) and the session snapshot shape, and every fresh CI install pulls it because the dependency is `fastmcp>=2.14.0` unbounded. Three test files fail on main right now (`test_mcp_client_adapter.py`, `test_mcp_goal_session_isolation.py`, `test_mcp_oauth_schema.py`), which also blocks every open PR's CI.

The runtime is unaffected: the source only does `isinstance` checks against `McpError` and never constructs it; the breakage is test-side construction plus snapshot/auth behavior. This caps the dependency below 4.0.0 until the adaptation lands, and I have filed the adaptation as the follow-up work.

## Verification

Reproduced all three failures locally under fastmcp 4.0.0; the same tests pass on the capped dependency set (the pre-4.0 line CI was green on).

## Risk / rollback

No code change beyond the version bound. Rollback: revert, and adapt to 4.0 instead. Prepared with AI assistance (Kimi K3); the drift was verified against the exact CI failure logs before capping.
