### PR TITLE
fix(codex): preserve response model metadata

### DIFF
--- a/agent/src/providers/openai_codex.py
+++ b/agent/src/providers/openai_codex.py
@@ -234,6 +234,8 @@ class CodexAIMessage:
             "finish_reason",
             self.response_metadata.get("finish_reason", "stop"),
         )
+        response_metadata = {**self.response_metadata, **other.response_metadata}
+        response_metadata["finish_reason"] = finish_reason
         reasoning = self.additional_kwargs.get("reasoning_content", "") + other.additional_kwargs.get(
             "reasoning_content", ""
         )
@@ -241,7 +243,7 @@ class CodexAIMessage:
             content=(self.content or "") + (other.content or ""),
             tool_calls=[*self.tool_calls, *other.tool_calls],
             additional_kwargs={"reasoning_content": reasoning} if reasoning else {},
-            response_metadata={"finish_reason": finish_reason},
+            response_metadata=response_metadata,
             usage_metadata=other.usage_metadata or self.usage_metadata,
         )
 
@@ -599,6 +601,10 @@ def _message_chunks_from_events(events: Iterable[dict[str, Any]]) -> Iterable[Co
         elif event_type == "response.completed":
             response = event.get("response") or {}
             status = response.get("status")
+            response_metadata = {"finish_reason": _map_finish_reason(status)}
+            model = response.get("model")
+            if isinstance(model, str) and model.strip():
+                response_metadata["model_name"] = model.strip()
             usage = response.get("usage")
             usage_metadata = None
             if isinstance(usage, dict):
@@ -609,7 +615,7 @@ def _message_chunks_from_events(events: Iterable[dict[str, Any]]) -> Iterable[Co
                 if all(isinstance(value, int) and not isinstance(value, bool) for value in values.values()):
                     usage_metadata = values
             yield CodexAIMessage(
-                response_metadata={"finish_reason": _map_finish_reason(status)},
+                response_metadata=response_metadata,
                 usage_metadata=usage_metadata,
             )
         elif event_type in {"error", "response.failed"}:

--- a/agent/tests/test_openai_codex_usage.py
+++ b/agent/tests/test_openai_codex_usage.py
@@ -29,6 +29,24 @@ def test_completed_event_exposes_codex_token_usage() -> None:
     }
 
 
+def test_completed_event_exposes_codex_response_model() -> None:
+    [chunk] = list(
+        _message_chunks_from_events(
+            [
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "status": "completed",
+                        "model": "gpt-5.4",
+                    },
+                }
+            ]
+        )
+    )
+
+    assert chunk.response_metadata["model_name"] == "gpt-5.4"
+
+
 def test_codex_message_accumulation_preserves_final_usage() -> None:
     message = CodexAIMessage(content="hello") + CodexAIMessage(
         usage_metadata={
@@ -44,6 +62,18 @@ def test_codex_message_accumulation_preserves_final_usage() -> None:
         "output_tokens": 7,
         "total_tokens": 19,
     }
+
+
+def test_codex_message_accumulation_preserves_response_model() -> None:
+    message = CodexAIMessage(content="hello") + CodexAIMessage(
+        response_metadata={
+            "finish_reason": "stop",
+            "model_name": "gpt-5.4",
+        }
+    )
+
+    assert message.content == "hello"
+    assert message.response_metadata["model_name"] == "gpt-5.4"
 
 
 def test_completed_event_without_usage_stays_unreported() -> None:


### PR DESCRIPTION
## Summary

- Propagate the provider-reported model from Codex `response.completed` events.
- Preserve response metadata while accumulating streamed `CodexAIMessage` chunks.
- Add regression coverage for model metadata propagation and accumulation.

## Why

The Codex adapter currently drops the model reported by the provider. As a result, `ChatLLM` cannot expose the authoritative response model even though it already supports `response_metadata["model_name"]`.

## Changes

- Capture the Codex response `model` as `response_metadata["model_name"]`.
- Preserve response metadata across `CodexAIMessage` accumulation.
- Add focused tests covering both behaviours.

## Test Plan

- [ ] `pytest agent/tests/test_openai_codex_usage.py -q`
- [x] New regression tests added
- [ ] Existing tests pass

## Checklist

- [x] Changes are limited to the Codex provider and its focused tests.
- [x] No hardcoded credentials or paths.
- [x] No unrelated changes.
- [ ] Full test suite passes.