### PR TITLE
fix(ci): upgrade Docker actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -40,10 +40,10 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
 
       - name: Log in to GHCR
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
@@ -61,7 +61,7 @@ jobs:
 
       - name: Extract metadata for GHCR
         id: meta-ghcr
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}
           tags: |
@@ -70,7 +70,7 @@ jobs:
 
       - name: Extract metadata for Docker Hub
         id: meta-dockerhub
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_IMAGE_NAME }}
           tags: |
@@ -78,7 +78,7 @@ jobs:
             type=raw,value=latest,enable=${{ inputs.image_tag != 'latest' }}
 
       - name: Build and push
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: Dockerfile


### PR DESCRIPTION
## Summary

Upgrade Docker-related GitHub Actions to their latest major versions that support Node.js 24, resolving the deprecation warnings.

## Changes

| Action | Old Version | New Version |
|--------|-------------|-------------|
| docker/setup-buildx-action | v3.12.0 | v4.3.0 |
| docker/setup-qemu-action | v3.7.0 | v4.3.0 |
| docker/metadata-action | v5.10.0 | v6.2.0 |
| docker/build-push-action | v5.4.0 | v7.3.0 |

## Problem

GitHub Actions CI was showing deprecation warnings:
- Node.js 20 is deprecated
- Actions targeting Node.js 20 are being forced to run on Node.js 24

## Verification

Successfully triggered and completed a workflow run with all steps passing. The Node.js 20 deprecation warnings are no longer present.

## Note

The remaining warning about README exceeding DockerHub's 25000 byte limit is pre-existing and unrelated to this change.