### PR TITLE
fix(factors): propagate NaN through alpha101_009 and alpha101_046 gaps

### DIFF
--- a/agent/src/factors/zoo/alpha101/alpha_009.py
+++ b/agent/src/factors/zoo/alpha101/alpha_009.py
@@ -80,7 +80,14 @@ def compute(panel: dict) -> pd.DataFrame:
     # Helper aliases (local closures keep the file standalone & purity-safe).
     where_ternary = _where_ternary
     d1 = delta(close, 1)
-    cond1 = ts_min(d1, 5) > 0
-    cond2 = ts_max(d1, 5) < 0
+    min5 = ts_min(d1, 5)
+    max5 = ts_max(d1, 5)
+    cond1 = min5 > 0
+    cond2 = max5 < 0
     out = where_ternary(cond1, d1, where_ternary(cond2, d1, -1.0 * d1))
-    return out
+    # A NaN comparison is False, not NaN, so where_ternary's own
+    # np.isfinite safety net never fires here: the innermost fallback
+    # only needs a 1-day delta and stays finite well before the 5-day
+    # lookback is available, fabricating a signal during warmup instead
+    # of NaN.
+    return out.where(min5.notna() & max5.notna())

--- a/agent/src/factors/zoo/alpha101/alpha_046.py
+++ b/agent/src/factors/zoo/alpha101/alpha_046.py
@@ -96,4 +96,9 @@ def compute(panel: dict) -> pd.DataFrame:
     x = ((delay(close, 20) - delay(close, 10)) / 10.0) - ((delay(close, 10) - close) / 10.0)
     one = make_one(close)
     out = where_ternary(0.25 < x, -1.0 * one, where_ternary(x < 0.0, one, -1.0 * (close - delay(close, 1))))
-    return out
+    # A NaN comparison is False, not NaN, so where_ternary's own
+    # np.isfinite safety net never fires here: the innermost fallback
+    # only needs a 1-day delay and stays finite well before x's 20-day
+    # lookback is available, fabricating a signal during warmup instead
+    # of NaN.
+    return out.where(x.notna())

--- a/agent/tests/factors/test_alpha101_alpha009_046_nan_propagation.py
+++ b/agent/tests/factors/test_alpha101_alpha009_046_nan_propagation.py
@@ -1,0 +1,87 @@
+"""Regression: alpha101_009 and alpha101_046 must not fabricate a signal
+before their declared warmup, and must propagate NaN through a gap.
+
+Both use where_ternary(cond, a, b) chains where cond is a comparison
+against a rolling or delay-based intermediate that is NaN during warmup.
+A NaN comparison evaluates False, not NaN, so where_ternary always falls
+through to a fallback branch that stays finite well before the real
+lookback is available. Same bug class already fixed in
+alpha101_007/049/051.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from src.factors.registry import Registry
+
+N_ROWS = 30
+GAP_ROW = 15
+
+
+def _panel_with_one_gap() -> dict[str, pd.DataFrame]:
+    rng = np.random.default_rng(7)
+    idx = pd.date_range("2024-01-01", periods=N_ROWS, freq="D")
+    cols = ["SYM0", "SYM1"]
+
+    close = pd.DataFrame(
+        100.0 + np.cumsum(rng.normal(0.0, 1.0, size=(N_ROWS, 2)), axis=0),
+        index=idx,
+        columns=cols,
+    )
+    close.loc[idx[GAP_ROW], "SYM1"] = np.nan
+    return {"close": close}
+
+
+def test_alpha009_no_signal_before_declared_warmup():
+    panel = _panel_with_one_gap()
+    out = Registry().compute("alpha101_009", panel)
+
+    warmup = out["SYM0"].iloc[:5]
+    assert warmup.isna().all(), (
+        f"alpha101_009: rows before the 5-day lookback must stay NaN, "
+        f"got {warmup.tolist()}"
+    )
+    assert pd.notna(out["SYM0"].iloc[5])
+
+
+def test_alpha009_gap_stays_nan():
+    panel = _panel_with_one_gap()
+    out = Registry().compute("alpha101_009", panel)
+
+    for row in (GAP_ROW, GAP_ROW + 1):
+        assert pd.isna(out["SYM1"].iloc[row]), (
+            f"alpha101_009: row {row} touching the gap must stay NaN, "
+            f"got {out['SYM1'].iloc[row]!r}"
+        )
+    unaffected = out["SYM0"].iloc[6:]
+    assert (
+        not unaffected.isna().any()
+    ), "alpha101_009: a symbol with no gap must not pick up stray NaN"
+
+
+def test_alpha046_no_signal_before_declared_warmup():
+    panel = _panel_with_one_gap()
+    out = Registry().compute("alpha101_046", panel)
+
+    warmup = out["SYM0"].iloc[:20]
+    assert warmup.isna().all(), (
+        f"alpha101_046: rows before the 20-day lookback must stay NaN, "
+        f"got {warmup.tolist()}"
+    )
+    assert pd.notna(out["SYM0"].iloc[20])
+
+
+def test_alpha046_gap_stays_nan():
+    panel = _panel_with_one_gap()
+    out = Registry().compute("alpha101_046", panel)
+
+    assert pd.isna(out["SYM1"].iloc[GAP_ROW]), (
+        f"alpha101_046: the gap row itself must stay NaN, "
+        f"got {out['SYM1'].iloc[GAP_ROW]!r}"
+    )
+    unaffected = out["SYM0"].iloc[21:]
+    assert (
+        not unaffected.isna().any()
+    ), "alpha101_046: a symbol with no gap must not pick up stray NaN"


### PR DESCRIPTION
## Summary
alpha101_009 and alpha101_046 fabricate a signal during warmup and gaps instead of NaN.

## Why
where_ternary falls through to a fallback branch whenever the condition is undefined, since a NaN comparison evaluates False. Both fallbacks stay finite well before the real lookback is ready.

## Changes
Mask the output to NaN wherever the condition-determining value is NaN.

## Test Plan
- [x] Existing tests pass
- [x] New tests added

## Checklist
- [x] No changes to protected areas
- [x] No hardcoded values
- [x] Code follows CONTRIBUTING.md

## Alpha PR Reviewer Checklist
- [x] Purity gate passes
- [x] Lookahead gate passes
- [x] compute() preserves NaN at missing-data positions
- [x] DCO signed off