### PR TITLE
fix(providers): strip relocated extra_body.temperature in the Anthropic self-heal

### DIFF
--- a/agent/src/providers/llm.py
+++ b/agent/src/providers/llm.py
@@ -1003,6 +1003,17 @@ def _make_temperature_safe_anthropic(base_cls: type) -> type:
         payload = base_cls._get_request_payload(self, *args, **kwargs)
         if isinstance(payload, dict) and self.model in _ANTHROPIC_TEMPERATURE_UNSUPPORTED:
             payload.pop("temperature", None)
+            # langchain-anthropic relocates sampling params the installed
+            # anthropic SDK (>=1) no longer accepts as named arguments into
+            # `extra_body`, which the SDK merges into the request JSON as-is.
+            # The API rejects `temperature` from either location.
+            extra_body = payload.get("extra_body")
+            if isinstance(extra_body, dict) and "temperature" in extra_body:
+                extra_body = {k: v for k, v in extra_body.items() if k != "temperature"}
+                if extra_body:
+                    payload["extra_body"] = extra_body
+                else:
+                    payload.pop("extra_body", None)
         return payload
 
     def _remember_and_should_retry(self: Any, exc: BaseException) -> bool:

--- a/agent/tests/test_llm.py
+++ b/agent/tests/test_llm.py
@@ -1091,3 +1091,110 @@ class TestGetLlmCredentials:
         ):
             creds = get_llm_credentials("deepseek", "deepseek-v4-pro")
             assert creds["base_url"] == "https://legacy.example/v1"
+
+
+# ---------------------------------------------------------------------------
+# Anthropic temperature self-heal: SDK >= 1 relocates sampling params
+# ---------------------------------------------------------------------------
+
+
+def _make_relocating_anthropic_base():
+    """ChatAnthropic stand-in for langchain-anthropic >= 1.4 on anthropic >= 1.
+
+    ``anthropic>=1`` dropped ``temperature`` from ``Messages.create``, so
+    langchain-anthropic moves it into ``extra_body`` (which the SDK merges into
+    the request JSON as-is). The API rejects it from either location, so the
+    self-heal must strip both — popping the top-level key alone retried with
+    ``extra_body={"temperature": 0.0}`` and failed a second time.
+    """
+
+    class _RelocatingAnthropicBase:
+        def __init__(self, **kwargs: object) -> None:
+            self.model = kwargs.get("model")
+            self.temperature = kwargs.get("temperature")
+            self.extra_body = kwargs.get("extra_body")
+            self.calls: list[dict] = []
+
+        def _get_request_payload(self, *args: object, **kwargs: object) -> dict:
+            payload: dict = {"model": self.model, "messages": []}
+            relocated = (
+                {"temperature": self.temperature}
+                if self.temperature is not None
+                else {}
+            )
+            merged = {**relocated, **(self.extra_body or {})}
+            if merged:
+                payload["extra_body"] = merged
+            return payload
+
+        @staticmethod
+        def _has_temperature(payload: dict) -> bool:
+            return "temperature" in payload or "temperature" in (
+                payload.get("extra_body") or {}
+            )
+
+        def _generate(self, *args: object, **kwargs: object):
+            payload = self._get_request_payload(*args, **kwargs)
+            self.calls.append(
+                {**payload, "extra_body": dict(payload.get("extra_body") or {})}
+            )
+            if self.model == "deprecates-temp" and self._has_temperature(payload):
+                raise RuntimeError("`temperature` is deprecated for this model.")
+            return SimpleNamespace(payload=payload)
+
+    return _RelocatingAnthropicBase
+
+
+def test_anthropic_temperature_self_heal_strips_relocated_extra_body() -> None:
+    import src.providers.llm as llm_mod
+
+    llm_mod._ANTHROPIC_TEMPERATURE_UNSUPPORTED.discard("deprecates-temp")
+    safe_cls = llm_mod._make_temperature_safe_anthropic(
+        _make_relocating_anthropic_base()
+    )
+    inst = safe_cls(model="deprecates-temp", temperature=0.0)
+
+    result = inst._generate([])
+
+    assert len(inst.calls) == 2
+    assert inst.calls[0]["extra_body"] == {"temperature": 0.0}
+    # The retry must not carry temperature anywhere, and an emptied extra_body
+    # must not be sent as `{}`.
+    assert "temperature" not in inst.calls[1]
+    assert (
+        "extra_body" not in inst.calls[1]
+        or "temperature" not in inst.calls[1]["extra_body"]
+    )
+    assert "extra_body" not in result.payload
+    assert "deprecates-temp" in llm_mod._ANTHROPIC_TEMPERATURE_UNSUPPORTED
+
+
+def test_anthropic_temperature_self_heal_keeps_other_extra_body_keys() -> None:
+    import src.providers.llm as llm_mod
+
+    llm_mod._ANTHROPIC_TEMPERATURE_UNSUPPORTED.discard("deprecates-temp")
+    safe_cls = llm_mod._make_temperature_safe_anthropic(
+        _make_relocating_anthropic_base()
+    )
+    inst = safe_cls(model="deprecates-temp", temperature=0.0, extra_body={"top_k": 40})
+
+    result = inst._generate([])
+
+    assert len(inst.calls) == 2
+    assert result.payload["extra_body"] == {"top_k": 40}
+
+
+def test_anthropic_relocated_temperature_preserved_for_supported_model() -> None:
+    import src.providers.llm as llm_mod
+
+    llm_mod._ANTHROPIC_TEMPERATURE_UNSUPPORTED.discard("supports-temp")
+    safe_cls = llm_mod._make_temperature_safe_anthropic(
+        _make_relocating_anthropic_base()
+    )
+    inst = safe_cls(model="supports-temp", temperature=0.0)
+
+    result = inst._generate([])
+
+    assert len(inst.calls) == 1
+    assert result.payload["extra_body"] == {"temperature": 0.0}
+    assert "supports-temp" not in llm_mod._ANTHROPIC_TEMPERATURE_UNSUPPORTED


### PR DESCRIPTION
## Summary

- Make the Anthropic `temperature` self-heal in `src/providers/llm.py` also strip `temperature` from `extra_body`, where langchain-anthropic ≥ 1.4 now relocates it, so the retry after the "`temperature` is deprecated for this model." 400 actually succeeds on Claude 5-family models.
- No change for models that accept `temperature`: the configured value is still sent, in whichever location the adapter puts it.

## Why

Every run on `claude-sonnet-5` / `claude-opus-5` currently fails. The self-heal fires (the "rejects `temperature`; retrying without it" log line appears) but the retry hits the same 400, because the installed `anthropic` SDK (0.109.1, via #1324) dropped `temperature`/`top_p`/`top_k` from `Messages.create`, and langchain-anthropic's `_sdk_compat._route_unsupported_sampling_params` moves them into `extra_body`. `payload.pop("temperature", None)` is a no-op against that shape, so `extra_body={"temperature": 0.0}` goes out on the retry.

Closes #1329

## Changes

- `_make_temperature_safe_anthropic._get_request_payload`: after popping the top-level key for a remembered model, drop `temperature` from `payload["extra_body"]`, keep any other keys there, and remove `extra_body` altogether when that leaves it empty (an empty `{}` should not be sent). ~11 lines; `_generate` / `_agenerate` / `_stream` / `_astream` all build their payload through this override, so all four paths are covered. The runtime-discovery design (first 400 → remember → retry) is unchanged.
- `tests/test_llm.py`: a second fake `ChatAnthropic` base that mirrors the relocating payload shape, plus three tests — retry carries `temperature` nowhere and no empty `extra_body`; unrelated `extra_body` keys survive; a model that accepts `temperature` keeps it in `extra_body` with no retry. The existing fake only modelled the pre-relocation (top-level) shape, which is why this regression passed the suite.

## Test Plan

- [x] Existing tests pass — verified for the touched component: `pytest agent/tests/test_llm.py` (74 passed). The full `pytest --ignore=agent/tests/e2e_backtest` run was not executed for this PR.
- [x] New tests added (`test_anthropic_temperature_self_heal_strips_relocated_extra_body`, `..._keeps_other_extra_body_keys`, `test_anthropic_relocated_temperature_preserved_for_supported_model`); the first fails on `main` with the retry payload still carrying `extra_body.temperature`.
- [x] Tested manually against the live API with `LANGCHAIN_MODEL_NAME=claude-sonnet-5`, `LANGCHAIN_TEMPERATURE=0.0`, no `LANGCHAIN_REASONING_EFFORT`: before — 400, retry 400; after — 400, retry `extra_body: None` → 200 (instrumented `_create`). `black --check` / `ruff check` clean on the added lines (the file is not black-clean on `main`; no unrelated reformatting included).

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion — raised in #1329 with the root cause and this exact fix; follows the self-heal precedent on the same function from #1224 / #1246.
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines (DCO sign-off on the commit)
- [x] Documentation updated (if user-facing change) — none needed; behaviour now matches what the self-heal already promised.

---

This change was AI-assisted. The payload traces and test results above come from runs on my local install, not from inference.
