### PR TITLE
fix(backtest): mark halted positions at last traded close, not entry cost

### DIFF
--- a/agent/backtest/engines/base.py
+++ b/agent/backtest/engines/base.py
@@ -240,7 +240,9 @@ def _align(
         optimizer: Optional weight optimiser ``(ret, pos, dates) -> pos``.
 
     Returns:
-        (dates, close_df, positions_df, returns_df)
+        (dates, close_df, close_val_df, positions_df, returns_df). ``close_df``
+        is the bounded-ffill trading view; ``close_val_df`` carries the last
+        traded close through halts of any length and is only for valuation.
     """
     # Build unified sorted date index from all symbols' trading calendars
     indexes = [data_map[c].index for c in codes]
@@ -271,6 +273,9 @@ def _align(
     # Vectorized ffill with limit using pandas (C-optimized internals)
     _tmp = pd.DataFrame(close_arr)
     close_arr = _tmp.ffill(limit=ffill_limit).values
+    # Valuation marks carry the last traded close through a halt of any
+    # length; the bounded matrix above stays the trading/decision view.
+    close_val_arr = _tmp.ffill().values
 
     # Drop symbols that are entirely NaN (no data overlap with date range)
     all_nan_mask = np.all(np.isnan(close_arr), axis=0)
@@ -282,6 +287,7 @@ def _align(
         if not codes:
             raise ValueError("All symbols have no data in the requested date range")
         close_arr = close_arr[:, keep_mask]
+        close_val_arr = close_val_arr[:, keep_mask]
         n_codes = len(codes)
 
     # Build position matrix: shift on each symbol's OWN calendar, then fill
@@ -313,6 +319,7 @@ def _align(
 
     # Construct DataFrames for return
     close = pd.DataFrame(close_arr, index=dates, columns=codes)
+    close_val = pd.DataFrame(close_val_arr, index=dates, columns=codes)
     pos = pd.DataFrame(pos_arr, index=dates, columns=codes)
     ret = bar_returns(close, label="engine per-symbol returns")
 
@@ -322,7 +329,7 @@ def _align(
     scale = pos.abs().sum(axis=1).clip(lower=1.0)
     pos = pos.div(scale, axis=0)
 
-    return dates, close, pos, ret
+    return dates, close, close_val, pos, ret
 
 
 def _load_optimizer(config: Dict[str, Any]) -> Optional[Callable]:
@@ -875,7 +882,7 @@ class BaseEngine(ABC):
 
         # 3. Pre-compute target weights (with optimizer)
         opt_fn = _load_optimizer(config)
-        dates, close_df, target_pos, ret_df = _align(
+        dates, close_df, close_val_df, target_pos, ret_df = _align(
             data_map, signal_map, valid_codes, optimizer=opt_fn,
         )
 
@@ -891,11 +898,12 @@ class BaseEngine(ABC):
         if warmup_end:
             dates = dates[warmup_end:]
             close_df = close_df.iloc[warmup_end:]
+            close_val_df = close_val_df.iloc[warmup_end:]
             target_pos = target_pos.iloc[warmup_end:]
             ret_df = ret_df.iloc[warmup_end:]
 
         # 4. Bar-by-bar execution
-        self._execute_bars(dates, data_map, close_df, target_pos, valid_codes)
+        self._execute_bars(dates, data_map, close_df, target_pos, valid_codes, close_val_df=close_val_df)
         actual_pos = self._actual_positions_frame(valid_codes)
 
         # 5. Build output series
@@ -1107,6 +1115,7 @@ class BaseEngine(ABC):
         close_df: pd.DataFrame,
         target_pos: pd.DataFrame,
         codes: List[str],
+        close_val_df: Optional[pd.DataFrame] = None,
     ) -> None:
         """Bar-by-bar execution with market rule enforcement."""
         # Pre-extract numpy arrays for O(1) indexed access instead of DataFrame.at[]
@@ -1114,9 +1123,13 @@ class BaseEngine(ABC):
         # regardless of DataFrame internal column ordering (which may be alphabetical).
         _target_arr = target_pos[codes].values  # (n_dates, n_codes) ndarray
         _close_arr = close_df[codes].values  # (n_dates, n_codes) ndarray
+        if close_val_df is None:
+            close_val_df = close_df.ffill()
+        _val_arr = close_val_df[codes].values  # unbounded ffill, valuation only
         _code_to_col = {c: j for j, c in enumerate(codes)}
         # Store as instance attrs for use in _calc_equity / _safe_price
         self._close_arr = _close_arr
+        self._val_arr = _val_arr
         self._code_to_col = _code_to_col
         self.actual_position_snapshots = []
         execution_dates = resolve_rebalance_dates(self.rebalance_mask, dates)
@@ -1243,6 +1256,7 @@ class BaseEngine(ABC):
                     self._safe_price(
                         close_df, ts, s, ep,
                         _arr=_close_arr, _row=i, _col=_code_to_col.get(s),
+                        _val_arr=_val_arr,
                     )
                     for s, ep in zip(_syms, _eps)
                 ])
@@ -1253,6 +1267,7 @@ class BaseEngine(ABC):
                     cp = self._safe_price(
                         close_df, ts, p.symbol, p.entry_price,
                         _arr=_close_arr, _row=i, _col=_code_to_col.get(p.symbol),
+                        _val_arr=_val_arr,
                     )
                     total_unrealized += self._calc_pnl(p.symbol, p.direction, p.size, p.entry_price, cp)
             self.equity_snapshots.append(EquitySnapshot(
@@ -1275,6 +1290,7 @@ class BaseEngine(ABC):
                 mark_price = self._safe_price(
                     close_df, last_ts, c, pos.entry_price,
                     _arr=_close_arr, _row=_last_row, _col=_code_to_col.get(c),
+                    _val_arr=_val_arr,
                 )
                 self._active_symbol = c
                 exit_price = self.apply_slippage(mark_price, -pos.direction)
@@ -1298,6 +1314,7 @@ class BaseEngine(ABC):
 
         # Clean up temporary instance attributes
         self._close_arr = None
+        self._val_arr = None
         self._code_to_col = None
 
     def _calc_open_equity(
@@ -1319,11 +1336,13 @@ class BaseEngine(ABC):
         equity = self.capital
         for sym, pos in self.positions.items():
             _arr = getattr(self, "_close_arr", None)
+            _varr = getattr(self, "_val_arr", None)
             _row = getattr(self, "_bar_idx", None)
             _c2c = getattr(self, "_code_to_col", None)
             current_price = self._safe_price(
                 close_df, ts, sym, pos.entry_price,
                 _arr=_arr, _row=_row, _col=(_c2c.get(sym) if _c2c else None),
+                _val_arr=_varr,
             )
             frame = data_map.get(sym)
             if frame is not None and ts in frame.index:
@@ -1355,6 +1374,7 @@ class BaseEngine(ABC):
 
         # Use array fast-path when available
         _arr = getattr(self, "_close_arr", None)
+        _varr = getattr(self, "_val_arr", None)
         _row = getattr(self, "_bar_idx", None)
         _c2c = getattr(self, "_code_to_col", None)
 
@@ -1369,6 +1389,7 @@ class BaseEngine(ABC):
                 self._safe_price(
                     close_df, ts, s, ep,
                     _arr=_arr, _row=_row, _col=(_c2c.get(s) if _c2c else None),
+                    _val_arr=_varr,
                 )
                 for s, ep in zip(syms, entry_prices)
             ])
@@ -1382,6 +1403,7 @@ class BaseEngine(ABC):
             cp = self._safe_price(
                 close_df, ts, sym, pos.entry_price,
                 _arr=_arr, _row=_row, _col=(_c2c.get(sym) if _c2c else None),
+                _val_arr=_varr,
             )
             margin = self._calc_margin(sym, pos.size, pos.entry_price, pos.leverage)
             unrealized = self._calc_pnl(sym, pos.direction, pos.size, pos.entry_price, cp)
@@ -1858,6 +1880,7 @@ class BaseEngine(ABC):
                 _arr=getattr(self, "_close_arr", None),
                 _row=getattr(self, "_bar_idx", None),
                 _col=getattr(self, "_code_to_col", {}).get(symbol),
+                _val_arr=getattr(self, "_val_arr", None),
             )
             margin_value = self._calc_margin(
                 symbol, pos.size, price, pos.leverage
@@ -2119,12 +2142,24 @@ class BaseEngine(ABC):
         _arr: "np.ndarray | None" = None,
         _row: "int | None" = None,
         _col: "int | None" = None,
+        _val_arr: "np.ndarray | None" = None,
     ) -> float:
-        """Get close price with fallback. Uses array fast-path when available."""
+        """Get close price with fallback. Uses array fast-path when available.
+
+        Valuation call sites pass ``_val_arr`` (unbounded ffill) so a halted
+        position marks at its last traded close instead of ``fallback`` once
+        the bounded matrix goes NaN past the ffill limit.
+        """
         # Fast path: pre-computed array indexing (O(1) vs DataFrame.at hash lookup)
         if _arr is not None and _row is not None and _col is not None:
             val = _arr[_row, _col]
-            return float(val) if not np.isnan(val) else fallback
+            if not np.isnan(val):
+                return float(val)
+            if _val_arr is not None:
+                vval = _val_arr[_row, _col]
+                if not np.isnan(vval):
+                    return float(vval)
+            return fallback
         # Original path (backward compatible for subclasses)
         if ts in close_df.index and symbol in close_df.columns:
             val = close_df.at[ts, symbol]

--- a/agent/backtest/engines/crypto.py
+++ b/agent/backtest/engines/crypto.py
@@ -445,7 +445,7 @@ class CryptoEngine(BaseEngine):
         )
         self._risk_after_atomic_mutation(timestamp)
 
-    def _execute_bars(self, dates, data_map, close_df, target_pos, codes) -> None:
+    def _execute_bars(self, dates, data_map, close_df, target_pos, codes, close_val_df=None) -> None:
         if self.perpetual_strict:
             try:
                 close_df = pd.DataFrame(
@@ -453,7 +453,8 @@ class CryptoEngine(BaseEngine):
                 )
             except KeyError as exc:
                 raise ValueError(f"missing strict mark-close data: {exc}") from exc
-        super()._execute_bars(dates, data_map, close_df, target_pos, codes)
+            close_val_df = close_df.ffill()
+        super()._execute_bars(dates, data_map, close_df, target_pos, codes, close_val_df=close_val_df)
         if self.perpetual_strict and self.terminal_status == "active":
             self.terminal_status = "completed"
 

--- a/agent/tests/test_base_engine.py
+++ b/agent/tests/test_base_engine.py
@@ -591,7 +591,7 @@ class TestAlign:
         frame = pd.DataFrame({"open": [100.0] * 3, "close": [100.0] * 3}, index=dates)
         signals = pd.Series([0.0, 1.0, 0.0], index=dates)
 
-        out_dates, close_df, pos_df, _ = _align(
+        out_dates, close_df, _, pos_df, _ = _align(
             {"BTC-USDT-PERP": frame}, {"BTC-USDT-PERP": signals}, ["BTC-USDT-PERP"]
         )
 
@@ -601,7 +601,7 @@ class TestAlign:
 
     def test_output_shapes(self) -> None:
         data_map, signal_map, dates = _simple_data_and_signals()
-        out_dates, close_df, pos_df, ret_df = _align(data_map, signal_map, ["A", "B"])
+        out_dates, close_df, _, pos_df, ret_df = _align(data_map, signal_map, ["A", "B"])
         assert len(out_dates) == len(dates)
         assert close_df.shape == (len(dates), 2)
         assert pos_df.shape == (len(dates), 2)
@@ -610,7 +610,7 @@ class TestAlign:
     def test_signal_shifted_by_one(self) -> None:
         """Signal at bar i should produce position at bar i+1 (next-bar-open)."""
         data_map, signal_map, dates = _simple_data_and_signals()
-        _, _, pos_df, _ = _align(data_map, signal_map, ["A", "B"])
+        _, _, _, pos_df, _ = _align(data_map, signal_map, ["A", "B"])
         # Signal A goes to 1.0 at index 3 → position should be 0 at index 3, non-zero at index 4
         assert pos_df.at[dates[3], "A"] == 0.0
         assert pos_df.at[dates[4], "A"] > 0.0
@@ -618,7 +618,7 @@ class TestAlign:
     def test_positions_normalized(self) -> None:
         """Sum of abs(weights) should be <= 1.0 per row."""
         data_map, signal_map, dates = _simple_data_and_signals()
-        _, _, pos_df, _ = _align(data_map, signal_map, ["A", "B"])
+        _, _, _, pos_df, _ = _align(data_map, signal_map, ["A", "B"])
         row_sums = pos_df.abs().sum(axis=1)
         assert (row_sums <= 1.0 + 1e-10).all()
 
@@ -629,7 +629,7 @@ class TestAlign:
         sig = pd.Series([0, 0, 2.0, -3.0, 0.5], index=dates)
         data_map = {"X": df}
         signal_map = {"X": sig}
-        _, _, pos_df, _ = _align(data_map, signal_map, ["X"])
+        _, _, _, pos_df, _ = _align(data_map, signal_map, ["X"])
         # After shift, clipped values show up at indices 3 and 4
         assert pos_df["X"].abs().max() <= 1.0 + 1e-10
 
@@ -639,7 +639,7 @@ class TestAlign:
         sig = pd.Series([np.nan, 1.0, np.nan, 0.5, np.nan], index=dates)
         data_map = {"X": df}
         signal_map = {"X": sig}
-        _, _, pos_df, _ = _align(data_map, signal_map, ["X"])
+        _, _, _, pos_df, _ = _align(data_map, signal_map, ["X"])
         assert not pos_df.isna().any().any()
 
     def test_close_ffill_bfill(self) -> None:
@@ -650,7 +650,7 @@ class TestAlign:
             index=dates,
         )
         sig = pd.Series([0, 1, 1, 1, 0], index=dates)
-        _, close_df, _, _ = _align({"X": df}, {"X": sig}, ["X"])
+        _, close_df, _, _, _ = _align({"X": df}, {"X": sig}, ["X"])
         assert not close_df.isna().any().any()
 
     def test_with_optimizer(self) -> None:
@@ -660,9 +660,9 @@ class TestAlign:
         def dummy_optimizer(ret, pos, dates_arg):
             return pos * 0.5  # halve everything
 
-        _, _, pos_df, _ = _align(data_map, signal_map, ["A", "B"], optimizer=dummy_optimizer)
+        _, _, _, pos_df, _ = _align(data_map, signal_map, ["A", "B"], optimizer=dummy_optimizer)
         # Positions should be smaller due to optimizer
-        _, _, pos_no_opt, _ = _align(data_map, signal_map, ["A", "B"])
+        _, _, _, pos_no_opt, _ = _align(data_map, signal_map, ["A", "B"])
         assert pos_df.abs().sum().sum() <= pos_no_opt.abs().sum().sum() + 1e-10
 
 
@@ -787,3 +787,35 @@ class TestSafePrice:
         dates = pd.DatetimeIndex([pd.Timestamp("2025-01-02")])
         close_df = pd.DataFrame({"X": [np.nan]}, index=dates)
         assert BaseEngine._safe_price(close_df, dates[0], "X", 10.0) == 10.0
+
+
+def test_halted_position_marks_at_last_close_past_ffill_limit():
+    # #1318: a position held through a halt longer than the ffill limit used to
+    # be re-marked at entry price, producing a phantom drawdown mid-halt.
+    run_dates = pd.date_range("2026-01-02", periods=30, freq="B")
+    halt_dates = run_dates[:10]
+    halt_close = [100.0 + 5.0 * i for i in range(10)]
+    data_map = {
+        "HALT": pd.DataFrame({"open": halt_close, "close": halt_close}, index=halt_dates),
+        "RUN": pd.DataFrame({"open": 50.0, "close": 50.0}, index=run_dates),
+    }
+    signal_map = {
+        "HALT": pd.Series(0.5, index=halt_dates),
+        "RUN": pd.Series(0.0, index=run_dates),
+    }
+    dates, close_df, close_val_df, target_pos, _ = _align(data_map, signal_map, ["HALT", "RUN"])
+
+    engine = _AdjustmentEngine()
+    engine._execute_bars(
+        dates, data_map, close_df, target_pos, ["HALT", "RUN"],
+        close_val_df=close_val_df,
+    )
+
+    snaps = {s.timestamp: s.equity for s in engine.equity_snapshots}
+    marked_at_last_close = snaps[run_dates[9]]
+    # Deep into the halt the equity must not fall back to the entry-cost mark.
+    for bar in (14, 15, 20, 29):
+        assert snaps[run_dates[bar]] == pytest.approx(marked_at_last_close, rel=1e-9)
+    # The terminal forced liquidation also marks at the last traded close, so
+    # the halt's unrealized PnL survives into the final equity.
+    assert engine.equity_snapshots[-1].equity == pytest.approx(marked_at_last_close, rel=1e-6)

--- a/agent/tests/test_engine_robustness.py
+++ b/agent/tests/test_engine_robustness.py
@@ -39,7 +39,7 @@ class TestFfillLimit:
         df = pd.DataFrame({"close": close, "open": close}, index=dates)
         sig = pd.Series(1.0, index=dates)
 
-        _, close_df, _, _ = _align({"A": df}, {"A": sig}, ["A"])
+        _, close_df, _, _, _ = _align({"A": df}, {"A": sig}, ["A"])
         # 3-bar gap should be filled — no NaN in close
         assert close_df["A"].isna().sum() == 0
 
@@ -50,7 +50,7 @@ class TestFfillLimit:
         df = pd.DataFrame({"close": close, "open": close}, index=dates)
         sig = pd.Series(1.0, index=dates)
 
-        _, close_df, _, _ = _align({"A": df}, {"A": sig}, ["A"])
+        _, close_df, _, _, _ = _align({"A": df}, {"A": sig}, ["A"])
         # 8-bar gap: ffill covers first 5, remaining 3 should be NaN
         nan_count = close_df["A"].isna().sum()
         assert nan_count == 3, f"Expected 3 NaN bars after ffill limit=5, got {nan_count}"
@@ -72,7 +72,7 @@ class TestFfillLimit:
             "BAD": pd.Series(1.0, index=dates),
         }
 
-        _, close_df, pos_df, _ = _align(data_map, signal_map, ["GOOD", "BAD"])
+        _, close_df, _, pos_df, _ = _align(data_map, signal_map, ["GOOD", "BAD"])
         assert "BAD" not in close_df.columns, "All-NaN symbol should be dropped"
         assert "GOOD" in close_df.columns
         assert "BAD" not in pos_df.columns
@@ -115,7 +115,7 @@ class TestSymbolIsolation:
         signal_map = {"GOOD": sig.copy(), "BAD": sig.copy()}
         valid_codes = ["GOOD", "BAD"]
 
-        _, close_df, target_pos, _ = _align(data_map, signal_map, valid_codes)
+        _, close_df, _, target_pos, _ = _align(data_map, signal_map, valid_codes)
 
         engine = ChinaAEngine({"initial_cash": 1_000_000})
 
@@ -559,7 +559,7 @@ class TestFullBacktestRobustness:
         signal_map = {"NORMAL": sig.copy(), "SUSPENDED": sig.copy()}
         valid_codes = ["NORMAL", "SUSPENDED"]
 
-        _, close_df, target_pos, _ = _align(data_map, signal_map, valid_codes)
+        _, close_df, _, target_pos, _ = _align(data_map, signal_map, valid_codes)
 
         # The 14-bar gap should not be fully filled
         suspended_nan_count = close_df["SUSPENDED"].isna().sum()

--- a/agent/tests/test_returns_gaps_and_infinities.py
+++ b/agent/tests/test_returns_gaps_and_infinities.py
@@ -172,7 +172,7 @@ def test_align_keeps_move_across_halt_longer_than_ffill_limit() -> None:
     data_map = {"HALTED": _frame(halted), "NORMAL": _frame(normal)}
     signal_map = {c: pd.Series(1.0, index=df.index) for c, df in data_map.items()}
 
-    _, close, _, ret = _align(data_map, signal_map, ["HALTED", "NORMAL"])
+    _, close, _, _, ret = _align(data_map, signal_map, ["HALTED", "NORMAL"])
 
     # Precondition: the halt really does outlive the ffill limit.
     assert np.isnan(close.loc[dates[7], "HALTED"])

--- a/agent/tests/test_signal_alignment_perf.py
+++ b/agent/tests/test_signal_alignment_perf.py
@@ -157,7 +157,7 @@ class TestAlignGoldStandard:
         dates_ref, close_ref, pos_ref, ret_ref = _align_pandas_reference(
             data_map, signal_map, list(codes)
         )
-        dates_opt, close_opt, pos_opt, ret_opt = _align(
+        dates_opt, close_opt, _, pos_opt, ret_opt = _align(
             data_map, signal_map, list(codes)
         )
 
@@ -175,7 +175,7 @@ class TestAlignGoldStandard:
         dates_ref, close_ref, pos_ref, ret_ref = _align_pandas_reference(
             data_map, signal_map, list(codes)
         )
-        dates_opt, close_opt, pos_opt, ret_opt = _align(
+        dates_opt, close_opt, _, pos_opt, ret_opt = _align(
             data_map, signal_map, list(codes)
         )
 
@@ -211,7 +211,7 @@ class TestAlignGoldStandard:
         dates_ref, close_ref, pos_ref, ret_ref = _align_pandas_reference(
             data_map, signal_map, list(codes)
         )
-        dates_opt, close_opt, pos_opt, ret_opt = _align(
+        dates_opt, close_opt, _, pos_opt, ret_opt = _align(
             data_map, signal_map, list(codes)
         )
 
@@ -242,7 +242,7 @@ class TestAlignGoldStandard:
         dates_ref, close_ref, pos_ref, ret_ref = _align_pandas_reference(
             data_map, signal_map, list(codes)
         )
-        dates_opt, close_opt, pos_opt, ret_opt = _align(
+        dates_opt, close_opt, _, pos_opt, ret_opt = _align(
             data_map, signal_map, list(codes)
         )
 
@@ -266,7 +266,7 @@ class TestAlignGoldStandard:
         dates_ref, close_ref, pos_ref, ret_ref = _align_pandas_reference(
             data_map, signal_map, list(codes), optimizer=scale_optimizer
         )
-        dates_opt, close_opt, pos_opt, ret_opt = _align(
+        dates_opt, close_opt, _, pos_opt, ret_opt = _align(
             data_map, signal_map, list(codes), optimizer=scale_optimizer
         )
 
@@ -282,7 +282,7 @@ class TestAlignGoldStandard:
         )
 
         # New (optimized) path
-        dates_opt, close_opt, pos_opt, _ = _align(data_map, signal_map, list(codes))
+        dates_opt, close_opt, _, pos_opt, _ = _align(data_map, signal_map, list(codes))
         codes_opt = list(pos_opt.columns)
         engine_opt = ChinaAEngine({"initial_cash": 1_000_000})
         engine_opt._execute_bars(dates_opt, data_map, close_opt, pos_opt, codes_opt)
@@ -322,7 +322,7 @@ class TestAlignConsistency:
         data_map, signal_map, codes = _build_synthetic_dataset(
             n_bars=150, n_symbols=5, nan_ratio=0.03
         )
-        dates, close_df, _, _ = _align(data_map, signal_map, codes)
+        dates, close_df, _, _, _ = _align(data_map, signal_map, codes)
 
         # For each symbol, non-NaN source values should appear at correct positions
         for code in codes:
@@ -344,7 +344,7 @@ class TestAlignConsistency:
         sig = pd.Series(0.0, index=dates)
         sig.iloc[5] = 1.0
 
-        _, _, pos_df, _ = _align({"X": df}, {"X": sig}, ["X"])
+        _, _, _, pos_df, _ = _align({"X": df}, {"X": sig}, ["X"])
 
         # At bar 5 position should still be 0 (signal not yet effective)
         assert pos_df.at[dates[5], "X"] == 0.0
@@ -367,7 +367,7 @@ class TestAlignConsistency:
         data_map = {"X": df}
         signal_map = {"X": sig}
 
-        _, close_df, _, _ = _align(data_map, signal_map, ["X"])
+        _, close_df, _, _, _ = _align(data_map, signal_map, ["X"])
 
         # Bar 0 filled, bars 1-5 should be ffilled from bar 0
         for i in range(1, 6):
@@ -391,7 +391,7 @@ class TestAlignConsistency:
         data_map = {"GOOD": df_good, "BAD": df_bad}
         signal_map = {"GOOD": sig, "BAD": sig}
 
-        _, close_df, pos_df, _ = _align(data_map, signal_map, ["GOOD", "BAD"])
+        _, close_df, _, pos_df, _ = _align(data_map, signal_map, ["GOOD", "BAD"])
 
         assert "GOOD" in close_df.columns
         assert "BAD" not in close_df.columns
@@ -414,7 +414,7 @@ class TestAlignConsistency:
         data_map = {"000001.SZ": df_equity, "BTC-USDT": df_crypto}
         signal_map = {"000001.SZ": sig, "BTC-USDT": sig}
 
-        _, close_df, _, _ = _align(data_map, signal_map, ["000001.SZ", "BTC-USDT"])
+        _, close_df, _, _, _ = _align(data_map, signal_map, ["000001.SZ", "BTC-USDT"])
 
         # With ffill_limit=10, bars 1-10 should be ffilled from bar 0
         for i in range(1, 11):
@@ -500,7 +500,7 @@ class TestExecuteBarsOptimization:
         data_map, signal_map, codes = _build_synthetic_dataset(
             n_bars=200, n_symbols=3, nan_ratio=0.01
         )
-        dates, close_df, target_pos, _ = _align(data_map, signal_map, codes)
+        dates, close_df, _, target_pos, _ = _align(data_map, signal_map, codes)
         # Sync codes after potential all-NaN drops
         codes = [c for c in codes if c in target_pos.columns]
 
@@ -662,7 +662,7 @@ class TestFundPanelCompatibility:
             n_dates=200, n_codes=5
         )
 
-        _, close_df, pos_df, ret_df = _align(data_map, signal_map, list(codes))
+        _, close_df, _, pos_df, ret_df = _align(data_map, signal_map, list(codes))
 
         # Columns must only be symbol codes, no fund:* leakage
         for col in close_df.columns:
@@ -717,10 +717,10 @@ class TestFundPanelCompatibility:
                 index=dates,
             )
 
-        _, close_clean, pos_clean, ret_clean = _align(
+        _, close_clean, _, pos_clean, ret_clean = _align(
             data_map_clean, signal_map, list(codes)
         )
-        _, close_fund, pos_fund, ret_fund = _align(
+        _, close_fund, _, pos_fund, ret_fund = _align(
             data_map_fund, signal_map, list(codes)
         )
 
@@ -767,7 +767,7 @@ class TestFundPanelCompatibility:
             )
 
         # Should not raise
-        _, close_df, pos_df, ret_df = _align(data_map, signal_map, list(codes))
+        _, close_df, _, pos_df, ret_df = _align(data_map, signal_map, list(codes))
 
         assert set(close_df.columns) == set(codes)
         assert set(pos_df.columns) == set(codes)
@@ -781,7 +781,7 @@ class TestFundPanelCompatibility:
             n_dates=200, n_codes=4
         )
 
-        dates, close_df, target_pos, _ = _align(data_map, signal_map, list(codes))
+        dates, close_df, _, target_pos, _ = _align(data_map, signal_map, list(codes))
         valid_codes = [c for c in codes if c in target_pos.columns]
 
         engine = ChinaAEngine({"initial_cash": 1_000_000})
@@ -827,7 +827,7 @@ class TestFundPanelCompatibility:
             data_map[c] = df
             signal_map[c] = pd.Series(1.0, index=dates)
 
-        _, close_df, _, _ = _align(data_map, signal_map, list(codes))
+        _, close_df, _, _, _ = _align(data_map, signal_map, list(codes))
 
         # No cell in close_df should contain the sentinel value
         assert not (close_df == sentinel).any().any(), (


### PR DESCRIPTION
## Summary

- Held positions now mark at the last traded close through a halt of any length, instead of snapping back to entry cost once the bounded ffill limit expires.
- The terminal forced liquidation marks at the same last traded close, so halt unrealized PnL survives into final equity.

## Why

Closes #1318. Measured on main (899d3c7): a position held past the 5-bar ffill limit was re-marked at entry price, printing equity 1441.58 -> 1009.11 mid-halt with no market event, and rebalance sizing in that window ran against the phantom mark.

Root cause: `_align` bounds the aligned close with `ffill(limit=5)` on purpose (trading must not act on stale prices), but `_safe_price` then falls back to `pos.entry_price` at every valuation call site, so the side effect landed on valuation.

## Changes

- `_align` additionally returns an unbounded-ffill valuation frame; the bounded matrix stays the trading/decision view.
- `_safe_price` gains an optional valuation array consulted only when the bounded value is NaN.
- Valuation call sites wired to it: open equity (rebalance sizing input), equity snapshots, actual weights, terminal forced liquidation. Order/fill pricing is untouched: a halted symbol still cannot fill at a stale price.
- Regression test reproduces the issue shape (position held through a 20-bar halt): equity flat at the last-close mark across bars 9/14/15/20/29 and through terminal liquidation. Pre-fix the same scenario drops to the entry-cost mark at bar 15.
- `_execute_bars` keeps its old signature (new frame is an optional kwarg, derived as `close_df.ffill()` when absent); `crypto.py` perpetual-strict passes its mark-close view through.

## Test Plan

- [x] Existing tests pass: full agent suite 12109 passed, 92 skipped
- [x] New tests added: `test_halted_position_marks_at_last_close_past_ffill_limit`
- [x] Red-green checked: same scenario on pre-fix engine drops equity 1177.07 -> 1014.72 at the first bar past the ffill limit; with the fix it holds 1177.07 through terminal liquidation

Out of scope: the target-weight decay past the ffill limit (positions keep their last target), which is pre-existing and unchanged here. No live/broker/MCP/network surface; backtest engine only. Rollback: revert the single commit.

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Documentation updated (not user-facing)
