### PR TITLE
fix(market-data): flag the stooq anti-bot challenge instead of sliding past it

### DIFF
--- a/agent/backtest/loaders/stooq_loader.py
+++ b/agent/backtest/loaders/stooq_loader.py
@@ -38,6 +38,17 @@ HOST_KEY = "stooq"
 _MIN_INTERVAL_ENV = "VIBE_TRADING_STOOQ_MIN_INTERVAL"
 _DEFAULT_MIN_INTERVAL_S = 0.6
 
+# Stooq currently answers non-browser clients with a JavaScript proof-of-work
+# challenge page (HTTP 200, HTML body) instead of CSV. Without detection the
+# loader parses it as "no data" and the fallback chain slides past a source
+# that never serves, with nothing in the run log to show for it.
+_challenge_warned = False
+
+
+def _looks_like_challenge_page(body: str) -> bool:
+    text = (body or "").lstrip().lower()
+    return text.startswith("<") or "challenge" in text[:2000] or "proof of work" in text[:2000]
+
 # Stooq's CSV header columns mapped to our output field names.
 _COLUMN_MAP = {
     "Open": "open",
@@ -162,6 +173,17 @@ class DataLoader:
             params=params,
         )
         response.raise_for_status()
+        if _looks_like_challenge_page(response.text):
+            global _challenge_warned
+            if not _challenge_warned:
+                logger.warning(
+                    "stooq is serving an anti-bot challenge page instead of CSV "
+                    "data; treating it as unavailable for the rest of this "
+                    "process. Reorder the chain via VIBE_TRADING_MARKET_DATA_ORDER_* "
+                    "or drop stooq from it."
+                )
+                _challenge_warned = True
+            return None
         return _parse_csv(response.text)
 
 

--- a/agent/tests/test_stooq_loader.py
+++ b/agent/tests/test_stooq_loader.py
@@ -7,6 +7,7 @@ we monkeypatch that name on the ``stooq_loader`` module.
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Dict, List
 
 import pandas as pd
@@ -174,3 +175,47 @@ class TestParseCsv:
     def test_all_rows_dropped_returns_none(self):
         body = "Date,Open,High,Low,Close,Volume\n2024-01-02,,,,,\n"
         assert stooq_loader._parse_csv(body) is None
+
+
+# ---------------------------------------------------------------------------
+# Anti-bot challenge detection (#1315)
+# ---------------------------------------------------------------------------
+
+
+class TestChallengePageDetection:
+    """The PoW challenge page must read as source-unavailable, not as no data."""
+
+    _CHALLENGE_HTML = (
+        "<html><head><title>One moment, please...</title></head>"
+        "<body>Verifying your browser... proof of work challenge</body></html>"
+    )
+
+    def test_challenge_page_yields_no_data_and_warns_once(self, monkeypatch, caplog):
+        monkeypatch.setattr(stooq_loader, "_challenge_warned", False)
+        monkeypatch.setattr(
+            stooq_loader,
+            "throttled_get",
+            lambda url, **kw: _FakeResponse(text=self._CHALLENGE_HTML),
+        )
+
+        with caplog.at_level(logging.WARNING, logger="backtest.loaders.stooq_loader"):
+            out = stooq_loader.DataLoader().fetch(
+                ["AAPL.US", "MSFT.US"], "2024-01-01", "2024-01-31",
+            )
+
+        assert out == {}
+        warnings = [r.message for r in caplog.records if "anti-bot challenge" in r.message]
+        assert len(warnings) == 1  # two symbols, one warning
+
+    def test_challenge_page_does_not_reach_csv_parser(self, monkeypatch):
+        monkeypatch.setattr(stooq_loader, "_challenge_warned", True)  # latch already set
+        monkeypatch.setattr(
+            stooq_loader,
+            "throttled_get",
+            lambda url, **kw: _FakeResponse(text=self._CHALLENGE_HTML),
+        )
+        # A CSV parse of HTML would return None anyway; the point here is the
+        # detector fires before parsing and the source counts as unavailable.
+        assert stooq_loader._looks_like_challenge_page(self._CHALLENGE_HTML)
+        assert not stooq_loader._looks_like_challenge_page(_CSV)
+        assert not stooq_loader._looks_like_challenge_page("N/D\n")


### PR DESCRIPTION
## Summary

- The stooq loader now detects the JavaScript proof-of-work challenge page it currently gets (HTTP 200, HTML body) and treats the source as unavailable, instead of parsing it as "no data" and silently falling through the chain.
- A once-per-process warning tells the operator the source never serves and how to reorder or drop it.

## Why

Closes #1315. Measured by @warren618 on 2026-08-31: us_equity chain position 2 is dead weight today, and an operator reordering via `VIBE_TRADING_MARKET_DATA_ORDER_*` had no signal. The fix is deliberately detection-plus-visibility, not satisfying the challenge: it exists to keep non-browser clients out, and playing along would be fragile by design.

## Changes

- `_looks_like_challenge_page()` gates `_fetch_one` before the CSV parser: HTML body or challenge markers in the head.
- One latched WARNING per process; the call still returns None so the fallback chain continues.
- Tests: challenge page yields no data and warns exactly once across a two-symbol batch; the detector accepts CSV and `N/D` bodies untouched.

## Test Plan

- [x] Existing tests pass (`pytest tests/ -k "loader or loaders"`: 665 passed, 11 skipped)
- [x] New tests added (`TestChallengePageDetection`, red on unpatched code: the warn-once assertion fails there)
- [x] Red-green checked by stashing the loader change

Out of scope: demoting or dropping stooq from the default chain, which is a separate call. No live/broker/MCP/network surface. Rollback: revert the single commit.

## Checklist

- [x] No changes to protected areas without prior discussion
- [x] No hardcoded values
- [x] Code follows CONTRIBUTING.md guidelines
- [x] Documentation updated (not user-facing)
