### PR TITLE
Fix/codex token usagefix(providers): propagate Codex token usage

### DIFF
--- a/agent/src/providers/openai_codex.py
+++ b/agent/src/providers/openai_codex.py
@@ -227,6 +227,7 @@ class CodexAIMessage:
     tool_calls: list[dict[str, Any]] = field(default_factory=list)
     additional_kwargs: dict[str, Any] = field(default_factory=dict)
     response_metadata: dict[str, Any] = field(default_factory=lambda: {"finish_reason": "stop"})
+    usage_metadata: dict[str, int] | None = None
 
     def __add__(self, other: "CodexAIMessage") -> "CodexAIMessage":
         finish_reason = other.response_metadata.get(
@@ -241,6 +242,7 @@ class CodexAIMessage:
             tool_calls=[*self.tool_calls, *other.tool_calls],
             additional_kwargs={"reasoning_content": reasoning} if reasoning else {},
             response_metadata={"finish_reason": finish_reason},
+            usage_metadata=other.usage_metadata or self.usage_metadata,
         )
 
 
@@ -595,8 +597,21 @@ def _message_chunks_from_events(events: Iterable[dict[str, Any]]) -> Iterable[Co
                 )
                 yield CodexAIMessage(tool_calls=[tool.as_langchain_tool_call()])
         elif event_type == "response.completed":
-            status = (event.get("response") or {}).get("status")
-            yield CodexAIMessage(response_metadata={"finish_reason": _map_finish_reason(status)})
+            response = event.get("response") or {}
+            status = response.get("status")
+            usage = response.get("usage")
+            usage_metadata = None
+            if isinstance(usage, dict):
+                values = {
+                    key: usage.get(key)
+                    for key in ("input_tokens", "output_tokens", "total_tokens")
+                }
+                if all(isinstance(value, int) and not isinstance(value, bool) for value in values.values()):
+                    usage_metadata = values
+            yield CodexAIMessage(
+                response_metadata={"finish_reason": _map_finish_reason(status)},
+                usage_metadata=usage_metadata,
+            )
         elif event_type in {"error", "response.failed"}:
             detail = event.get("error") or event.get("message") or event
             raise RuntimeError(f"OpenAI Codex response failed: {str(detail)[:500]}")

--- a/agent/tests/test_openai_codex_usage.py
+++ b/agent/tests/test_openai_codex_usage.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from src.providers.openai_codex import CodexAIMessage, _message_chunks_from_events
+
+
+def test_completed_event_exposes_codex_token_usage() -> None:
+    [chunk] = list(
+        _message_chunks_from_events(
+            [
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "status": "completed",
+                        "usage": {
+                            "input_tokens": 12,
+                            "output_tokens": 7,
+                            "total_tokens": 19,
+                        },
+                    },
+                }
+            ]
+        )
+    )
+
+    assert chunk.usage_metadata == {
+        "input_tokens": 12,
+        "output_tokens": 7,
+        "total_tokens": 19,
+    }
+
+
+def test_codex_message_accumulation_preserves_final_usage() -> None:
+    message = CodexAIMessage(content="hello") + CodexAIMessage(
+        usage_metadata={
+            "input_tokens": 12,
+            "output_tokens": 7,
+            "total_tokens": 19,
+        }
+    )
+
+    assert message.content == "hello"
+    assert message.usage_metadata == {
+        "input_tokens": 12,
+        "output_tokens": 7,
+        "total_tokens": 19,
+    }
+
+
+def test_completed_event_without_usage_stays_unreported() -> None:
+    [chunk] = list(
+        _message_chunks_from_events(
+            [{"type": "response.completed", "response": {"status": "completed"}}]
+        )
+    )
+
+    assert chunk.usage_metadata is None


### PR DESCRIPTION
## Summary

- Propagate Codex token usage from `response.completed`.
- Preserve usage metadata when streamed message chunks are combined.

## Why

The Codex response includes token usage, but the provider adapter discarded it. Downstream token tracking could therefore fall back to estimated usage instead of provider-reported values.

## Changes

- Add `usage_metadata` to `CodexAIMessage`.
- Read `input_tokens`, `output_tokens`, and `total_tokens` from completed responses.
- Preserve usage during message accumulation.
- Add regression tests for present and absent usage metadata.

## Test Plan

- [ ] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [x] New tests added
- [ ] Tested manually

## Checklist

- [ ] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] Documentation updated (if user-facing change)