### PR TITLE
fix(multi-factor): exclude assets without factor observations

### DIFF
--- a/agent/src/skills/multi-factor/example_signal_engine.py
+++ b/agent/src/skills/multi-factor/example_signal_engine.py
@@ -128,6 +128,7 @@ class SignalEngine:
 
             # 调仓日：截面排名
             composite_scores: Dict[str, float] = {}
+            observed_factors = {code: 0 for code in codes}
             for factor_name in factor_names:
                 raw_vals = {}
                 for code in codes:
@@ -135,13 +136,23 @@ class SignalEngine:
                         raw_vals[code] = factor_map[code].at[dt, factor_name]
                     else:
                         raw_vals[code] = np.nan
+                    if not np.isnan(raw_vals[code]):
+                        observed_factors[code] += 1
                 z_vals = zscore_cross_section(raw_vals)
                 for code in codes:
                     composite_scores[code] = composite_scores.get(code, 0.0) + z_vals.get(code, 0.0)
 
             # 排名取 TopN
-            ranked = sorted(composite_scores.items(), key=lambda x: x[1], reverse=True)
-            effective_n = min(self.top_n, len([s for _, s in ranked if not np.isnan(s)]))
+            ranked = sorted(
+                (
+                    (code, score)
+                    for code, score in composite_scores.items()
+                    if observed_factors[code] > 0
+                ),
+                key=lambda x: x[1],
+                reverse=True,
+            )
+            effective_n = min(self.top_n, len(ranked))
             selected = [code for code, _ in ranked[:effective_n]]
             last_selected = selected
 

--- a/agent/tests/test_multi_factor_strategy_template.py
+++ b/agent/tests/test_multi_factor_strategy_template.py
@@ -1,0 +1,57 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+
+_TEMPLATE_PATH = (
+    Path(__file__).parents[1]
+    / "src"
+    / "skills"
+    / "multi-factor"
+    / "example_signal_engine.py"
+)
+
+
+def _load_signal_engine():
+    spec = spec_from_file_location("multi_factor_strategy_template", _TEMPLATE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.SignalEngine
+
+
+def test_multi_factor_excludes_assets_without_factor_observations():
+    index = pd.date_range("2026-01-01", periods=8)
+    data_map = {
+        "A": pd.DataFrame(
+            {
+                "close": [100, 102, 104, 106, 108, 110, 112, 114],
+                "volume": [100, 110, 120, 130, 140, 150, 160, 170],
+            },
+            index=index,
+        ),
+        "B": pd.DataFrame(
+            {
+                "close": [100, 99, 98, 97, 96, 95, 94, 93],
+                "volume": [100, 90, 80, 70, 60, 50, 40, 30],
+            },
+            index=index,
+        ),
+        "MISSING": pd.DataFrame(
+            {"close": [np.nan] * 8, "volume": [np.nan] * 8},
+            index=index,
+        ),
+    }
+
+    signals = _load_signal_engine()(
+        momentum_window=2,
+        vol_window=2,
+        top_n=2,
+        rebalance_freq=1,
+    ).generate(data_map)
+
+    assert signals["A"].iloc[-1] == 0.5
+    assert signals["B"].iloc[-1] == 0.5
+    assert signals["MISSING"].iloc[-1] == 0.0


### PR DESCRIPTION
## Summary

Exclude assets with no available factor observations from multi-factor ranking.

## Why

Assets with no valid factor values currently receive neutral scores and can still enter TopN selection. This can cause an asset with no usable factor data to displace one with valid observations.

## Changes

* Track whether each asset has at least one valid factor observation on each rebalance date.
* Exclude assets with no available factor values from ranking.
* Add a regression test covering an asset with entirely missing factor data.

## Test Plan

* [x] Focused regression test passes with the fix.
* [x] The same regression test fails against the previous implementation.
* [x] Python compilation check passes.
* [ ] Full repository test suite not run.

## Checklist

* [x] Change is limited to multi-factor selection and its regression test.
* [x] No live trading, broker, MCP, network, secret, or deployment behaviour changed.
* [x] DCO sign-off included.
