### PR TITLE
fix(cross-market): preserve missing price gaps in volatility weights

### DIFF
--- a/agent/src/skills/cross-market-strategy/SKILL.md
+++ b/agent/src/skills/cross-market-strategy/SKILL.md
@@ -51,7 +51,7 @@ BTC daily vol ~ 5%, A-share daily vol ~ 1.5%. Without vol-adjustment, crypto eat
 def _vol_adjust(self, signals, data_map):
     vols = {}
     for code, df in data_map.items():
-        ret = df["close"].pct_change().dropna()
+        ret = df["close"].pct_change(fill_method=None).dropna()
         vols[code] = ret.rolling(20).std().iloc[-1] if len(ret) > 20 else ret.std()
 
     inv_vols = {c: 1.0 / (v + 1e-10) for c, v in vols.items()}

--- a/agent/src/skills/cross-market-strategy/example_signal_engine.py
+++ b/agent/src/skills/cross-market-strategy/example_signal_engine.py
@@ -64,7 +64,7 @@ class SignalEngine:
     def _vol_adjust(self, signals: dict, data_map: dict) -> dict:
         vols = {}
         for code, df in data_map.items():
-            ret = df["close"].pct_change().dropna()
+            ret = df["close"].pct_change(fill_method=None).dropna()
             vols[code] = (
                 ret.rolling(20).std().iloc[-1]
                 if len(ret) > 20

--- a/agent/tests/test_cross_market_strategy_template.py
+++ b/agent/tests/test_cross_market_strategy_template.py
@@ -48,7 +48,7 @@ def test_cross_market_volatility_weights_preserve_missing_price_gaps():
         "BTC-USDT": pd.Series(0.5, index=index),
     }
 
-    adjusted = _load_signal_engine()._vol_adjust(
+    adjusted = _load_signal_engine()()._vol_adjust(
         signals,
         {"AAPL.US": gapped, "BTC-USDT": peer},
     )

--- a/agent/tests/test_cross_market_strategy_template.py
+++ b/agent/tests/test_cross_market_strategy_template.py
@@ -1,0 +1,64 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+_TEMPLATE_PATH = (
+    Path(__file__).parents[1]
+    / "src"
+    / "skills"
+    / "cross-market-strategy"
+    / "example_signal_engine.py"
+)
+
+
+def _load_signal_engine():
+    spec = spec_from_file_location("cross_market_strategy_template", _TEMPLATE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.SignalEngine
+
+
+def test_cross_market_volatility_weights_preserve_missing_price_gaps():
+    index = pd.date_range("2026-01-01", periods=7)
+    gapped = pd.DataFrame(
+        {
+            "close": [
+                100.0,
+                91.99768809729663,
+                84.9885742607376,
+                80.4613602033837,
+                77.0077833662644,
+                np.nan,
+                101.00351323123887,
+            ]
+        },
+        index=index,
+    )
+    peer = pd.DataFrame(
+        {"close": [100.0, 105.0, 100.0, 104.0, 99.0, 103.0, 98.0]},
+        index=index,
+    )
+    signals = {
+        "AAPL.US": pd.Series(0.5, index=index),
+        "BTC-USDT": pd.Series(0.5, index=index),
+    }
+
+    adjusted = _load_signal_engine()._vol_adjust(
+        signals,
+        {"AAPL.US": gapped, "BTC-USDT": peer},
+    )
+
+    gapped_vol = gapped["close"].pct_change(fill_method=None).dropna().std()
+    peer_vol = peer["close"].pct_change(fill_method=None).dropna().std()
+    expected_weight = (
+        (1.0 / (gapped_vol + 1e-10))
+        / ((1.0 / (gapped_vol + 1e-10)) + (1.0 / (peer_vol + 1e-10)))
+        * 2
+    )
+
+    assert adjusted["AAPL.US"].iloc[-1] == pytest.approx(0.5 * expected_weight)


### PR DESCRIPTION
## Summary

* Preserve missing price gaps when calculating cross-market volatility weights.

## Why

The strategy used pandas `pct_change()` with implicit filling, allowing missing closes to alter volatility estimates and cross-market allocation.

## Changes

* Disable filling in volatility return calculations.
* Update the skill example to match.
* Add regression coverage for missing-price gaps.

## Test Plan

* [ ] Full repository test suite not run.
* [x] New focused regression test passes.
* [x] `python -m py_compile` passes.
* [x] Whitespace check passes.

## Compatibility and Risk

Low risk. Limited to cross-market strategy weighting, with no live trading or broker changes.

## Related Issue

No existing issue identified.
