### PR TITLE
fix(report-audit): fail closed when nothing was verified

### DIFF
--- a/agent/src/tools/report_audit_tool.py
+++ b/agent/src/tools/report_audit_tool.py
@@ -272,7 +272,9 @@ def render_verdict(results: list[dict[str, Any]], report_name: str = "") -> dict
 
     A point whose ``reported_value`` is missing, ``None``, or non-finite is
     unverifiable, so it fails with an explicit ``reason`` instead of being
-    treated as a reported zero. A genuine reported ``0`` stays valid.
+    treated as a reported zero. A genuine reported ``0`` stays valid. A
+    supplied but non-finite ``fetched_value`` fails the point the same way
+    (unverifiable evidence), while an absent one is skipped as "not verified".
 
     Args:
         results: List of verification objects — ``{id, label, reported_value,
@@ -281,7 +283,10 @@ def render_verdict(results: list[dict[str, Any]], report_name: str = "") -> dict
         report_name: Optional report name for display.
 
     Returns:
-        Verdict dict: ``verdict`` is ``PASS`` (zero failures) or ``FAIL``.
+        Verdict dict: ``verdict`` is ``PASS`` (zero failures, at least one
+        verified point) or ``FAIL``. A call in which nothing was verified
+        fails closed — a report certified with zero evidence is the failure
+        mode this gate exists to prevent.
     """
     fail_items: list[dict[str, Any]] = []
     warn_items: list[dict[str, Any]] = []
@@ -289,9 +294,33 @@ def render_verdict(results: list[dict[str, Any]], report_name: str = "") -> dict
     total = 0
 
     for item in results:
-        fetched = item.get("fetched_value")
+        raw_fetched = item.get("fetched_value")
+        if raw_fetched is None:
+            continue  # not verified — skip, do not count (pinned design)
+        # Coerce through _finite_number so a non-numeric fetched value (a
+        # string, NaN, …) is treated as unusable evidence, not a crash.
+        fetched = _finite_number(raw_fetched)
         if fetched is None:
-            continue  # not verified — skip, do not count
+            # Supplied but unusable is NOT "not verified" (which is silently
+            # skipped): fail the point. Otherwise a junk fetch could be used
+            # to drop a hard-to-verify number from the audit entirely.
+            total += 1
+            label = item.get("label", "?")
+            fail_items.append({
+                "id": item.get("id"), "label": label,
+                "reported": _finite_number(item.get("reported_value")),
+                "unit": item.get("unit", ""),
+                "fetched": None, "source": item.get("fetched_source", "?"),
+                "fetched2": None, "source2": item.get("fetched_source2", ""),
+                "diff1_pct": None, "diff2_pct": None,
+                "reason": (
+                    f"fetched value is not a finite number ({raw_fetched!r}) "
+                    "— cannot verify"
+                ),
+                "raw_text": item.get("raw_text", ""),
+                "line_number": item.get("line_number", 0),
+            })
+            continue
         total += 1
         label = item.get("label", "?")
         unit = item.get("unit", "")
@@ -306,7 +335,7 @@ def render_verdict(results: list[dict[str, Any]], report_name: str = "") -> dict
             fail_items.append({
                 "id": item.get("id"), "label": label,
                 "reported": None, "unit": unit,
-                "fetched": _finite_number(fetched), "source": source,
+                "fetched": fetched, "source": source,
                 "fetched2": _finite_number(item.get("fetched_value2")),
                 "source2": item.get("fetched_source2", ""),
                 "diff1_pct": None, "diff2_pct": None,
@@ -320,10 +349,11 @@ def render_verdict(results: list[dict[str, Any]], report_name: str = "") -> dict
             })
             continue
 
-        fetched = float(fetched)
         diff1 = _pct_diff(reported, fetched)
 
-        fetched2 = item.get("fetched_value2")
+        # A non-finite second source is ignored (single-source semantics)
+        # instead of crashing the verdict; a garbage source verifies nothing.
+        fetched2 = _finite_number(item.get("fetched_value2"))
         source2 = item.get("fetched_source2", "")
         pass1 = diff1 <= _TOLERANCE
 
@@ -344,7 +374,7 @@ def render_verdict(results: list[dict[str, Any]], report_name: str = "") -> dict
         else:
             # Two sources: PASS only if both agree within tolerance; FAIL if
             # both miss; otherwise WARN (a caliber / GAAP mismatch, not a fail).
-            f2 = float(fetched2)
+            f2 = fetched2  # already coerced finite above
             diff2 = _pct_diff(reported, f2)
             pass2 = diff2 <= _TOLERANCE
             if pass1 and pass2:
@@ -367,6 +397,18 @@ def render_verdict(results: list[dict[str, Any]], report_name: str = "") -> dict
                     "diff1_pct": _pct_diff_for_json(diff1),
                     "diff2_pct": _pct_diff_for_json(diff2),
                 })
+
+    if total == 0:
+        # Fail closed: zero verified points means the audit gathered no
+        # evidence at all. Certifying that as PASS would let an unaudited
+        # report — or an agent that fetched nothing — through the gate.
+        fail_items.append({
+            "id": None, "label": "audit", "reported": None, "unit": "",
+            "fetched": None, "source": "", "fetched2": None, "source2": "",
+            "diff1_pct": None, "diff2_pct": None,
+            "reason": "no data points were verified — every result lacked a fetched_value",
+            "raw_text": "", "line_number": 0,
+        })
 
     fail_count = len(fail_items)
     verdict = "PASS" if fail_count == 0 else "FAIL"

--- a/agent/tests/test_report_audit_tool.py
+++ b/agent/tests/test_report_audit_tool.py
@@ -231,7 +231,70 @@ def test_verdict_skips_points_without_fetched_value() -> None:
     assert out["verdict"] == "PASS"
 
 
-# ── tool contract ─────────────────────────────────────────────────────────
+def test_verdict_zero_verified_points_fails_closed() -> None:
+    """A verdict where NOTHING was verified must not certify the report."""
+    out = render_verdict([
+        {"id": 1, "label": "a", "reported_value": 100, "fetched_value": None},
+        {"id": 2, "label": "b", "reported_value": 200, "fetched_value": None},
+    ])
+    assert out["verdict"] == "FAIL"
+    assert out["total"] == 0
+    assert out["fail_count"] == 1
+    assert "no data points were verified" in out["fail_items"][0]["reason"]
+
+
+def test_verdict_garbage_fetched_value_fails_point() -> None:
+    """A supplied-but-unusable fetched value fails the point, not a crash.
+
+    Junk is NOT the same as an absent fetch: skipping it would let an agent
+    drop a hard-to-verify number by padding it with a garbage fetch.
+    """
+    out = render_verdict([
+        {"id": 1, "label": "a", "reported_value": 100,
+         "fetched_value": "about 100", "fetched_source": "s"},
+    ])
+    assert out["verdict"] == "FAIL"
+    assert out["total"] == 1
+    assert out["fail_count"] == 1
+    assert "fetched value is not a finite number" in out["fail_items"][0]["reason"]
+
+
+def test_verdict_garbage_fetch_cannot_pad_a_clean_report() -> None:
+    """One good point does not launder a garbage-fetch sibling."""
+    out = render_verdict([
+        {"id": 1, "label": "good", "reported_value": 100,
+         "fetched_value": 100, "fetched_source": "m"},
+        {"id": 2, "label": "hard", "reported_value": 500,
+         "fetched_value": "see above", "fetched_source": "s"},
+    ])
+    assert out["verdict"] == "FAIL"
+    assert out["total"] == 2
+    assert out["fail_count"] == 1
+
+
+def test_verdict_absent_fetched_with_good_point_still_passes() -> None:
+    """Absent fetch is legitimately 'not verified' and stays skippable."""
+    out = render_verdict([
+        {"id": 1, "label": "a", "reported_value": 100, "fetched_value": None},
+        {"id": 2, "label": "b", "reported_value": 100,
+         "fetched_value": 100, "fetched_source": "m"},
+    ])
+    assert out["verdict"] == "PASS"
+    assert out["total"] == 1
+
+
+def test_verdict_garbage_second_source_falls_back_to_single() -> None:
+    """A non-finite second source degrades to single-source, not a crash."""
+    out = render_verdict([
+        {"id": 1, "label": "a", "reported_value": 100,
+         "fetched_value": 100, "fetched_source": "m",
+         "fetched_value2": "n/a", "fetched_source2": "x"},
+    ])
+    assert out["verdict"] == "PASS"
+    assert out["total"] == 1
+
+
+# ── tool contract ─────────────────────────────────────────────────────
 
 
 def test_tool_metadata() -> None:


### PR DESCRIPTION
## Problem

`render_verdict` returned **PASS** on a verdict call where *zero* data points were verified:

```python
render_verdict([
    {"id": 1, "label": "净利润", "reported_value": 1234.5, "fetched_value": None},
    {"id": 2, "label": "revenue", "reported_value": 999.0, "fetched_value": None},
])
# -> {"verdict": "PASS", "total": 0, "pass_count": 0, "fail_count": 0}
```

Items whose `fetched_value` is missing are deliberately skipped ("not verified — skip, do not count"), and the verdict was `PASS if fail_count == 0`. With nothing verified, `fail_count` is 0 — so the gate certifies a report that had **no evidence at all**. The failure is silent: the report ships as "audited".

This is the aggregate version of a failure mode the same function already guards against at the point level — the existing comment on `reported_value` handling: *"fabricating 0.0 here would … falsely certify the report."* The zero-evidence hole contradicts that stated intent; the original skip logic (ef74a223) never appears to have considered the all-unverified case, and no test pins it.

## Fix

- `total == 0` now appends an explicit fail item (`reason: "no data points were verified — every result lacked a fetched_value"`) → verdict is **FAIL**. Fail-closed; the binary PASS/FAIL contract is unchanged.
- A **supplied but non-finite** `fetched_value` (e.g. the string `"about 100"`, NaN) fails its point with a reason instead of raising `ValueError` and killing the whole verdict. It is deliberately **not** treated as "absent": skipping it would let an agent drop a hard-to-verify number by padding it with a junk fetch. Unverifiable evidence fails loudly — matching how `reported_value` is already handled. An **absent** `fetched_value` stays skippable (pinned by the pre-existing partial-coverage test).
- A non-finite `fetched_value2` degrades to single-source semantics — equivalent to omitting it, which is already a legitimate path, so no new attack surface.

## Behavior table

| Input | before | after |
|---|---|---|
| all `fetched_value` absent | PASS (total=0) | FAIL + reason |
| garbage `fetched_value` | ValueError kills whole verdict | FAIL point + reason |
| garbage fetch + clean sibling | ValueError | FAIL (can't launder) |
| garbage `fetched_value2` | ValueError | single-source degrade |
| absent fetch + verified point | PASS | PASS (unchanged) |

## Known limitation (unchanged)

A hallucinating agent that fabricates `fetched_value`s *matching* its reported values passes either way — no client-side check can catch that; this fix only closes the zero-evidence and garbage-evidence paths.

## Tests

4 new tests pin: zero-verified FAIL, garbage-fetch FAIL (incl. the padding case), absent-fetch skip preserved, garbage source2 degrade. 92 passing across `test_report_audit_tool.py`, `test_report_audit_empty_table_cells.py`, `test_tools_type_value_safety.py`.