### PR TITLE
fix(factors): propagate NaN through gtja191_004 instead of fabricating -1.0

### DIFF
--- a/agent/src/factors/zoo/gtja191/alpha_004.py
+++ b/agent/src/factors/zoo/gtja191/alpha_004.py
@@ -60,4 +60,10 @@ def compute(panel: dict) -> pd.DataFrame:
     res = np.where(cond_top, -1.0,
                    np.where(cond_bot, 1.0,
                             np.where(vol_strong, 1.0, -1.0)))
+    # NaN comparisons are False, not NaN, so a gap in any trailing window
+    # (a halt day inside the 8/20-day lookback, not just series warmup)
+    # would otherwise fall through to the innermost -1.0 branch instead of
+    # propagating NaN like every other operator in this zoo.
+    invalid = ma8.isna() | sd8.isna() | ma2.isna() | vmean20.isna()
+    res = np.where(invalid.to_numpy(), np.nan, res)
     return pd.DataFrame(res, index=c.index, columns=c.columns).astype(float)

--- a/agent/tests/factors/test_gtja191_alpha004_nan_propagation.py
+++ b/agent/tests/factors/test_gtja191_alpha004_nan_propagation.py
@@ -1,0 +1,69 @@
+"""Regression: gtja191_004 must propagate NaN through a data gap, not
+fabricate a -1.0 signal.
+
+compute() picks a branch with nested np.where on comparisons like
+``upper < ma2``. A NaN comparison evaluates False, not NaN, so when any
+of the underlying rolling stats (ma8/sd8/ma2/vmean20) is NaN because a
+trading halt sits inside its lookback window, every comparison falls
+through to the innermost branch and returns a hard -1.0 instead of NaN.
+base.py's own NaN policy ("every operator propagates NaN; no silent
+fillna") requires the gap to stay NaN, and it must stay NaN for every
+bar whose window still touches the gap, not just the gap bar itself.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from src.factors.registry import Registry
+
+N_ROWS = 60
+GAP_ROW = 30  # past min_warmup_bars=20
+
+
+def _panel_with_one_gap() -> dict[str, pd.DataFrame]:
+    rng = np.random.default_rng(0)
+    idx = pd.date_range("2024-01-01", periods=N_ROWS, freq="D")
+    cols = ["SYM0", "SYM1"]
+
+    close = pd.DataFrame(
+        100.0 + np.cumsum(rng.normal(0.0, 1.0, size=(N_ROWS, 2)), axis=0),
+        index=idx,
+        columns=cols,
+    )
+    volume = pd.DataFrame(
+        rng.integers(1_000, 100_000, size=(N_ROWS, 2)).astype(float),
+        index=idx,
+        columns=cols,
+    )
+
+    close.loc[idx[GAP_ROW], "SYM1"] = np.nan
+    volume.loc[idx[GAP_ROW], "SYM1"] = np.nan
+
+    return {"close": close, "volume": volume}
+
+
+def test_gap_stays_nan_through_the_full_affected_window():
+    panel = _panel_with_one_gap()
+    out = Registry().compute("gtja191_004", panel)
+
+    # The gap poisons every rolling window (up to 8/20 bars) still
+    # touching it, not just the gap row.
+    affected = out["SYM1"].iloc[GAP_ROW : GAP_ROW + 8]
+    assert affected.isna().all(), (
+        f"gtja191_004: every bar whose 8-day window touches the gap must "
+        f"stay NaN, got {affected.tolist()}"
+    )
+
+
+def test_unaffected_symbol_still_computes_real_values():
+    panel = _panel_with_one_gap()
+    out = Registry().compute("gtja191_004", panel)
+
+    unaffected = out["SYM0"].iloc[20:]
+    assert not unaffected.isna().any(), (
+        "gtja191_004: a symbol with no gap must not pick up stray NaN "
+        "from another symbol's column"
+    )
+    assert set(unaffected.unique()) <= {-1.0, 1.0}


### PR DESCRIPTION
## Summary

- gtja191_004 now returns NaN through a data gap instead of a fabricated -1.0.
- Added a regression test with a synthetic single-bar gap.

## Why

compute() branches on nested np.where comparisons against rolling stats. A NaN comparison evaluates False, not NaN, so a trading halt inside any lookback window falls through every branch to the innermost -1.0 instead of NaN, violating the zoo's own NaN propagation policy.

## Changes

- Mask the result to NaN wherever any underlying rolling stat is NaN.
- New test verifies the full affected window stays NaN and an unaffected symbol is untouched.

## Test Plan

- [x] New regression test fails on main, passes with the fix
- [x] pytest agent/tests/factors/test_gtja191_alpha004_nan_propagation.py -q
- [x] Full factors test suite (1071 passed, 5 skipped)

## Checklist

- [x] Changes limited to gtja191_004 and its test
- [x] No hardcoded credentials or paths
- [x] No unrelated changes
