### PR TITLE
fix(grounding): lock HK-prefixed symbols (HK.06693 -> 06693.HK) so id…

### DIFF
--- a/agent/src/agent/grounding.py
+++ b/agent/src/agent/grounding.py
@@ -198,6 +198,7 @@ _JOINED_CRYPTO_RE = re.compile(
 _CANONICAL_SYMBOL_RE = re.compile(
     r"(?<![A-Za-z0-9_])(?:"
     r"\d{3,6}\.(?:SH|SZ|BJ|SS|HK|KS|KQ)|"
+    r"HK\.\d{3,6}|"          # <-- added: HK-prefixed code (Futu connector format, e.g. HK.06693)
     r"[A-Z][A-Z0-9&.-]{0,19}\.(?:US|NS|BO|FX|TO|V)|"
     r"[A-Z0-9]{2,15}(?:-|/)(?:USDT|USDC|USD|BTC|ETH)|"
     r"[A-Z]{2,15}(?:" + "|".join(_JOINED_CRYPTO_QUOTE_SUFFIXES) + r")|"
@@ -800,6 +801,12 @@ def _normalize_symbol(value: Any) -> str:
                     if base_part.isalpha():
                         return f"{base_part}-{quote}"
         return symbol
+    # HK-prefixed listing (Futu connector format, e.g. HK.06693 / HK.01288):
+    # rewrite to the canonical .HK suffix so identity matching agrees with the
+    # market-data chain (06693.HK) used by get_market_data.
+    if base == "HK" and suffix.replace(".", "", 1).isdigit():
+        digits = suffix.split(".")[0]
+        return f"{digits.zfill(5)}.HK"
     if suffix == "SS":
         suffix = "SH"
     if suffix == "HK" and base.isdigit():


### PR DESCRIPTION
## Problem

When analyzing HK-listed stocks (e.g. 06693.HK / HK.06693), the grounding identity gate relies on `search_symbol` to lock the instrument identity. `search_symbol` depends on two fallible upstream sources (Eastmoney parsing errors, Yahoo 429 rate-limiting), which are frequently unavailable. This causes:

- A user-supplied prefixed code `HK.06693` (the Futu connector format) is **not** locked by `_seed_symbols`, because `_CANONICAL_SYMBOL_RE` only matches the suffix form `06693.HK`, not the prefixed `HK.06693`.
- The identity stays unresolved, so every price-fetching tool (`get_market_data`, `trading_quote`, `trading_history`, `get_financial_statements`, `get_sector_info`) is rejected with `identity_required`.
- The agent cannot produce any analysis even though `get_market_data` itself can return data via the Tencent/Eastmoney market-data chain.

## Fix

1. Extend `_CANONICAL_SYMBOL_RE` with the `HK\.\d{3,6}` prefix form so that `HK.06693` in the user message is also locked by `_seed_symbols`.
2. Update `_normalize_symbol` to canonicalize the prefixed form `HK.06693` / `HK.01288` into the `.HK` suffix form (`06693.HK` / `01288.HK`), keeping identity consistent with the market-data chain used by `get_market_data`.

With this change, the identity gate no longer depends on the possibly-unavailable `search_symbol`; both `HK.06693` and `06693.HK` can be locked and analyzed.

## Verification

- `_scan_symbols("分析港股(HK.06693)")` → `{'06693.HK'}`
- `_normalize_symbol("HK.06693")` → `"06693.HK"`
- `get_market_data("06693.HK")` returns data (source: Tencent) and the agent produces a full quote/analysis without `identity_required`.