### PR TITLE
fix(grounding): don't split clauses on full-width brackets (#1260)

### DIFF
--- a/agent/src/agent/grounding.py
+++ b/agent/src/agent/grounding.py
@@ -451,10 +451,12 @@ _PROSPECTIVE_LEVEL_RE = re.compile(
     r")",
     re.IGNORECASE,
 )
-# Full-width brackets and enumeration commas delimit prose clauses. ASCII
-# parentheses are deliberately not separators: an explicit derivation such as
-# "(8.5 - 7.9) / 2" must stay in one segment for the formula check.
-_CLAUSE_SEPARATOR_RE = re.compile(r"[,，;；。、\n（）【】]")
+# Full-width enumeration commas delimit prose clauses. Paired brackets (ASCII
+# or full-width ()()[]) are deliberately not separators: an explicit
+# derivation such as "(8.5 - 7.9) / 2" must stay in one segment for the
+# formula check, and 公司名（代码）价格 must stay in one segment so the
+# unsourced-symbol gate can see the symbol with its figure (#1260).
+_CLAUSE_SEPARATOR_RE = re.compile(r"[,，;；。、\n]")
 
 
 # The ASCII comma both separates clauses and groups thousands, and the clause

--- a/agent/tests/test_agent_grounding.py
+++ b/agent/tests/test_agent_grounding.py
@@ -2129,6 +2129,67 @@ def test_fullwidth_parentheses_do_not_split_symbol_from_figure(
     ]
 
     assert issues, f"{paren_width} parentheses must fire unsourced_symbol_figures"
+    # Pin the offending symbol, not just "some issue fired": the gate must
+    # blame the unsourced 000858.SZ, not the sourced 600519.SH.
+    assert [issue["symbol"] for issue in issues] == ["000858.SZ"]
+
+
+def test_unsourced_symbol_without_a_figure_stays_silent(tmp_path: Path) -> None:
+    """#1260 guard arm: figure co-presence is what the gate checks.
+
+    The regression test above pins that the gate fires when symbol and figure
+    share a clause. This arm pins the inverse: an unsourced symbol with NO
+    nearby figure must not fire unsourced_symbol_figures, so the gate's
+    figure-presence guard (_numbers_without_dates_or_percent) cannot be
+    dropped without this test failing.
+    """
+    ledger = GroundingLedger(
+        run_dir=tmp_path,
+        user_message="What is Kweichow Moutai (600519.SH) trading at this week?",
+    )
+    ledger.ingest_tool_result(
+        tool_name="get_market_data",
+        arguments={
+            "codes": ["600519.SH"],
+            "start_date": "2026-08-24",
+            "end_date": "2026-08-28",
+            "source": "baostock",
+        },
+        result=json.dumps(
+            {
+                "600519.SH": [
+                    {
+                        "trade_date": "2026-08-28T00:00:00",
+                        "open": 1289.0,
+                        "high": 1297.89,
+                        "low": 1288.0,
+                        "close": 1297.4,
+                        "volume": 16126.11,
+                    }
+                ],
+                "_provenance": {
+                    "600519.SH": {
+                        "source": "baostock",
+                        "fallback_used": False,
+                        "currency_conversion": "none",
+                        "volume_unit": "lots",
+                    }
+                },
+            }
+        ),
+        call_id="c1",
+        success=True,
+    )
+
+    issues = [
+        issue
+        for issue in ledger.validate_final_answer(
+            "同期五粮液（000858.SZ）是知名白酒企业。"
+        ).issues
+        if issue.get("code") == "unsourced_symbol_figures"
+    ]
+
+    assert issues == []
 
 
 def test_a_shortlist_answers_the_user_but_still_cannot_fetch_a_quote(

--- a/agent/tests/test_agent_grounding.py
+++ b/agent/tests/test_agent_grounding.py
@@ -2064,6 +2064,73 @@ def test_an_unevidenced_price_is_still_rejected_without_any_tool_call(
     }
 
 
+@pytest.mark.parametrize(
+    ("draft", "paren_width"),
+    [
+        ("同期五粮液（000858.SZ）收 168.50 元。", "full-width"),
+        ("同期五粮液(000858.SZ)收 168.50 元。", "half-width"),
+    ],
+)
+def test_fullwidth_parentheses_do_not_split_symbol_from_figure(
+    tmp_path: Path,
+    draft: str,
+    paren_width: str,
+) -> None:
+    """#1260: 公司名（代码）价格 must stay in one clause for the gate.
+
+    Full-width （） were treated as clause separators, so the symbol landed in
+    one segment and the figure in the next and the unsourced-symbol gate
+    never saw them together — a false negative that flipped on parenthesis
+    width alone. Both widths must fire now; the half-width form is the
+    control that already passed.
+    """
+    ledger = GroundingLedger(
+        run_dir=tmp_path,
+        user_message="What is Kweichow Moutai (600519.SH) trading at this week?",
+    )
+    ledger.ingest_tool_result(
+        tool_name="get_market_data",
+        arguments={
+            "codes": ["600519.SH"],
+            "start_date": "2026-08-24",
+            "end_date": "2026-08-28",
+            "source": "baostock",
+        },
+        result=json.dumps(
+            {
+                "600519.SH": [
+                    {
+                        "trade_date": "2026-08-28T00:00:00",
+                        "open": 1289.0,
+                        "high": 1297.89,
+                        "low": 1288.0,
+                        "close": 1297.4,
+                        "volume": 16126.11,
+                    }
+                ],
+                "_provenance": {
+                    "600519.SH": {
+                        "source": "baostock",
+                        "fallback_used": False,
+                        "currency_conversion": "none",
+                        "volume_unit": "lots",
+                    }
+                },
+            }
+        ),
+        call_id="c1",
+        success=True,
+    )
+
+    issues = [
+        issue
+        for issue in ledger.validate_final_answer(draft).issues
+        if issue.get("code") == "unsourced_symbol_figures"
+    ]
+
+    assert issues, f"{paren_width} parentheses must fire unsourced_symbol_figures"
+
+
 def test_a_shortlist_answers_the_user_but_still_cannot_fetch_a_quote(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## What

Fixes #1260 — `_validate_unsourced_symbols` requires a symbol and its figure to land in the same clause, but `_CLAUSE_SEPARATOR_RE` treated full-width brackets `（）【】` (not ASCII, which was already excluded) as clause separators. The idiomatic Chinese citation form — `公司名（代码）价格` — split the symbol from the number, so the hallucination gate `unsourced_symbol_figures` never fired: a false negative that flipped on parenthesis width alone.

## Change

`agent/src/agent/grounding.py`:
```diff
-_CLAUSE_SEPARATOR_RE = re.compile(r"[,，;；。、\n（）【】]")
+_CLAUSE_SEPARATOR_RE = re.compile(r"[,，;；。、\n]")
```

Paired full-width brackets are grouping characters for the same reason ASCII parens are excluded (the existing `"(8.5 - 7.9) / 2"` formula case).

## Validation

- Regression test `test_fullwidth_parentheses_do_not_split_symbol_from_figure`: parametrized over full-width (bug) + half-width (control), end-to-end through `validate_final_answer`, asserts `unsourced_symbol_figures` fires **and** pins the offending symbol to `000858.SZ`.
- Negative arm `test_unsourced_symbol_without_a_figure_stays_silent`: an unsourced symbol with no nearby figure stays silent, so the gate's figure-presence guard cannot be dropped unnoticed.
- Both tests verified to **fail** on the old regex where applicable (mutation check) — the full-width case produces 0 issues pre-fix.
- Grounding suite: **195 passed** (186 baseline + new cases), no regressions.

## Post-review notes (adversarial review, accepted)

Known tradeoffs of this change:

- **False-positive parity**: a non-figure number in full-width parens (e.g. `（000858.SZ）公司有 3 大业务板块` or `（较昨日上涨 0.03 元）`) is now compared by the clause-based gates when a price-context/unsourced symbol is also present. This is parity with the existing ASCII-paren behavior (same draft with `()` already fires), not a new class. Both `_validate_price_claims` and `_validate_unsourced_symbols` are affected; masking change/count amounts would be a separate follow-up.
- **Residual false negative**: any separator inside the parens (`，`/`；`/`、`) still splits symbol from figure, so `公司名（代码，价格）` escapes the gate. Pre-existing; #1260 is closed only for the no-internal-separator form. Follow-up candidate.
