### PR TITLE
fix(swarm): give investment-committee researchers the fundamental data panel (#1343)

### DIFF
--- a/agent/src/swarm/presets/investment_committee.yaml
+++ b/agent/src/swarm/presets/investment_committee.yaml
@@ -44,7 +44,9 @@ agents:
       7. **Main risk to the bull case** — Honestly list 2–3 scenarios that would invalidate the bull thesis
 
       Use factor_analysis for quant support; use load_skill for frameworks.
-    tools: [bash, read_file, write_file, load_skill, get_market_data, factor_analysis]
+    tools: [bash, read_file, write_file, load_skill, get_market_data, factor_analysis,
+            get_financial_statements, get_fund_flow, get_margin_trading, get_research_reports,
+            get_stock_news]
     skills: [technical-basic, fundamental-filter, yfinance, earnings-revision, sentiment-analysis]
     max_iterations: 50
     timeout_seconds: 1800
@@ -113,7 +115,9 @@ agents:
       7. **What would disprove the bear case** — Signals that would invalidate the bear thesis (i.e., bull-side rebuttal points)
 
       Use factor_analysis for risk-factor views; use load_skill for risk frameworks.
-    tools: [bash, read_file, write_file, load_skill, get_market_data, factor_analysis, get_options_chain]
+    tools: [bash, read_file, write_file, load_skill, get_market_data, factor_analysis, get_options_chain,
+            get_financial_statements, get_fund_flow, get_margin_trading, get_research_reports,
+            get_stock_news]
     skills: [technical-basic, fundamental-filter, yfinance, risk-analysis, volatility]
     max_iterations: 50
     timeout_seconds: 1800
@@ -183,7 +187,9 @@ agents:
       7. **Risk conditions** — If approval is conditional, state prerequisites (e.g., wait for earnings)
 
       Stay independent; do not cheerlead either side; optimize portfolio-level risk.
-    tools: [bash, read_file, write_file, load_skill, get_market_data, get_options_chain, options_pricing, options_payoff]
+    tools: [bash, read_file, write_file, load_skill, get_market_data, get_options_chain, options_pricing, options_payoff,
+            get_financial_statements, get_fund_flow, get_margin_trading, get_research_reports,
+            get_stock_news]
     skills: [risk-analysis, volatility, correlation-analysis]
     max_iterations: 50
     timeout_seconds: 1800

--- a/agent/tests/test_swarm_presets_packaging.py
+++ b/agent/tests/test_swarm_presets_packaging.py
@@ -208,3 +208,48 @@ def test_explicit_user_preset_accepted_by_swarm_tool(user_presets_dir) -> None:
     assert _normalize_preset_name("no_such_preset_anywhere") is None
     # A user preset must never be reachable via keyword auto-routing.
     assert _match_preset("please analyze my custom desk topic") != "my_custom_desk"
+
+
+_INVESTMENT_COMMITTEE_FUNDAMENTAL_TOOLS = (
+    "get_financial_statements",
+    "get_fund_flow",
+    "get_margin_trading",
+    "get_research_reports",
+    "get_stock_news",
+)
+
+
+def test_investment_committee_research_workers_have_fundamental_tools() -> None:
+    """#1343: bull/bear/risk workers mandate fundamental analysis but their
+    whitelist lacked every fundamental data tool, so each run reported "no
+    fundamental data tool executable" and degraded to price-only claims."""
+    preset = load_preset("investment_committee")
+    researchers = {
+        agent["id"]: set(agent.get("tools") or [])
+        for agent in preset["agents"]
+        if agent["id"] in ("bull_advocate", "bear_advocate", "risk_officer")
+    }
+    assert researchers, "expected the three research workers"
+    for agent_id, tools in researchers.items():
+        missing = [
+            tool for tool in _INVESTMENT_COMMITTEE_FUNDAMENTAL_TOOLS if tool not in tools
+        ]
+        assert not missing, f"{agent_id} lacks fundamental data tools: {missing}"
+
+
+def test_every_preset_tool_exists_in_local_registry() -> None:
+    """A whitelist name the registry does not provide is silently dropped
+    (_filter_registry logs and skips), leaving the worker without a tool its
+    prompt may depend on. Every bundled preset tool must resolve."""
+    from src.tools import build_registry
+
+    registry = build_registry(include_shell_tools=True)
+    for entry in list_presets():
+        preset = load_preset(entry["name"])
+        for agent in preset["agents"]:
+            for tool_name in agent.get("tools") or []:
+                assert registry.get(tool_name), (
+                    f"{entry['name']}/{agent.id} requests tool {tool_name!r} "
+                    "that the local registry does not provide; the worker "
+                    "whitelist would silently drop it (#1343)."
+                )

--- a/agent/tests/test_swarm_presets_packaging.py
+++ b/agent/tests/test_swarm_presets_packaging.py
@@ -249,7 +249,7 @@ def test_every_preset_tool_exists_in_local_registry() -> None:
         for agent in preset["agents"]:
             for tool_name in agent.get("tools") or []:
                 assert registry.get(tool_name), (
-                    f"{entry['name']}/{agent.id} requests tool {tool_name!r} "
+                    f"{entry['name']}/{agent['id']} requests tool {tool_name!r} "
                     "that the local registry does not provide; the worker "
                     "whitelist would silently drop it (#1343)."
                 )


### PR DESCRIPTION
## What

Partial fix for #1343 — the worker-side half. (The main dedup × microcompact interaction deserves its own focused change; this PR deliberately does not touch it.)

The `investment_committee` preset's `bull_advocate`, `bear_advocate` and `risk_officer` system prompts **mandate** fundamental analysis — PE/PB percentiles, earnings quality (ROE/ROIC, FCF), fund flows, margin balance, analyst reports, news — but their `tools:` whitelists contained **none** of the fundamental data tools. Since swarm workers get a strict whitelist (`build_swarm_registry` → `_filter_registry`), every run degraded exactly as the issue observed: workers reported "本 run 无基本面数据工具可执行" and fell back to price-only, qualitative claims.

This adds `get_financial_statements`, `get_fund_flow`, `get_margin_trading`, `get_research_reports` and `get_stock_news` to the three researchers' whitelists. The risk officer gets them too deliberately: its framework requires checking the advocates for "cherry-picking favorable data", which is impossible without access to the same sources.

## Tests

- `test_investment_committee_research_workers_have_fundamental_tools` — pins the five-tool panel on all three researchers (red before, green after).
- `test_every_preset_tool_exists_in_local_registry` — generic guard: every tool named in every bundled preset must resolve in the local registry. A whitelist name the registry lacks is **silently dropped** by `_filter_registry` (log-only) — the same failure mode one level down, now caught at test time instead of in a user run.

Suite: preset packaging/inspect/matching/route/registry-assembly/grounding/output-contract/worker-report/trust-model/e2e — **120 passed**.

## Scope note

#1343's primary defect (context-clear + name-based dedup making successful results unreadable) is a separate loop-level change and is intentionally left to a focused follow-up.
