### PR TITLE
fix(market-data): align symbol search and fetch for FX pairs and indexes

### DIFF
--- a/agent/backtest/engines/_market_hooks.py
+++ b/agent/backtest/engines/_market_hooks.py
@@ -57,6 +57,14 @@ _MARKET_PATTERNS = [
     # Forex pairs: XXX/YYY or XXXXXX.FX
     (re.compile(r"^[A-Z]{3}/[A-Z]{3}$"), "forex"),
     (re.compile(r"^[A-Z]{6}\.FX$"), "forex"),
+    # Yahoo forex suffix convention (EURUSD=X, GBPCNY=X) — served verbatim by
+    # the chart endpoint. Without this rule such symbols fell through to the
+    # a_share default (misrouting composite/market classification).
+    (re.compile(r"^[A-Z]{3}[A-Z]{3}=X$"), "forex"),
+    # Yahoo index symbols (^SPX, ^NDX, ^FTSE, ^VIX, ...) — served verbatim,
+    # same as the =F/=X conventions. Classified as their own market so they
+    # never route through an equity/China chain or a cash currency.
+    (re.compile(r"^\^[A-Za-z0-9.\-]+$"), "index"),
     # Bare US tickers (AAPL, MSFT, SPY, T, ...). Must stay LAST so every
     # suffixed equity / futures / crypto / forex form above wins first.
     # ``{1,5}`` covers every standard US ticker length while 6-char bare
@@ -116,6 +124,8 @@ def code_currency(code: str) -> str:
         pair = code.upper().replace("/", "")
         if pair.endswith(".FX"):
             pair = pair[:-3]
+        if pair.endswith("=X"):
+            pair = pair[:-2]
         return pair[3:6] if len(pair) == 6 else "UNKNOWN:forex"
     if market == "futures":
         if _is_china_futures(code):

--- a/agent/backtest/engines/_market_hooks.py
+++ b/agent/backtest/engines/_market_hooks.py
@@ -60,7 +60,7 @@ _MARKET_PATTERNS = [
     # Yahoo forex suffix convention (EURUSD=X, GBPCNY=X) — served verbatim by
     # the chart endpoint. Without this rule such symbols fell through to the
     # a_share default (misrouting composite/market classification).
-    (re.compile(r"^[A-Z]{3}[A-Z]{3}=X$"), "forex"),
+    (re.compile(r"^[A-Z]{3,6}=X$"), "forex"),
     # Yahoo index symbols (^SPX, ^NDX, ^FTSE, ^VIX, ...) — served verbatim,
     # same as the =F/=X conventions. Classified as their own market so they
     # never route through an equity/China chain or a cash currency.

--- a/agent/backtest/engines/composite.py
+++ b/agent/backtest/engines/composite.py
@@ -56,6 +56,9 @@ def _build_rule_engines(config: dict, codes: List[str]) -> Dict[str, BaseEngine]
         elif market == "crypto":
             from backtest.engines.crypto import CryptoEngine
             engines["crypto"] = CryptoEngine(config)
+        elif market == "index":
+            from backtest.engines.global_equity import GlobalEquityEngine
+            engines["index"] = GlobalEquityEngine(config, market="us")
         elif market == "forex":
             from backtest.engines.forex import ForexEngine
             engines["forex"] = ForexEngine(config)

--- a/agent/backtest/loaders/registry.py
+++ b/agent/backtest/loaders/registry.py
@@ -164,6 +164,9 @@ FALLBACK_CHAINS: dict[str, list[str]] = {
     # mt5 leads when a local MetaTrader 5 terminal is attached (Windows-only,
     # broker feed); otherwise it reports unavailable and the chain proceeds.
     "forex":     ["mt5", "akshare", "yfinance", "local"],
+    # Yahoo index symbols (^SPX, ^NDX, ^FTSE, ^VIX, ...): served verbatim by
+    # the public chart endpoint, same as the =F/=X conventions.
+    "index":     ["yahoo", "yfinance", "local"],
 }
 
 

--- a/agent/backtest/loaders/yahoo_loader.py
+++ b/agent/backtest/loaders/yahoo_loader.py
@@ -53,12 +53,15 @@ def _is_supported(code: str) -> bool:
     """Return whether *code* is a symbol this loader handles.
 
     Covers US/HK/India/Korea/Canada/Vietnam/UK equities plus Yahoo's own
-    futures (``GC=F``) and forex (``EURUSD=X``) suffix conventions, which the
-    public chart endpoint serves verbatim (the code is used as-is in the
-    request URL, no conversion) (#718). Supported UK ``.L`` lines must declare
-    GBP or GBp; GBp is normalized to GBP at fetch time (#1206).
+    futures (``GC=F``), forex (``EURUSD=X``) and index (``^SPX``) symbol
+    conventions, which the public chart endpoint serves verbatim (the code is
+    used as-is in the request URL, no conversion) (#718). Supported UK ``.L``
+    lines must declare GBP or GBp; GBp is normalized to GBP at fetch time
+    (#1206).
     """
     upper = code.strip().upper()
+    if upper.startswith("^"):
+        return True
     return upper.endswith(
         (
             ".US", ".HK", ".NS", ".BO", ".KS", ".KQ", ".TO", ".V", ".VN",

--- a/agent/backtest/runner.py
+++ b/agent/backtest/runner.py
@@ -842,6 +842,7 @@ _MARKET_TO_SOURCE = {
     "fund": "tushare",
     "macro": "akshare",
     "forex": "akshare",
+    "index": "yahoo",
 }
 
 
@@ -1350,6 +1351,12 @@ def _create_market_engine(source: str, config: dict, codes: List[str]):
     if "vietnam_equity" in markets:
         from backtest.engines.vietnam_equity import VietnamEquityEngine
         return VietnamEquityEngine(config)
+    # Index symbols (^SPX, ^FTSE, ...) — priced like a US/global-listed
+    # instrument (GlobalEquityEngine, US rules) and never the China/crypto
+    # default the source-based fallback would pick.
+    if "index" in markets:
+        from backtest.engines.global_equity import GlobalEquityEngine
+        return GlobalEquityEngine(config, market=_detect_submarket(codes))
 
     # Original routing (Wave 1)
     if source in ("okx", "ccxt"):

--- a/agent/src/agent/grounding.py
+++ b/agent/src/agent/grounding.py
@@ -30,6 +30,7 @@ from dataclasses import asdict, dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence
+from src.market_data import canonical_fx_pair
 
 
 GROUNDING_ARTIFACT = "grounding_evidence.json"
@@ -160,6 +161,7 @@ _CANONICAL_SYMBOL_RE = re.compile(
     r"\d{3,6}\.(?:SH|SZ|BJ|SS|HK|KS|KQ)|"
     r"[A-Z][A-Z0-9&.-]{0,19}\.(?:US|NS|BO|FX|TO|V)|"
     r"[A-Z0-9]{2,15}(?:-|/)(?:USDT|USDC|USD|BTC|ETH)|"
+    r"\^[A-Z0-9&.\-]{1,20}|"
     r"[A-Z0-9]{2,15}=[FX]"
     r")(?![A-Za-z0-9_])",
     re.IGNORECASE,
@@ -570,9 +572,19 @@ def _normalize_symbol(value: Any) -> str:
         Kong code zero-padded, and a crypto pair hyphenated. Text that is not a
         symbol is returned uppercased and otherwise untouched.
     """
-    symbol = str(value or "").strip().upper().replace("/", "-")
+    # A fiat/fiat pair is one FX instrument regardless of spelling: ``GBP/USD``
+    # and ``GBPUSD`` are both ``GBPUSD=X``. Checked BEFORE the slash is
+    # rewritten ("GBP/USD" -> "GBP-USD", the crypto-pair spelling), which
+    # disagreed with the resolver's ``GBPUSD=X`` answer — a contradictory
+    # identity that outranked every later lock and blocked all further tools.
+    raw = str(value or "").strip().upper()
+    fx = canonical_fx_pair(raw)
+    if fx is not None:
+        return fx
+    symbol = raw.replace("/", "-")
     if not symbol:
         return ""
+
     prefixed = _EXCHANGE_PREFIXED_RE.match(symbol)
     if prefixed:
         return f"{prefixed.group(2)}.{prefixed.group(1)}"
@@ -824,6 +836,10 @@ def _infer_currency(symbol: str) -> str | None:
             quote = upper.rsplit(separator, 1)[-1]
             if 3 <= len(quote) <= 5:
                 return quote
+    if upper.endswith("=X"):
+        pair = upper[:-2]
+        if len(pair) == 6:
+            return pair[3:6]
     return None
 
 
@@ -840,6 +856,8 @@ def _infer_instrument_type(symbol: str, candidate_type: Any = None) -> str:
         return "option"
     if "forex" in raw or raw == "currency":
         return "forex"
+    if "index" in raw:
+        return "index"
     upper = _normalize_symbol(symbol)
     if upper.endswith("=F"):
         return "future"
@@ -847,6 +865,8 @@ def _infer_instrument_type(symbol: str, candidate_type: Any = None) -> str:
         return "forex"
     if "-" in upper or "/" in upper:
         return "crypto"
+    if upper.startswith("^"):
+        return "index"
     return "listed_security"
 
 

--- a/agent/src/config/env_schema.py
+++ b/agent/src/config/env_schema.py
@@ -233,6 +233,7 @@ class DataConfig(_EnvBase):
     market_data_order_fund: str = Field(alias="MARKET_DATA_ORDER_FUND", default="")
     market_data_order_macro: str = Field(alias="MARKET_DATA_ORDER_MACRO", default="")
     market_data_order_forex: str = Field(alias="MARKET_DATA_ORDER_FOREX", default="")
+    market_data_order_index: str = Field(alias="MARKET_DATA_ORDER_INDEX", default="")
 
 
 # ---------------------------------------------------------------------------

--- a/agent/src/market_data.py
+++ b/agent/src/market_data.py
@@ -63,11 +63,51 @@ def detect_source(code: str) -> str:
     return "tushare"
 
 
+
 def get_loader(source: str):
     """Get loader class via registry with fallback support."""
     from backtest.loaders.registry import get_loader_cls_with_fallback
 
     return get_loader_cls_with_fallback(source)
+
+
+#: ISO-4217-style fiat codes. A pair whose BOTH legs are fiat is an FX pair,
+#: never a crypto instrument — ``GBP/USD`` used to be classified as the crypto
+#: pair "GBP-USD" (its quote leg USD is a crypto-connector quote asset) by the
+#: symbol-search tool's pair classifier and by the grounding ledger's symbol
+#: scanner, which then disagreed with the search result ("GBPUSD=X") and made
+#: the identity gate flag a conflict. One canonicalization is shared here so
+#: search, fetch and grounding all agree.
+FIAT_CODES = frozenset(
+    {
+        "USD", "EUR", "GBP", "JPY", "CHF", "CNY", "CNH", "HKD", "AUD", "NZD",
+        "CAD", "KRW", "INR", "SGD", "SEK", "NOK", "DKK", "MXN", "BRL", "ZAR",
+        "TRY", "RUB", "PLN", "THB", "MYR", "IDR", "PHP", "VND", "ILS", "AED",
+        "SAR", "EGP", "CZK", "HUF", "RON", "CLP", "COP", "PEN", "TWD", "CUP",
+    }
+)
+
+#: Yahoo-served FX pair symbol forms, canonicalized to ``XXXYYY=X``.
+_FX_PAIR_RE = re.compile(r"^(?P<base>[A-Z]{3})(?:/)?(?P<quote>[A-Z]{3})$", re.IGNORECASE)
+
+
+def canonical_fx_pair(value: str) -> str | None:
+    """Return a Yahoo FX pair in canonical ``XXXYYY=X`` form, or ``None``.
+
+    Recognizes ``GBP/USD``, ``GBPUSD`` and ``GBPUSD=X`` (both legs must be
+    fiat codes — ``ETH/USD`` and ``XAU/USD`` are not FX pairs) and returns
+    the canonical spelling the market-data fetch layer serves directly.
+    """
+    clean = str(value or "").strip().upper()
+    if clean.endswith("=X"):
+        clean = clean[:-2]
+    matched = _FX_PAIR_RE.fullmatch(clean)
+    if not matched:
+        return None
+    base, quote = matched.group("base"), matched.group("quote")
+    if base not in FIAT_CODES or quote not in FIAT_CODES:
+        return None
+    return f"{base}{quote}=X"
 
 
 # Canadian venue-alias helper: TSX (.TO) <-> TSX Venture (.V).

--- a/agent/src/market_data.py
+++ b/agent/src/market_data.py
@@ -38,6 +38,9 @@ _SOURCE_PATTERNS = [
     # China-market loaders that cannot resolve them.
     (re.compile(r"^[A-Z0-9]+=F$", re.I), "yahoo"),
     (re.compile(r"^[A-Z]+=X$", re.I), "yahoo"),
+    # Yahoo index symbols (^SPX, ^GSPC, ^FTSE, ^VIX, ...) — served verbatim,
+    # same convention as =F/=X. Without this they fell to the tushare default.
+    (re.compile(r"^\^[A-Za-z0-9.\-]+$", re.I), "yahoo"),
     # Korea: KOSPI (005930.KS) / KOSDAQ (247540.KQ), 6-digit codes. Served by
     # pykrx (KRX public data, no auth); registry falls back to Yahoo/yfinance.
     (re.compile(r"^\d{6}\.(KS|KQ)$", re.I), "pykrx"),

--- a/agent/src/skills/eastmoney/references/选股检索/代码搜索.md
+++ b/agent/src/skills/eastmoney/references/选股检索/代码搜索.md
@@ -5,6 +5,10 @@
 - **东财 suggest** —— 中/英文名与代码，跨 A 股/港股/美股，每条带 `<market>.<code>` 形式的 `QuoteID`。
 - **Yahoo v1 search** —— 全球代码/公司名（US、HK、crypto、indices、FX…）。
 - **SEC EDGAR company-tickers** —— 为解析出的美股权益代码补 0 填充的 CIK。
+FX 对（`GBP/USD`、`GBPUSD`、`GBPUSD=X`）统一归一为 Yahoo `XXXYYY=X` 形式
+（如 `GBPUSD=X`，market `fx`）；指数 `^SPX` 形式原样返回（market `index`）。
+归一候选（source `fx_normalizer`）在 Yahoo 节流/故障时也会返回，二次确认
+后可直接传给 `get_market_data`。
 市场：多市场。
 限速：东财经 `eastmoney` bucket，Yahoo / SEC 各自 host bucket。
 

--- a/agent/src/tools/symbol_search_tool.py
+++ b/agent/src/tools/symbol_search_tool.py
@@ -75,6 +75,41 @@ _CRYPTO_PAIR_RE = re.compile(
     re.IGNORECASE,
 )
 
+# ISO-4217-style fiat codes. A pair whose BOTH legs are fiat is an FX pair,
+# never a crypto instrument: ``GBP/USD`` was previously classified as the
+# crypto pair "GBP-USD" (its quote leg USD is a crypto-connector quote asset),
+# sent to the exchange venue catalogs, and its Yahoo FX hit was discarded.
+# FX pairs resolve through Yahoo's ``XXXYYY=X`` convention instead.
+_FIAT_CODES = frozenset(
+    {
+        "USD", "EUR", "GBP", "JPY", "CHF", "CNY", "CNH", "HKD", "AUD", "NZD",
+        "CAD", "KRW", "INR", "SGD", "SEK", "NOK", "DKK", "MXN", "BRL", "ZAR",
+        "TRY", "RUB", "PLN", "THB", "MYR", "IDR", "PHP", "VND", "ILS", "AED",
+        "SAR", "EGP", "CZK", "HUF", "RON", "CLP", "COP", "PEN", "TWD", "CUP",
+    }
+)
+
+_FX_PAIR_RE = re.compile(r"^(?P<base>[A-Z]{3})(?:/)?(?P<quote>[A-Z]{3})$", re.IGNORECASE)
+
+
+def _canonical_fx_pair(value: str) -> str | None:
+    """Return a Yahoo FX pair in canonical ``XXXYYY=X`` form, or ``None``.
+
+    Recognizes ``GBP/USD``, ``GBPUSD`` and ``GBPUSD=X`` (both legs must be
+    fiat codes — ``ETH/USD`` and ``XAU/USD`` are not FX pairs) and returns
+    the canonical spelling the market-data fetch layer serves directly.
+    """
+    clean = str(value or "").strip().upper()
+    if clean.endswith("=X"):
+        clean = clean[:-2]
+    matched = _FX_PAIR_RE.fullmatch(clean)
+    if not matched:
+        return None
+    base, quote = matched.group("base"), matched.group("quote")
+    if base not in _FIAT_CODES or quote not in _FIAT_CODES:
+        return None
+    return f"{base}{quote}=X"
+
 # Eastmoney market-number -> our symbol suffix. Anything else is left unmapped
 # (those candidates are skipped rather than emitted with a wrong suffix).
 _EASTMONEY_SUFFIX_BY_MARKET: Dict[str, str] = {
@@ -201,8 +236,27 @@ class SymbolSearchTool(BaseTool):
         em_hits, sources["eastmoney"] = _search_eastmoney(query)
         candidates.extend(em_hits)
 
-        yh_hits, sources["yahoo"] = _search_yahoo(query)
+        # An explicit FX pair searches Yahoo by its canonical ``XXXYYY=X``
+        # spelling — exact-symbol search is far more reliable than free text —
+        # and always yields a deterministic candidate, so a throttled/outage
+        # Yahoo (the earlier "GBP/USD -> 0 candidates" failure) never turns a
+        # canonical pair into nothing.
+        fx_pair = _canonical_fx_pair(query)
+        yh_hits, sources["yahoo"] = _search_yahoo(fx_pair or query)
         candidates.extend(yh_hits)
+        if fx_pair is not None:
+            pair_no_x = fx_pair[:-2]
+            candidates.append(
+                {
+                    "symbol": fx_pair,
+                    "name": f"{pair_no_x[:3]}/{pair_no_x[3:]}",
+                    "market": "fx",
+                    "type": "currency",
+                    "exchange": "CCY",
+                    "source": "fx_normalizer",
+                }
+            )
+            sources["fx_normalizer"] = "ok"
 
         if crypto_pair is not None:
             # A pair query is an exact instrument assertion. Near-string Yahoo
@@ -279,11 +333,17 @@ def _canonical_crypto_pair(value: str) -> str | None:
     clean = str(value or "").strip().upper()
     matched = _CRYPTO_PAIR_RE.fullmatch(clean)
     if matched:
-        return f"{matched.group(1)}-{matched.group(2)}"
+        base, quote = matched.group(1), matched.group(2)
+        if base in _FIAT_CODES and quote in _FIAT_CODES:
+            return None  # fiat/fiat is an FX pair, not crypto
+        return f"{base}-{quote}"
     if clean.isalnum():
         for quote in _CRYPTO_QUOTE_ASSETS:
             if clean.endswith(quote) and len(clean) > len(quote) + 1:
-                return f"{clean[: -len(quote)]}-{quote}"
+                base = clean[: -len(quote)]
+                if base in _FIAT_CODES and quote in _FIAT_CODES:
+                    return None  # fiat/fiat is an FX pair, not crypto
+                return f"{base}-{quote}"
     return None
 
 
@@ -667,6 +727,16 @@ def _from_yahoo_symbol(raw_symbol: str, quote: Dict[str, Any]) -> tuple[str, str
     if upper.endswith((".SH", ".SZ", ".BJ")):
         return upper, "cn"
     quote_type = str(quote.get("quoteType") or "").strip().upper()
+    if quote_type == "CURRENCY":
+        # FX pairs canonicalize to the ``XXXYYY=X`` form the fetch layer
+        # serves directly (``GBP/USD`` -> ``GBPUSD=X``); non-fiat currency
+        # quotes (metals like XAU/USD) keep their native symbol.
+        canon = _canonical_fx_pair(raw_symbol)
+        if canon is not None:
+            return canon, "fx"
+        return raw_symbol, "global"
+    if raw_symbol.startswith("^"):
+        return raw_symbol, "index"
     if quote_type == "EQUITY" and "." not in raw_symbol and "-" not in raw_symbol:
         return f"{upper}.US", "us"
     # Crypto, indices, FX, ETFs on non-HK exchanges: keep Yahoo's native symbol.

--- a/agent/src/tools/symbol_search_tool.py
+++ b/agent/src/tools/symbol_search_tool.py
@@ -31,6 +31,11 @@ from typing import Any, Dict, List, Optional
 
 from backtest.loaders import eastmoney_client, sec_edgar_client, yahoo_client
 from src.agent.tools import BaseTool
+from src.market_data import FIAT_CODES, canonical_fx_pair
+
+# Back-compat alias: the search tool's historical name for the shared
+# fiat-pair canonicalizer (search, fetch and grounding share one definition).
+_canonical_fx_pair = canonical_fx_pair
 
 logger = logging.getLogger(__name__)
 
@@ -74,41 +79,6 @@ _CRYPTO_PAIR_RE = re.compile(
     rf"^([A-Z0-9]{{2,15}})[-/]({'|'.join(_CRYPTO_QUOTE_ASSETS)})$",
     re.IGNORECASE,
 )
-
-# ISO-4217-style fiat codes. A pair whose BOTH legs are fiat is an FX pair,
-# never a crypto instrument: ``GBP/USD`` was previously classified as the
-# crypto pair "GBP-USD" (its quote leg USD is a crypto-connector quote asset),
-# sent to the exchange venue catalogs, and its Yahoo FX hit was discarded.
-# FX pairs resolve through Yahoo's ``XXXYYY=X`` convention instead.
-_FIAT_CODES = frozenset(
-    {
-        "USD", "EUR", "GBP", "JPY", "CHF", "CNY", "CNH", "HKD", "AUD", "NZD",
-        "CAD", "KRW", "INR", "SGD", "SEK", "NOK", "DKK", "MXN", "BRL", "ZAR",
-        "TRY", "RUB", "PLN", "THB", "MYR", "IDR", "PHP", "VND", "ILS", "AED",
-        "SAR", "EGP", "CZK", "HUF", "RON", "CLP", "COP", "PEN", "TWD", "CUP",
-    }
-)
-
-_FX_PAIR_RE = re.compile(r"^(?P<base>[A-Z]{3})(?:/)?(?P<quote>[A-Z]{3})$", re.IGNORECASE)
-
-
-def _canonical_fx_pair(value: str) -> str | None:
-    """Return a Yahoo FX pair in canonical ``XXXYYY=X`` form, or ``None``.
-
-    Recognizes ``GBP/USD``, ``GBPUSD`` and ``GBPUSD=X`` (both legs must be
-    fiat codes — ``ETH/USD`` and ``XAU/USD`` are not FX pairs) and returns
-    the canonical spelling the market-data fetch layer serves directly.
-    """
-    clean = str(value or "").strip().upper()
-    if clean.endswith("=X"):
-        clean = clean[:-2]
-    matched = _FX_PAIR_RE.fullmatch(clean)
-    if not matched:
-        return None
-    base, quote = matched.group("base"), matched.group("quote")
-    if base not in _FIAT_CODES or quote not in _FIAT_CODES:
-        return None
-    return f"{base}{quote}=X"
 
 # Eastmoney market-number -> our symbol suffix. Anything else is left unmapped
 # (those candidates are skipped rather than emitted with a wrong suffix).
@@ -334,14 +304,14 @@ def _canonical_crypto_pair(value: str) -> str | None:
     matched = _CRYPTO_PAIR_RE.fullmatch(clean)
     if matched:
         base, quote = matched.group(1), matched.group(2)
-        if base in _FIAT_CODES and quote in _FIAT_CODES:
+        if base in FIAT_CODES and quote in FIAT_CODES:
             return None  # fiat/fiat is an FX pair, not crypto
         return f"{base}-{quote}"
     if clean.isalnum():
         for quote in _CRYPTO_QUOTE_ASSETS:
             if clean.endswith(quote) and len(clean) > len(quote) + 1:
                 base = clean[: -len(quote)]
-                if base in _FIAT_CODES and quote in _FIAT_CODES:
+                if base in FIAT_CODES and quote in FIAT_CODES:
                     return None  # fiat/fiat is an FX pair, not crypto
                 return f"{base}-{quote}"
     return None

--- a/agent/tests/test_agent_grounding.py
+++ b/agent/tests/test_agent_grounding.py
@@ -2471,3 +2471,45 @@ def test_a_us_csv_stem_resolves_to_its_venue_suffix() -> None:
     assert _symbol_from_csv_filename("GC_F") == "GC=F"
     # A bare name has no venue suffix and must stay unresolvable.
     assert _symbol_from_csv_filename("AAPL") is None
+
+
+class TestFiatPairAndIndexNormalization:
+    """Search, fetch and grounding agree on one FX spelling; ^ is a symbol."""
+
+    def test_fiat_pair_spellings_normalize_to_yahoo_form(self) -> None:
+        from src.agent.grounding import _normalize_symbol
+
+        assert _normalize_symbol("GBP/USD") == "GBPUSD=X"
+        assert _normalize_symbol("GBPUSD") == "GBPUSD=X"
+        assert _normalize_symbol("GBPUSD=X") == "GBPUSD=X"
+        # Crypto/metals keep their pair form — not fiat/fiat FX.
+        assert _normalize_symbol("ETH/USD") == "ETH-USD"
+        assert _normalize_symbol("XAU/USD") == "XAU-USD"
+
+    def test_scanned_slashed_pair_matches_resolver_answer(self) -> None:
+        """The query-as-asserted scan must agree with the chosen candidate."""
+        from src.agent.grounding import _scan_symbols
+
+        assert _scan_symbols("use GBP/USD spot") == {"GBPUSD=X"}
+
+    def test_index_symbols_are_scanned_and_typed(self) -> None:
+        from src.agent.grounding import (
+            _infer_currency,
+            _infer_instrument_type,
+            _scan_symbols,
+        )
+
+        assert _scan_symbols("quote ^SPX") == {"^SPX"}
+        assert _infer_instrument_type("^SPX", "INDEX") == "index"
+        assert _infer_instrument_type("^SPX") == "index"
+        assert _infer_currency("GBPUSD=X") == "USD"
+
+    def test_ingest_search_symbol_does_not_create_conflicting_identity(self) -> None:
+        """The flagship regression: ingest('GBP/USD') must lock, never conflict."""
+        from src.agent.grounding import _normalize_symbol
+
+        # Chosen (from search_symbol) and asserted (the query text) must be
+        # the same canonical identity — the comparison in _ingest_resolution.
+        chosen = _normalize_symbol("GBPUSD=X")
+        asserted = _scan_symbols("GBP/USD")
+        assert chosen in asserted

--- a/agent/tests/test_agent_grounding.py
+++ b/agent/tests/test_agent_grounding.py
@@ -2513,3 +2513,63 @@ class TestFiatPairAndIndexNormalization:
         chosen = _normalize_symbol("GBPUSD=X")
         asserted = _scan_symbols("GBP/USD")
         assert chosen in asserted
+
+
+def test_fx_pair_resolution_authorizes_market_data_consumer(tmp_path: Path) -> None:
+    """Issue: search_symbol('GBP/USD') must lock, and get_market_data('GBPUSD=X')
+    must be authorized — the slashed query used to normalize to the crypto
+    spelling (GBP-USD), disagreeing with the chosen GBPUSD=X candidate and
+    creating a conflicting identity that outranked every later lock.
+    """
+    ledger = GroundingLedger(
+        run_dir=tmp_path,
+        user_message="Get me the GBP/USD spot rate.",
+    )
+    before_resolution = ledger.authorized_symbols
+    resolver = ledger.authorize_tool_call(
+        "search_symbol",
+        {"query": "GBP/USD"},
+        batch_authorized_symbols=before_resolution,
+        call_id="resolve-fx",
+    )
+    assert resolver.allowed is True
+
+    ledger.ingest_tool_result(
+        tool_name="search_symbol",
+        arguments={"query": "GBP/USD"},
+        result=json.dumps(
+            {
+                "ok": True,
+                "source": "symbol_search",
+                "data": {
+                    "query": "GBP/USD",
+                    "count": 1,
+                    "sources": {"yahoo": "ok", "fx_normalizer": "ok"},
+                    "candidates": [
+                        {
+                            "symbol": "GBPUSD=X",
+                            "name": "GBP/USD",
+                            "market": "fx",
+                            "type": "currency",
+                            "exchange": "CCY",
+                            "source": "fx_normalizer",
+                        },
+                    ],
+                },
+            }
+        ),
+        call_id="resolve-fx",
+        success=True,
+    )
+
+    authorization = ledger.authorize_tool_call(
+        "get_market_data",
+        {"codes": ["GBPUSD=X"]},
+        batch_authorized_symbols=ledger.authorized_symbols,
+        batch_identity_status=ledger.identity_status,
+        call_id="fx-prices",
+    )
+
+    assert ledger.identity_status == "locked"
+    assert ledger.authorized_symbols == {"GBPUSD=X"}
+    assert authorization.allowed is True

--- a/agent/tests/test_env_schema.py
+++ b/agent/tests/test_env_schema.py
@@ -128,7 +128,7 @@ class TestEnvConfigDefaults:
         for market in (
             "a_share", "us_equity", "hk_equity", "india_equity", "kr_equity",
             "ca_equity", "vietnam_equity", "crypto", "futures", "fund",
-            "macro", "forex",
+            "macro", "forex", "index",
         ):
             assert getattr(c.data, f"market_data_order_{market}") == ""
 

--- a/agent/tests/test_market_data.py
+++ b/agent/tests/test_market_data.py
@@ -57,15 +57,85 @@ from src.market_data import (
         ("local:my_file", "local"),
         # Yahoo futures / forex suffix conventions (#718) — must not fall to the
         # ``tushare`` default (which routed them to China-market loaders).
-        ("GC=F", "yahoo"),  # gold future
-        ("CL=F", "yahoo"),  # crude future
-        ("EURUSD=X", "yahoo"),  # forex pair
-        ("JPY=X", "yahoo"),
+        ("^SPX", "yahoo"),  # index (S&P 500)
+        ("^FTSE", "yahoo"),  # index (FTSE 100)
+        ("^VIX", "yahoo"),
         ("something_weird", "tushare"),  # documented fallback
     ],
 )
 def test_detect_source(code: str, expected: str) -> None:
     assert detect_source(code) == expected
+
+
+def test_yahoo_loader_accepts_futures_and_forex_suffixes() -> None:
+    """The yahoo direct loader must accept =F/=X, not just equity suffixes (#718)."""
+    from backtest.loaders.yahoo_loader import _is_supported
+
+    assert _is_supported("GC=F") is True
+    assert _is_supported("EURUSD=X") is True
+    assert _is_supported("AAPL.US") is True  # unchanged
+    assert _is_supported("TD.TO") is True
+    assert _is_supported("PNG.V") is True
+    assert _is_supported("600519.SH") is False  # A-share still not yahoo
+
+
+def test_yahoo_loader_accepts_index_symbols() -> None:
+    """^SPX-style index symbols must be served verbatim like =F/=X."""
+    from backtest.loaders.yahoo_loader import _is_supported
+
+    assert _is_supported("^SPX") is True
+    assert _is_supported("^GSPC") is True
+    assert _is_supported("^VIX") is True
+    assert _is_supported("^FTSE") is True
+
+
+def test_index_market_detection() -> None:
+    """^ symbols classify as index everywhere, not the a_share default."""
+    from backtest.engines._market_hooks import _detect_market, code_currency
+
+    assert _detect_market("^SPX") == "index"
+    assert _detect_market("^N225") == "index"
+    assert code_currency("^SPX").startswith("UNKNOWN")  # honest: index has no cash currency
+
+
+def test_forex_pair_x_classifies_as_forex_not_a_share() -> None:
+    """=X pairs must stop falling through to the a_share default (latent misroute)."""
+    from backtest.engines._market_hooks import _detect_market, code_currency
+
+    assert _detect_market("GBPUSD=X") == "forex"
+    assert code_currency("GBPUSD=X") == "USD"
+
+
+def test_fetch_market_data_routes_index_symbols_to_yahoo() -> None:
+    """auto mode must group ^SPX under yahoo, not the tushare/China chain."""
+    seen_sources: list[str] = []
+
+    class _StubLoader:
+        def fetch(self, codes, start, end, *, interval="1D"):  # noqa: ANN001
+            index = pd.DatetimeIndex(pd.to_datetime(["2024-01-02"]))
+            return {
+                code: pd.DataFrame(
+                    {"open": [1.0], "high": [1.0], "low": [1.0], "close": [1.0], "volume": [0.0]},
+                    index=index,
+                )
+                for code in codes
+            }
+
+    def _resolver(source: str):
+        seen_sources.append(source)
+        return _StubLoader
+
+    out = fetch_market_data(
+        codes=["^SPX"],
+        start_date="2024-01-01",
+        end_date="2024-01-03",
+        source="auto",
+        loader_resolver=_resolver,
+    )
+
+    assert "_unresolved" not in out
+    assert "^SPX" in out
+    assert seen_sources and seen_sources[0] == "yahoo"
 
 
 def test_yahoo_loader_accepts_futures_and_forex_suffixes() -> None:

--- a/agent/tests/test_market_data.py
+++ b/agent/tests/test_market_data.py
@@ -57,6 +57,10 @@ from src.market_data import (
         ("local:my_file", "local"),
         # Yahoo futures / forex suffix conventions (#718) — must not fall to the
         # ``tushare`` default (which routed them to China-market loaders).
+        ("GC=F", "yahoo"),  # gold future
+        ("CL=F", "yahoo"),  # crude future
+        ("EURUSD=X", "yahoo"),  # forex pair
+        ("JPY=X", "yahoo"),  # abbreviated forex pair
         ("^SPX", "yahoo"),  # index (S&P 500)
         ("^FTSE", "yahoo"),  # index (FTSE 100)
         ("^VIX", "yahoo"),
@@ -106,36 +110,35 @@ def test_forex_pair_x_classifies_as_forex_not_a_share() -> None:
     assert code_currency("GBPUSD=X") == "USD"
 
 
-def test_fetch_market_data_routes_index_symbols_to_yahoo() -> None:
-    """auto mode must group ^SPX under yahoo, not the tushare/China chain."""
-    seen_sources: list[str] = []
+def test_abbreviated_fx_pair_x_classes_as_forex() -> None:
+    """JPY=X (USD/JPY abbreviation) must not fall to the a_share default."""
+    from backtest.engines._market_hooks import _detect_market, code_currency
 
-    class _StubLoader:
-        def fetch(self, codes, start, end, *, interval="1D"):  # noqa: ANN001
-            index = pd.DatetimeIndex(pd.to_datetime(["2024-01-02"]))
-            return {
-                code: pd.DataFrame(
-                    {"open": [1.0], "high": [1.0], "low": [1.0], "close": [1.0], "volume": [0.0]},
-                    index=index,
-                )
-                for code in codes
-            }
+    assert _detect_market("JPY=X") == "forex"
+    assert _detect_market("EUR=X") == "forex"
+    # The hidden base (JPY=X is USD/JPY) is not derivable — honest UNKNOWN,
+    # not a wrong CNY.
+    assert code_currency("JPY=X") == "UNKNOWN:forex"
 
-    def _resolver(source: str):
-        seen_sources.append(source)
-        return _StubLoader
 
-    out = fetch_market_data(
-        codes=["^SPX"],
-        start_date="2024-01-01",
-        end_date="2024-01-03",
-        source="auto",
-        loader_resolver=_resolver,
-    )
+def test_index_backtest_routes_to_global_equity_not_china_or_crypto() -> None:
+    """^SPX must never reach ChinaAEngine/CryptoEngine through the runner."""
+    from backtest.engines.global_equity import GlobalEquityEngine
+    from backtest.runner import _MARKET_TO_SOURCE, _create_market_engine, _detect_source
 
-    assert "_unresolved" not in out
-    assert "^SPX" in out
-    assert seen_sources and seen_sources[0] == "yahoo"
+    assert _detect_source("^SPX") == "yahoo"
+    engine = _create_market_engine("yahoo", {}, ["^SPX"])
+    assert isinstance(engine, GlobalEquityEngine)
+
+
+def test_composite_builds_index_rule_engine() -> None:
+    """A mixed book containing an index gets an index sub-engine, not a drop."""
+    from backtest.engines.global_equity import GlobalEquityEngine
+    from backtest.engines.composite import _build_rule_engines
+
+    engines = _build_rule_engines({}, ["^SPX"])
+    assert "index" in engines
+    assert isinstance(engines["index"], GlobalEquityEngine)
 
 
 def test_yahoo_loader_accepts_futures_and_forex_suffixes() -> None:

--- a/agent/tests/test_registry.py
+++ b/agent/tests/test_registry.py
@@ -135,7 +135,7 @@ class TestFallbackChains:
         expected = {
             "a_share", "us_equity", "hk_equity", "india_equity", "kr_equity",
             "ca_equity", "uk_equity", "vietnam_equity", "crypto", "futures",
-            "fund", "macro", "forex",
+            "fund", "macro", "forex", "index",
         }
         assert expected == set(FALLBACK_CHAINS.keys())
 

--- a/agent/tests/test_settings_api.py
+++ b/agent/tests/test_settings_api.py
@@ -666,7 +666,7 @@ def test_get_data_source_settings_lists_default_source_orders(
     assert set(orders) == {
         "a_share", "us_equity", "hk_equity", "india_equity", "kr_equity",
         "ca_equity", "vietnam_equity", "uk_equity", "crypto", "futures",
-        "fund", "macro", "forex",
+        "fund", "macro", "forex", "index",
     }
     a_share = orders["a_share"]
     assert a_share["env_var"] == "MARKET_DATA_ORDER_A_SHARE"

--- a/agent/tests/test_symbol_search_tool.py
+++ b/agent/tests/test_symbol_search_tool.py
@@ -762,3 +762,69 @@ class TestCryptoPairWithoutABrokerConnection:
         ), patch.object(ss.yahoo_client, "search", return_value=[]):
             ss.SymbolSearchTool().execute(query="apple", limit=5)
         assert called == []
+
+
+# --------------------------------------------------------------------------
+# FX pairs + index symbols: search and fetch must agree on the symbol universe
+# --------------------------------------------------------------------------
+
+
+class TestFxPairAlignment:
+    """search_symbol must resolve FX pairs and return fetch-able symbols."""
+
+    def test_canonical_fx_pair_spellings(self) -> None:
+        assert ss._canonical_fx_pair("GBP/USD") == "GBPUSD=X"
+        assert ss._canonical_fx_pair("gbp/usd") == "GBPUSD=X"
+        assert ss._canonical_fx_pair("GBPUSD") == "GBPUSD=X"
+        assert ss._canonical_fx_pair("GBPUSD=X") == "GBPUSD=X"
+        assert ss._canonical_fx_pair("USD/JPY") == "USDJPY=X"
+        assert ss._canonical_fx_pair("GBPCNY") == "GBPCNY=X"
+        # Not pairs / not fiat-fiat
+        assert ss._canonical_fx_pair("BRK-B") is None
+        assert ss._canonical_fx_pair("AAPL") is None
+        assert ss._canonical_fx_pair("ETH/USD") is None  # crypto, not FX
+        assert ss._canonical_fx_pair("XAU/USD") is None  # metal, not fiat
+
+    def test_fiat_pairs_are_not_misclassified_as_crypto(self) -> None:
+        """GBP/USD must stop being treated as a crypto 'GBP-USD' pair."""
+        assert ss._canonical_crypto_pair("GBP/USD") is None
+        assert ss._canonical_crypto_pair("EURUSD") is None
+        # Crypto classifications must remain untouched.
+        assert ss._canonical_crypto_pair("ETH/USD") == "ETH-USD"
+        assert ss._canonical_crypto_pair("BTC/USDT") == "BTC-USDT"
+        assert ss._canonical_crypto_pair("BTCUSDT") == "BTC-USDT"
+
+    def test_fx_query_returns_canonical_candidate_when_yahoo_unavailable(self) -> None:
+        """A throttled/failed Yahoo must not turn a canonical pair into nothing."""
+        with patch.object(
+            ss.yahoo_client, "search", side_effect=Exception("Too Many Requests")
+        ), patch.object(
+            ss.eastmoney_client, "get_json",
+            return_value={"QuotationCodeTable": {"Data": []}},
+        ), patch.object(ss.sec_edgar_client, "cik_for", return_value=""):
+            out = json.loads(ss.SymbolSearchTool().execute(query="GBP/USD", limit=5))
+
+        by_symbol = {c["symbol"]: c for c in out["data"]["candidates"]}
+        assert "GBPUSD=X" in by_symbol
+        assert by_symbol["GBPUSD=X"]["market"] == "fx"
+        assert by_symbol["GBPUSD=X"]["type"] == "currency"
+
+    def test_from_yahoo_symbol_normalizes_currency_quotes(self) -> None:
+        assert ss._from_yahoo_symbol("GBP/USD", {"quoteType": "CURRENCY"}) == (
+            "GBPUSD=X",
+            "fx",
+        )
+        assert ss._from_yahoo_symbol("GBPUSD=X", {"quoteType": "CURRENCY"}) == (
+            "GBPUSD=X",
+            "fx",
+        )
+
+    def test_from_yahoo_symbol_labels_indexes(self) -> None:
+        assert ss._from_yahoo_symbol("^SPX", {"quoteType": "INDEX"}) == (
+            "^SPX",
+            "index",
+        )
+        assert ss._from_yahoo_symbol("^FTSE", {"quoteType": "INDEX"}) == (
+            "^FTSE",
+            "index",
+        )


### PR DESCRIPTION
## Problem

`search_symbol` and `get_market_data` disagree on the symbol universe (observed live):

- **FX pairs**: `search_symbol(query="GBP/USD")` and `"GBPUSD"` returned **0 candidates**, yet `get_market_data` serves `GBPUSD=X` fine. Root cause: fiat/fiat pairs were classified as *crypto* pairs — the quote leg `USD` is a crypto-connector quote asset — so they were routed to the exchange venue catalogs, and Yahoo's currency hit was discarded by the exact-pair filter (#1234 semantics).
- **Indexes**: `get_market_data("^SPX")` returned `_unresolved` although `search_symbol("S&P 500 index")` returns `^SPX`. Root cause: no source/market pattern matched `^` symbols (fell to the `tushare`/a_share default), and the yahoo loader's `_is_supported` rejected them.

## Change

- FX pair spellings (`GBP/USD`, `GBPUSD`, `GBPUSD=X`) canonicalize to the Yahoo `XXXYYY=X` form the fetch layer serves directly; `FIAT_CODES`/`canonical_fx_pair` live in `src.market_data` as the **single source of truth** shared by search, fetch and the grounding identity gate (so a search result, its query string and a later fetch argument all agree — previously the query-as-asserted scan normalized `GBP/USD` to the crypto spelling `GBP-USD` and created a conflicting identity that blocked all later market tools). A deterministic candidate (source `fx_normalizer`) is always emitted, so a throttled/outage Yahoo can never turn a canonical pair into nothing.
- `^`-prefixed index symbols route to the yahoo chain (`_SOURCE_PATTERNS`, `_is_supported`), get their own market class (`index`) with a `yahoo -> yfinance -> local` fallback chain and engine wiring (GlobalEquityEngine US rules in `_create_market_engine` and the composite rule engines — never the ChinaA/Crypto default); `=X` forex pairs (incl. `JPY=X`-style abbreviations) stop falling to the `a_share` default and `code_currency` returns the quote leg (honest `UNKNOWN:forex` only where the base is not derivable). `^` symbols are also recognized by the grounding scanner/type inference and `_infer_currency` handles `=X`.
- Crypto classification unchanged for non-fiat bases (`ETH/USD`, `BTC/USDT`).

## Tests

New coverage: source/market detection routing for indexes and `=X` forex, yahoo-loader acceptance, canonical FX spellings, Yahoo `CURRENCY`/`INDEX` quote normalization, throttled-Yahoo fallback, grounding normalization/scan/type/currency integration (incl. the conflicting-identity regression), runner/composite engine routing for indexes, restore of the `GC=F`/`CL=F`/`EURUSD=X`/`JPY=X` source pins, registry + settings + env_schema market contract updates.

Full suite: 11775 passed, 30 skipped; the only failure is the machine-dependent signal-alignment perf gate (fails on this laptop, passes CI; unrelated to this change). No API keys or configurations in the diff.