### PR TITLE
fix(sdm): preserve missing price gaps in strategy template

### DIFF
--- a/agent/src/skills/strategy-dev-manager/templates/strategy_signal_engine.py
+++ b/agent/src/skills/strategy-dev-manager/templates/strategy_signal_engine.py
@@ -54,8 +54,10 @@ class SignalEngine:
             # Example: Mean-reversion strategy (Avramov & Chordia 2006)
 
             # Compute signal indicator
-            returns = df["close"].pct_change(self.lookback)
-            volatility = df["close"].pct_change().rolling(self.lookback).std()
+            returns = df["close"].pct_change(self.lookback, fill_method=None)
+            volatility = (
+                df["close"].pct_change(fill_method=None).rolling(self.lookback).std()
+            )
 
             # Normalized signal: return / volatility
             normalized = returns / volatility.replace(0, float("nan"))

--- a/agent/tests/test_strategy_dev_manager_template.py
+++ b/agent/tests/test_strategy_dev_manager_template.py
@@ -1,0 +1,34 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+
+_TEMPLATE_PATH = (
+    Path(__file__).parents[1]
+    / "src"
+    / "skills"
+    / "strategy-dev-manager"
+    / "templates"
+    / "strategy_signal_engine.py"
+)
+
+
+def _load_signal_engine():
+    spec = spec_from_file_location("strategy_signal_engine_template", _TEMPLATE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.SignalEngine
+
+
+def test_strategy_template_preserves_missing_price_gaps():
+    df = pd.DataFrame(
+        {"close": [80.0, 80.0, 90.0, np.nan, 80.0]},
+        index=pd.date_range("2026-01-01", periods=5),
+    )
+
+    signal = _load_signal_engine()(lookback=2).generate({"TEST": df})["TEST"]
+
+    assert signal.iloc[-1] == 0.0


### PR DESCRIPTION
## Summary

Preserve missing price observations in the Strategy Development Manager signal template.

## Problem

The template used pandas `pct_change()` with its default fill behaviour. Missing close prices could therefore be forward-filled when computing returns and volatility, producing signals from unavailable observations.

## Changes

* Disable filling when computing percentage changes.
* Add a regression test covering a missing-price gap that previously produced a false mean-reversion entry.

## Testing

* Focused regression test: 1 passed.
* `python -m py_compile`: passed.
* Whitespace check: passed.
* Ruff and Black were not available in the execution environment.
* Full repository test suite was not run.

## Compatibility and Risk

Low risk. The change is limited to the Strategy Development Manager template and preserves existing behaviour for complete price data.

## Related Issue

No existing issue identified for this bug.
