### PR TITLE
fix(agent): unblock tools whose results microcompact cleared

### DIFF
--- a/agent/src/agent/loop.py
+++ b/agent/src/agent/loop.py
@@ -1170,13 +1170,7 @@ class AgentLoop:
                 # tool history available for the model to reference instead of
                 # having every result past the most recent few cleared.
                 if tokens > int(_token_threshold() * 0.5):
-                    unreadable_tools = _microcompact(messages)
-                    if unreadable_tools:
-                        # The dedup ledger may only point the model at results
-                        # that are still in context; a cleared result is not,
-                        # so those tools become callable again.
-                        self._called_ok.difference_update(unreadable_tools)
-                        trace.write({"type": "microcompact_cleared", "iter": iteration, "tools": unreadable_tools})
+                    self._microcompact_and_unblock(messages, trace, iteration)
                     tokens = estimate_tokens(messages)
 
                 # Layer 2: context collapse (fold long text, zero API cost)
@@ -2506,6 +2500,36 @@ class AgentLoop:
             "was to create or update a file, a plain-text answer without the "
             "file write is a failure."
         )
+
+    def _microcompact_and_unblock(self, messages: list, trace: TraceWriter, iteration: int) -> list[str]:
+        """Run layer-1 microcompact and re-open the tools it made unreadable.
+
+        The dedup ledger may only point the model at a result that is still in
+        context. Once microcompact clears every result a tool produced, the
+        "already completed successfully, use the previous result" skip is
+        pointing at ``[cleared]``, which is how #1343 deadlocked: the model
+        needed the numbers, could not see them, re-called, and was blocked 44
+        times.
+
+        Args:
+            messages: Message list, mutated in place by the compaction.
+            trace: Run trace; a ``microcompact_cleared`` event is written
+                whenever the ledger is re-opened, because this layer used to
+                act silently and left no evidence for diagnosis.
+            iteration: Current ReAct iteration, recorded on the trace event.
+
+        Returns:
+            The tool names re-opened, for callers and tests to assert on.
+        """
+        unreadable_tools = _microcompact(messages)
+        if unreadable_tools:
+            self._called_ok.difference_update(unreadable_tools)
+            trace.write({
+                "type": "microcompact_cleared",
+                "iter": iteration,
+                "tools": unreadable_tools,
+            })
+        return unreadable_tools
 
     def _identical_call_key(self, tool_name: str, arguments: Mapping[str, Any]) -> tuple[str, str] | None:
         """Build a stable key identifying a deterministic tool invocation.

--- a/agent/src/agent/loop.py
+++ b/agent/src/agent/loop.py
@@ -434,19 +434,30 @@ def _verification_ledger(messages: list) -> str:
             break
     return "\n".join(unique)
 
-def _microcompact(messages: list) -> None:
+def _microcompact(messages: list) -> list:
     """Layer 1: silently prune old tool results, keeping the most recent N intact.
 
     Args:
         messages: Message list (mutated in place).
+
+    Returns:
+        Names of tools whose every result just became unreadable. The caller
+        drops these from the dedup ledger: blocking a re-call with "use the
+        previous result" only makes sense while that result is still in
+        context, and a cleared result is not.
     """
     tool_msgs = [m for m in messages if m.get("role") == "tool"]
     if len(tool_msgs) <= KEEP_RECENT:
-        return
+        return []
+    newly_cleared = []
     for msg in tool_msgs[:-KEEP_RECENT]:
         content = msg.get("content", "")
         if isinstance(content, str) and len(content) > 100:
             msg["content"] = "[cleared]"
+            if msg.get("name"):
+                newly_cleared.append(msg["name"])
+    surviving = {m.get("name") for m in tool_msgs if m.get("content") != "[cleared]"}
+    return sorted(set(newly_cleared) - surviving)
 
 
 def _context_collapse(messages: list) -> None:
@@ -1159,7 +1170,13 @@ class AgentLoop:
                 # tool history available for the model to reference instead of
                 # having every result past the most recent few cleared.
                 if tokens > int(_token_threshold() * 0.5):
-                    _microcompact(messages)
+                    unreadable_tools = _microcompact(messages)
+                    if unreadable_tools:
+                        # The dedup ledger may only point the model at results
+                        # that are still in context; a cleared result is not,
+                        # so those tools become callable again.
+                        self._called_ok.difference_update(unreadable_tools)
+                        trace.write({"type": "microcompact_cleared", "iter": iteration, "tools": unreadable_tools})
                     tokens = estimate_tokens(messages)
 
                 # Layer 2: context collapse (fold long text, zero API cost)

--- a/agent/tests/test_agent_loop_repeatable_tools.py
+++ b/agent/tests/test_agent_loop_repeatable_tools.py
@@ -12,6 +12,7 @@ from src.agent.context import ContextBuilder
 from src.agent.loop import AgentLoop
 from src.agent.tools import ToolRegistry
 from src.agent.trace import TraceWriter
+from src.tools.fund_flow_tool import FundFlowTool
 from src.tools.get_fundamentals_tool import GetFundamentalsTool
 from src.tools.market_data_tool import MarketDataTool
 from src.tools.market_screener_tool import MarketScreenerTool
@@ -114,4 +115,82 @@ def test_repeatable_query_executes_again_with_different_arguments(
     assert len(messages) == 2
     assert not any(
         event["type"] == "tool_skipped" for event in TraceWriter.read(run_dir)
+    )
+
+
+def test_cleared_result_reopens_the_dedup_gate(monkeypatch, tmp_path: Path) -> None:
+    """#1343: a non-repeatable tool blocked by the dedup ledger must become
+    callable again once microcompact has cleared its only result.
+
+    This drives the real gate in ``_process_tool_calls`` rather than only the
+    return value of ``_microcompact``: the first call fills ``_called_ok``, the
+    second is correctly skipped while the result is still readable, and the
+    third must actually execute once the result has been cleared. Without the
+    ledger update at the call site the third call is skipped too, which is the
+    44-blocked-retries deadlock this fixes.
+    """
+    from src.agent.loop import KEEP_RECENT
+
+    calls: list[dict[str, object]] = []
+    # One of the five tools #1343 actually saw blocked; GetFundamentalsTool
+    # above is repeatable and therefore has no gate to exercise.
+    tool = FundFlowTool()
+    assert not tool.repeatable, "test needs a non-repeatable tool to have a gate at all"
+
+    def _execute(**kwargs: object) -> str:
+        calls.append(kwargs)
+        # Long enough that microcompact clears it (>100 chars).
+        return json.dumps({"status": "ok", "rows": ["x" * 200]})
+
+    monkeypatch.setattr(tool, "execute", _execute)
+    registry = ToolRegistry()
+    registry.register(tool)
+    agent = AgentLoop(registry=registry, llm=SimpleNamespace(), max_iterations=5)
+
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    agent.memory.run_dir = str(run_dir)
+    trace = TraceWriter(run_dir)
+    messages: list[dict[str, object]] = []
+    react_trace: list[dict[str, object]] = []
+    args = {"code": "600584.SH"}
+
+    def _call(call_id: str, iteration: int) -> None:
+        agent._process_tool_calls(
+            [SimpleNamespace(id=call_id, name=tool.name, arguments=dict(args))],
+            ContextBuilder,
+            messages,
+            trace,
+            react_trace,
+            iteration,
+        )
+
+    _call("call_1", 1)
+    assert len(calls) == 1, "first call must execute"
+
+    _call("call_2", 2)
+    assert len(calls) == 1, "second call must be skipped while the result is readable"
+
+    # Pad past KEEP_RECENT so the real result is old enough to be cleared, then
+    # run the actual production path rather than reaching into _called_ok.
+    for i in range(KEEP_RECENT + 1):
+        messages.append({
+            "role": "tool",
+            "tool_call_id": f"pad_{i}",
+            "name": "padding_tool",
+            "content": "y" * 200,
+        })
+    reopened = agent._microcompact_and_unblock(messages, trace, 3)
+    assert tool.name in reopened, f"{tool.name} should have been re-opened, got {reopened}"
+
+    _call("call_3", 4)
+    trace.close()
+
+    assert len(calls) == 2, (
+        "third call must execute: its only result was cleared from context, so "
+        "'use the previous result' points at [cleared]"
+    )
+    events = TraceWriter.read(run_dir)
+    assert any(e["type"] == "microcompact_cleared" for e in events), (
+        "the clear must leave a trace event; this layer used to act silently"
     )

--- a/agent/tests/test_loop_helpers.py
+++ b/agent/tests/test_loop_helpers.py
@@ -24,10 +24,12 @@ from src.agent.loop import (
 )
 
 
-def _apply_microcompact_gate(messages: list) -> None:
+def _apply_microcompact_gate(messages: list, called_ok: set | None = None) -> None:
     """Mirror AgentLoop layer-1 gate (``loop.py`` ~572-573)."""
     if estimate_tokens(messages) > MICROCOMPACT_THRESHOLD:
-        _microcompact(messages)
+        unreadable = _microcompact(messages)
+        if called_ok is not None:
+            called_ok.difference_update(unreadable)
 
 
 # ---------------------------------------------------------------------------
@@ -145,6 +147,72 @@ class TestMicrocompactThresholdGate:
         preserved = [m for m in tool_msgs if m["content"] != "[cleared]"]
         assert len(cleared) == 5
         assert len(preserved) == KEEP_RECENT
+
+
+class TestMicrocompactDedupLedger:
+    """#1343: a cleared result cannot back "use the previous result", so the
+    tools it came from must leave the dedup ledger and become callable again."""
+
+    @staticmethod
+    def _tool(name: str, content: str) -> dict:
+        return {"role": "tool", "name": name, "content": content, "tool_call_id": f"tc_{name}_{len(content)}"}
+
+    def test_cleared_tool_is_returned_for_unblocking(self) -> None:
+        messages = [
+            self._tool("get_fund_flow", "x" * 200),
+            self._tool("get_stock_news", "y" * 200),
+            self._tool("recent_a", "a" * 200),
+            self._tool("recent_b", "b" * 200),
+            self._tool("recent_c", "c" * 200),
+        ]
+        assert _microcompact(messages) == ["get_fund_flow", "get_stock_news"]
+
+    def test_tool_with_surviving_result_stays_blocked(self) -> None:
+        # Same name has an old cleared result AND a result inside KEEP_RECENT:
+        # the model can still read one, so the dedup block must stay.
+        messages = [
+            self._tool("get_fund_flow", "x" * 200),
+            self._tool("other", "y" * 200),
+            self._tool("get_fund_flow", "fresh" + "z" * 200),
+            self._tool("recent_b", "b" * 200),
+            self._tool("recent_c", "c" * 200),
+        ]
+        assert _microcompact(messages) == ["other"]
+
+    def test_short_old_result_still_counts_as_readable(self) -> None:
+        messages = [
+            self._tool("get_fund_flow", "x" * 200),
+            self._tool("get_fund_flow", "ok"),
+            self._tool("recent_a", "a" * 200),
+            self._tool("recent_b", "b" * 200),
+            self._tool("recent_c", "c" * 200),
+        ]
+        assert _microcompact(messages) == []
+
+    def test_unnamed_messages_clear_without_unblocking(self) -> None:
+        messages = [{"role": "tool", "content": "x" * 200, "tool_call_id": f"tc_{i}"} for i in range(KEEP_RECENT + 2)]
+        assert _microcompact(messages) == []
+
+    def test_second_pass_reports_nothing_new(self) -> None:
+        messages = [
+            self._tool("get_fund_flow", "x" * 200),
+            self._tool("recent_a", "a" * 200),
+            self._tool("recent_b", "b" * 200),
+            self._tool("recent_c", "c" * 200),
+        ]
+        assert _microcompact(messages) == ["get_fund_flow"]
+        assert _microcompact(messages) == []
+
+    def test_gate_updates_dedup_ledger(self) -> None:
+        messages = [{"role": "system", "content": "sys"}]
+        messages.append({"role": "user", "content": "x" * (MICROCOMPACT_THRESHOLD * 4 + 1000)})
+        messages.append(self._tool("get_fund_flow", "y" * 200))
+        for name in ("recent_a", "recent_b", "recent_c"):
+            messages.append(self._tool(name, "z" * 200))
+
+        called_ok = {"get_fund_flow", "recent_a"}
+        _apply_microcompact_gate(messages, called_ok)
+        assert called_ok == {"recent_a"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1343.

## What breaks today

Two mechanisms that are each fine on their own combine into a dead end. Under token pressure, the layer-1 microcompact rewrites old tool results to `[cleared]` (`loop.py:437`), silently (no trace event). The dedup ledger (`loop.py:1933`) then keeps blocking re-calls of the same tool name with "already completed successfully. Use the previous result", except that result is gone. The issue's trace shows it exactly: financial tools succeed in iter 2, get cleared, and every retry from iter 3 on is intercepted (44 skips), so the model ends up declaring fundamentals unavailable despite having fetched them.

## Fix

`_microcompact` now returns the names of tools whose every result just became unreadable, and the loop drops those names from `_called_ok` and writes a `microcompact_cleared` trace event. A tool stays blocked whenever any result of it is still in context: the recent KEEP_RECENT window, or an older result under the 100-char clearing floor. Repeatable tools are untouched.

## Risk and rollback

Low. The clearing behavior itself is unchanged (same threshold, same KEEP_RECENT); the only new behavior is that a re-call can go through when its previous result is no longer in context, which is the intended escape. Worst case is a redundant re-fetch, not wrong data. Rollback: revert this commit; the helper's return value is ignored by the old call site.

## Tests

6 new cases in `tests/test_loop_helpers.py`, red without the source change (6 failed), green with it. They pin: cleared tool unblocks, surviving recent result keeps the block, short old result keeps the block, unnamed messages don't unblock, second pass is a no-op, and the gated caller updates the ledger. Full agent suite: 12164 passed, 92 skipped.

AI-assisted: yes (Kimi K3). Mechanism verified against the issue's trace evidence before writing the fix.
