### PR TITLE
fix(backtest): scale over-committed rebalance basket instead of aborting (#1274)

### DIFF
--- a/agent/backtest/engines/base.py
+++ b/agent/backtest/engines/base.py
@@ -1686,7 +1686,10 @@ class BaseEngine(ABC):
         )
         self._validate_rebalance_values(projected_capital)
         if projected_capital < -1e-9:
-            raise ValueError("insufficient capital for position rebalance")
+            fitted = self._fit_rebalance_opens(opens, reductions, ts)
+            if fitted is None:
+                raise ValueError("insufficient capital for position rebalance")
+            opens = fitted
 
         for order in reductions:
             if order.target_size <= 1e-9:
@@ -1698,6 +1701,94 @@ class BaseEngine(ABC):
                 self._execute_position_increase(order, ts)
             else:
                 self._execute_open_order(order, ts)
+
+    def _fit_rebalance_opens(
+        self,
+        opens: list[_OpenOrder],
+        reductions: list[_ReductionOrder],
+        ts: pd.Timestamp,
+    ) -> Optional[list[_OpenOrder]]:
+        """Scale the open sleeve by one common factor so the basket fits.
+
+        #1274: a fully invested target basket plus commission overdrafts by a
+        hair and used to abort atomically. Instead, mirror the open-basket
+        path's fairness behavior: reductions commit as planned (they release
+        capital toward the targets), and every capital-consuming sleeve —
+        fresh opens and same-direction increases alike — scales by one common
+        factor, preserving portfolio proportions on sizes/notionals (post-fee
+        capital weights shift by each sleeve's fee, as with the open path).
+        Sizes re-round per market lot rules; a sleeve whose rounded size hits
+        zero is dropped and recorded via ``_on_plan_rejected`` as
+        ``zero_size`` — the same record a too-small plan gets in the open
+        path — so run-card diagnostics see the dropped leg.
+
+        Returns the fitted orders, or ``None`` when no scale fits — not even
+        an empty open sleeve — which the caller must treat as an atomic
+        abort (nothing has been committed at that point).
+        """
+        released = sum(order.capital_credit for order in reductions)
+
+        def _fits(candidate: list[_OpenOrder]) -> bool:
+            projected = self.capital + released - sum(order.cost for order in candidate)
+            self._validate_rebalance_values(projected)
+            return projected >= -1e-9
+
+        def _at_scale(scale: float) -> list[_OpenOrder]:
+            scaled: list[_OpenOrder] = []
+            for order in opens:
+                # round_size/calc_commission dispatch on the active symbol
+                # (lot grids, per-symbol fee schedules) — same contract as
+                # _plan_open_order.
+                self._active_symbol = order.symbol
+                size = self.round_size(order.size * scale, order.price)
+                if size <= 0:
+                    continue
+                candidate = _OpenOrder(
+                    symbol=order.symbol,
+                    direction=order.direction,
+                    price=order.price,
+                    size=size,
+                    leverage=order.leverage,
+                    margin=self._calc_margin(
+                        order.symbol, size, order.price, order.leverage
+                    ),
+                    commission=self.calc_commission(
+                        size, order.price, order.direction, is_open=True
+                    ),
+                )
+                self._validate_rebalance_values(
+                    candidate.price,
+                    candidate.leverage,
+                    candidate.size,
+                    candidate.margin,
+                    candidate.commission,
+                )
+                scaled.append(candidate)
+            return scaled
+
+        fitted: Optional[list[_OpenOrder]] = None
+        low, high = 0.0, 1.0
+        for _ in range(50):
+            mid = (low + high) / 2.0
+            candidate = _at_scale(mid)
+            if _fits(candidate):
+                low, fitted = mid, candidate
+            else:
+                high = mid
+        if fitted is not None and len(fitted) < len(opens):
+            dropped_symbols = sorted(
+                {order.symbol for order in opens}
+                - {order.symbol for order in fitted}
+            )
+            for symbol in dropped_symbols:
+                self._on_plan_rejected(symbol, "zero_size", ts)
+            logger.warning(
+                "Rebalance basket scaled to fit capital; sleeves rounded to "
+                "zero and dropped: %s. Set position_adjustment='hold' or "
+                "reduce targets if these fills are required.",
+                ", ".join(dropped_symbols),
+            )
+        return fitted
 
     @staticmethod
     def _validate_rebalance_values(*values: float, positive: bool = False) -> None:

--- a/agent/tests/test_base_engine.py
+++ b/agent/tests/test_base_engine.py
@@ -309,25 +309,116 @@ def test_existing_rebalance_does_not_churn_inside_slippage_band(direction):
     _assert_unchanged(engine, {"A": before})
 
 
-def test_rebalance_insufficient_capital_is_atomic():
+def test_rebalance_overcommitted_single_basket_scales_instead_of_aborting():
+    """#1274: 100% target plus commission scales the basket, not abort."""
     engine = _AdjustmentEngine(fee_rate=0.10)
-    with pytest.raises(ValueError, match="insufficient capital"):
-        _run_adjustments(engine, {"A": [1.0]})
-    _assert_unchanged(engine)
+    _run_adjustments(engine, {"A": [1.0]})
+
+    position = engine.bar_positions[0]["A"]
+    assert position.size == pytest.approx(10.0 * 1000.0 / 1100.0, rel=1e-3)
+    assert engine.bar_capitals[0] >= 0.0
 
 
-def test_existing_multi_symbol_rebalance_failure_is_atomic():
+def test_rebalance_basket_with_commission_scales_to_fit():
+    """#1274: a 100% target basket plus fees fills proportionally scaled."""
+    engine = _AdjustmentEngine(fee_rate=0.001)
+    _run_adjustments(engine, {"A": [0.60], "B": [0.40]})
+
+    sizes = _sizes(engine.bar_positions[0])
+    # One common scale factor: each sleeve keeps its share of the portfolio.
+    assert sizes["A"] == pytest.approx(6.0 * 1000.0 / 1001.0, rel=1e-3)
+    assert sizes["A"] / sizes["B"] == pytest.approx(0.60 / 0.40, rel=1e-4)
+    assert 0.0 <= engine.bar_capitals[0] < 0.01
+
+
+def test_rebalance_scaled_basket_is_independent_of_input_code_order():
+    """#1274: scaling preserves the fairness contract of the open path."""
+
+    class _FeeAdjustmentEngine(_AdjustmentEngine):
+        def __init__(self):
+            super().__init__(fee_rate=0.001)
+
+    first, second = _run_both_code_orders(_FeeAdjustmentEngine, {"A": [0.60], "B": [0.40]})
+    assert first.bar_positions == second.bar_positions
+    assert first.bar_capitals == second.bar_capitals
+
+
+def test_rebalance_scaled_sizes_keep_weights_with_differing_fees():
+    """#1274: one common size factor — per-symbol fees must not re-weight.
+
+    A cost-weighted per-order scale would keep the 60/40 *spend* split while
+    distorting sizes. Sizes must stay near the 1.5 ratio, and each symbol
+    must be rounded and commissioned under its own rules while scaling —
+    a stale active symbol would charge B's 2% fee on A's fill.
+    """
+
+    class _SymbolFeeAdjustmentEngine(_AdjustmentEngine):
+        def round_size(self, raw_size, price):
+            lot = {"A": 0.05, "B": 0.05}[self._active_symbol]
+            return round(max(raw_size, 0.0) / lot) * lot
+
+        def calc_commission(self, size, price, direction, is_open):
+            rate = {"A": 0.01, "B": 0.02}[self._active_symbol]
+            return size * price * rate
+
+    engine = _SymbolFeeAdjustmentEngine(fee_rate=0.0)
+    _run_adjustments(
+        engine,
+        {"A": [0.60], "B": [0.40]},
+        execution_prices={"A": [100.0], "B": [80.0]},
+    )
+
+    positions = engine.bar_positions[0]
+    sizes = _sizes(positions)
+    # Proportions live in NOTIONAL space (A@100 vs B@80 → share ratio 1.2);
+    # fine lots (0.5% of each fill) keep the assertion meaningful.
+    assert sizes["A"] / sizes["B"] == pytest.approx(1.2, rel=2e-2)
+    notionals = (sizes["A"] * 100.0, sizes["B"] * 80.0)
+    assert notionals[0] / sum(notionals) == pytest.approx(0.60, rel=2e-2)
+    # Each fill commissioned under its OWN symbol's schedule.
+    assert positions["A"].entry_commission == pytest.approx(
+        sizes["A"] * 100.0 * 0.01
+    )
+    assert positions["B"].entry_commission == pytest.approx(
+        sizes["B"] * 80.0 * 0.02
+    )
+    assert engine.bar_capitals[0] >= 0.0
+
+
+def test_rebalance_reduction_commits_and_increase_scales_to_fit():
+    """#1274: reductions commit as planned; the open sleeve scales to fit."""
     engine = _AdjustmentEngine(fee_rate=0.01)
+    _run_adjustments(engine, {"A": [0.25, 0.10], "B": [0.25, 0.90]})
 
+    first, second = engine.bar_positions
+    assert _sizes(first) == {"A": 2.5, "B": 2.5}
+    assert engine.bar_capitals[0] == 495.0
+    assert _sizes(second)["A"] == pytest.approx(0.995)  # 10% of bar-2 equity 995
+    # B's increase is scaled by the one common factor to fit capital.
+    assert 2.5 < _sizes(second)["B"] < 9.0
+    assert engine.bar_capitals[1] >= 0.0
+
+
+def test_rebalance_irrecoverably_infeasible_basket_fails_atomically():
+    """#1274: when no scale fits — not even an empty open sleeve — abort."""
+    engine = _AdjustmentEngine()
     with pytest.raises(ValueError, match="insufficient capital"):
-        _run_adjustments(engine, {"A": [0.25, 0.10], "B": [0.25, 0.90]})
-
-    assert engine.capital == engine.bar_capitals[0] == 495.0
-    assert engine.positions == engine.bar_positions[0]
+        _run_adjustments(
+            engine,
+            {"A": [-0.50, 0.0]},
+            execution_prices={"A": [100.0, 1000.0]},
+        )
+    # Bar 1's short is intact; the unrecoverable close released negative
+    # capital no scaling of opens (there are none) could repair. The abort
+    # committed nothing: exactly bar 1's fill exists, no bar-2 artifacts.
+    assert engine.capital == 500.0
+    position = engine.positions["A"]
+    assert (position.direction, position.size) == (-1, 5.0)
+    # Opens don't append trade records or adjustment events; the abort
+    # committed no close.
     assert engine.trades == []
     assert engine.adjustment_events == []
     assert len(engine.bar_positions) == 1
-
 
 @pytest.mark.parametrize(
     ("target_weight", "expected_position", "bar_capital", "trade_fees"),
@@ -819,3 +910,19 @@ def test_halted_position_marks_at_last_close_past_ffill_limit():
     # The terminal forced liquidation also marks at the last traded close, so
     # the halt's unrealized PnL survives into the final equity.
     assert engine.equity_snapshots[-1].equity == pytest.approx(marked_at_last_close, rel=1e-6)
+
+
+def test_rebalance_scaled_away_sleeve_is_recorded_as_plan_rejection():
+    """#1274: a sleeve rounded to zero by scaling leaves an audit record.
+
+    A fills 9 of its 10 target shares; B's one-lot fill scales below one lot
+    and vanishes — run-card diagnostics must see it as a zero_size rejection,
+    not silence.
+    """
+    engine = _SymbolRulesAdjustmentEngine()
+    _run_adjustments(engine, {"A": [1.0], "B": [0.003]})
+
+    sizes = _sizes(engine.bar_positions[0])
+    assert sizes == {"A": 9.0}  # scaled to fit; B's leg dropped entirely
+    assert engine.plan_rejections[("B", "zero_size")] == 1
+    assert engine.bar_capitals[0] >= 0.0


### PR DESCRIPTION
## What

Fixes #1274. A rebalance-mode portfolio whose targets sum to 100% raised `ValueError: insufficient capital for position rebalance` whenever commission was nonzero — the engine planned the full basket, projected it one commission-width past capital, and aborted atomically, even though the legacy open-basket path already has a scale-to-fit mechanism.

`_execute_target_rebalance` now mirrors that behavior:

- When the planned basket overdrafts, **reductions commit as planned** (they release capital toward the targets) and every **capital-consuming sleeve** — fresh opens *and* same-direction increases — scales by **one common factor** (binary search, 50 iterations, same shape as the open path), preserving portfolio proportions and code-order independence.
- Scaled sizes **re-round per symbol lot rules and re-price under the symbol's own fee schedule** (`_active_symbol` is set per order inside the fit loop — without this, engines that dispatch on it (`china_futures`, `composite`, `global_futures`, `forex`) silently apply the wrong lot grid/fee).
- A sleeve whose rounded size hits zero is **dropped and recorded** via `_on_plan_rejected(symbol, "zero_size", ts)` plus a warning log, so run-card diagnostics (`plan_rejections`, `unfilled_plan_rejections_by_symbol`) see the dropped leg instead of silence.
- When **no scale fits** — not even an empty open sleeve (e.g. a reduction whose realized loss exceeds released margin) — the basket still **fails atomically** before any commit.

## Tests

Replaces the two abort-pinning tests with the contract the issue asks for, plus adversarial-review hardening (three independent reviewers; all findings addressed):

- over-committed single basket scales (fee 10%, 100% target → size ≈ 10·1000/1100)
- 60/40 basket + commission: ratio preserved, capital fits, leftover < 0.01
- code-order independence of the scaled basket
- differing per-symbol fees/lot grids: notional weights stay 60/40 and each fill is commissioned under its own schedule (catches the stale-`_active_symbol` blocker)
- reduction commits while the increase sleeve scales to fit
- irrecoverably infeasible basket (short closed deep underwater): still raises, zero side effects (trades/events/bar snapshots pinned)
- scaled-away sleeve recorded as `zero_size` plan rejection

Full engine suite: **374 passed, 1 skipped** (`test_base_engine`, `china_a`, `china_futures`, `crypto`, `engine_metrics_json`, `engine_robustness`, `composite_fallback`, `runner_security`, `cli_backtest_summary`, `autopilot_validation`).

## Known limitations

- Bisection assumes cost is monotone in scale; holds for all shipped engines. A hypothetical size-discounted commission could make the search return a feasible-but-suboptimal scale — never an overdraft, since every candidate is verified against its actual rounded cost.
- If a subclass returns NaN margin/commission during fitting, the error message is the generic "non-finite position rebalance value" rather than "insufficient capital" — still pre-commit atomic.
