### PR TITLE
fix(backtest): match china futures product codes case-insensitively

### DIFF
--- a/agent/backtest/engines/china_futures.py
+++ b/agent/backtest/engines/china_futures.py
@@ -128,6 +128,27 @@ def _extract_product(symbol: str) -> str:
     return m.group(1) if m else code
 
 
+def _ci_lookup(table: dict, product: str, default):
+    """Case-insensitive product lookup.
+
+    The tables above key CFFEX/ZCE products uppercase (IF, CF) and
+    SHFE/DCE/INE/GFEX products lowercase (au, rb) — but this project's
+    own documented symbol convention and Tushare's real ts_code values
+    (data-routing/SKILL.md: CU2406.SHFE; tushare 日线行情.md: CU1811.SHF)
+    use uppercase product codes across every exchange. A caller that
+    follows that convention for a SHFE/DCE/INE/GFEX product would
+    otherwise miss the table entirely and silently fall back to the
+    generic default.
+    """
+    if product in table:
+        return table[product]
+    if product.lower() in table:
+        return table[product.lower()]
+    if product.upper() in table:
+        return table[product.upper()]
+    return default
+
+
 class ChinaFuturesEngine(FuturesBaseEngine):
     """China futures engine covering CFFEX / SHFE / DCE / ZCE / INE / GFEX.
 
@@ -146,7 +167,7 @@ class ChinaFuturesEngine(FuturesBaseEngine):
             codes = config.get("codes", [])
             if codes:
                 product = _extract_product(codes[0])
-                mr = _MARGIN_RATE.get(product, 0.10)
+                mr = _ci_lookup(_MARGIN_RATE, product, 0.10)
                 leverage = 1.0 / mr
             else:
                 leverage = 10.0  # ~10% margin default
@@ -174,7 +195,7 @@ class ChinaFuturesEngine(FuturesBaseEngine):
 
         # Price limit, tested at execution time (see _blocked_by_limit).
         product = _extract_product(symbol)
-        limit = _PRICE_LIMIT.get(product, _DEFAULT_PRICE_LIMIT)
+        limit = _ci_lookup(_PRICE_LIMIT, product, _DEFAULT_PRICE_LIMIT)
         pos = self.positions.get(symbol) if direction == 0 else None
         if pos is None and direction == 0:
             return True
@@ -216,8 +237,8 @@ class ChinaFuturesEngine(FuturesBaseEngine):
             Commission in RMB.
         """
         product = _extract_product(symbol)
-        mode, value = _COMMISSION.get(product, _DEFAULT_COMMISSION)
-        cm = _MULTIPLIER.get(product, 10)
+        mode, value = _ci_lookup(_COMMISSION, product, _DEFAULT_COMMISSION)
+        cm = _ci_lookup(_MULTIPLIER, product, 10)
         if mode == "rate":
             return size * price * cm * value
         return size * value
@@ -229,7 +250,7 @@ class ChinaFuturesEngine(FuturesBaseEngine):
     def get_contract_multiplier(self, symbol: str) -> float:
         """Look up contract multiplier from product code."""
         product = _extract_product(symbol)
-        return float(_MULTIPLIER.get(product, 10))
+        return float(_ci_lookup(_MULTIPLIER, product, 10))
 
     def get_margin_rate(self, symbol: str) -> float:
         """Look up exchange margin rate for a product.
@@ -241,7 +262,7 @@ class ChinaFuturesEngine(FuturesBaseEngine):
             Margin rate (e.g. 0.10 for 10%).
         """
         product = _extract_product(symbol)
-        return _MARGIN_RATE.get(product, 0.10)
+        return _ci_lookup(_MARGIN_RATE, product, 0.10)
 
     def _leverage_for_symbol(self, symbol: str) -> float:
         """Derive leverage from this contract's own margin requirement."""

--- a/agent/tests/test_china_futures_engine.py
+++ b/agent/tests/test_china_futures_engine.py
@@ -251,6 +251,64 @@ class TestMarginRate:
 
 
 # ---------------------------------------------------------------------------
+# Case-insensitive product lookup (this project's documented symbol
+# convention, and Tushare's real ts_code values, use uppercase product
+# codes across every exchange, including SHFE/DCE/INE/GFEX)
+# ---------------------------------------------------------------------------
+
+
+class TestCaseInsensitiveLookup:
+    def test_uppercase_shfe_multiplier(self) -> None:
+        engine = _make_engine()
+        assert engine.get_contract_multiplier("AU2412.SHFE") == 1000
+
+    def test_uppercase_shfe_margin_rate(self) -> None:
+        engine = _make_engine()
+        assert engine.get_margin_rate("AU2412.SHFE") == 0.08
+
+    def test_uppercase_dce_multiplier(self) -> None:
+        # pg's real multiplier (20) differs from the generic default
+        # (10), so a missed case-sensitive lookup can't coincidentally
+        # pass by falling back to the same number.
+        engine = _make_engine()
+        assert engine.get_contract_multiplier("PG2501.DCE") == 20
+
+    def test_uppercase_ine_multiplier(self) -> None:
+        engine = _make_engine()
+        assert engine.get_contract_multiplier("SC2503.INE") == 1000
+
+    def test_uppercase_shfe_fixed_commission(self) -> None:
+        engine = _make_engine()
+        comm = engine.calc_commission_for_symbol("AU2412.SHFE", 3, 500.0, is_open=True)
+        assert comm == pytest.approx(3 * 10.0)
+
+    def test_lowercase_cffex_multiplier(self) -> None:
+        """The opposite direction: CFFEX/ZCE keys are uppercase-only."""
+        engine = _make_engine()
+        assert engine.get_contract_multiplier("if2406.cffex") == 300
+
+    def test_lowercase_zce_multiplier(self) -> None:
+        engine = _make_engine()
+        assert engine.get_contract_multiplier("cf501.zce") == 5
+
+    def test_uppercase_shfe_leverage_from_margin(self) -> None:
+        """__init__ derives leverage from the first code's margin rate."""
+        engine = ChinaFuturesEngine(
+            {"initial_cash": 1_000_000, "codes": ["AU2412.SHFE"]}
+        )
+        assert engine.default_leverage == pytest.approx(1.0 / 0.08)
+
+    def test_lowercase_cffex_price_limit_still_specific(self) -> None:
+        """IF's own 10% limit must still apply lowercase, not the 5%
+        generic default a missed lookup would silently substitute."""
+        engine = _make_engine()
+        # +6%: inside IF's real 10% band, but outside the 5% default a
+        # missed case-sensitive lookup would wrongly fall back to.
+        bar = _make_bar(close=5300.0, pre_close=5000.0)
+        assert engine.can_execute("if2406.cffex", 1, bar) is True
+
+
+# ---------------------------------------------------------------------------
 # Slippage
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
ChinaFuturesEngine silently uses wrong multiplier, margin, and commission for uppercase SHFE/DCE/INE/GFEX symbols.

## Why
SHFE/DCE/INE/GFEX keys are lowercase, but the documented convention and real Tushare data use uppercase, so lookups silently miss and fall back to generic defaults.

## Changes
Added a case-insensitive lookup helper, applied at all six product-table call sites.

## Test Plan
- [x] Existing tests pass (49 passed)
- [x] New tests added

## Checklist
- [x] No changes to protected areas
- [x] No hardcoded values
- [x] Code follows CONTRIBUTING.md
