### PR TITLE
feat(providers): cache the Anthropic static prefix and record cache usage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
         # OpenBB Workspace bridge would report green while never being exercised.
         # `stats` is included for the same reason: the quantlib econometrics
         # tests skip without statsmodels/arch, and skipped is not tested.
-        run: pip install -e ".[dev,openbb,stats]"
+        run: pip install -e ".[dev,openbb,stats,anthropic]"
 
       - name: Verify optional extras under test are importable
         # Fails loudly if an extra stops resolving, instead of letting its
@@ -104,6 +104,7 @@ jobs:
           python -c "import openbb_ai, importlib.metadata as m; print('openbb-ai', m.version('openbb-ai'))"
           python -c "import statsmodels; print('statsmodels', statsmodels.__version__)"
           python -c "import arch; print('arch', arch.__version__)"
+          python -c "import langchain_anthropic; print('langchain-anthropic', langchain_anthropic.__version__)"
 
       - name: Repository safety gates
         run: bash tools/ci_grep_gates.sh

--- a/agent/.env.example
+++ b/agent/.env.example
@@ -156,6 +156,12 @@ MAX_RETRIES=2
 # Ignore HTTP_PROXY/HTTPS_PROXY for OpenAI-compatible LLM requests only. The
 # explicit direct transports still honor SSL_CERT_FILE/SSL_CERT_DIR.
 # VIBE_TRADING_DISABLE_HTTP_PROXY=0
+# Anthropic prompt caching (native provider only): requests that carry the agent's
+# system prompt get an explicit cache breakpoint on that block plus the top-level
+# automatic breakpoint, so the static tools+system prefix is read from cache instead
+# of resent at full price on every call. Set to 0 if a compatible proxy rejects the
+# cache_control request parameter.
+# VIBE_TRADING_ANTHROPIC_PROMPT_CACHE=1
 
 # Reasoning effort: none / low / medium / high / max.
 # ChatOpenAI-compatible providers use their supported Chat Completions reasoning

--- a/agent/src/agent/loop.py
+++ b/agent/src/agent/loop.py
@@ -223,11 +223,21 @@ def _normalize_llm_usage(usage: Any) -> dict[str, int] | None:
         total_tokens = input_tokens + output_tokens
     if not (input_tokens or output_tokens or total_tokens):
         return None
-    return {
+    normalized: dict[str, int] = {
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
         "total_tokens": total_tokens,
     }
+    details = usage.get("input_token_details")
+    if isinstance(details, dict):
+        if details.get("cache_read") is not None:
+            normalized["cache_read_tokens"] = _coerce_usage_int(details["cache_read"])
+        creation_keys = ("cache_creation", "ephemeral_5m_input_tokens", "ephemeral_1h_input_tokens")
+        if any(details.get(key) is not None for key in creation_keys):
+            normalized["cache_creation_tokens"] = sum(
+                _coerce_usage_int(details.get(key)) for key in creation_keys
+            )
+    return normalized
 
 
 def _new_llm_usage_summary(llm: Any) -> dict[str, Any]:
@@ -265,6 +275,9 @@ def _record_llm_usage(
     totals["output_tokens"] = int(totals.get("output_tokens") or 0) + normalized["output_tokens"]
     totals["total_tokens"] = int(totals.get("total_tokens") or 0) + normalized["total_tokens"]
     totals["calls"] = int(totals.get("calls") or 0) + 1
+    for key in ("cache_read_tokens", "cache_creation_tokens"):
+        if key in normalized:
+            totals[key] = int(totals.get(key) or 0) + normalized[key]
     summary.setdefault("per_iteration", []).append({"iter": iteration, **normalized})
     summary["updated_at"] = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 

--- a/agent/src/config/env_schema.py
+++ b/agent/src/config/env_schema.py
@@ -161,6 +161,9 @@ class LLMConfig(_EnvBase):
     vibe_trading_disable_http_proxy: EnvBool = Field(
         alias="VIBE_TRADING_DISABLE_HTTP_PROXY", default=False,
     )
+    vibe_trading_anthropic_prompt_cache: EnvBool = Field(
+        alias="VIBE_TRADING_ANTHROPIC_PROMPT_CACHE", default=True,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/agent/src/providers/chat.py
+++ b/agent/src/providers/chat.py
@@ -21,6 +21,33 @@ from src.providers.llm import build_llm
 
 logger = logging.getLogger(__name__)
 
+_PROMPT_CACHE_CONTROL: dict[str, str] = {"type": "ephemeral"}
+_DIRECT_ANTHROPIC_LLM_TYPE = "anthropic-chat"
+
+
+def prompt_cache_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Return a message list whose leading system string carries a cache breakpoint.
+
+    The system prompt is the end of the static prefix (tools render before it),
+    so a breakpoint there gives that prefix a guaranteed cache read point even
+    when later messages are edited by context compression. Anything other than
+    a leading ``{"role": "system", "content": <non-empty str>}`` is returned
+    unchanged, and the caller's list is never mutated.
+    """
+    if not messages:
+        return messages
+    first = messages[0]
+    if not isinstance(first, dict) or first.get("role") != "system":
+        return messages
+    content = first.get("content")
+    if not isinstance(content, str) or not content:
+        return messages
+    cached = dict(first)
+    cached["content"] = [
+        {"type": "text", "text": content, "cache_control": dict(_PROMPT_CACHE_CONTROL)}
+    ]
+    return [cached, *messages[1:]]
+
 
 def _dedupe_finish_reason(raw: str) -> str:
     """Relays (OpenRouter) emit finish_reason per chunk; AIMessageChunk.__add__
@@ -358,6 +385,26 @@ class ChatLLM:
             except Exception:
                 logger.debug("ChatLLM.aclose: failed to close %s", label, exc_info=True)
 
+    def _prompt_cache_request(
+        self, messages: List[Dict[str, Any]]
+    ) -> tuple[List[Dict[str, Any]], Dict[str, Any]]:
+        """Return the messages and call kwargs to send, with cache markers when they apply.
+
+        Markers are added only for the direct Anthropic adapter, only when the
+        flag is on, and only when the request carries a leading system prompt:
+        one explicit breakpoint on that block plus the top-level automatic one.
+        One-shot calls without a system prompt (context compaction, image
+        vision, title generation) are sent unchanged.
+        """
+        if getattr(self._llm, "_llm_type", None) != _DIRECT_ANTHROPIC_LLM_TYPE:
+            return messages, {}
+        if get_env_config().llm.vibe_trading_anthropic_prompt_cache is not True:
+            return messages, {}
+        prepared = prompt_cache_messages(messages)
+        if prepared is messages:
+            return messages, {}
+        return prepared, {"cache_control": dict(_PROMPT_CACHE_CONTROL)}
+
     def _close_candidates(self) -> list[tuple[str, Any]]:
         """Return unique clients this wrapper is responsible for closing."""
         llm = self._llm
@@ -417,7 +464,8 @@ class ChatLLM:
         """
         llm = self._llm.bind_tools(tools) if tools else self._llm
         config = {"timeout": timeout} if timeout else {}
-        ai_message = llm.invoke(messages, config=config)
+        messages, call_kwargs = self._prompt_cache_request(messages)
+        ai_message = llm.invoke(messages, config=config, **call_kwargs)
         return self._parse_response(ai_message)
 
     def stream_chat(
@@ -455,12 +503,13 @@ class ChatLLM:
         try:
             llm = self._llm.bind_tools(tools) if tools else self._llm
             config = {"timeout": timeout} if timeout else {}
+            messages, call_kwargs = self._prompt_cache_request(messages)
             accumulated = None
             pending_text = ""
             possible_dsml_text = True
             cancelled = False
             last_chunk_ts = _time.monotonic()
-            for chunk in llm.stream(messages, config=config):
+            for chunk in llm.stream(messages, config=config, **call_kwargs):
                 now = _time.monotonic()
                 if idle_timeout_s and now - last_chunk_ts > idle_timeout_s:
                     # No delta for too long: the provider is stalled, not
@@ -498,7 +547,7 @@ class ChatLLM:
                     "Provider stream returned no chunks; falling back to "
                     "non-streaming invoke."
                 )
-                return self.chat(messages, tools=tools, timeout=timeout)
+                return self._parse_response(llm.invoke(messages, config=config, **call_kwargs))
             response = self._parse_response(accumulated)
             if pending_text and not (response.has_tool_calls and response.content == ""):
                 on_text_chunk(pending_text)
@@ -512,7 +561,7 @@ class ChatLLM:
                     "non-streaming invoke.",
                     type(exc).__name__,
                 )
-                return self.chat(messages, tools=tools, timeout=timeout)
+                return self._parse_response(llm.invoke(messages, config=config, **call_kwargs))
             _cfg = get_env_config()
             provider = _cfg.llm.langchain_provider.strip().lower() or "openai"
             model = self.model_name or _cfg.llm.langchain_model_name.strip() or "(unset)"

--- a/agent/tests/test_anthropic_prompt_cache.py
+++ b/agent/tests/test_anthropic_prompt_cache.py
@@ -1,0 +1,287 @@
+"""Prompt caching for the Anthropic provider (flag, payload, usage)."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+import src.providers.llm as llm_mod
+from src.agent.loop import _normalize_llm_usage, _record_llm_usage
+from src.config.accessor import get_env_config, reset_env_config
+from src.providers.chat import ChatLLM, prompt_cache_messages
+
+
+@pytest.fixture(autouse=True)
+def _fresh_env_config(monkeypatch):
+    # _dotenv_loaded suppresses .env loading for the tests that build a real
+    # adapter; monkeypatch restores it so the flag does not leak to later tests.
+    monkeypatch.setattr(llm_mod, "_dotenv_loaded", True)
+    reset_env_config()
+    yield
+    reset_env_config()
+
+
+def test_prompt_cache_flag_defaults_on() -> None:
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("VIBE_TRADING_ANTHROPIC_PROMPT_CACHE", None)
+        reset_env_config()
+        assert get_env_config().llm.vibe_trading_anthropic_prompt_cache is True
+
+
+def test_prompt_cache_flag_parses_off() -> None:
+    with patch.dict(os.environ, {"VIBE_TRADING_ANTHROPIC_PROMPT_CACHE": "0"}, clear=False):
+        reset_env_config()
+        assert get_env_config().llm.vibe_trading_anthropic_prompt_cache is False
+
+
+_ANTHROPIC_ENV = {
+    "LANGCHAIN_PROVIDER": "anthropic",
+    "LANGCHAIN_MODEL_NAME": "claude-sonnet-5",
+    "LANGCHAIN_TEMPERATURE": "0",
+    "LANGCHAIN_REASONING_EFFORT": "medium",
+    "ANTHROPIC_API_KEY": "test-key",
+    "ANTHROPIC_BASE_URL": "https://api.anthropic.com",
+}
+
+
+def test_prompt_cache_messages_marks_leading_system_string() -> None:
+    messages = [{"role": "system", "content": "stable prefix"}, {"role": "user", "content": "hi"}]
+    out = prompt_cache_messages(messages)
+    assert out[0] == {
+        "role": "system",
+        "content": [{"type": "text", "text": "stable prefix", "cache_control": {"type": "ephemeral"}}],
+    }
+    assert out[1] is messages[1]
+    assert messages[0] == {"role": "system", "content": "stable prefix"}
+
+
+def test_prompt_cache_messages_leaves_other_shapes_alone() -> None:
+    no_system = [{"role": "user", "content": "hi"}]
+    assert prompt_cache_messages(no_system) is no_system
+    blocks = [{"role": "system", "content": [{"type": "text", "text": "x"}]}]
+    assert prompt_cache_messages(blocks) is blocks
+    assert prompt_cache_messages([]) == []
+
+
+class _FakeChunk:
+    """Minimal AIMessageChunk stand-in, same shape tests/test_chat_llm_streaming.py uses."""
+
+    def __init__(self, content: str = "", finish_reason: str = "stop") -> None:
+        self.content = content
+        self.tool_calls: list[dict[str, Any]] = []
+        self.additional_kwargs: dict[str, Any] = {}
+        self.response_metadata = {"finish_reason": finish_reason}
+        self.usage_metadata = None
+
+    def __add__(self, other: "_FakeChunk") -> "_FakeChunk":
+        return _FakeChunk(
+            content=f"{self.content}{other.content}",
+            finish_reason=other.response_metadata.get("finish_reason", "stop"),
+        )
+
+
+class _RecordingLLM:
+    """Records the messages and call kwargs each send path handed to the adapter."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[Any, dict[str, Any]]] = []
+
+    def bind_tools(self, tools):
+        self.tools = tools
+        return self
+
+    def invoke(self, messages, config=None, **kwargs):
+        self.calls.append((messages, kwargs))
+        return _FakeChunk(content="ok")
+
+    def stream(self, messages, config=None, **kwargs):
+        self.calls.append((messages, kwargs))
+        yield _FakeChunk(content="ok")
+
+
+class _FakeAnthropicLLM(_RecordingLLM):
+    _llm_type = "anthropic-chat"
+
+
+class _FakeOtherLLM(_RecordingLLM):
+    pass
+
+
+class _FakeAnthropicNoStreamLLM(_RecordingLLM):
+    """Anthropic adapter whose stream yields nothing, forcing the invoke fallback."""
+
+    _llm_type = "anthropic-chat"
+
+    def stream(self, messages, config=None, **kwargs):
+        self.calls.append((messages, kwargs))
+        return iter(())
+
+
+def _chat_client(fake) -> ChatLLM:
+    client = ChatLLM.__new__(ChatLLM)
+    client.model_name = "m"
+    client._llm = fake
+    return client
+
+
+_CACHE_KWARGS = {"cache_control": {"type": "ephemeral"}}
+
+
+def test_prompt_cache_request_marks_only_anthropic_calls_with_a_system_prompt() -> None:
+    msgs = [{"role": "system", "content": "s"}, {"role": "user", "content": "u"}]
+    no_system = [{"role": "user", "content": "u"}]
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("VIBE_TRADING_ANTHROPIC_PROMPT_CACHE", None)
+        reset_env_config()
+        prepared, call_kwargs = _chat_client(_FakeAnthropicLLM())._prompt_cache_request(msgs)
+        assert prepared[0]["content"][0]["cache_control"] == {"type": "ephemeral"}
+        assert call_kwargs == _CACHE_KWARGS
+        # A one-shot call (compaction, vision) has no system prompt: sent unchanged.
+        assert _chat_client(_FakeAnthropicLLM())._prompt_cache_request(no_system) == (no_system, {})
+        assert _chat_client(_FakeOtherLLM())._prompt_cache_request(msgs) == (msgs, {})
+    with patch.dict(os.environ, {"VIBE_TRADING_ANTHROPIC_PROMPT_CACHE": "0"}, clear=False):
+        reset_env_config()
+        assert _chat_client(_FakeAnthropicLLM())._prompt_cache_request(msgs) == (msgs, {})
+
+
+def test_chat_and_stream_chat_send_the_marked_request() -> None:
+    """The seam: both send paths must apply the gate, not just the pure helper."""
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("VIBE_TRADING_ANTHROPIC_PROMPT_CACHE", None)
+        reset_env_config()
+        for send in ("chat", "stream_chat"):
+            msgs = [{"role": "system", "content": "s"}, {"role": "user", "content": "u"}]
+            fake = _FakeAnthropicLLM()
+            getattr(_chat_client(fake), send)(msgs)
+            sent, kwargs = fake.calls[0]
+            assert sent[0]["content"] == [
+                {"type": "text", "text": "s", "cache_control": {"type": "ephemeral"}}
+            ]
+            assert sent[1] is msgs[1]
+            assert kwargs == _CACHE_KWARGS
+            # The caller's list is never mutated.
+            assert msgs[0] == {"role": "system", "content": "s"}
+
+            other = _FakeOtherLLM()
+            getattr(_chat_client(other), send)(msgs)
+            assert other.calls[0] == (msgs, {})
+
+
+def test_stream_chat_no_chunk_fallback_keeps_cache_kwargs(caplog) -> None:
+    """The no-chunk invoke fallback must send the same cache markers as chat()."""
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("VIBE_TRADING_ANTHROPIC_PROMPT_CACHE", None)
+        reset_env_config()
+        msgs = [{"role": "system", "content": "s"}, {"role": "user", "content": "u"}]
+        fake = _FakeAnthropicNoStreamLLM()
+        with caplog.at_level("WARNING"):
+            _chat_client(fake).stream_chat(msgs)
+        sent, kwargs = fake.calls[-1]
+        assert sent[0]["content"] == [
+            {"type": "text", "text": "s", "cache_control": {"type": "ephemeral"}}
+        ]
+        assert kwargs == _CACHE_KWARGS
+
+
+def test_normalize_usage_keeps_cache_details() -> None:
+    usage = {
+        "input_tokens": 1200,
+        "output_tokens": 30,
+        "total_tokens": 1230,
+        "input_token_details": {"cache_read": 70000, "cache_creation": 900},
+    }
+    assert _normalize_llm_usage(usage) == {
+        "input_tokens": 1200,
+        "output_tokens": 30,
+        "total_tokens": 1230,
+        "cache_read_tokens": 70000,
+        "cache_creation_tokens": 900,
+    }
+
+
+def test_cache_creation_survives_langchain_ttl_breakdown() -> None:
+    pytest.importorskip("langchain_anthropic")
+    from anthropic.types import Usage
+    from langchain_anthropic.chat_models import _create_usage_metadata
+
+    usage = Usage(
+        input_tokens=500,
+        output_tokens=12,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=46404,
+        cache_creation={"ephemeral_5m_input_tokens": 46404, "ephemeral_1h_input_tokens": 0},
+    )
+    normalized = _normalize_llm_usage(_create_usage_metadata(usage))
+    assert normalized["cache_creation_tokens"] == 46404
+    assert normalized["cache_read_tokens"] == 0
+
+
+def test_normalize_usage_without_details_is_unchanged() -> None:
+    assert _normalize_llm_usage({"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}) == {
+        "input_tokens": 10,
+        "output_tokens": 5,
+        "total_tokens": 15,
+    }
+    assert _normalize_llm_usage({"input_tokens": 1, "input_token_details": {"cache_read": None}}) == {
+        "input_tokens": 1,
+        "output_tokens": 0,
+        "total_tokens": 1,
+    }
+
+
+def test_record_usage_accumulates_cache_totals(tmp_path) -> None:
+    summary = {"provider": "anthropic", "model": "m", "totals": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0, "calls": 0}, "per_iteration": []}
+    details = {"cache_read": 70000, "cache_creation": 0}
+    _record_llm_usage(tmp_path, summary, {"input_tokens": 100, "output_tokens": 1, "input_token_details": {"cache_read": 0, "cache_creation": 70000}}, 1)
+    _record_llm_usage(tmp_path, summary, {"input_tokens": 100, "output_tokens": 1, "input_token_details": details}, 2)
+    assert summary["totals"]["cache_read_tokens"] == 70000
+    assert summary["totals"]["cache_creation_tokens"] == 70000
+    assert summary["totals"]["calls"] == 2
+    assert summary["per_iteration"][1]["cache_read_tokens"] == 70000
+    assert (tmp_path / "llm_usage.json").exists()
+
+
+def test_real_adapter_request_payload_carries_both_breakpoints() -> None:
+    pytest.importorskip("langchain_anthropic")
+    with patch.dict(os.environ, _ANTHROPIC_ENV, clear=True):
+        reset_env_config()
+        client = ChatLLM()
+        messages = [{"role": "system", "content": "S" * 5000}, {"role": "user", "content": "hi"}]
+        tools = [{"type": "function", "function": {"name": "read_file", "description": "d", "parameters": {"type": "object", "properties": {"path": {"type": "string"}}, "required": ["path"]}}}]
+        bound = client._llm.bind_tools(tools)
+        prepared, call_kwargs = client._prompt_cache_request(messages)
+        payload = bound._get_request_payload(prepared, **bound.kwargs, **call_kwargs)
+    assert payload["cache_control"] == {"type": "ephemeral"}
+    assert payload["system"] == [{"type": "text", "text": "S" * 5000, "cache_control": {"type": "ephemeral"}}]
+    assert [t["name"] for t in payload["tools"]] == ["read_file"]
+    assert payload["messages"] == [{"role": "user", "content": "hi"}]
+    assert payload["output_config"] == {"effort": "medium"}
+    assert payload.get("temperature") is None
+
+
+def test_real_adapter_payload_has_no_cache_markers_when_flag_off() -> None:
+    pytest.importorskip("langchain_anthropic")
+    with patch.dict(os.environ, {**_ANTHROPIC_ENV, "VIBE_TRADING_ANTHROPIC_PROMPT_CACHE": "0"}, clear=True):
+        reset_env_config()
+        client = ChatLLM()
+        messages = [{"role": "system", "content": "S" * 5000}, {"role": "user", "content": "hi"}]
+        prepared, call_kwargs = client._prompt_cache_request(messages)
+        payload = client._llm._get_request_payload(prepared, **call_kwargs)
+    assert "cache_control" not in payload
+    assert payload["system"] == "S" * 5000
+
+
+def test_real_adapter_payload_has_no_cache_markers_without_a_system_prompt() -> None:
+    """One-shot calls (compaction, vision) carry no system prompt and no markers."""
+    pytest.importorskip("langchain_anthropic")
+    with patch.dict(os.environ, _ANTHROPIC_ENV, clear=True):
+        reset_env_config()
+        client = ChatLLM()
+        messages = [{"role": "user", "content": "summarize " + "x" * 5000}]
+        prepared, call_kwargs = client._prompt_cache_request(messages)
+        payload = client._llm._get_request_payload(prepared, **call_kwargs)
+    assert "cache_control" not in payload
+    assert payload.get("system") is None


### PR DESCRIPTION
## Summary

- Send Anthropic prompt caching markers on agent conversation calls: an explicit breakpoint on the system prompt block plus the top-level automatic `cache_control` as a per-call parameter. Requests without the agent's system prompt (context compaction, image vision, title generation) are sent unchanged.
- Record `cache_read_tokens` and `cache_creation_tokens` in `llm_usage.json` and the `llm_usage` event, only when the provider reports them.
- New flag `VIBE_TRADING_ANTHROPIC_PROMPT_CACHE` (default on) switches the markers off. Anthropic provider only; other providers are byte-identical to `main`.
- CI installs the `anthropic` extra so the new wire-payload tests run instead of skipping.

Closes #1365

## Why

Every model call resent the same static prefix (107 tool schemas plus the system prompt, about 70k tokens) at full price. The prefix is stable within a run (tools are registered once, the system prompt is built once at run start), so it is cacheable as is. Real usage from 19 local runs on `claude-sonnet-5`, priced at the official Sonnet 5 rates ($2 input, $2.50 cache write, $0.20 cache read per MTok); the last two columns assume only the fixed prefix is cached, so the saving is a lower bound:

| run | model calls | input tokens billed | of which the fixed prefix | conversation tail | cost at $2/MTok | cost if only the prefix were cached | saving |
|---|---|---|---|---|---|---|---|
| run 1 | 47 | 3,821,602 | 3,308,283 (87%) | 513,319 | $7.64 | $1.85 | 76% |
| run 2 | 28 | 2,542,973 | 1,970,892 (78%) | 572,081 | $5.09 | $1.70 | 67% |
| run 3 | 24 | 2,083,479 | 1,689,336 (81%) | 394,143 | $4.17 | $1.29 | 69% |
| run 4 | 20 | 1,563,832 | 1,407,780 (90%) | 156,052 | $3.13 | $0.76 | 76% |
| run 5 | 18 | 1,596,186 | 1,267,002 (79%) | 329,184 | $3.19 | $1.07 | 66% |
| run 6 | 17 | 1,428,836 | 1,196,613 (84%) | 232,223 | $2.86 | $0.87 | 70% |
| **all 19 runs** | 194 | 16,015,335 | 13,655,466 (85%) | 2,359,869 | $32.03 | $10.53 | 67% |

Details and the offline reproduction are in #1365.

## Changes

- `agent/src/config/env_schema.py`: `vibe_trading_anthropic_prompt_cache: EnvBool` (alias `VIBE_TRADING_ANTHROPIC_PROMPT_CACHE`, default `True`).
- `agent/src/providers/chat.py`: `prompt_cache_messages()` returns a new list whose leading `{"role": "system", "content": str}` becomes `[{"type": "text", "text": ..., "cache_control": {"type": "ephemeral"}}]`. `ChatLLM._prompt_cache_request()` applies it only when the bound model's `_llm_type` is `anthropic-chat`, the flag is on, and the request has that leading system prompt; it then also returns `cache_control={"type": "ephemeral"}` as a call kwarg, which langchain-anthropic forwards as the top-level automatic caching parameter. `chat()` and `stream_chat()` (including the no-chunk invoke fallback) pass both through. The caller's `messages` list is never mutated, so the loop's compression layers see exactly what they saw before. `_build_anthropic` in llm.py is unchanged.
- `agent/src/agent/loop.py`: `_normalize_llm_usage` keeps `input_token_details.cache_read` as `cache_read_tokens` and sums `cache_creation`, `ephemeral_5m_input_tokens` and `ephemeral_1h_input_tokens` into `cache_creation_tokens` (langchain-anthropic zeroes the generic key when it fills the per-TTL ones, so the sum never double counts). Keys appear only when the provider reported details; `_record_llm_usage` accumulates them into `totals` when present. Providers that report no details produce unchanged artifacts. langchain's `input_tokens` already includes cached tokens; the two new keys break that number down.
- `.github/workflows/test.yml`: install the `anthropic` extra and check `langchain_anthropic` imports, following the existing `stats` precedent, so the wire tests do not skip in CI.
- `agent/tests/test_anthropic_prompt_cache.py`: 14 tests (flag parsing, message transform and gating, `chat()` / `stream_chat()` wiring through recording fakes including the fallback path, usage normalisation including a real `anthropic.types.Usage` pushed through langchain's converter, real adapter wire payload with the flag on, off, and without a system prompt).

## Behavior

| | before (`main`) | after, flag on | after, flag off |
|---|---|---|---|
| top-level `cache_control` on conversation requests | absent | `{"type": "ephemeral"}` | absent |
| `system` on conversation requests | plain string | `[{"type": "text", "text": ..., "cache_control": {"type": "ephemeral"}}]` | plain string |
| requests without the agent's system prompt (compaction, vision, title) | unchanged | unchanged | unchanged |
| everything else in the payload (model, tools, `output_config.effort`, thinking, `max_tokens`, temperature handling) | as is | identical to before | identical to before |
| other providers | as is | identical to before | identical to before |
| `llm_usage.json` per iteration and totals | `input_tokens`, `output_tokens`, `total_tokens` | plus `cache_read_tokens`, `cache_creation_tokens` when the provider reports them | plus the same two keys, reported as 0 |
| caller's `messages` list | untouched | untouched | untouched |

## Validation

No paid API calls were used.

- `pytest tests/test_anthropic_prompt_cache.py`: 14 passed. The `test_real_adapter_*` tests construct the real `ChatAnthropic` through `build_llm()` with a dummy key and assert `_get_request_payload()` output; construction opens no socket.
- `pytest tests` (agent suite): 12,362 passed, 86 skipped (the same skips as `main`; none of them are the new tests).
- `ruff check` on the four changed Python files: clean. black was not run because the repo is not black-clean and CI enforces ruff only.
- End to end against a local stand-in for the Messages API (SSE streaming plus a prefix-hash cache simulation), driving the real `AgentLoop` with the real 107-tool registry for three model calls, flag off then on:

| run | call | uncached input | cache read | cache write |
|---|---|---|---|---|
| flag off | 1 | 45,556 | 0 | 0 |
| flag off | 2 | 46,150 | 0 | 0 |
| flag off | 3 | 46,388 | 0 | 0 |
| flag on | 1 | 0 | 0 | 45,572 |
| flag on | 2 | 0 | 45,572 | 594 |
| flag on | 3 | 0 | 46,166 | 238 |

Every flag-on request logged `has_top_level_cache_control: true` and a system block with `cache_control`; every flag-off request logged neither. Token counts in the harness are length estimates, so the ratios are the evidence rather than the absolute numbers.

![before and after](https://raw.githubusercontent.com/averatec0773/Vibe-Trading/assets/prompt-cache/prompt-cache/prompt-cache-before-after.png)

## Notes for review

- Two breakpoints are used out of Anthropic's four, both on the default 5 minute TTL, so neither documented 400 for stacked markers can occur. Nothing else in the repo adds `cache_control`.
- The saving is within a run. The system prompt's last line is the run timestamp at minute resolution and the prompt is built once per run, so the prefix is stable inside a run and differs between runs. Moving that line is a prompt change and is out of scope here.
- The forced text-only last iteration drops the tool list, so that one request has a different prefix and writes a fresh system entry that nothing reads. That is a property of the existing loop, not of this change, and costs one extra write per run.
- `cache_read_tokens` and `cache_creation_tokens` appear in `totals` once any call reported them, so a ratio against `input_tokens` should be computed per iteration rather than from totals.
- If a proxy at `ANTHROPIC_BASE_URL` rejects the top-level field, the call fails with the provider's 400 in `ProviderStreamError`; set `VIBE_TRADING_ANTHROPIC_PROMPT_CACHE=0`.
