### PR TITLE
fix(factors): propagate NaN through alpha101_007 and alpha101_051 gaps

### DIFF
--- a/agent/src/factors/zoo/alpha101/alpha_007.py
+++ b/agent/src/factors/zoo/alpha101/alpha_007.py
@@ -89,4 +89,9 @@ def compute(panel: dict) -> pd.DataFrame:
     d7 = delta(close, 7)
     expr = (-1.0 * ts_rank(d7.abs(), 60)) * np.sign(d7)
     out = where_ternary(adv20 < volume, expr, -1.0 * make_one(close))
-    return out
+    # A NaN comparison is False, not NaN, so where_ternary's own
+    # np.isfinite safety net never fires here: the else branch is a
+    # constant with no NaN dependency, so it stays finite well before
+    # adv20's 20-day lookback is available, fabricating a signal during
+    # the declared warmup instead of NaN.
+    return out.where(adv20.notna())

--- a/agent/src/factors/zoo/alpha101/alpha_051.py
+++ b/agent/src/factors/zoo/alpha101/alpha_051.py
@@ -96,4 +96,9 @@ def compute(panel: dict) -> pd.DataFrame:
     x = ((delay(close, 20) - delay(close, 10)) / 10.0) - ((delay(close, 10) - close) / 10.0)
     one = make_one(close)
     out = where_ternary(x < -0.05, one, -1.0 * (close - delay(close, 1)))
-    return out
+    # A NaN comparison is False, not NaN, so where_ternary's own
+    # np.isfinite safety net never fires here: the else branch only needs
+    # a 1-day delay and stays finite well before x's 20-day lookback is
+    # available, fabricating a signal during the declared warmup instead
+    # of NaN.
+    return out.where(x.notna())

--- a/agent/tests/factors/test_alpha101_alpha007_051_nan_propagation.py
+++ b/agent/tests/factors/test_alpha101_alpha007_051_nan_propagation.py
@@ -1,0 +1,106 @@
+"""Regression: alpha101_007 and alpha101_051 must not fabricate a signal
+before their declared warmup, and must propagate NaN through a gap.
+
+Both use where_ternary(cond, a, b), where cond is a comparison against a
+rolling or delay-based intermediate that is NaN during warmup. A NaN
+comparison evaluates False, not NaN, so where_ternary always falls to
+the else branch, which stays finite well before the real lookback is
+available. where_ternary's own np.isfinite safety net only catches a
+non-finite output, not an output computed from an undefined condition,
+so it never fires. Same bug class already fixed in alpha101_049.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from src.factors.registry import Registry
+
+N_ROWS = 40
+GAP_ROW = 25
+
+
+def test_alpha007_no_signal_before_declared_warmup():
+    idx = pd.date_range("2024-01-01", periods=N_ROWS, freq="D")
+    rng = np.random.default_rng(5)
+    close = pd.DataFrame(
+        100.0 + np.cumsum(rng.normal(0.0, 1.0, size=(N_ROWS, 2)), axis=0),
+        index=idx,
+        columns=["SYM0", "SYM1"],
+    )
+    volume = pd.DataFrame(
+        rng.integers(1_000, 2_000, size=(N_ROWS, 2)).astype(float),
+        index=idx,
+        columns=["SYM0", "SYM1"],
+    )
+    out = Registry().compute("alpha101_007", {"close": close, "volume": volume})
+
+    # adv20 needs 20 observations: rows 0-18 must stay NaN, not the
+    # else branch's fabricated constant -1.0.
+    warmup = out.iloc[:19]
+    assert warmup.isna().all().all(), (
+        f"alpha101_007: rows before adv20's 20-day lookback must stay NaN, "
+        f"got {warmup.stack().tolist()}"
+    )
+
+
+def test_alpha007_volume_gap_stays_nan():
+    idx = pd.date_range("2024-01-01", periods=N_ROWS, freq="D")
+    rng = np.random.default_rng(5)
+    close = pd.DataFrame(
+        100.0 + np.cumsum(rng.normal(0.0, 1.0, size=(N_ROWS, 2)), axis=0),
+        index=idx,
+        columns=["SYM0", "SYM1"],
+    )
+    volume = pd.DataFrame(
+        rng.integers(1_000, 2_000, size=(N_ROWS, 2)).astype(float),
+        index=idx,
+        columns=["SYM0", "SYM1"],
+    )
+    volume.loc[idx[GAP_ROW], "SYM1"] = np.nan
+    out = Registry().compute("alpha101_007", {"close": close, "volume": volume})
+
+    assert pd.isna(out["SYM1"].iloc[GAP_ROW]), (
+        f"alpha101_007: the gap row itself must stay NaN, "
+        f"got {out['SYM1'].iloc[GAP_ROW]!r}"
+    )
+
+
+def test_alpha051_no_signal_before_declared_warmup():
+    idx = pd.date_range("2024-01-01", periods=N_ROWS, freq="D")
+    rng = np.random.default_rng(6)
+    close = pd.DataFrame(
+        100.0 + np.cumsum(rng.normal(0.0, 1.0, size=(N_ROWS, 2)), axis=0),
+        index=idx,
+        columns=["SYM0", "SYM1"],
+    )
+    out = Registry().compute("alpha101_051", {"close": close})
+
+    warmup = out.iloc[:20]
+    assert warmup.isna().all().all(), (
+        f"alpha101_051: rows before the 20-day lookback must stay NaN, "
+        f"got {warmup.stack().tolist()}"
+    )
+    assert pd.notna(out["SYM0"].iloc[20])
+
+
+def test_alpha051_gap_stays_nan():
+    idx = pd.date_range("2024-01-01", periods=N_ROWS, freq="D")
+    rng = np.random.default_rng(6)
+    close = pd.DataFrame(
+        100.0 + np.cumsum(rng.normal(0.0, 1.0, size=(N_ROWS, 2)), axis=0),
+        index=idx,
+        columns=["SYM0", "SYM1"],
+    )
+    close.loc[idx[GAP_ROW], "SYM1"] = np.nan
+    out = Registry().compute("alpha101_051", {"close": close})
+
+    assert pd.isna(out["SYM1"].iloc[GAP_ROW]), (
+        f"alpha101_051: the gap row itself must stay NaN, "
+        f"got {out['SYM1'].iloc[GAP_ROW]!r}"
+    )
+    unaffected = out["SYM0"].iloc[20:]
+    assert (
+        not unaffected.isna().any()
+    ), "alpha101_051: a symbol with no gap must not pick up stray NaN"


### PR DESCRIPTION
## Summary
alpha101_007 and alpha101_051 fabricate a signal during warmup and gaps instead of NaN.

## Why
where_ternary falls to the else branch whenever the condition is undefined, since a NaN comparison evaluates False. Both else branches stay finite well before the real lookback is ready.

## Changes
Mask the output to NaN wherever the condition-determining value is NaN.

## Test Plan
- [x] Existing tests pass
- [x] New tests added

## Checklist
- [x] No changes to protected areas
- [x] No hardcoded values
- [x] Code follows CONTRIBUTING.md

## Alpha PR Reviewer Checklist
- [x] Purity gate passes
- [x] Lookahead gate passes
- [x] compute() preserves NaN at missing-data positions
- [x] DCO signed off