### PR TITLE
fix(backtest): classify Tushare-spelled China futures as China futures

### DIFF
--- a/agent/backtest/engines/_market_hooks.py
+++ b/agent/backtest/engines/_market_hooks.py
@@ -55,7 +55,8 @@ _MARKET_PATTERNS = [
     # they still reach the forex whitelist below.
     (re.compile(r"^[A-Z]{2,}(?:USDT|USDC|BUSD)$", re.I), "crypto"),
     # China futures: product+delivery.exchange (e.g. IF2406.CFFEX, rb2410.SHFE)
-    (re.compile(r"^[A-Za-z]{1,2}\d{3,4}\.(ZCE|DCE|SHFE|INE|CFFEX|GFEX)$", re.I), "futures"),
+    # Tushare suffix spellings (SHF/CZC/CFX/GFE) classify here too.
+    (re.compile(r"^[A-Za-z]{1,2}\d{3,4}\.(ZCE|DCE|SHFE|INE|CFFEX|GFEX|SHF|CZC|CFX|GFE)$", re.I), "futures"),
     # Global futures: product+month-code (e.g. ESZ4, CLF25, GCM2025)
     (re.compile(r"^[A-Z]{2,4}[FGHJKMNQUVXZ]\d{1,2}$", re.I), "futures"),
     # Global futures: product+YYMM (e.g. CL2412, ES2503)
@@ -101,6 +102,10 @@ _MARKET_PATTERNS = [
 ]
 
 _CHINA_EXCHANGES = {"CFFEX", "SHFE", "DCE", "ZCE", "INE", "GFEX"}
+
+# Tushare spells the same exchanges differently (ts_code='CU1811.SHF');
+# normalize to the canonical suffix before any set membership test (#1394).
+_EXCHANGE_ALIASES = {"SHF": "SHFE", "CZC": "ZCE", "CFX": "CFFEX", "GFE": "GFEX"}
 
 # Supported settlement-currency contract per market. A composite backtest holds
 # one shared capital pool, so a code set spanning two of these would add CNY to
@@ -222,7 +227,7 @@ def _is_china_futures(code: str) -> bool:
         # else = False. Without this guard the product-code heuristic below
         # would misclassify global futures whose product letters happen to
         # collide with a CN product (e.g. ``M2412.CBOT`` — US soybean meal).
-        return parts[1] in _CHINA_EXCHANGES
+        return _EXCHANGE_ALIASES.get(parts[1], parts[1]) in _CHINA_EXCHANGES
     # Bare code (no exchange suffix): fall back to product-code heuristic.
     m = re.match(r"([A-Za-z]+)\d+", parts[0])
     if m:

--- a/agent/tests/test_market_detection.py
+++ b/agent/tests/test_market_detection.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import pytest
 
 from backtest.engines._market_hooks import _is_china_futures, code_currency
+from backtest.engines._market_hooks import _is_china_futures
 from backtest.runner import (
     _detect_market,
     _detect_source,
@@ -122,6 +123,23 @@ class TestDetectMarket:
         assert _detect_market("12345") == "a_share"
         assert _detect_market("123456") == "a_share"
         assert _detect_market("@#$") == "a_share"
+
+    def test_tushare_suffix_china_futures_classify_as_china_futures(self) -> None:
+        # #1394: Tushare spells the exchanges SHF/CZC/CFX/GFE where the
+        # canonical set is SHFE/ZCE/CFFEX/GFEX; without the alias these
+        # contracts fell through to the a_share default or the global engine
+        # (wrong multiplier, wrong currency, wrong band rules).
+        for code in ("CU1811.SHF", "CF501.CZC", "IF2406.CFX", "SC2409.GFE"):
+            assert _detect_market(code) == "futures", code
+            assert code_currency(code) == "CNY", code
+        # Canonical spellings keep working.
+        assert _detect_market("CU2406.SHFE") == "futures"
+        assert code_currency("rb2410.DCE") == "CNY"
+        # A non-China exchange must still not classify as China futures.
+        assert not _is_china_futures("M2412.CBOT")
+        assert not _is_china_futures("CL2412.NYMEX")
+        # And a global futures code with a recognized venue keeps its currency.
+        assert code_currency("ES.CME") == "USD"
 
     def test_concatenated_crypto_pairs_route_to_crypto(self) -> None:
         # Separator-less spot pairs (the Binance spelling) used to fall


### PR DESCRIPTION
Fixes #1394.

## What

`_is_china_futures` trusted the exchange suffix against `{CFFEX, SHFE, DCE, ZCE, INE, GFEX}` verbatim, but Tushare spells them `SHF`/`CZC`/`CFX`/`GFE` (the repo's own tushare reference docs show `CU1811.SHF`). A Tushare-formatted code fell to "not a Chinese exchange" and was handed to `GlobalFuturesEngine`, which priced a CNY contract with the global USD per-contract multiplier and commission.

The suffix is now normalized through an alias map before the set-membership test, and the China-futures market pattern admits the Tushare spellings so `_detect_market` classifies them as futures in the first place.

## How I verified

Verified against current main first: `CU1811.SHF`, `CF501.CZC`, `IF2406.CFX` all classified `a_share` / non-China before; after the change they classify `futures` + CNY, and `ChinaFuturesEngine` resolves SHFE copper's multiplier 5 and 8% margin for `CU1811.SHF`. The non-China guards (`M2412.CBOT`, `CL2412.NYMEX`) still do not classify.

New test in `tests/test_market_detection.py` pins the four Tushare suffixes plus the canonical spellings and the non-China controls; it is red on current main and green here. The wider engine/market/shadow/composite subset: 945 passed, 5 skipped.

## Risk / rollback

Narrow classification change: only codes with the four Tushare suffixes change routing, and each now lands where the canonical spelling already landed. Rollback: revert this commit; no state or schema changes.

One caveat worth naming: the alias covers the suffix spellings Tushare actually emits per its docs; if another vendor spells the same exchanges differently again, that is a new alias entry, not a new mechanism.
