### PR TITLE
fix(frontend): proxy /api routes in Vite dev server

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,6 +3,7 @@ import react from "@vitejs/plugin-react";
 import path from "path";
 
 const PROXY_PATHS = [
+  "/api",
   "/auth",
   "/sessions",
   "/swarm/presets",


### PR DESCRIPTION
## Goal

Fix the portfolio page API proxy behavior in the frontend development server so portfolio-related requests are sent to the backend instead of falling back to the SPA `index.html`.

## What Changed

- Added `/api` to the Vite dev proxy allowlist in `frontend/vite.config.ts`.

## Affected Areas

- Frontend development server proxying
- Portfolio page account-management flows such as "Manage Accounts" and "Add Account"
- Other frontend requests under `/api/*` in local development

## Out of Scope

- No backend API changes
- No portfolio page UI or business-logic changes
- No production routing changes

## Root Cause

Portfolio page actions such as "Manage Accounts" and "Add Account" call
`/api/portfolio` and `/api/connections`.

In local development, `/api` was not included in the Vite proxy configuration.
As a result, those requests were handled by the frontend dev server as normal
page requests and fell back to `index.html` (`text/html`) instead of being
proxied to the backend. The frontend then failed when trying to parse the
response as JSON.

## Test Plan

Completed:
- [x] Use a Node.js version that satisfies the project requirement
      (`frontend/package.json` requires `node >= 22.22.0`)
- [x] Run `cd frontend && npm run build`

Manual verification:
- [x] Restart the frontend development server
- [x] Open `/portfolio`
- [x] Click "Manage Accounts"
- [x] Click "Add Account"
- [x] Confirm the page no longer shows:
      `Expected JSON from /api/portfolio, got text/html`
- [x] Confirm in the browser DevTools Network panel that
      `/api/portfolio` and `/api/connections` return backend JSON responses
      rather than `text/html` / `index.html`

## Risk

Low. This change only updates Vite development proxy routing and does not
modify backend handlers or portfolio business logic.

## Rollback

Revert this commit to remove the `/api` proxy entry from
`frontend/vite.config.ts`.