### PR TITLE
fix(agent): stop the loop discarding tool results the model still needs

### DIFF
--- a/agent/src/agent/loop.py
+++ b/agent/src/agent/loop.py
@@ -446,7 +446,17 @@ def _microcompact(messages: list) -> None:
     for msg in tool_msgs[:-KEEP_RECENT]:
         content = msg.get("content", "")
         if isinstance(content, str) and len(content) > 100:
-            msg["content"] = "[cleared]"
+            # A bare "[cleared]" is indistinguishable from a tool that
+            # returned nothing, so the model reports "no data was retrieved"
+            # for data it did receive and this layer then deleted. Say which
+            # it is, and say the result is recoverable.
+            msg["content"] = (
+                "[CLEARED FROM CONTEXT: this tool call SUCCEEDED and returned "
+                f"{len(content)} characters, which were removed to free "
+                "context space. This is NOT a tool failure and NOT an empty "
+                "result. If you need these values, call the tool again with "
+                "the same arguments.]"
+            )
 
 
 def _context_collapse(messages: list) -> None:
@@ -936,7 +946,18 @@ class AgentLoop:
         self.memory = memory or WorkspaceMemory()
         self._event_callback = event_callback
         self.max_iterations = max_iterations
-        self._called_ok: set[str] = set()
+        # Dedup identity is (tool name, canonical arguments) -- NOT the name
+        # alone. Keying on the name blocked every legitimate second call to a
+        # paginated or parameterised tool: get_financial_statements(
+        # statement='income') then (statement='balance') is one name but two
+        # different requests, and the second was answered with a synthetic
+        # 'already completed successfully' skip. The model then correctly
+        # reported that the balance sheet 'returned no readable content' -- a
+        # true statement about a fabricated tool result.
+        # Keys come from _identical_call_key, the same canonicaliser the
+        # deterministic cache uses, so the block path and the cache path can
+        # never disagree about what 'the same call' means.
+        self._called_ok: set[tuple[str, str]] = set()
         self._cancel_event = threading.Event()
         self._previous_summary: str = ""
         self._persistent_memory = persistent_memory
@@ -1930,7 +1951,17 @@ class AgentLoop:
 
             tool_def = self.registry.get(tc.name)
             is_repeatable = tool_def.repeatable if tool_def else False
-            if tc.name in self._called_ok and not is_repeatable:
+            # A None key means the arguments could not be canonicalised. The
+            # deterministic cache treats that as 'never cache'; the blocking
+            # gate must likewise treat it as 'never block', otherwise every
+            # un-serialisable call would collapse into a single identity and
+            # the second one would be skipped without ever running.
+            dedup_key = self._identical_call_key(tc.name, tc.arguments)
+            if (
+                dedup_key is not None
+                and dedup_key in self._called_ok
+                and not is_repeatable
+            ):
                 logger.warning(f"Blocked duplicate call: {tc.name} (already succeeded)")
                 skip_msg = json.dumps({"skipped": True, "reason": f"{tc.name} already completed successfully. Use the previous result."})
                 messages.append(context.format_tool_result(tc.id, tc.name, skip_msg))
@@ -2542,7 +2573,9 @@ class AgentLoop:
 
         success = _is_tool_success(result)
         if success:
-            self._called_ok.add(tc.name)
+            recorded_key = self._identical_call_key(tc.name, tc.arguments)
+            if recorded_key is not None:
+                self._called_ok.add(recorded_key)
             if tc.name == "backtest":
                 try:
                     _archive_backtest_result(result, self.memory.run_dir)

--- a/agent/tests/test_agent_loop_dedup_arguments.py
+++ b/agent/tests/test_agent_loop_dedup_arguments.py
@@ -1,0 +1,176 @@
+"""The duplicate-call gate must compare arguments, not just the tool name.
+
+`self._called_ok` stored `tc.name`, so the second call to any parameterised or
+paginated tool was answered with a synthetic ``{"skipped": true}`` result and
+never executed:
+
+    get_financial_statements(statement="income")   -> ok
+    get_financial_statements(statement="balance")  -> BLOCKED
+    get_financial_statements(offset=13)            -> BLOCKED
+
+`_result_paging` advertises `next_offset` and `complete: false`, so paging is
+the documented way to retrieve the rest -- and the gate made it impossible. The
+model then reported that the balance sheet "returned no readable content",
+which was a true statement about a fabricated tool result.
+
+The gate now keys on `_identical_call_key`, the same canonicaliser the
+deterministic cache uses, so the two paths cannot disagree about what "the same
+call" means.
+
+Harness mirrors test_agent_loop_deterministic_cache._drive.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from src.agent.context import ContextBuilder
+from src.agent.loop import AgentLoop
+from src.agent.tools import BaseTool, ToolRegistry
+from src.agent.trace import TraceWriter
+
+
+class _PagedTool(BaseTool):
+    """A NON-repeatable tool, so the duplicate gate applies to it."""
+
+    name = "get_financial_statements"
+    description = "test double for a paginated, parameterised fetch"
+    parameters: dict = {"type": "object", "properties": {}}
+    repeatable = False
+    is_readonly = True
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def execute(self, **kwargs: object) -> str:
+        self.calls.append(kwargs)
+        return json.dumps({"status": "ok", "call": len(self.calls), "args": kwargs})
+
+
+def _drive(
+    agent: AgentLoop,
+    tool_name: str,
+    run_dir: Path,
+    arg_sets: list[dict],
+) -> tuple[list[dict], list[dict]]:
+    """Run a sequence of tool calls through the loop's tool-call path."""
+    trace = TraceWriter(run_dir)
+    messages: list[dict] = []
+    react_trace: list[dict] = []
+    for index, arguments in enumerate(arg_sets, start=1):
+        agent._process_tool_calls(
+            [SimpleNamespace(id=f"call_{index}", name=tool_name, arguments=arguments)],
+            ContextBuilder,
+            messages,
+            trace,
+            react_trace,
+            index,
+        )
+    trace.close()
+    return messages, list(TraceWriter.read(run_dir))
+
+
+@pytest.fixture()
+def agent_factory(tmp_path: Path):
+    """Return a builder for an AgentLoop wired to a run dir and one tool."""
+
+    def _build(tool: BaseTool) -> tuple[AgentLoop, Path]:
+        registry = ToolRegistry()
+        registry.register(tool)
+        agent = AgentLoop(
+            registry=registry,
+            llm=SimpleNamespace(),
+            max_iterations=4,
+            event_callback=lambda name, data: None,
+        )
+        run_dir = tmp_path / tool.name
+        run_dir.mkdir()
+        agent.memory.run_dir = str(run_dir)
+        return agent, run_dir
+
+    return _build
+
+
+def _skipped(message: dict) -> bool:
+    """True when a message is the synthetic duplicate-skip result."""
+    try:
+        return json.loads(message["content"]).get("skipped") is True
+    except (ValueError, TypeError, KeyError):
+        return False
+
+
+def test_different_arguments_are_not_duplicates(agent_factory) -> None:
+    """The red test for the bug: two statements, two executions.
+
+    On the unfixed loop the second call is answered with a synthetic skip and
+    the tool never runs.
+    """
+    tool = _PagedTool()
+    agent, run_dir = agent_factory(tool)
+
+    messages, _ = _drive(
+        agent,
+        tool.name,
+        run_dir,
+        [{"statement": "income"}, {"statement": "balance"}],
+    )
+
+    assert len(tool.calls) == 2, "second distinct call was blocked, not executed"
+    assert tool.calls[0]["statement"] == "income"
+    assert tool.calls[1]["statement"] == "balance"
+    assert not any(_skipped(m) for m in messages), "a distinct call was skipped"
+
+
+def test_paging_offsets_are_not_duplicates(agent_factory) -> None:
+    """Paging is the documented way to finish a fetch; it must not self-block."""
+    tool = _PagedTool()
+    agent, run_dir = agent_factory(tool)
+
+    messages, _ = _drive(
+        agent,
+        tool.name,
+        run_dir,
+        [{"statement": "income"}, {"statement": "income", "offset": 13}],
+    )
+
+    assert len(tool.calls) == 2, "paged continuation was blocked"
+    assert tool.calls[1]["offset"] == 13
+    assert not any(_skipped(m) for m in messages)
+
+
+def test_identical_arguments_are_still_blocked(agent_factory) -> None:
+    """The negative control: the gate must keep doing its job.
+
+    Relaxing the key must not turn into 'never dedup'.
+    """
+    tool = _PagedTool()
+    agent, run_dir = agent_factory(tool)
+
+    args = {"statement": "income"}
+    messages, _ = _drive(agent, tool.name, run_dir, [dict(args), dict(args)])
+
+    assert len(tool.calls) == 1, "identical repeat executed twice"
+    assert _skipped(messages[1]), "identical repeat was not skipped"
+
+
+def test_argument_order_does_not_defeat_the_gate(agent_factory) -> None:
+    """Canonicalisation sorts keys, so dict ordering is not a new identity."""
+    tool = _PagedTool()
+    agent, run_dir = agent_factory(tool)
+
+    messages, _ = _drive(
+        agent,
+        tool.name,
+        run_dir,
+        [
+            {"statement": "income", "period": "annual"},
+            {"period": "annual", "statement": "income"},
+        ],
+    )
+
+    assert len(tool.calls) == 1, "key order was treated as a different call"
+    assert _skipped(messages[1])

--- a/agent/tests/test_loop_helpers.py
+++ b/agent/tests/test_loop_helpers.py
@@ -70,8 +70,14 @@ class TestMicrocompact:
 
         tool_msgs = [m for m in messages if m.get("role") == "tool"]
         # Old ones should be [cleared]
-        cleared = [m for m in tool_msgs if m["content"] == "[cleared]"]
-        preserved = [m for m in tool_msgs if m["content"] != "[cleared]"]
+        cleared = [
+            m for m in tool_msgs if m["content"].startswith("[CLEARED FROM CONTEXT:")
+        ]
+        preserved = [
+            m
+            for m in tool_msgs
+            if not m["content"].startswith("[CLEARED FROM CONTEXT:")
+        ]
         assert len(cleared) == 5
         assert len(preserved) == KEEP_RECENT
 
@@ -96,7 +102,7 @@ class TestMicrocompact:
             {"role": "tool", "content": "x" * 200, "tool_call_id": "tc_0"},
         ]
         _microcompact(messages)
-        assert messages[0]["content"] != "[cleared]"
+        assert not messages[0]["content"].startswith("[CLEARED FROM CONTEXT:")
 
     def test_does_not_touch_non_tool(self) -> None:
         messages = [
@@ -141,8 +147,14 @@ class TestMicrocompactThresholdGate:
         _apply_microcompact_gate(messages)
 
         tool_msgs = [m for m in messages if m.get("role") == "tool"]
-        cleared = [m for m in tool_msgs if m["content"] == "[cleared]"]
-        preserved = [m for m in tool_msgs if m["content"] != "[cleared]"]
+        cleared = [
+            m for m in tool_msgs if m["content"].startswith("[CLEARED FROM CONTEXT:")
+        ]
+        preserved = [
+            m
+            for m in tool_msgs
+            if not m["content"].startswith("[CLEARED FROM CONTEXT:")
+        ]
         assert len(cleared) == 5
         assert len(preserved) == KEEP_RECENT
 


### PR DESCRIPTION
## Summary

Three defects in the agent loop, plus one in grounding, combine to make the agent state that data was **not retrieved** while its own `grounding_evidence.json` holds thousands of evidence items produced by exactly those calls. The model is not confabulating — it is accurately describing a context that the loop emptied.

Reproduced on `ATRC.US` against SEC EDGAR XBRL, `claude-opus-5`. Same prompt for every run below.

## The four defects

### 1. Tool dedup is keyed on the tool *name* alone — `loop.py:1693`

`self._called_ok: set[str]` stores `tc.name`, so any second call to a parameterised or paginated tool is answered with a synthetic skip:

```
get_financial_statements(statement="income")   -> ok
get_financial_statements(statement="balance")  -> BLOCKED "already completed successfully"
get_financial_statements(offset=13)            -> BLOCKED
```

`_result_paging` returns `{"returned": 13, "total": 64, "next_offset": 13, "complete": false}` — paging is the documented way to fetch the remainder, and the loop made it unreachable. Note the data tools inherit `repeatable = False` from `BaseTool`; many other tools set `repeatable = True`, so this opt-in was simply never given to them.

Now keyed on `(name, canonical arguments)`. **Identical repeats are still blocked** — verified, not assumed.

### 2. `_microcompact` fires on effectively every turn — `loop.py:327,1029`

It clears all but `KEEP_RECENT = 3` tool results once tokens exceed `token_threshold * 0.5`. With the default `token_threshold = 40000` that trigger is **20,000** — but this workload's baseline context (system prompt + tool schemas, *before any tool runs*) is **~64,800 tokens**.

The condition is therefore true from iteration 1, and every subsequent turn erases all but the last three results. Visible in `llm_usage.json` as input tokens *falling* while data accumulates:

```
iter 6 -> 7 : 77,996 -> 72,013
iter 13 -> 14: 81,437 -> 76,994
```

**This PR does not change the default**, which is defensible for small-context models. It fixes the reporting half (#3) so operators can see it, and raising `TOKEN_THRESHOLD` to match the model's real context resolves it.

### 3. A cleared result is indistinguishable from an empty one — `loop.py:338`

The placeholder was the bare string `"[cleared]"`. A model cannot tell *"this tool returned nothing"* from *"this succeeded and the context layer deleted it"* — so it reports a retrieval failure that never happened. The placeholder now states the call succeeded, how much was removed, and that re-calling recovers it.

### 4. Percentage-point deltas are validated as prices — `grounding.py:2489`

`_numbers_without_dates_or_percent` masks `%` but not `pp`/`bps`. So:

```
"~3.6pp below Penumbra"  ->  extracts 3.0   (the ".6" consumed as a decimal)
```

That reaches the OHLC comparator as an unsourced price claim; `recovery_action` then demands **`get_market_data`** — price data — to substantiate a *gross-margin* comparison, and rejects an otherwise correct fundamentals answer. Under a prompt that explicitly forbids price retrieval this is unrecoverable.

Added `_PERCENTAGE_POINT_RE`. **Genuine price claims still validate** (`closing price 48.20` → `[48.2]`).

## Verification

| build | tool calls | context evictions | false blocks | answer |
|---|---|---|---|---|
| stock v0.1.14 | 10 | many | 5 | 4,835 ch — "not retrieved" for data that *was* retrieved |
| + fix 1 | 29 | many | 10 | 4,261 ch — still "not retrieved" |
| + fixes 1–4 | — | **0** | **0** | **7,095 ch — all sections answered with per-number provenance** |

Fix 1 alone is *insufficient*: more successful calls simply means more results to erase.

Figures in the passing run reconcile exactly against values derived independently from the grounding artifact (TTM revenue `569.622M`, gross margin `76.30%`, operating income `+9.665M`), and against an independent vendor source to four decimal places.

## Blast radius

Both fixes are **strictly narrower** than the behaviour they replace:

- no previously-blocked *identical* duplicate is now allowed through;
- no previously-validated price claim is now skipped.

Unit-tested both directions, including the negative controls.

## Not addressed here

`KEEP_RECENT = 3` being a fixed count rather than proportional to the context budget is arguably the deeper issue behind #2, but changing it is a policy decision for maintainers rather than a bug fix, so it is left alone.
