### PR TITLE
test(grounding): exercise the adjacent CJK boundary

### DIFF
--- a/agent/src/agent/grounding.py
+++ b/agent/src/agent/grounding.py
@@ -309,7 +309,7 @@ _PERCENT_RANGE_RE = re.compile(
 # The Chinese units take an optional measure word ("3.6 个百分点" is the
 # ordinary spelling; bare "3.6 百分点" is the rare one) and are matched
 # without a trailing \b: after a CJK character \b requires a non-word
-# character to follow, so "下降 3.6 个百分点，主因…" would not match. The
+# character to follow, so "下降 3.6 个百分点后企稳" would not match. The
 # ASCII units keep \b, which is what stops "3.6ppm" being read as pp.
 _PERCENTAGE_POINT_RE = re.compile(
     r"[-+~≈]?\s*\d[\d,]*(?:\.\d+)?\s*"

--- a/agent/tests/test_grounding_percentage_points.py
+++ b/agent/tests/test_grounding_percentage_points.py
@@ -86,7 +86,7 @@ def test_bare_number_still_extracted():
         # A trailing CJK character rather than punctuation: \b after a CJK
         # unit needs a non-word char to follow, so this is the case that
         # breaks if the boundary is reintroduced there.
-        "毛利率下降 3.6 个百分点，主因是原材料",
+        "毛利率下降 3.6 个百分点后企稳",
     ],
 )
 def test_chinese_percentage_point_deltas_are_masked(text: str) -> None:


### PR DESCRIPTION
## Summary

Follow-up to #1346's Chinese percentage-point coverage. The production regex is correct; the fixture intended to protect its CJK boundary behavior did not exercise that behavior.

`毛利率下降 3.6 个百分点，主因是原材料` has a comma immediately after `百分点`. The comma is a non-word character, so a trailing `\b` **does** match there. Reintroducing the unwanted CJK `\b` left all 29 tests green, including the test described as catching it.

Replace that one fixture with `毛利率下降 3.6 个百分点后企稳`, where `后` immediately follows the unit. Update the source comment to use the same accurate example. No executable production code changes; existing Chinese spelling, English unit-boundary, and genuine-price controls are preserved.

## Verification

On upstream `5c2766f` with Python 3.11:

- Existing fixture + in-memory mutation restoring `\b` after `个?(?:百分点|基点)`: **29 passed** (missing coverage).
- Corrected fixture + the same mutation: **1 failed, 28 passed**, leaking `[3.6]` from the new sentence.
- Corrected fixture + unchanged production regex: **282 passed** across `test_grounding_percentage_points.py`, `test_grounding_language_parity.py`, `test_agent_grounding.py`, and `test_agent_output_discipline.py`.
- Ruff on the changed test and `git diff --check`: passed.

The mutation was applied only in memory for a separate pytest process; it is not part of the diff.

## Scope / risk / rollback

One test input and one explanatory comment. No broker/order, credentials, provider, MCP, deployment, dependency, or runtime-policy changes. No live trading or market-data requests. Revert the commit to undo.

AI-assisted contribution; checks above were executed locally. Full backend/frontend suites were not run for this two-line test-only change.
