### PR TITLE
fix(grounding): don't read percentage-point deltas as quoted prices

### DIFF
--- a/agent/src/agent/grounding.py
+++ b/agent/src/agent/grounding.py
@@ -256,6 +256,17 @@ _RANGE_TAIL = r"(?:\s*[-–—~～至到]\s*[-+]?\d[\d,]*(?:\.\d+)?)?"
 _PERCENT_RANGE_RE = re.compile(
     r"\d[\d,]*(?:\.\d+)?\s*[-–—~至]\s*\d[\d,]*(?:\.\d+)?\s*[%％]"
 )
+# A percentage-POINT delta is not a quoted price. "~3.6pp below Penumbra"
+# describes a margin gap; left unmasked the ".6" is consumed as a decimal
+# and the number reaches the OHLC comparator, which then rejects an
+# otherwise correct fundamentals answer and demands `get_market_data` to
+# substantiate a claim that has nothing to do with price.
+# The trailing "%" spellings are already handled above; this covers the
+# percentage-point spellings, which the percent masks never matched.
+_PERCENTAGE_POINT_RE = re.compile(
+    r"[-+~≈]?\s*\d[\d,]*(?:\.\d+)?\s*(?:pp|ppt|ppts|bps|bp|百分点)\b",
+    re.IGNORECASE,
+)
 # Localized calendar text carries digits that the ISO pattern above leaves
 # behind: "8 月 3 日" otherwise contributes 8 and 3 as candidate prices.
 _LOCALIZED_DATE_RE = re.compile(
@@ -2548,6 +2559,7 @@ class GroundingLedger:
         masked = _SHORT_DATE_RE.sub(" ", masked)
         masked = _DASH_DATE_RE.sub(" ", masked)
         masked = _PERCENT_RANGE_RE.sub(" ", masked)
+        masked = _PERCENTAGE_POINT_RE.sub(" ", masked)
         masked = _ORDER_LEVEL_RE.sub(" ", masked)
         masked = _AGGREGATE_AMOUNT_RE.sub(" ", masked)
         masked = _LABELLED_SCORE_RE.sub(" ", masked)

--- a/agent/src/agent/grounding.py
+++ b/agent/src/agent/grounding.py
@@ -263,8 +263,14 @@ _PERCENT_RANGE_RE = re.compile(
 # substantiate a claim that has nothing to do with price.
 # The trailing "%" spellings are already handled above; this covers the
 # percentage-point spellings, which the percent masks never matched.
+# The Chinese units take an optional measure word ("3.6 个百分点" is the
+# ordinary spelling; bare "3.6 百分点" is the rare one) and are matched
+# without a trailing \b: after a CJK character \b requires a non-word
+# character to follow, so "下降 3.6 个百分点，主因…" would not match. The
+# ASCII units keep \b, which is what stops "3.6ppm" being read as pp.
 _PERCENTAGE_POINT_RE = re.compile(
-    r"[-+~≈]?\s*\d[\d,]*(?:\.\d+)?\s*(?:pp|ppt|ppts|bps|bp|百分点)\b",
+    r"[-+~≈]?\s*\d[\d,]*(?:\.\d+)?\s*"
+    r"(?:(?:pp|ppt|ppts|bps|bp)\b|个?(?:百分点|基点))",
     re.IGNORECASE,
 )
 # Localized calendar text carries digits that the ISO pattern above leaves

--- a/agent/tests/test_grounding_percentage_points.py
+++ b/agent/tests/test_grounding_percentage_points.py
@@ -65,3 +65,51 @@ def test_mixed_sentence_keeps_price_drops_percentage_point():
 def test_bare_number_still_extracted():
     """Guard against the mask being over-broad: a plain number is untouched."""
     assert 48.20 in _extract("48.20")
+
+
+# The English spellings above were the ones the report named, but this gate
+# sees whatever language the model answered in, and the UI ships seven locales.
+# The first version of the mask required the number to sit directly against
+# "百分点", which is the rare Chinese spelling — the ordinary one puts the
+# measure word 个 in between, and "基点" was not covered at all. Both were
+# still being read as prices, so a Chinese fundamentals answer kept getting
+# rejected while the identical English answer passed.
+@pytest.mark.parametrize(
+    "text",
+    [
+        "毛利率下降 3.6 个百分点",
+        "毛利率下降3.6个百分点",
+        "净利率提升 2 个百分点。",
+        "同比下降 3.6 百分点",
+        "利差扩大 250 个基点",
+        "利差扩大250基点",
+        # A trailing CJK character rather than punctuation: \b after a CJK
+        # unit needs a non-word char to follow, so this is the case that
+        # breaks if the boundary is reintroduced there.
+        "毛利率下降 3.6 个百分点，主因是原材料",
+    ],
+)
+def test_chinese_percentage_point_deltas_are_masked(text: str) -> None:
+    assert _extract(text) == [], f"{text!r} leaked a price-like number"
+
+
+# The other arm. Narrowing the false positives must not blind the gate to a
+# real unsourced price, in either language.
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("TSLA.US last traded at 412.35 USD", [412.35]),
+        ("closed at 412.35", [412.35]),
+        ("现价 412.35 元", [412.35]),
+        ("收盘价 412.35", [412.35]),
+        # "ppm" is not "pp": the ASCII units keep their word boundary, so the
+        # mask does not apply and a number still reaches the comparator. The
+        # value is 3.0 rather than 3.6 because the extractor drops a decimal
+        # tail followed immediately by letters — the same quirk the pp report
+        # describes, pre-existing and untouched here. Pinned as-is so a future
+        # change to either behaviour is visible.
+        ("3.6ppm impurity", [3.0]),
+    ],
+)
+def test_real_prices_still_extracted(text: str, expected: list) -> None:
+    assert _extract(text) == expected

--- a/agent/tests/test_grounding_percentage_points.py
+++ b/agent/tests/test_grounding_percentage_points.py
@@ -1,0 +1,67 @@
+"""Percentage-point deltas must not be read as quoted prices.
+
+Regression test for the false positive described in HKUDS/Vibe-Trading#1341:
+`_numbers_without_dates_or_percent` masked "%" but not the percentage-point
+spellings, so "~3.6pp below Penumbra" yielded 3.0 (the ".6" consumed as a
+decimal). That number reached the OHLC comparator as an unsourced price claim,
+which rejected a correct fundamentals answer and demanded `get_market_data` to
+substantiate a statement that had nothing to do with price.
+
+Both directions are pinned here: percentage-point deltas are masked, and a
+genuine price is still extracted.
+"""
+
+import pytest
+
+from src.agent.grounding import GroundingLedger
+
+_extract = GroundingLedger._numbers_without_dates_or_percent
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "gross margin ~3.6pp below Penumbra",
+        "gross margin 3.6 pp below Penumbra",
+        "operating margin improved 2.4ppt year over year",
+        "operating margin improved 12.5 ppts sequentially",
+        "spread widened 45bps after the print",
+        "spread widened 45 bps after the print",
+        "yield moved 7bp on the day",
+        "\u6bdb\u5229\u7387\u4e0b\u964d 3.6 \u767e\u5206\u70b9",
+        "margin fell -1.8pp sequentially",
+        "margin rose +0.9pp sequentially",
+        "roughly \u22483.6pp of dilution",
+    ],
+)
+def test_percentage_point_deltas_are_not_prices(text):
+    """No percentage-point delta should survive as a candidate price."""
+    assert _extract(text) == [], f"leaked a price candidate from: {text!r}"
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("closing price 48.20", 48.20),
+        ("the stock closed at 48.20 on heavy volume", 48.20),
+        ("last trade 152.75", 152.75),
+        ("opened at 1,204.50 and faded", 1204.50),
+    ],
+)
+def test_genuine_prices_are_still_extracted(text, expected):
+    """The mask must not swallow real quoted prices -- that would blind the
+    grounding check it exists to feed."""
+    assert expected in _extract(text), f"lost a real price from: {text!r}"
+
+
+def test_mixed_sentence_keeps_price_drops_percentage_point():
+    """A sentence carrying both must yield only the price."""
+    values = _extract("closed at 48.20, with gross margin ~3.6pp below peers")
+    assert 48.20 in values
+    assert 3.0 not in values
+    assert 3.6 not in values
+
+
+def test_bare_number_still_extracted():
+    """Guard against the mask being over-broad: a plain number is untouched."""
+    assert 48.20 in _extract("48.20")


### PR DESCRIPTION
Split out of #1341 at review request — this is the 11-line half that is independent of the loop work.

## The bug

`GroundingLedger._numbers_without_dates_or_percent` masks `%` but not the percentage-point spellings. So:

```
"gross margin ~3.6pp below Penumbra"  ->  [3.0]
```

The `.6` is consumed as a decimal and the leading `3` survives as a candidate price. That number reaches the OHLC comparator as an unsourced price claim.

On an ATRC.US fundamentals run this rejected an otherwise correct answer and demanded `get_market_data` to substantiate a gross-margin comparison that has nothing to do with price. The margin gap was real, sourced, and correctly computed — it was thrown out because a *comparison of two percentages* was mistaken for a quoted share price.

## The fix

One regex, applied alongside the existing percent masks in the same masking chain:

```python
_PERCENTAGE_POINT_RE = re.compile(
    r"[-+~≈]?\s*\d[\d,]*(?:\.\d+)?\s*(?:pp|ppt|ppts|bps|bp|百分点)\b",
    re.IGNORECASE,
)
```

Covers `pp` / `ppt` / `ppts` / `bps` / `bp` / `百分点`, with or without a space, and with an optional leading sign or approximation marker.

## Tests, both directions

Per the review note on #1341 — the mask must not become a way to lose real prices:

- 11 percentage-point spellings are masked, including `-1.8pp`, `+0.9pp`, `≈3.6pp`, `45 bps`, and `3.6 百分点`
- 4 genuine prices are still extracted: `closing price 48.20`, `the stock closed at 48.20 on heavy volume`, `last trade 152.75`, `opened at 1,204.50 and faded`
- a mixed sentence (`closed at 48.20, with gross margin ~3.6pp below peers`) yields **only** the price
- a bare `48.20` is untouched, guarding against an over-broad mask

## Verification

| | result |
|---|---|
| RED, on `d71ed8dd` without the fix | 10 failed, 7 passed |
| GREEN, with the fix | 17 passed |
| surrounding grounding suite, baseline | 168 passed, 2 failed |
| surrounding grounding suite, with fix | 168 passed, 2 failed |

The 2 failures are pre-existing and identical before and after (a missing optional dependency in the test environment), so this adds no regression.

One test fixture is worth flagging: my first draft used `"operating margin improved 12.5 ppts since 2021"` and it failed *with* the fix — because the bare year `2021` leaks through as a price candidate. That is a separate pre-existing behaviour, not something this PR claims to address, so I changed the fixture rather than widening the mask to hide it. Happy to open a follow-up if bare-year handling is of interest.
