### PR TITLE
fix(social-media): correct sentiment factor evaluation

### DIFF
--- a/agent/src/skills/social-media-intelligence/SKILL.md
+++ b/agent/src/skills/social-media-intelligence/SKILL.md
@@ -756,13 +756,17 @@ def build_sentiment_factor(
         raw_data.groupby("date")["sentiment_score"]
         .transform(lambda x: (x - x.mean()) / (x.std() + 1e-8))
     )
+    factor_data = raw_data.assign(sentiment_norm=factor)
 
     # 2. Compute period-by-period IC
     ic_list = []
-    dates = raw_data["date"].unique()
-    for date in sorted(dates)[:-forward_days]:
-        fwd_date = dates[dates > date][:forward_days][-1]
-        f = raw_data[raw_data["date"] == date].set_index("ticker")["sentiment_norm"]
+    dates = np.sort(raw_data["date"].unique())
+    for date in dates[:-forward_days]:
+        fwd_dates = dates[dates > date]
+        if len(fwd_dates) < forward_days:
+            continue
+        fwd_date = fwd_dates[forward_days - 1]
+        f = factor_data[factor_data["date"] == date].set_index("ticker")["sentiment_norm"]
         r = raw_data[raw_data["date"] == fwd_date].set_index("ticker")["return"]
         ic_list.append((date, compute_ic(f, r)))
 
@@ -808,14 +812,20 @@ def orthogonalize_sentiment(
     from sklearn.linear_model import LinearRegression
     import numpy as np
 
-    # Regress on the traditional factors and keep the residual.
-    X = traditional_factors.fillna(0).values
-    y = sentiment_factor.fillna(0).values
+    # Regress on complete observations and keep missing rows missing.
+    factors = traditional_factors.reindex(sentiment_factor.index)
+    valid = sentiment_factor.notna() & factors.notna().all(axis=1)
+    residual = pd.Series(np.nan, index=sentiment_factor.index, name="sentiment_orthogonal")
+    if not valid.any():
+        return residual
+
+    X = factors.loc[valid].values
+    y = sentiment_factor.loc[valid].values
 
     reg = LinearRegression(fit_intercept=True).fit(X, y)
-    residual = y - reg.predict(X)
+    residual.loc[valid] = y - reg.predict(X)
 
-    return pd.Series(residual, index=sentiment_factor.index)
+    return residual
 ```
 
 ---

--- a/agent/tests/test_social_media_intelligence_skill.py
+++ b/agent/tests/test_social_media_intelligence_skill.py
@@ -1,0 +1,87 @@
+"""Regression tests for the social-media sentiment factor examples."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+
+SKILL_MD = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "skills"
+    / "social-media-intelligence"
+    / "SKILL.md"
+)
+
+
+def _load_python_block(section_title: str) -> dict[str, object]:
+    """Load the first Python block from a named skill section."""
+    text = SKILL_MD.read_text(encoding="utf-8")
+    section = text.split(section_title, 1)[1]
+    code = section.split("```python\n", 1)[1].split("```", 1)[0]
+    namespace: dict[str, object] = {"np": np, "pd": pd}
+    exec(code, namespace)
+    return namespace
+
+
+def _sentiment_rows(date_order: list[int]) -> pd.DataFrame:
+    dates = pd.to_datetime(["2026-01-01", "2026-01-02", "2026-01-03", "2026-01-04"])
+    rows = []
+    for day_number in date_order:
+        date = dates[day_number - 1]
+        for ticker_number, ticker in enumerate(["A", "B", "C", "D", "E", "F"]):
+            rows.append(
+                {
+                    "date": date,
+                    "ticker": ticker,
+                    "sentiment_score": float(ticker_number),
+                    "return": float(day_number),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def test_build_sentiment_factor_uses_computed_normalization() -> None:
+    """The example should not require a sentiment_norm input column."""
+    namespace = _load_python_block("### 4.1 Social-Sentiment Factor Construction")
+    build_sentiment_factor = namespace["build_sentiment_factor"]
+    raw_data = _sentiment_rows([1, 2, 3, 4])
+
+    result = build_sentiment_factor(raw_data, forward_days=1)
+
+    assert len(result["factor"]) == len(raw_data)
+    assert not raw_data.columns.isin(["sentiment_norm"]).any()
+
+
+def test_build_sentiment_factor_sorts_forward_dates() -> None:
+    """Forward horizons should follow date order rather than input row order."""
+    namespace = _load_python_block("### 4.1 Social-Sentiment Factor Construction")
+    raw_data = _sentiment_rows([3, 1, 4, 2])
+    raw_data["sentiment_norm"] = raw_data.groupby("date")["sentiment_score"].transform(
+        lambda x: (x - x.mean()) / (x.std() + 1e-8)
+    )
+
+    namespace["compute_ic"] = lambda _factor, returns: returns.iloc[0]
+    result = namespace["build_sentiment_factor"](raw_data, forward_days=2)
+
+    first_date = pd.Timestamp("2026-01-01")
+    assert result["ic_series"].loc[first_date] == 3.0
+
+
+def test_orthogonalize_sentiment_preserves_missing_observations() -> None:
+    """Missing sentiment or factor rows should stay missing after regression."""
+    namespace = _load_python_block("### 4.2 Orthogonalization Against Traditional Factors")
+    sentiment = pd.Series([1.0, np.nan, 3.0, 4.0], index=["a", "b", "c", "d"])
+    factors = pd.DataFrame(
+        {"size": [40.0, np.nan, 20.0, 10.0]},
+        index=["d", "c", "b", "a"],
+    )
+
+    residual = namespace["orthogonalize_sentiment"](sentiment, factors)
+
+    assert residual.index.equals(sentiment.index)
+    assert residual[["b", "c"]].isna().all()
+    assert residual[["a", "d"]].notna().all()


### PR DESCRIPTION
## Summary

Fix social sentiment factor evaluation and missing-data handling.

## Why

The example could fail when `sentiment_norm` is missing, use the wrong forward date when rows are unsorted, and create artificial values by filling missing regression data with zero.

## Changes

* Use the computed normalized sentiment values.
* Sort dates before forward-return selection.
* Regress only on complete observations.
* Preserve missing residuals.
* Add regression tests.

## Test Plan

* [x] Targeted regression tests added.
* [x] Python compilation passed.
* [ ] Full test suite not run.

## Checklist

* [x] Focused change only.
* [x] No live trading or external service behaviour changed.
* [x] DCO sign-off included.
