### PR TITLE
fix(loop): size compaction by tool-call arguments, fold cleared-pair payloads

### DIFF
--- a/agent/src/agent/loop.py
+++ b/agent/src/agent/loop.py
@@ -63,6 +63,13 @@ COLLAPSE_TEXT_MIN = 2400
 COLLAPSE_HEAD = 900
 COLLAPSE_TAIL = 500
 
+# Placeholder contents that mean a tool result's real data was compacted
+# away. Two sources: ``_microcompact`` clears old results in place to
+# ``_CLEARED_CONTENT``, and ``_fix_tool_pairs`` inserts a ``_STUB_RESULT_CONTENT``
+# stub for a call whose result a layer-3 fold consumed.
+_CLEARED_CONTENT = "[cleared]"
+_STUB_RESULT_CONTENT = "[Result from earlier context — see summary above]"
+
 TAIL_TOKEN_BUDGET = 20_000
 SUMMARY_CHUNK_CHARS = 80_000
 
@@ -446,7 +453,16 @@ def _microcompact(messages: list) -> None:
     for msg in tool_msgs[:-KEEP_RECENT]:
         content = msg.get("content", "")
         if isinstance(content, str) and len(content) > 100:
-            msg["content"] = "[cleared]"
+            msg["content"] = _CLEARED_CONTENT
+
+
+def _result_data_gone(content: Any) -> bool:
+    """True when ``content`` is a placeholder meaning the tool result's real
+    data was compacted away (microcompact's ``[cleared]``, or the stub that
+    ``_fix_tool_pairs`` inserts after a layer-3 fold)."""
+    return isinstance(content, str) and (
+        content == _CLEARED_CONTENT or content == _STUB_RESULT_CONTENT
+    )
 
 
 def _context_collapse(messages: list) -> None:
@@ -464,7 +480,7 @@ def _context_collapse(messages: list) -> None:
         content = msg.get("content")
         if not isinstance(content, str) or len(content) <= COLLAPSE_TEXT_MIN:
             continue
-        if content == "[cleared]":
+        if _result_data_gone(content):
             continue
         head = content[:COLLAPSE_HEAD]
         tail = content[-COLLAPSE_TAIL:]
@@ -481,7 +497,7 @@ def _context_collapse(messages: list) -> None:
     cleared_ids = {
         m.get("tool_call_id")
         for m in messages
-        if m.get("role") == "tool" and m.get("content") == "[cleared]"
+        if m.get("role") == "tool" and _result_data_gone(m.get("content"))
     }
     for msg in messages[1:-COLLAPSE_PRESERVE_RECENT]:
         for tc in msg.get("tool_calls") or []:
@@ -508,10 +524,10 @@ def _msg_estimate_chars(msg: dict) -> int:
     size = len(str(msg.get("content", "")))
     for tc in msg.get("tool_calls") or []:
         fn = tc.get("function")
-        if isinstance(fn, dict):
-            args = fn.get("arguments")
-            if isinstance(args, str):
-                size += len(args)
+        if isinstance(fn, dict) and fn.get("arguments") is not None:
+            # Sized via ``str`` (matches ``estimate_tokens``' full-serialization
+            # gate) so dict/object arguments count instead of being ignored.
+            size += len(str(fn["arguments"]))
     return size
 
 
@@ -586,7 +602,7 @@ def _fix_tool_pairs(messages: list) -> None:
                     "role": "tool",
                     "tool_call_id": tc_id,
                     "name": tc.get("function", {}).get("name", "unknown"),
-                    "content": "[Result from earlier context — see summary above]",
+                    "content": _STUB_RESULT_CONTENT,
                 }
                 inserts.append((idx + 1, stub))
                 result_ids.add(tc_id)

--- a/agent/src/agent/loop.py
+++ b/agent/src/agent/loop.py
@@ -471,6 +471,72 @@ def _context_collapse(messages: list) -> None:
         trimmed = len(content) - COLLAPSE_HEAD - COLLAPSE_TAIL
         msg["content"] = f"{head}\n\n...[{trimmed} chars collapsed]...\n\n{tail}"
 
+    # Zero-cost relief for oversized tool-call payloads whose paired result
+    # was already compacted away (``[cleared]``): the arguments blob is now
+    # useless to the model (the data it requested is gone), so fold it to a
+    # valid JSON stub. The call id/name survive, so tool pairing and the
+    # model's "I called tool X" memory are intact, and the provider still
+    # receives well-formed ``arguments``. Nothing re-reads historical
+    # arguments for re-dispatch, so this is safe.
+    cleared_ids = {
+        m.get("tool_call_id")
+        for m in messages
+        if m.get("role") == "tool" and m.get("content") == "[cleared]"
+    }
+    for msg in messages[1:-COLLAPSE_PRESERVE_RECENT]:
+        for tc in msg.get("tool_calls") or []:
+            fn = tc.get("function")
+            if not isinstance(fn, dict):
+                continue
+            args = fn.get("arguments")
+            if (
+                isinstance(args, str)
+                and len(args) > COLLAPSE_TEXT_MIN
+                and tc.get("id") in cleared_ids
+            ):
+                fn["arguments"] = "{}"
+
+
+def _msg_estimate_chars(msg: dict) -> int:
+    """Rough character size of a message for token budgeting.
+
+    Sizes ``content`` plus every tool-call ``arguments`` payload. Assistant
+    tool-call messages carry their payload in ``tool_calls[].function.
+    arguments`` with empty ``content``; sizing them by content alone made the
+    layer-3 tail budget count a 100 KB arguments blob as ~10 tokens.
+    """
+    size = len(str(msg.get("content", "")))
+    for tc in msg.get("tool_calls") or []:
+        fn = tc.get("function")
+        if isinstance(fn, dict):
+            args = fn.get("arguments")
+            if isinstance(args, str):
+                size += len(args)
+    return size
+
+
+def _tail_cut_index(body: list, budget: int = TAIL_TOKEN_BUDGET) -> int:
+    """First index of the preserved ``body`` tail that fits ``budget`` tokens.
+
+    Walks back from the end accumulating each message's estimated tokens and
+    returns the earliest index that fits, never splitting a tool_call /
+    tool_result pair. Sized with ``_msg_estimate_chars`` so oversized tool-call
+    arguments push their message into the folded head instead of being counted
+    as a handful of tokens in the preserved tail.
+    """
+    accumulated = 0
+    cut_idx = len(body)
+    for i in range(len(body) - 1, -1, -1):
+        msg_tokens = (_msg_estimate_chars(body[i]) // 4) + 10
+        if accumulated + msg_tokens > budget:
+            cut_idx = i + 1
+            break
+        accumulated += msg_tokens
+        cut_idx = i
+    while 0 < cut_idx < len(body) and body[cut_idx].get("role") == "tool":
+        cut_idx += 1
+    return cut_idx
+
 
 def _fix_tool_pairs(messages: list) -> None:
     """Repair orphaned tool_call / tool_result pairs after compression.
@@ -2646,21 +2712,9 @@ class AgentLoop:
         system_msg = messages[0]
         body = messages[1:]
 
-        # Token-budget tail: walk backward to find how many recent messages to preserve
-        accumulated = 0
-        cut_idx = len(body)
-        for i in range(len(body) - 1, -1, -1):
-            content = body[i].get("content", "")
-            msg_tokens = (len(str(content)) // 4) + 10
-            if accumulated + msg_tokens > TAIL_TOKEN_BUDGET:
-                cut_idx = i + 1
-                break
-            accumulated += msg_tokens
-            cut_idx = i
-
-        # Don't split in the middle of a tool_call/tool_result pair
-        while 0 < cut_idx < len(body) and body[cut_idx].get("role") == "tool":
-            cut_idx += 1
+        # Token-budget tail: size messages with their tool-call arguments so
+        # oversized tool calls are folded instead of hiding in the tail.
+        cut_idx = _tail_cut_index(body)
 
         head = body[:cut_idx]
         tail = body[cut_idx:]

--- a/agent/tests/test_loop_helpers.py
+++ b/agent/tests/test_loop_helpers.py
@@ -682,3 +682,46 @@ def test_context_collapse_keeps_args_when_result_intact_or_pending() -> None:
     _context_collapse(msgs)
     assert c1["tool_calls"][0]["function"]["arguments"] == fat
     assert c2["tool_calls"][0]["function"]["arguments"] == fat
+
+
+def test_context_collapse_stubs_args_for_fix_tool_pairs_stub_result() -> None:
+    """#adversarial: layer-3's ``_fix_tool_pairs`` stub result marker must also
+    count as 'result data gone' — a call that survived a layer-3 fold gets its
+    huge arguments stubbed too, not only microcompact's ``[cleared]``."""
+    from src.agent.loop import _STUB_RESULT_CONTENT
+
+    fat = "Y" * (COLLAPSE_TEXT_MIN * 3)
+    call_msg = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [{"id": "c7", "type": "function", "function": {"name": "f", "arguments": fat}}],
+    }
+    msgs = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "u0"},
+        call_msg,  # index 2 — inside the collapse window
+        {"role": "tool", "tool_call_id": "c7", "content": _STUB_RESULT_CONTENT},
+        {"role": "assistant", "content": "a0"},
+        {"role": "user", "content": "u1"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "user", "content": "u2"},
+        {"role": "assistant", "content": "a2"},
+        {"role": "user", "content": "u3"},
+    ]
+    _context_collapse(msgs)
+    assert call_msg["tool_calls"][0]["function"]["arguments"] == "{}"
+
+
+def test_msg_estimate_chars_counts_dict_arguments() -> None:
+    """#adversarial: dict (non-string) arguments must count toward sizing,
+    consistent with ``estimate_tokens``' full serialization gate."""
+    from src.agent.loop import _msg_estimate_chars
+
+    big_dict = {"q": "X" * 4000}
+    msg = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [{"function": {"name": "f", "arguments": big_dict}}],
+    }
+    assert _msg_estimate_chars(msg) >= 4000
+    assert _msg_estimate_chars({"role": "user", "content": "hi"}) >= 2

--- a/agent/tests/test_loop_helpers.py
+++ b/agent/tests/test_loop_helpers.py
@@ -598,3 +598,87 @@ def test_stall_timeout_seconds_default_and_override(monkeypatch) -> None:
     assert _stall_timeout_seconds() == 42.0
     monkeypatch.delattr(loop_module, "STALL_TIMEOUT_SECONDS", raising=False)
     assert _stall_timeout_seconds() > 0
+
+
+# ---------------------------------------------------------------------------
+# tool_calls[].function.arguments must count toward compaction sizing/relief
+# ---------------------------------------------------------------------------
+
+def test_tail_cut_index_counts_tool_call_arguments() -> None:
+    """#tail-budget: a fat tool_call (empty content, huge arguments) must be
+    pushed into the folded head, not counted as ~10 tokens in the tail."""
+    from src.agent.loop import _tail_cut_index  # new helper: absent on pre-fix code
+
+    fat = "X" * 90_000  # ~22.5K tokens once arguments are counted
+    body = [
+        {"role": "user", "content": "old header"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "c1", "type": "function", "function": {"name": "t", "arguments": fat}}
+            ],
+        },
+    ]
+    # Old content-only sizing: both messages fit the 20K budget -> cut at 0.
+    # New sizing: the call alone exceeds it -> cut at len(body), tail empty,
+    # the oversized call goes into the folded head.
+    assert _tail_cut_index(body) == len(body)
+    assert _tail_cut_index(body) != 0
+
+
+def test_context_collapse_stubs_args_of_cleared_paired_call() -> None:
+    """#layer-2: a tool_call whose paired result was [cleared] gets its huge
+    arguments folded to a valid JSON '{}' stub (call id/name preserved)."""
+    fat = "Y" * (COLLAPSE_TEXT_MIN * 3)
+    call_msg = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [{"id": "c9", "type": "function", "function": {"name": "f", "arguments": fat}}],
+    }
+    msgs = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "u0"},
+        call_msg,  # index 2 — inside the collapse window
+        {"role": "tool", "tool_call_id": "c9", "content": "[cleared]"},
+        {"role": "assistant", "content": "a0"},
+        {"role": "user", "content": "u1"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "user", "content": "u2"},
+        {"role": "assistant", "content": "a2"},
+        {"role": "user", "content": "u3"},
+    ]
+    _context_collapse(msgs)
+    assert call_msg["tool_calls"][0]["function"]["arguments"] == "{}"
+    assert call_msg["tool_calls"][0]["function"]["name"] == "f"
+
+
+def test_context_collapse_keeps_args_when_result_intact_or_pending() -> None:
+    """#layer-2 negative arm: arguments are NOT stubbed when the result still
+    carries data, nor when the call is pending (no result in the transcript)."""
+    fat = "Y" * (COLLAPSE_TEXT_MIN * 3)
+    c1 = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "f", "arguments": fat}}],
+    }
+    c2 = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [{"id": "c2", "type": "function", "function": {"name": "g", "arguments": fat}}],
+    }
+    msgs = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "u0"},
+        c1,  # index 2 — inside the collapse window
+        {"role": "tool", "tool_call_id": "c1", "content": "still have the data"},
+        c2,  # pending — result never arrived
+        {"role": "assistant", "content": "continue"},
+        {"role": "user", "content": "u1"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "user", "content": "u2"},
+        {"role": "assistant", "content": "a2"},
+    ]
+    _context_collapse(msgs)
+    assert c1["tool_calls"][0]["function"]["arguments"] == fat
+    assert c2["tool_calls"][0]["function"]["arguments"] == fat


### PR DESCRIPTION
## What

Context compaction sized and relieved messages by `content` only, so assistant tool-call payloads (empty `content`, large `tool_calls[].function.arguments`) were effectively invisible to the very mechanisms meant to control context growth:

- **Architectural-mismatch quote:** *"`_auto_compact`'s token-budget tail walk counted `len(content)//4 + 10` per message, so a 90 KB arguments blob counted as ~10 tokens and survived in the preserved tail instead of being folded into the LLM summary."*

Two sites:

1. **`_auto_compact` token-budget tail walk** — sized each message by `content` only, so oversized `arguments` dodged the fold and were retained in the "~20K recent tokens" tail, blowing through the budget unboundedly under a heavy tool-calling loop.
2. **`_context_collapse` (zero-cost layer 2)** — folded only long `content` strings; oversized tool-call payloads got no relief short of spending LLM tokens at layer 3.

## How

- `_msg_estimate_chars(msg)` — sizes `content` **plus** every tool-call `arguments` payload.
- `_tail_cut_index(body, budget=TAIL_TOKEN_BUDGET)` — extracted the tail walk into a pure, pair-safe helper, now argument-aware; `_auto_compact` calls it.
- `_context_collapse` — folds a tool-call's huge `arguments` to a valid JSON `"{}"` stub **only when its paired tool result was already `[cleared]`** (the data is gone; the call id/name are preserved so pairing and the model's "I called tool X" memory survive). Provider still receives well-formed `arguments`.

Safety: verified no code re-reads historical `tool_calls[].arguments` for re-dispatch (dedup keys on incoming calls; grounding reads only live call args; `context.py` only writes them).

## Proof

- **Red (origin/main):** `test_tail_cut_index_counts_tool_call_arguments` and `test_context_collapse_stubs_args_of_cleared_paired_call` fail — the 90K arguments blob is untouched.
- **Green (this branch):** 3 new tests pass; 283 related tests across loop/auto-compact/grounding/output-discipline stay green.
- Negative arm `test_context_collapse_keeps_args_when_result_intact_or_pending` guards against over-stubbing (intact or pending calls keep their arguments).

## Related but distinct (not claimed / not duplicated)

- **#1337** (closed) — arguments in **market-data dedup keys**; different mechanism, different failure mode.
- **#1224** (closed) — run.json **output-token usage telemetry** fallback ignoring tool-call arguments; tracing/accounting subsystem, not context compaction.
- **#1055** (closed) — auto-compaction silently **drops** conversation content; the opposite concern.
- **#1341 / #1349** — dedup dead-pointer after microcompact (`_microcompact`/`_called_ok`); they do not touch this tail-walk or layer-2 relief.

## Scope note

`_context_collapse` deliberately does **not** text-fold `arguments` in general (would corrupt the JSON the provider re-validates); it only stubs payloads whose result is already gone. The tail-walk handles general oversized-call folding via the LLM summary at layer 3.
