### PR TITLE
fix(backtest): extract product code from digit-prefixed and month-code-colliding futures

### DIFF
--- a/agent/backtest/engines/global_futures.py
+++ b/agent/backtest/engines/global_futures.py
@@ -94,6 +94,13 @@ _DEFAULT_COMMISSION = 2.50
 
 _MONTH_CODES = set("FGHJKMNQUVXZ")
 
+# Every listed product, for two disambiguation checks _extract_product needs:
+# a bare symbol that already IS a full product name (M2K has a digit in the
+# middle, so the letters-only regexes below can't recognize it on their own),
+# and a product whose own last letter happens to double as a month code
+# (MYM, FESX, FDAX all end in one).
+_KNOWN_PRODUCTS = frozenset(_MULTIPLIER)
+
 
 def _extract_product(symbol: str) -> str:
     """Extract product code from futures symbol.
@@ -108,17 +115,32 @@ def _extract_product(symbol: str) -> str:
     product group also accepts a single leading digit followed by one
     letter (e.g. 6EZ4 -> 6E), on top of the plain 2-4 letter form.
 
+    A product whose own last letter is itself a valid month code (MYM,
+    FESX, FDAX) reads as ambiguous in YYMM form: MYM2503 parses just as
+    well as "MY" + June + year 2503 as it does as MYM + YYMM 2503. When
+    that happens, the longer, listed product wins over the coincidental
+    month-code reading. A bare symbol with a digit in the middle of its
+    letters (M2K) cannot be split by the regexes below at all, so it is
+    checked directly against the listed products first.
+
     Args:
         symbol: Futures symbol string.
 
     Returns:
-        Product code (e.g. 'ES', 'CL', 'GC', '6E').
+        Product code (e.g. 'ES', 'CL', 'GC', '6E', 'M2K').
     """
     code = symbol.split(".")[0].upper()
+
+    if code in _KNOWN_PRODUCTS:
+        return code
 
     # Pattern 1: product + month-code + year (ESZ4, CLF25, GCM2025, 6EZ4)
     m = re.match(r"(\d[A-Z]|[A-Z]{2,4})([FGHJKMNQUVXZ])(\d{1,4})$", code)
     if m:
+        extended = m.group(1) + m.group(2)
+        rest = code[len(extended) :]
+        if extended in _KNOWN_PRODUCTS and rest.isdigit() and len(rest) == 4:
+            return extended
         return m.group(1)
 
     # Pattern 2: product + YYMM (NQ2503, CL2412, 6EH25)

--- a/agent/backtest/engines/global_futures.py
+++ b/agent/backtest/engines/global_futures.py
@@ -104,26 +104,30 @@ def _extract_product(symbol: str) -> str:
       - Product.exchange:            ES.CME
       - Bare product:                ES
 
+    CME currency futures (6E, 6J, 6B, 6A, 6C) start with a digit, so the
+    product group also accepts a single leading digit followed by one
+    letter (e.g. 6EZ4 -> 6E), on top of the plain 2-4 letter form.
+
     Args:
         symbol: Futures symbol string.
 
     Returns:
-        Product code (e.g. 'ES', 'CL', 'GC').
+        Product code (e.g. 'ES', 'CL', 'GC', '6E').
     """
     code = symbol.split(".")[0].upper()
 
-    # Pattern 1: product + month-code + year (ESZ4, CLF25, GCM2025)
-    m = re.match(r"([A-Z]{2,4})([FGHJKMNQUVXZ])(\d{1,4})$", code)
+    # Pattern 1: product + month-code + year (ESZ4, CLF25, GCM2025, 6EZ4)
+    m = re.match(r"(\d[A-Z]|[A-Z]{2,4})([FGHJKMNQUVXZ])(\d{1,4})$", code)
     if m:
         return m.group(1)
 
-    # Pattern 2: product + YYMM (NQ2503, CL2412)
-    m = re.match(r"([A-Z]+)(\d{4})$", code)
+    # Pattern 2: product + YYMM (NQ2503, CL2412, 6EH25)
+    m = re.match(r"(\d?[A-Z]+)(\d{4})$", code)
     if m:
         return m.group(1)
 
     # Pattern 3: bare product or fallback
-    m = re.match(r"([A-Z]+)", code)
+    m = re.match(r"(\d?[A-Z]+)", code)
     return m.group(1) if m else code
 
 

--- a/agent/tests/test_global_futures_engine.py
+++ b/agent/tests/test_global_futures_engine.py
@@ -69,6 +69,12 @@ class TestExtractProduct:
             ("6JH25", "6J"),
             ("6B", "6B"),
             ("6A.CME", "6A"),
+            ("M2K", "M2K"),
+            ("MYM2503", "MYM"),
+            ("MYMZ4", "MYM"),
+            ("FESX2503", "FESX"),
+            ("FESXZ4", "FESX"),
+            ("FDAXH25", "FDAX"),
         ],
     )
     def test_extract(self, symbol: str, expected: str) -> None:
@@ -205,6 +211,9 @@ class TestContractMultiplier:
             ("6EZ4", 125000),
             ("6JH25", 12500000),
             ("6B", 62500),
+            ("M2K", 5),
+            ("MYM2503", 0.5),
+            ("FESXZ4", 10),
         ],
     )
     def test_multipliers(self, symbol: str, expected: float) -> None:

--- a/agent/tests/test_global_futures_engine.py
+++ b/agent/tests/test_global_futures_engine.py
@@ -65,6 +65,10 @@ class TestExtractProduct:
             ("NQ2503", "NQ"),
             ("ES.CME", "ES"),
             ("ZCH4", "ZC"),
+            ("6EZ4", "6E"),
+            ("6JH25", "6J"),
+            ("6B", "6B"),
+            ("6A.CME", "6A"),
         ],
     )
     def test_extract(self, symbol: str, expected: str) -> None:
@@ -198,6 +202,9 @@ class TestContractMultiplier:
             ("ZCH4", 50),
             ("ZBM5", 1000),
             ("MESZ4", 5),
+            ("6EZ4", 125000),
+            ("6JH25", 12500000),
+            ("6B", 62500),
         ],
     )
     def test_multipliers(self, symbol: str, expected: float) -> None:


### PR DESCRIPTION
## Summary

- Widen product code extraction to accept CME currency futures (6E, 6J, 6B, 6A, 6C).
- Resolve two more listed products the same function mis-parsed: M2K (embedded digit) and MYM/FESX/FDAX (month-code collision).
- Add regression coverage for all affected symbols.

## Why

_extract_product's regexes require the product prefix to start with a letter, so several listed products fall through to returning the whole unparsed symbol, and get_contract_multiplier silently uses the default multiplier instead of the real one.

## Changes

- Accept a leading digit in the product-code group.
- Check bare symbols against the known product list directly.
- Prefer the longer known product when a month-code split's own extension is itself real with a genuine 4-digit YYMM remainder.

## Test Plan

- [x] New regression tests fail on main, pass with the fix
- [x] pytest agent/tests/test_global_futures_engine.py -q (49 passed)
- [x] Broader futures engine test suite (89 passed)

## Checklist

- [x] Changes limited to global_futures engine and its tests
- [x] No hardcoded credentials or paths
- [x] No unrelated changes