### PR TITLE
fix(shadow): key the result cache by window and journal hash, not shadow alone

### DIFF
--- a/agent/src/shadow_account/backtester.py
+++ b/agent/src/shadow_account/backtester.py
@@ -17,6 +17,7 @@ simulation rebuild. This keeps the numbers auditable and reproducible.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 from pathlib import Path
@@ -283,13 +284,35 @@ def run_shadow_backtest(
         real_total_pnl=real_pnl,
         delta_pnl=round(shadow_pnl - real_pnl, 2) if shadow_pnl is not None else None,
     )
-    _cache_result(base_dir, result)
+    _cache_result(
+        base_dir, result,
+        profile=profile, window_start=window_start, window_end=window_end,
+    )
     return result
 
 
-def load_cached_result(shadow_id: str) -> ShadowBacktestResult | None:
-    """Load the last cached backtest result for a shadow, if any."""
-    cache_path = runs_dir(shadow_id) / "shadow_result.json"
+
+def _cache_key(profile: ShadowProfile, window_start: str, window_end: str) -> str:
+    """Digest for the result cache: window plus the journal hash the profile
+    was extracted from, so a re-render with a different window or an edited
+    journal cannot silently reuse a stale run."""
+    raw = f"{window_start}|{window_end}|{profile.journal_hash}"
+    return hashlib.sha1(raw.encode()).hexdigest()[:12]
+
+
+def load_cached_result(
+    profile: ShadowProfile,
+    *,
+    window_start: str,
+    window_end: str,
+) -> ShadowBacktestResult | None:
+    """Load the cached backtest result matching this window and journal.
+
+    The cache is keyed by shadow + run parameters; a different window or a
+    re-extracted (re-hashed) journal deliberately misses instead of serving a
+    stale run.
+    """
+    cache_path = runs_dir(profile.shadow_id) / f"shadow_result_{_cache_key(profile, window_start, window_end)}.json"
     if not cache_path.exists():
         return None
     try:
@@ -319,13 +342,20 @@ def load_cached_result(shadow_id: str) -> ShadowBacktestResult | None:
     )
 
 
-def _cache_result(run_dir: Path, result: ShadowBacktestResult) -> None:
+def _cache_result(
+    run_dir: Path,
+    result: ShadowBacktestResult,
+    *,
+    profile: ShadowProfile,
+    window_start: str,
+    window_end: str,
+) -> None:
     """Persist a ShadowBacktestResult so downstream tools don't re-backtest."""
     from dataclasses import asdict as _asdict
 
     payload = _asdict(result)
     try:
-        (run_dir / "shadow_result.json").write_text(
+        (run_dir / f"shadow_result_{_cache_key(profile, window_start, window_end)}.json").write_text(
             json.dumps(payload, ensure_ascii=False, indent=2, default=str),
             encoding="utf-8",
         )

--- a/agent/src/tools/shadow_account_tool.py
+++ b/agent/src/tools/shadow_account_tool.py
@@ -280,11 +280,13 @@ class RenderShadowReportTool(BaseTool):
         except ValueError as exc:
             return _err(str(exc))
 
-        result = load_cached_result(profile.shadow_id)
+        today = date.today()
+        window_end = kwargs.get("window_end") or today.isoformat()
+        window_start = kwargs.get("window_start") or (today - timedelta(days=365)).isoformat()
+        result = load_cached_result(
+            profile, window_start=window_start, window_end=window_end,
+        )
         if result is None:
-            today = date.today()
-            window_end = kwargs.get("window_end") or today.isoformat()
-            window_start = kwargs.get("window_start") or (today - timedelta(days=365)).isoformat()
             try:
                 result = run_shadow_backtest(
                     profile,

--- a/agent/tests/test_shadow_account.py
+++ b/agent/tests/test_shadow_account.py
@@ -423,7 +423,7 @@ def test_run_shadow_backtest_handles_runner_failure(
 
     from src.shadow_account.backtester import load_cached_result
 
-    cached = load_cached_result(profile.shadow_id)
+    cached = load_cached_result(profile, window_start="2026-01-01", window_end="2026-06-30")
     assert cached is not None
     assert cached.shadow_total_pnl is None
     assert cached.delta_pnl is None
@@ -488,7 +488,7 @@ def test_run_shadow_backtest_derives_pnl_from_final_value(
 
     from src.shadow_account.backtester import load_cached_result
 
-    cached = load_cached_result(profile.shadow_id)
+    cached = load_cached_result(profile, window_start="2026-01-01", window_end="2026-06-30")
     assert cached is not None
     assert cached.shadow_total_pnl == pytest.approx(-165_858.20, abs=0.01)
     assert cached.delta_pnl == result.delta_pnl
@@ -621,7 +621,9 @@ def test_run_shadow_backtest_runs_once_per_currency(
     for call in calls:
         currencies = {code_currency(c) for c in call["codes"]}  # type: ignore[union-attr]
         assert len(currencies) == 1
-    assert (runs_dir(profile.shadow_id) / "shadow_result.json").exists()
+    from src.shadow_account.backtester import _cache_key
+    digest = _cache_key(profile, "2026-01-01", "2026-06-30")
+    assert (runs_dir(profile.shadow_id) / f"shadow_result_{digest}.json").exists()
     assert set(result.per_market.keys()) == {"china_a", "hk", "us", "crypto"}
 
 

--- a/agent/tests/test_shadow_result_cache.py
+++ b/agent/tests/test_shadow_result_cache.py
@@ -1,0 +1,94 @@
+"""Shadow result cache is keyed by window and journal hash, not shadow alone.
+
+The report flow used to load `runs_dir(shadow_id)/shadow_result.json` with no
+parameter check, so re-rendering a report with a different window silently
+reused the previous run. The cache is now keyed by shadow + window + journal
+hash; a different window deliberately misses.
+"""
+
+from __future__ import annotations
+
+from src.shadow_account.backtester import _cache_key, _cache_result, load_cached_result
+from src.shadow_account.models import (
+    AttributionBreakdown,
+    ShadowBacktestResult,
+    ShadowProfile,
+    ShadowRule,
+)
+
+
+def _profile() -> ShadowProfile:
+    rule = ShadowRule(
+        rule_id="R1",
+        human_text="x",
+        entry_condition={"market": "us"},
+        exit_condition={"holding_days": {"min": 2, "max": 5}},
+        holding_days_range=(3, 3),
+        support_count=10,
+        coverage_rate=0.5,
+        sample_trades=("AAPL@2026-01-10",),
+    )
+    return ShadowProfile(
+        shadow_id="shadow_cache_test",
+        created_at="2026-01-01T00:00:00",
+        journal_hash="hash-v1",
+        source_market="us",
+        profitable_roundtrips=10,
+        total_roundtrips=20,
+        date_range=("2025-01-01", "2026-01-01"),
+        profile_text="test",
+        rules=(rule,),
+        preferred_markets=("us",),
+        typical_holding_days=(3.0, 3.0),
+    )
+
+
+def _result() -> ShadowBacktestResult:
+    return ShadowBacktestResult(
+        shadow_id="shadow_cache_test",
+        per_market={},
+        combined={"final_value": 1_010_000.0},
+        equity_curves={},
+        attribution=AttributionBreakdown(
+            missed_signals_pnl=0.0,
+            noise_trades_pnl=0.0,
+            early_exit_pnl=0.0,
+            late_exit_pnl=0.0,
+            overtrading_pnl=0.0,
+            counterfactual_trades=(),
+        ),
+        shadow_total_pnl=10_000.0,
+        real_total_pnl=9_000.0,
+        delta_pnl=1_000.0,
+    )
+
+
+def test_cache_hits_only_on_exact_window_and_journal(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    profile = _profile()
+    from src.shadow_account.storage import runs_dir
+
+    _cache_result(
+        runs_dir(profile.shadow_id), _result(),
+        profile=profile, window_start="2025-01-01", window_end="2026-01-01",
+    )
+
+    hit = load_cached_result(profile, window_start="2025-01-01", window_end="2026-01-01")
+    assert hit is not None
+    assert hit.shadow_total_pnl == 10_000.0
+
+    # Different window must miss, not silently reuse the previous run.
+    assert load_cached_result(profile, window_start="2025-06-01", window_end="2026-01-01") is None
+
+    # A re-extracted journal (different hash) must miss too.
+    other = ShadowProfile(**{**profile.__dict__, "journal_hash": "hash-v2"})
+    assert load_cached_result(other, window_start="2025-01-01", window_end="2026-01-01") is None
+
+
+def test_cache_key_changes_with_window_and_hash() -> None:
+    profile = _profile()
+    base = _cache_key(profile, "2025-01-01", "2026-01-01")
+    assert base != _cache_key(profile, "2025-06-01", "2026-01-01")
+    other = ShadowProfile(**{**profile.__dict__, "journal_hash": "hash-v2"})
+    assert base != _cache_key(other, "2025-01-01", "2026-01-01")
+    assert base == _cache_key(profile, "2025-01-01", "2026-01-01")


### PR DESCRIPTION
## What

The shadow report's result cache is now keyed by shadow + window + journal hash instead of shadow id alone. The report flow used to load `shadow_result.json` with no parameter check, so re-rendering a report with a different window silently reused the previous run's numbers. A different window or a re-extracted journal now deliberately misses and re-runs. Item from the roadmap's minor batch (#1207).

## Tests

New `agent/tests/test_shadow_result_cache.py`: exact window+journal hits, a different window misses, and a re-hashed journal misses; the existing shadow suite passes (86 tests).

## Risk / rollback

A report re-rendered with a different window now costs a fresh backtest instead of serving stale numbers, which is the intended correctness trade. Rollback: revert this commit. Prepared with AI assistance (Kimi K3); the stale-cache behavior was validated on current main before the fix.
