### PR TITLE
fix(stooq): name the override variable the config layer actually reads

### DIFF
--- a/agent/backtest/loaders/stooq_loader.py
+++ b/agent/backtest/loaders/stooq_loader.py
@@ -179,8 +179,10 @@ class DataLoader:
                 logger.warning(
                     "stooq is serving an anti-bot challenge page instead of CSV "
                     "data; treating it as unavailable for the rest of this "
-                    "process. Reorder the chain via VIBE_TRADING_MARKET_DATA_ORDER_* "
-                    "or drop stooq from it."
+                    "process. Move stooq to the end of the chain via "
+                    "MARKET_DATA_ORDER_* (e.g. MARKET_DATA_ORDER_US_EQUITY); the "
+                    "override must be a permutation of the default chain, so a "
+                    "source can be reordered but not removed."
                 )
                 _challenge_warned = True
             return None

--- a/agent/tests/test_stooq_loader.py
+++ b/agent/tests/test_stooq_loader.py
@@ -219,3 +219,63 @@ class TestChallengePageDetection:
         assert stooq_loader._looks_like_challenge_page(self._CHALLENGE_HTML)
         assert not stooq_loader._looks_like_challenge_page(_CSV)
         assert not stooq_loader._looks_like_challenge_page("N/D\n")
+
+
+class TestChallengeWarningNamesRealOverride:
+    """The remediation advice must be executable as written (#1315 follow-up).
+
+    The warning tells the operator how to route around a challenge-blocked
+    stooq. Both halves of that advice are load-bearing: the env var has to be
+    the one ``registry`` actually reads, and the suggested edit has to survive
+    ``is_valid_source_order``. Pin them to the registry so the message cannot
+    drift away from the code again.
+    """
+
+    _CHALLENGE_HTML = (
+        "<html><head><title>One moment, please...</title></head>"
+        "<body>Verifying your browser... proof of work challenge</body></html>"
+    )
+
+    def _warning(self, monkeypatch, caplog) -> str:
+        monkeypatch.setattr(stooq_loader, "_challenge_warned", False)
+        monkeypatch.setattr(
+            stooq_loader,
+            "throttled_get",
+            lambda url, **kw: _FakeResponse(text=self._CHALLENGE_HTML),
+        )
+        with caplog.at_level(logging.WARNING, logger="backtest.loaders.stooq_loader"):
+            stooq_loader.DataLoader().fetch(["AAPL.US"], "2024-01-01", "2024-01-31")
+        return next(r.message for r in caplog.records if "anti-bot challenge" in r.message)
+
+    def test_warning_names_the_env_var_registry_reads(self, monkeypatch, caplog):
+        """A substring check would pass on ``VIBE_TRADING_MARKET_DATA_ORDER_*``.
+
+        That name is not read anywhere, so following the advice is a silent
+        no-op. Compare whole tokens: any env-var-shaped word mentioning the
+        override must *be* the prefix, not merely contain it.
+        """
+        import re
+
+        from backtest.loaders.registry import source_order_env_var
+
+        message = self._warning(monkeypatch, caplog)
+        prefix = source_order_env_var("us_equity").rsplit("US_EQUITY", 1)[0]
+
+        named = [t for t in re.findall(r"[A-Z][A-Z0-9_]*", message) if "MARKET_DATA_ORDER" in t]
+        assert named, f"warning names no override variable at all: {message!r}"
+        for token in named:
+            assert token.startswith(prefix), (
+                f"{token!r} is not read by the config layer; the real prefix is {prefix!r}"
+            )
+
+    def test_warning_does_not_advise_dropping_a_source(self, monkeypatch, caplog):
+        """``is_valid_source_order`` rejects a chain with a source removed."""
+        from backtest.loaders.registry import get_default_source_order, is_valid_source_order
+
+        without_stooq = [s for s in get_default_source_order("us_equity") if s != "stooq"]
+        assert not is_valid_source_order("us_equity", without_stooq)
+
+        message = self._warning(monkeypatch, caplog)
+        assert "drop stooq" not in message.lower(), (
+            f"advice is rejected by is_valid_source_order: {message!r}"
+        )


### PR DESCRIPTION
## Problem

When Stooq serves its anti-bot challenge page, the loader warns and tells the operator how to route around it. Both halves of that advice are unreachable as printed:

```
Reorder the chain via VIBE_TRADING_MARKET_DATA_ORDER_* or drop stooq from it.
```

**1. `VIBE_TRADING_MARKET_DATA_ORDER_*` is not read anywhere.** `source_order_env_var` (`registry.py:309`) builds `MARKET_DATA_ORDER_<MARKET>`, and `get_env_value` (`config/accessor.py:141`) is a plain `os.getenv` passthrough that adds no prefix — the `env_schema.py:227` aliases agree. Exporting the name as printed is a silent no-op: the chain keeps its default order and stooq stays at position 2 of `us_equity`, still serving challenge pages.

**2. "drop stooq from it" is rejected.** `is_valid_source_order` requires a permutation of the default chain, so removing a source fails validation and the default order is kept.

Verified live on 0.1.15:

```
$ MARKET_DATA_ORDER_US_EQUITY="yahoo,sina,eastmoney,yfinance,..." python -c ...
Ignoring invalid MARKET_DATA_ORDER_US_EQUITY=...: value must be a permutation
of the default chain [...]; keeping default order
stooq still in chain -> True
```

An operator hitting the challenge page has no working escape from the message alone.

## Fix

Point at moving stooq to the end (a legal permutation), name one concrete variable, and state the permutation constraint.

## Tests

Two tests pin the message to the registry rather than to a literal, so it cannot drift again.

Worth flagging for review: the env-var test compares **whole tokens**, not substrings. A containment check passes on the buggy string, because `VIBE_TRADING_MARKET_DATA_ORDER_*` contains `MARKET_DATA_ORDER_`. The test failed correctly only after switching to a regex over env-var-shaped words. Please keep it that way if this area is ever simplified.

- `agent/tests/test_stooq_loader.py` — 16 passed (14 existing + 2 new)
- `-k "stooq or registry or source_order or loader"` — 893 passed, 11 skipped
- `tools/ci_grep_gates.sh` — all gates pass

No behavior change outside the log message.