### PR TITLE
fix(loop): release dedup lock when microcompact clears a tool result (#1343)

### DIFF
--- a/agent/src/agent/loop.py
+++ b/agent/src/agent/loop.py
@@ -56,6 +56,10 @@ from src.tools.redaction import redact_payload, redact_tool_result
 RUNS_DIR = get_runs_dir()
 SESSIONS_DIR = get_sessions_dir()
 KEEP_RECENT = 3
+# (#1343) Placeholder written in place of tool results that no longer exist in
+# the model-visible context. Used by both _fix_tool_pairs and the dedup
+# reconciliation in _auto_compact — single source so the two never drift.
+_COMPACT_STUB_CONTENT = "[Result from earlier context — see summary above]"
 LLM_USAGE_ARTIFACT = "llm_usage.json"
 
 COLLAPSE_PRESERVE_RECENT = 6
@@ -529,7 +533,7 @@ def _fix_tool_pairs(messages: list) -> None:
                     "role": "tool",
                     "tool_call_id": tc_id,
                     "name": tc.get("function", {}).get("name", "unknown"),
-                    "content": "[Result from earlier context — see summary above]",
+                    "content": _COMPACT_STUB_CONTENT,
                 }
                 inserts.append((idx + 1, stub))
                 result_ids.add(tc_id)
@@ -2805,6 +2809,22 @@ class AgentLoop:
 
         # Fix orphaned tool pairs in the reconstructed message list
         _fix_tool_pairs(messages)
+
+        # (#1343) Dedup may only point at results the model can still see.
+        # After reconstruction only the preserved tail retains verbatim tool
+        # results — everything else survives solely inside the summary (or not
+        # at all), so the dedup guard's "use the previous result" would point
+        # at a dead reference and lock the model out of re-fetching under
+        # sustained pressure (same 44-wasted-call failure as layer 1). Release
+        # every lock whose tool no longer has a real, visible result.
+        self._called_ok &= {
+            m.get("name")
+            for m in messages
+            if m.get("role") == "tool"
+            and m.get("name")
+            and isinstance(m.get("content"), str)
+            and m["content"] not in ("[cleared]", _COMPACT_STUB_CONTENT)
+        }
 
     def _emit(self, event_type: str, data: Dict[str, Any]) -> None:
         """Fire an event via the callback."""

--- a/agent/src/agent/loop.py
+++ b/agent/src/agent/loop.py
@@ -60,6 +60,10 @@ KEEP_RECENT = 3
 # the model-visible context. Used by both _fix_tool_pairs and the dedup
 # reconciliation in _auto_compact — single source so the two never drift.
 _COMPACT_STUB_CONTENT = "[Result from earlier context — see summary above]"
+# Tool-result sentinel written by _microcompact when a result is cleared, and
+# matched by callers so cleared results are never treated as live evidence or
+# as a valid dedup target. Single source so writer and readers never drift.
+_CLEARED_CONTENT = "[cleared]"
 LLM_USAGE_ARTIFACT = "llm_usage.json"
 
 COLLAPSE_PRESERVE_RECENT = 6
@@ -457,7 +461,7 @@ def _microcompact(messages: list, called_ok: set[str] | None = None) -> None:
     for msg in tool_msgs[:-KEEP_RECENT]:
         content = msg.get("content", "")
         if isinstance(content, str) and len(content) > 100:
-            msg["content"] = "[cleared]"
+            msg["content"] = _CLEARED_CONTENT
             if called_ok is not None:
                 called_ok.discard(msg.get("name"))
 
@@ -477,7 +481,7 @@ def _context_collapse(messages: list) -> None:
         content = msg.get("content")
         if not isinstance(content, str) or len(content) <= COLLAPSE_TEXT_MIN:
             continue
-        if content == "[cleared]":
+        if content == _CLEARED_CONTENT:
             continue
         head = content[:COLLAPSE_HEAD]
         tail = content[-COLLAPSE_TAIL:]
@@ -2823,7 +2827,7 @@ class AgentLoop:
             if m.get("role") == "tool"
             and m.get("name")
             and isinstance(m.get("content"), str)
-            and m["content"] not in ("[cleared]", _COMPACT_STUB_CONTENT)
+            and m["content"] not in (_CLEARED_CONTENT, _COMPACT_STUB_CONTENT)
         }
 
     def _emit(self, event_type: str, data: Dict[str, Any]) -> None:

--- a/agent/src/agent/loop.py
+++ b/agent/src/agent/loop.py
@@ -434,11 +434,18 @@ def _verification_ledger(messages: list) -> str:
             break
     return "\n".join(unique)
 
-def _microcompact(messages: list) -> None:
+def _microcompact(messages: list, called_ok: set[str] | None = None) -> None:
     """Layer 1: silently prune old tool results, keeping the most recent N intact.
 
     Args:
         messages: Message list (mutated in place).
+        called_ok: Names of already-completed non-repeatable tools the loop
+            dedup guard blocks from re-calling (#1343). Clearing a result
+            destroys the only copy the model could "use the previous result"
+            from, so release the dedup lock for every tool whose result gets
+            cleared — otherwise the model retries the same tool forever and
+            every retry is skipped (44 wasted tool_skipped calls in the
+            2026-09-04 investment_committee run).
     """
     tool_msgs = [m for m in messages if m.get("role") == "tool"]
     if len(tool_msgs) <= KEEP_RECENT:
@@ -447,6 +454,8 @@ def _microcompact(messages: list) -> None:
         content = msg.get("content", "")
         if isinstance(content, str) and len(content) > 100:
             msg["content"] = "[cleared]"
+            if called_ok is not None:
+                called_ok.discard(msg.get("name"))
 
 
 def _context_collapse(messages: list) -> None:
@@ -1159,7 +1168,7 @@ class AgentLoop:
                 # tool history available for the model to reference instead of
                 # having every result past the most recent few cleared.
                 if tokens > int(_token_threshold() * 0.5):
-                    _microcompact(messages)
+                    _microcompact(messages, called_ok=self._called_ok)
                     tokens = estimate_tokens(messages)
 
                 # Layer 2: context collapse (fold long text, zero API cost)

--- a/agent/tests/test_agent_loop_no_assistant_prefill.py
+++ b/agent/tests/test_agent_loop_no_assistant_prefill.py
@@ -146,3 +146,49 @@ def test_auto_compact_handoff_summary_is_reintroduced_as_user_message(
 
     assert messages[-1]["role"] == "user"
     assert "Continue from the summary above" in messages[-1]["content"]
+
+
+def test_auto_compact_releases_dedup_locks_for_unseeable_results(
+    tmp_path: Path,
+) -> None:
+    """#1343: layer-3 compaction must not leave dedup locks pointing at
+    results that no longer exist. After reconstruction only the preserved
+    tail keeps verbatim tool results — locks for tools whose results were
+    folded into the summary are released (model may re-fetch); locks for
+    tools whose results survived in the tail are kept.
+    """
+    llm = _StubLLM()
+    agent = _build_agent(llm, max_iter=1, tmp_run_dir=tmp_path / "run")
+    agent._called_ok.update({"get_fund_flow", "get_financial_statements"})
+    trace = TraceWriter(tmp_path / "trace")
+    messages = [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": "turn 0"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "old_1", "type": "function", "function": {"name": "get_fund_flow", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "name": "get_fund_flow", "tool_call_id": "old_1", "content": "fund flow data " + "x" * 200},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "old_2", "type": "function", "function": {"name": "get_financial_statements", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "name": "get_financial_statements", "tool_call_id": "old_2", "content": "balance sheet data " + "y" * 200},
+        {"role": "user", "content": "recent " + "z" * 40_000},
+    ]
+    try:
+        agent._auto_compact(messages, tmp_path / "run", trace, iteration=1)
+    finally:
+        trace.close()
+
+    # Body (6 msgs) is far under TAIL_TOKEN_BUDGET -> force split at 3:
+    # head = [turn 0, fund-flow pair] (folded into the summary),
+    # tail = [balance-sheet pair, big user message] (verbatim).
+    assert "get_fund_flow" not in agent._called_ok
+    assert "get_financial_statements" in agent._called_ok

--- a/agent/tests/test_loop_helpers.py
+++ b/agent/tests/test_loop_helpers.py
@@ -598,3 +598,89 @@ def test_stall_timeout_seconds_default_and_override(monkeypatch) -> None:
     assert _stall_timeout_seconds() == 42.0
     monkeypatch.delattr(loop_module, "STALL_TIMEOUT_SECONDS", raising=False)
     assert _stall_timeout_seconds() > 0
+
+
+# ---------------------------------------------------------------------------
+# _microcompact + dedup interplay (#1343)
+# ---------------------------------------------------------------------------
+
+
+class TestMicrocompactReleasesDedupLock:
+    """Clearing a tool result destroys the copy the dedup guard says to reuse.
+
+    loop.py blocks re-calls of succeeded non-repeatable tools with
+    ``"use the previous result"`` — but if microcompact already cleared that
+    result, the model can never see it and retries forever (44 wasted
+    tool_skipped calls in the 2026-09-04 investment_committee run). Clearing
+    a result must release the dedup lock (#1343).
+    """
+
+    def _messages_with_old_results(self) -> list:
+        tools = [
+            "get_financial_statements",
+            "get_fund_flow",
+            "get_margin_trading",
+            "get_research_reports",
+        ]
+        messages: list = [
+            {"role": "system", "content": "system"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": f"tc_{i}", "type": "function", "function": {"name": t, "arguments": "{}"}}
+                    for i, t in enumerate(tools)
+                ],
+            },
+        ]
+        for i, t in enumerate(tools):
+            messages.append(
+                {
+                    "role": "tool",
+                    "name": t,
+                    "tool_call_id": f"tc_{i}",
+                    "content": f"{'x' * 300} result_{t}",
+                }
+            )
+        # Recent — fresh get_market_data results must stay intact.
+        for i in range(KEEP_RECENT):
+            messages.append(
+                {
+                    "role": "tool",
+                    "name": "get_market_data",
+                    "tool_call_id": f"recent_{i}",
+                    "content": f"{'x' * 300} recent_{i}",
+                }
+            )
+        return messages
+
+    def test_clearing_result_releases_dedup_lock(self) -> None:
+        called_ok = {"get_financial_statements", "get_fund_flow", "get_margin_trading", "get_research_reports"}
+        messages = self._messages_with_old_results()
+
+        _microcompact(messages, called_ok=called_ok)
+
+        cleared = [m for m in messages if m.get("role") == "tool" and m["content"] == "[cleared]"]
+        assert len(cleared) == 4
+        # Dedup guard (`tc.name in called_ok and not repeatable`) must not fire.
+        assert "get_financial_statements" not in called_ok
+        assert "get_fund_flow" not in called_ok
+        assert "get_margin_trading" not in called_ok
+        assert "get_research_reports" not in called_ok
+
+    def test_preserved_results_keep_dedup_lock(self) -> None:
+        called_ok = {"get_market_data", "get_financial_statements"}
+        messages = self._messages_with_old_results()
+
+        _microcompact(messages, called_ok=called_ok)
+
+        recent = [m for m in messages if m.get("tool_call_id", "").startswith("recent_")]
+        assert all(m["content"] != "[cleared]" for m in recent)
+        assert "get_market_data" in called_ok
+
+    def test_no_called_ok_arg_back_compatible(self) -> None:
+        messages = self._messages_with_old_results()
+        # Existing callers / tests pass only messages.
+        _microcompact(messages)
+        cleared = [m for m in messages if m.get("role") == "tool" and m["content"] == "[cleared]"]
+        assert len(cleared) == 4


### PR DESCRIPTION
## What

Fixes #1343's main defect (the tool-whitelist half already shipped via #1345).

**Root cause (two correct mechanisms, fatal combination):**
1. **Layer-1 microcompact** (`loop.py::_microcompact`) silently replaces old tool-result contents with `[cleared]` under token pressure (`KEEP_RECENT=3` results preserved).
2. **Dedup guard** (`loop.py` ~L1942): a non-repeatable tool that already succeeded (`_called_ok`) is blocked on re-call with `"already completed successfully. Use the previous result."`

After either compaction layer destroys a result, that pointer is dead — the model can never see the data, so it retries the same tool, and every retry is skipped. Live trace evidence (issue #1343, 2026-09-04 14:56 `investment_committee` run): **44 wasted `tool_skipped` calls** across 5 fundamental-data tools, while the agent correctly refused to fabricate the figures.

## The invariant (applied at both compaction sites)

> **Dedup may only point at results the model can still see.**

- **Layer 1 (microcompact):** `_microcompact` now takes the loop's `_called_ok` set and releases the lock for every tool whose result it clears. Intact results (the `KEEP_RECENT` recent window) keep their lock.
- **Layer 3 (auto-compact):** `_auto_compact` reconstructs messages keeping only a ~20K-token tail; everything else survives solely inside the LLM summary. Reconcile `self._called_ok` after `_fix_tool_pairs`: release every lock whose tool no longer has a real, visible result (excludes `[cleared]` and the `_COMPACT_STUB_CONTENT` placeholder — now a single shared constant so the two sites never drift). Locks for results that survived in the tail are kept.
- **Swarm workers** (`worker.py`) have their own microcompact but **no name-dedup**, so they cannot dead-lock — re-execution there costs a redundant API call at worst. Out of scope by design.
- **Layer 2 (`_context_collapse`)** truncates the middle but keeps head+tail verbatim — the pointer retains value, locks stay.

## Why not other shapes
- *Don't clear results for non-repeatable tools:* those results (financial statements, fund flow) are exactly the largest payloads — skipping them defeats compaction under pressure.
- *Check visibility inside the hot guard loop:* needs a per-call-id reverse lookup on every tool call; releasing/reconciling at compaction time is simpler and equally sound (re-execution after losing data is exactly what we want).
- Voll compaction intentionally trades verbatim data for a summary — reconciliation keeps the guard sound relative to that design rather than fighting it.

## Tests
- **Layer 1:** `test_clearing_result_releases_dedup_lock` (4 blocked research tools released — mirrors the live trace), `test_preserved_results_keep_dedup_lock`, `test_no_called_ok_arg_back_compatible`.
- **Layer 3:** `test_auto_compact_releases_dedup_locks_for_unseeable_results` — deterministic force-split fixture: fund-flow pair folded into summary → lock released; balance-sheet pair verbatim in tail → lock kept. Both arms verified.
- **279 loop/grounding/discipline tests pass** (incl. `test_agent_loop_repeatable_tools.py`, `test_auto_compact_chunked_summary.py`).

## Known limitations
The summary text itself is written by the LLM and may or may not quote exact figures — that is the intended design of summarizing compaction. After this PR the model can always re-fetch when it needs an exact number again, which is strictly better than being locked out.
