### PR TITLE
fix(grounding): preserve generic evidence timestamps

### DIFF
--- a/agent/src/agent/grounding.py
+++ b/agent/src/agent/grounding.py
@@ -1968,8 +1968,9 @@ class GroundingLedger:
             )
         source = str(payload.get("source") or tool_name)
         remaining = _MAX_GENERIC_EVIDENCE
+        timestamp_fields = (*_TIMESTAMP_FIELDS, "as_of")
 
-        def visit(value: Any, path: str) -> None:
+        def visit(value: Any, path: str, timestamp: str | None = None) -> None:
             nonlocal remaining
             if remaining <= 0:
                 return
@@ -1980,7 +1981,7 @@ class GroundingLedger:
                         tool=tool_name,
                         symbol=symbol,
                         source=source,
-                        timestamp=None,
+                        timestamp=timestamp,
                         field=path or "value",
                         value=value,
                         status="observed",
@@ -1991,11 +1992,25 @@ class GroundingLedger:
                 remaining -= 1
                 return
             if isinstance(value, dict):
+                local_timestamp = next(
+                    (
+                        str(value[key])
+                        for key in timestamp_fields
+                        if value.get(key) is not None
+                    ),
+                    timestamp,
+                )
                 for key, item in value.items():
-                    visit(item, f"{path}.{key}" if path else str(key))
+                    if str(key).casefold() in timestamp_fields:
+                        continue
+                    visit(
+                        item,
+                        f"{path}.{key}" if path else str(key),
+                        local_timestamp,
+                    )
             elif isinstance(value, list):
                 for index, item in enumerate(value):
-                    visit(item, f"{path}[{index}]")
+                    visit(item, f"{path}[{index}]", timestamp)
 
         visit(payload, "")
 

--- a/agent/tests/test_grounding_generic_timestamps.py
+++ b/agent/tests/test_grounding_generic_timestamps.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.agent.grounding import GroundingLedger
+
+pytestmark = pytest.mark.unit
+
+
+def _ledger(tmp_path: Path, payload: dict) -> GroundingLedger:
+    ledger = GroundingLedger(run_dir=tmp_path, user_message="Show AAPL.US prices by date")
+    ledger.ingest_tool_result(
+        tool_name="external_market_tool",
+        arguments={"symbol": "AAPL.US"},
+        result=json.dumps(payload),
+        call_id="quote",
+        success=True,
+    )
+    return ledger
+
+
+def test_generic_quote_inherits_parent_as_of(tmp_path: Path) -> None:
+    ledger = _ledger(
+        tmp_path,
+        {
+            "source": "external",
+            "as_of": "2026-08-03T15:30:00Z",
+            "data": {"quote": [{"close": 212.5}]},
+        },
+    )
+
+    result = ledger.validate_final_answer(
+        "| Date | Close |\n|---|---|\n| 2026-08-03 | 212.5 |"
+    )
+
+    assert result.valid is True, result.issues
+
+
+def test_generic_rows_keep_their_own_trade_dates(tmp_path: Path) -> None:
+    ledger = _ledger(
+        tmp_path,
+        {
+            "source": "external",
+            "as_of": "2026-08-04T23:59:00Z",
+            "data": {
+                "bars": [
+                    {"trade_date": "2026-08-03", "close": 212.5},
+                    {"trade_date": "2026-08-04", "close": 214.0},
+                ]
+            },
+        },
+    )
+
+    result = ledger.validate_final_answer(
+        "| Date | Close |\n|---|---|\n| 2026-08-03 | 212.5 |\n| 2026-08-04 | 214.0 |"
+    )
+
+    assert result.valid is True, result.issues
+
+
+def test_generic_quote_without_timestamp_stays_undated(tmp_path: Path) -> None:
+    ledger = _ledger(
+        tmp_path,
+        {"source": "external", "data": {"quote": [{"close": 212.5}]}},
+    )
+
+    result = ledger.validate_final_answer(
+        "| Date | Close |\n|---|---|\n| 2026-08-03 | 212.5 |"
+    )
+
+    assert result.valid is False
+    assert [issue["code"] for issue in result.issues] == ["numeric_claim_unavailable"]


### PR DESCRIPTION
## Summary

- Preserve timestamps in generic grounding evidence.
- Support inherited `as_of` and row-level dates.

## Why

Generic tool results could contain both a price and its date, but the grounding ledger discarded the timestamp. Dated claims could then be rejected as having no matching evidence.

## Changes

- Carry timestamp context while flattening generic numeric results.
- Let row-level timestamps override inherited parent timestamps.
- Add regression tests for dated and undated evidence.

## Test Plan

- [ ] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [x] New tests added
- [ ] Tested manually

## Checklist

- [ ] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows `CONTRIBUTING.md` guidelines
- [ ] Documentation updated (not user-facing)