### PR TITLE
fix(backtest): route dotted US class shares as us_equity (BRK.B.US, BF.B.US)

### DIFF
--- a/agent/backtest/engines/_market_hooks.py
+++ b/agent/backtest/engines/_market_hooks.py
@@ -25,7 +25,9 @@ from backtest.models import Position
 _MARKET_PATTERNS = [
     (re.compile(r"^\d{6}\.(SZ|SH|BJ)$", re.I), "a_share"),
     (re.compile(r"^(51|15|56)\d{4}\.(SZ|SH)$", re.I), "a_share"),
-    (re.compile(r"^[A-Z]+\.US$", re.I), "us_equity"),
+    # US equities: tickers may carry a class-share dot (BRK.B.US, BF.B.US)
+    # and a hyphen (e.g. BF-B.US) — same characters as ca/india/uk below.
+    (re.compile(r"^[A-Z0-9&.\-]+\.US$", re.I), "us_equity"),
     (re.compile(r"^\d{3,5}\.HK$", re.I), "hk_equity"),
     # India equities: NSE (RELIANCE.NS) / BSE (500325.BO); tickers may carry
     # '&' and '-' (e.g. M&M.NS, BAJAJ-AUTO.NS).

--- a/agent/backtest/loaders/yahoo_client.py
+++ b/agent/backtest/loaders/yahoo_client.py
@@ -85,7 +85,9 @@ def map_symbol(symbol: str) -> str:
     cleaned = symbol.strip()
     upper = cleaned.upper()
     if upper.endswith(".US"):
-        return cleaned[: -len(".US")]
+        # US class shares are hyphenated on Yahoo (BRK-B): the dot form
+        # returns an empty chart (live-verified), so map BRK.B.US -> BRK-B.
+        return cleaned[: -len(".US")].replace(".", "-")
     if upper.endswith(".HK"):
         base = cleaned[: -len(".HK")]
         digits = base.lstrip("0") or "0"

--- a/agent/backtest/loaders/yfinance_loader.py
+++ b/agent/backtest/loaders/yfinance_loader.py
@@ -62,7 +62,9 @@ def _to_yfinance_symbol(code: str) -> str:
     """
     upper = code.strip().upper()
     if upper.endswith(".US"):
-        return upper[:-3]
+        # US class shares are hyphenated on Yahoo/yfinance (BRK-B): the dot
+        # form returns empty data (live-verified), so map BRK.B.US -> BRK-B.
+        return upper[:-3].replace(".", "-")
     if upper.endswith(".HK"):
         digits = upper[:-3]
         width = max(4, len(digits))

--- a/agent/tests/test_market_detection.py
+++ b/agent/tests/test_market_detection.py
@@ -46,6 +46,14 @@ class TestDetectMarket:
             ("AAPL.US", "us_equity"),
             ("TSLA.US", "us_equity"),
             ("NVDA.US", "us_equity"),
+            # US equity — dotted class shares in the .US form (BRK.B, BF.A,
+            # RDS.A) must not fall through to the a_share default.
+            ("BRK.B.US", "us_equity"),
+            ("BRK.A.US", "us_equity"),
+            ("BF.B.US", "us_equity"),
+            ("RDS.A.US", "us_equity"),
+            ("WRB.B.US", "us_equity"),
+            ("LEN.B.US", "us_equity"),
             # US equity — bare tickers without the .US suffix (issue #986)
             ("AAPL", "us_equity"),
             ("MSFT", "us_equity"),
@@ -101,6 +109,7 @@ class TestDetectMarket:
         assert _detect_market("aapl") == "us_equity"
         assert _detect_market("btc-usdt") == "crypto"
         assert _detect_market("td.to") == "ca_equity"
+        assert _detect_market("brk.b.us") == "us_equity"
 
     def test_unknown_defaults_to_a_share(self) -> None:
         assert _detect_market("UNKNOWN") == "a_share"
@@ -134,6 +143,17 @@ class TestBareUsTickerRouting:
         assert _detect_source("AAPL") == "yfinance"
         assert code_currency("AAPL") == "USD"
         assert code_currency("AAPL.US") == "USD"
+
+    def test_dotted_class_share_source_and_currency(self) -> None:
+        """Dotted class shares must route to USD + yfinance, not CNY/tushare."""
+        for code in ("BRK.B.US", "BRK.A.US", "BF.B.US"):
+            assert _detect_source(code) == "yfinance", code
+            assert code_currency(code) == "USD", code
+
+    def test_dotted_class_share_groups_with_other_us_equities(self) -> None:
+        basket = ["BRK.B.US", "AAPL.US"]
+        groups = _group_codes_by_market(basket)
+        assert groups == {"us_equity": basket}
 
     def test_canadian_tickers_route_to_canada_and_cad(self) -> None:
         assert _detect_source("TD.TO") == "yahoo"

--- a/agent/tests/test_yahoo_client.py
+++ b/agent/tests/test_yahoo_client.py
@@ -57,6 +57,12 @@ class TestMapSymbol:
         assert yahoo_client.map_symbol("AAPL.US") == "AAPL"
         assert yahoo_client.map_symbol("aapl.us") == "aapl"
 
+        # US class shares: dot form is unserved by Yahoo (live-verified
+        # empty chart); the hyphen form is what the chart API needs (#1351).
+        assert yahoo_client.map_symbol("BRK.B.US") == "BRK-B"
+        assert yahoo_client.map_symbol("BRK.A.US") == "BRK-A"
+        assert yahoo_client.map_symbol("BF.B.US") == "BF-B"
+
     def test_hk_normalized_to_four_digits(self):
         assert yahoo_client.map_symbol("00700.HK") == "0700.HK"
         assert yahoo_client.map_symbol("09988.HK") == "9988.HK"

--- a/agent/tests/test_yfinance_symbol_map.py
+++ b/agent/tests/test_yfinance_symbol_map.py
@@ -1,0 +1,24 @@
+"""yfinance symbol translation for US class shares (#1351).
+
+Yahoo/yfinance serve US class shares only in hyphen form (``BRK-B``);
+the dot form (``BRK.B``) returns empty data, so the ``.US`` conversion
+must fold internal dots to hyphens.
+"""
+
+from backtest.loaders.yfinance_loader import _to_yfinance_symbol
+
+
+def test_class_shares_map_to_hyphen_form() -> None:
+    assert _to_yfinance_symbol("BRK.B.US") == "BRK-B"
+    assert _to_yfinance_symbol("BRK.A.US") == "BRK-A"
+    assert _to_yfinance_symbol("BF.B.US") == "BF-B"
+
+
+def test_plain_tickers_unchanged() -> None:
+    assert _to_yfinance_symbol("AAPL.US") == "AAPL"
+    assert _to_yfinance_symbol("AAPL") == "AAPL"
+
+
+def test_crypto_and_suffix_forms_untouched() -> None:
+    assert _to_yfinance_symbol("BTC-USDT") == "BTC-USD"
+    assert _to_yfinance_symbol("TD.TO") == "TD.TO"


### PR DESCRIPTION
## What

Fixes dotted US class-share tickers (e.g. `BRK.B.US`, `BRK.A.US`, `BF.B.US`) at **both** layers: classification *and* data conversion, with live-API proof for each layer.

### Layer 1 — classification (`_market_hooks.py`)

```python
(re.compile(r"^[A-Z]+\.US$", re.I), "us_equity"),
```

`[A-Z]+` cannot match a dot, so a real class share in the project's canonical `.US` form matched **no** pattern and fell through the catch-all to the `a_share` default:

- `_detect_market("BRK.B.US")` → `a_share` (expected `us_equity`)
- `code_currency("BRK.B.US")` → `CNY` (expected `USD`)
- `_detect_source("BRK.B.US")` → `tushare` (expected the US equity chain)

Observed impact: a composite basket `[BRK.B.US, AAPL.US]` was rejected as a cross-currency set (CNY vs USD), and the symbol was fed to the A-share tencent/mootdx chain, which cannot serve a US listing.

Fix mirrors the directly adjacent ca/india/uk rows, which already admit `&`, `.`, `-` in the ticker portion (`M&M.NS`, `BAJAJ-AUTO.NS`, `SHEL.L`):

```python
(re.compile(r"^[A-Z0-9&.\-]+\.US$", re.I), "us_equity"),
```

### Layer 2 — conversion (found in adversarial review of this PR, live-proven)

After routing, both load-side converters still emitted the **dot** form, which Yahoo does **not** serve. Live-verified against the v8 chart endpoint (`query1.finance.yahoo.com/v8/finance/chart/...`, 5d/1d):

| request | result |
|---|---|
| `BRK-B` (hyphen) | OK — 5 rows, `meta.symbol=BRK-B` |
| `BRK.B` (dot) | **0 rows** |
| `BRK.A` (dot) | **0 rows** |
| `AAPL.US` | 0 rows (suffix stripped by `map_symbol` — consistent with existing behavior) |

So `BRK.B.US` would have failed at fetch even after Layer 1. Both `.US` branches now fold residual ticker dots to hyphens:

- `yahoo_client.map_symbol: BRK.B.US` → `BRK-B`
- `yfinance_loader._to_yfinance_symbol: BRK.B.US` → `BRK-B`

## Tests

- `tests/test_market_detection.py`: six dotted class shares in the `_detect_market` matrix, case-insensitivity, source/currency routing, composite grouping (all red on `main`).
- `tests/test_yahoo_client.py` / `tests/test_yfinance_symbol_map.py`: dot→hyphen conversions plus unchanged neighbors (`AAPL.US` → `AAPL`, crypto `-USDT`, pass-through suffixes).
- In all: 200+ tests across the market-routing and loader suites pass; the four new Layer-1 assertions fail on `main` before the fix.

**Scope note:** the *bare* dotted form (`BRK.B` without `.US`) still classifies as `a_share` — the bare catch-all `^[A-Z]{1,5}$` is letters-only by design, and `.US` is the project's canonical US form (loader docstrings, market-data tests). Fixing the bare form would widen the catch-all; left deliberately out of scope here, happy to follow up if someone depends on bare dotted input.
