### PR TITLE
fix(mcp): default goal_id/expected_goal_id to the current goal

### DIFF
--- a/agent/mcp_server.py
+++ b/agent/mcp_server.py
@@ -622,9 +622,9 @@ def get_research_goal(session_id: str = "", ctx: Context | None = None) -> str:
 
 @mcp.tool
 def add_goal_evidence(
-    goal_id: str,
-    expected_goal_id: str,
     text: str,
+    goal_id: str = "",
+    expected_goal_id: str = "",
     session_id: str = "",
     criterion_id: str | None = None,
     claim_id: str | None = None,
@@ -650,9 +650,11 @@ def add_goal_evidence(
     """Append traceable evidence to a finance research goal.
 
     Args:
-        goal_id: Goal being mutated.
-        expected_goal_id: Goal id captured before the tool/model turn started.
         text: Evidence note or result summary.
+        goal_id: Optional goal id. Defaults to the current goal for this
+            session.
+        expected_goal_id: Optional stale-write guard captured before the
+            tool/model turn started. Defaults to goal_id.
         session_id: Optional conversation id. Omit it unless the client tracks
             its own sessions; this server then uses one id per process.
         criterion_id: Optional criterion this evidence satisfies.
@@ -661,7 +663,9 @@ def add_goal_evidence(
         tool_call_id: Source tool call id for traceability; it does not verify evidence by itself.
         run_id: Vibe-Trading run id. It verifies evidence only when the run directory exists.
         source_provider: Data/provider name such as yfinance, OKX, tushare.
+            Defaults to "agent_tool" when omitted.
         source_type: Source category such as market_data, document, backtest.
+            Defaults to "tool_note" when omitted.
         source_uri: Optional source URL/path.
         symbol_universe: Symbols covered by the evidence.
         benchmark: Benchmark symbols covered by the evidence.
@@ -678,10 +682,20 @@ def add_goal_evidence(
     try:
         from src.goal import EvidenceInput, StaleGoalError
 
-        evidence = _get_goal_store().append_evidence(
-            session_id=_resolve_session_id(session_id, ctx),
-            goal_id=goal_id.strip(),
-            expected_goal_id=expected_goal_id.strip(),
+        store = _get_goal_store()
+        resolved_session_id = _resolve_session_id(session_id, ctx)
+        resolved_goal_id = goal_id.strip()
+        if not resolved_goal_id:
+            snapshot = store.get_current_snapshot(resolved_session_id)
+            if snapshot is None:
+                return _json_error("no current goal for this session", error_type="not_found")
+            resolved_goal_id = str(snapshot["goal"]["goal_id"])
+        resolved_expected_goal_id = expected_goal_id.strip() or resolved_goal_id
+
+        evidence = store.append_evidence(
+            session_id=resolved_session_id,
+            goal_id=resolved_goal_id,
+            expected_goal_id=resolved_expected_goal_id,
             evidence=EvidenceInput(
                 criterion_id=_blank_to_none(criterion_id),
                 claim_id=_blank_to_none(claim_id),
@@ -689,8 +703,8 @@ def add_goal_evidence(
                 text=text,
                 tool_call_id=_blank_to_none(tool_call_id),
                 run_id=_blank_to_none(run_id),
-                source_provider=_blank_to_none(source_provider),
-                source_type=_blank_to_none(source_type),
+                source_provider=_blank_to_none(source_provider) or "agent_tool",
+                source_type=_blank_to_none(source_type) or "tool_note",
                 source_uri=_blank_to_none(source_uri),
                 symbol_universe=_clean_list(symbol_universe),
                 benchmark=_clean_list(benchmark),
@@ -705,7 +719,7 @@ def add_goal_evidence(
                 contradicts_claim_ids=_clean_list(contradicts_claim_ids),
             ),
         )
-        snapshot = _get_goal_store().get_goal_snapshot(goal_id.strip())
+        snapshot = store.get_goal_snapshot(resolved_goal_id)
         if snapshot is None:
             return _json_error("Goal snapshot could not be reloaded")
         from dataclasses import asdict
@@ -719,9 +733,9 @@ def add_goal_evidence(
 
 @mcp.tool
 def update_research_goal_status(
-    goal_id: str,
-    expected_goal_id: str,
     status: str,
+    goal_id: str = "",
+    expected_goal_id: str = "",
     session_id: str = "",
     audit: _lenient_dict_list_opt = None,
     recap: str | None = None,
@@ -734,9 +748,11 @@ def update_research_goal_status(
     required criterion and verified evidence for satisfied rows.
 
     Args:
-        goal_id: Goal being mutated.
-        expected_goal_id: Goal id captured before the tool/model turn started.
         status: Goal lifecycle status, e.g. complete, cancelled, blocked.
+        goal_id: Optional goal id. Defaults to the current goal for this
+            session.
+        expected_goal_id: Optional stale-write guard captured before the
+            tool/model turn started. Defaults to goal_id.
         session_id: Optional conversation id. Omit it unless the client tracks
             its own sessions; this server then uses one id per process.
         audit: Optional list of criterion audit rows.
@@ -745,15 +761,25 @@ def update_research_goal_status(
     try:
         from src.goal import GoalStatus, StaleGoalError
 
-        updated = _get_goal_store().update_status(
-            session_id=_resolve_session_id(session_id, ctx),
-            goal_id=goal_id.strip(),
-            expected_goal_id=expected_goal_id.strip(),
+        store = _get_goal_store()
+        resolved_session_id = _resolve_session_id(session_id, ctx)
+        resolved_goal_id = goal_id.strip()
+        if not resolved_goal_id:
+            snapshot = store.get_current_snapshot(resolved_session_id)
+            if snapshot is None:
+                return _json_error("no current goal for this session", error_type="not_found")
+            resolved_goal_id = str(snapshot["goal"]["goal_id"])
+        resolved_expected_goal_id = expected_goal_id.strip() or resolved_goal_id
+
+        updated = store.update_status(
+            session_id=resolved_session_id,
+            goal_id=resolved_goal_id,
+            expected_goal_id=resolved_expected_goal_id,
             status=GoalStatus(status),
             audit=_audit_rows_from_payload(audit),
             recap=_blank_to_none(recap),
         )
-        snapshot = _get_goal_store().get_goal_snapshot(updated.goal_id)
+        snapshot = store.get_goal_snapshot(updated.goal_id)
         if snapshot is None:
             return _json_error("Goal snapshot could not be reloaded")
         return _json_ok(goal=snapshot["goal"], snapshot=snapshot)

--- a/agent/tests/test_mcp_goal_session_contract.py
+++ b/agent/tests/test_mcp_goal_session_contract.py
@@ -46,13 +46,15 @@ def test_session_id_is_not_a_required_argument(name, tool_parameters) -> None:
 
 
 def test_the_other_arguments_stay_required(tool_parameters) -> None:
-    """Making session_id optional must not loosen the real inputs."""
+    """Making session_id optional must not loosen the real inputs.
+
+    goal_id/expected_goal_id are deliberately not in this set: they default
+    to the current goal for the session, the same fallback the registered
+    AddGoalEvidenceTool/UpdateResearchGoalStatusTool already implement.
+    """
     assert tool_parameters["start_research_goal"]["required"] == ["objective"]
-    assert set(tool_parameters["update_research_goal_status"]["required"]) == {
-        "goal_id",
-        "expected_goal_id",
-        "status",
-    }
+    assert tool_parameters["update_research_goal_status"]["required"] == ["status"]
+    assert tool_parameters["add_goal_evidence"]["required"] == ["text"]
 
 
 def test_resolve_session_id_is_stable_within_a_process(mcp_server, monkeypatch) -> None:

--- a/agent/tests/test_mcp_goal_tool_optional_goal_id.py
+++ b/agent/tests/test_mcp_goal_tool_optional_goal_id.py
@@ -1,0 +1,106 @@
+"""add_goal_evidence and update_research_goal_status must not require
+goal_id/expected_goal_id when the caller means "the current goal".
+
+The registered tools (AddGoalEvidenceTool, UpdateResearchGoalStatusTool)
+document goal_id as optional, defaulting to the current goal for the
+session, and expected_goal_id as optional, defaulting to goal_id. Their
+execute() methods implement that fallback via
+GoalStore.get_current_snapshot(). The MCP wrappers bypassed the registered
+tools entirely, called the store directly, and declared both parameters
+required with no fallback: an MCP client that (like the internal agent)
+tries to add evidence or update status for "whatever the current goal is"
+without re-supplying its id got a hard validation error instead.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def mcp_server():
+    """Import agent/mcp_server.py without executing main()."""
+    agent_dir = Path(__file__).resolve().parent.parent
+    if str(agent_dir) not in sys.path:
+        sys.path.insert(0, str(agent_dir))
+    return importlib.import_module("mcp_server")
+
+
+@pytest.fixture()
+def fresh_goal_store(mcp_server, tmp_path, monkeypatch):
+    """Isolate each test's goal store and process-wide session id."""
+    from src.goal import GoalStore
+
+    monkeypatch.setattr(mcp_server, "_goal_store", GoalStore(db_path=tmp_path / "g.db"))
+    monkeypatch.setattr(mcp_server, "_mcp_session_id", None)
+    return mcp_server
+
+
+def test_add_goal_evidence_falls_back_to_the_current_goal(fresh_goal_store) -> None:
+    mcp = fresh_goal_store
+    start = json.loads(mcp.start_research_goal(objective="Analyse SPY drawdowns"))
+    assert start["status"] == "ok", start
+    goal_id = start["snapshot"]["goal"]["goal_id"]
+
+    result = json.loads(mcp.add_goal_evidence(text="Max drawdown was 18% in the sample window."))
+
+    assert result["status"] == "ok", result
+    assert result["evidence"]["goal_id"] == goal_id
+    assert result["snapshot"]["goal"]["goal_id"] == goal_id
+
+
+def test_add_goal_evidence_defaults_source_provider_and_type(fresh_goal_store) -> None:
+    mcp = fresh_goal_store
+    mcp.start_research_goal(objective="Analyse SPY drawdowns")
+
+    result = json.loads(mcp.add_goal_evidence(text="Evidence with no explicit source."))
+
+    assert result["evidence"]["source_provider"] == "agent_tool"
+    assert result["evidence"]["source_type"] == "tool_note"
+
+
+def test_add_goal_evidence_without_a_current_goal_reports_not_found(fresh_goal_store) -> None:
+    mcp = fresh_goal_store
+
+    result = json.loads(mcp.add_goal_evidence(text="Nothing to attach this to."))
+
+    assert result["status"] == "error", result
+    assert result.get("error_type") == "not_found"
+
+
+def test_update_research_goal_status_falls_back_to_the_current_goal(fresh_goal_store) -> None:
+    mcp = fresh_goal_store
+    start = json.loads(mcp.start_research_goal(objective="Analyse SPY drawdowns"))
+    goal_id = start["snapshot"]["goal"]["goal_id"]
+
+    result = json.loads(mcp.update_research_goal_status(status="paused"))
+
+    assert result["status"] == "ok", result
+    assert result["goal"]["goal_id"] == goal_id
+    assert result["goal"]["status"] == "paused"
+
+
+def test_update_research_goal_status_without_a_current_goal_reports_not_found(fresh_goal_store) -> None:
+    mcp = fresh_goal_store
+
+    result = json.loads(mcp.update_research_goal_status(status="paused"))
+
+    assert result["status"] == "error", result
+    assert result.get("error_type") == "not_found"
+
+
+def test_explicit_goal_id_still_works(fresh_goal_store) -> None:
+    """An explicit goal_id must keep working exactly as before."""
+    mcp = fresh_goal_store
+    start = json.loads(mcp.start_research_goal(objective="Analyse SPY drawdowns"))
+    goal_id = start["snapshot"]["goal"]["goal_id"]
+
+    result = json.loads(mcp.update_research_goal_status(status="paused", goal_id=goal_id, expected_goal_id=goal_id))
+
+    assert result["status"] == "ok", result
+    assert result["goal"]["goal_id"] == goal_id


### PR DESCRIPTION
## Summary

- `add_goal_evidence` and `update_research_goal_status` required `goal_id`/`expected_goal_id`, although the registered tools document them as optional.
- Both wrappers now fall back to the current goal when the id is omitted or blank.
- `add_goal_evidence` also applies the tool defaults for provenance when omitted.

## Why

The MCP wrappers call the goal store directly, so they did not inherit the registered tools' fallback behaviour. Clients using the current goal without supplying its id received a validation error.

## Changes

- Resolve the goal id from the current session goal when omitted or blank.
- Apply default provenance in `add_goal_evidence`.
- Explicit-ID calls remain unchanged.

## Test Plan

- Regression tests fail on unpatched `main` and pass with the fix.
- Targeted: 14 passed.
- MCP/goal selection: 352 passed, 5 skipped.

## Risk

Low. The change only adds fallback behaviour when the goal id is not supplied.