### PR TITLE
fix(correlation): handle unnamed series in Engle-Granger

### DIFF
--- a/agent/src/skills/correlation-analysis/SKILL.md
+++ b/agent/src/skills/correlation-analysis/SKILL.md
@@ -239,7 +239,7 @@ def sector_clustering(
 ### Comparison of Three Linkage Methods
 
 | Method | Feature | Best Use Case | Weakness |
-|------|------|---------|------|
+|------|------|---------|--------|
 | Ward | Minimizes within-cluster variance, gives compact clusters | **Default recommendation**, stock-sector discovery | Works best for spherical clusters, weaker for irregular shapes |
 | Complete | Uses maximum pairwise distance, conservative | When high within-cluster similarity is required | Can produce elongated clusters |
 | Average | Uses average distance, compromise approach | General analysis where compactness is not the top priority | Sensitive to noise |
@@ -369,9 +369,10 @@ def engle_granger_coint(
         Test results and spread series
     """
     # Step 1: estimate the cointegrating vector with OLS.
-    x_const = sm.add_constant(x)
+    x_reg = x.rename("x")
+    x_const = sm.add_constant(x_reg)
     ols = sm.OLS(y, x_const).fit()
-    hedge_ratio = ols.params[x.name if x.name else "x"]
+    hedge_ratio = ols.params["x"]
     intercept = ols.params["const"]
     residuals = ols.resid
 

--- a/agent/tests/test_correlation_analysis_skill.py
+++ b/agent/tests/test_correlation_analysis_skill.py
@@ -1,0 +1,36 @@
+"""Regression tests for the correlation-analysis skill examples."""
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+SKILL_MD = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "skills"
+    / "correlation-analysis"
+    / "SKILL.md"
+)
+
+
+def _load_engle_granger():
+    text = SKILL_MD.read_text(encoding="utf-8")
+    section = text.split("### Engle-Granger Two-Step Method", 1)[1]
+    code = section.split("```python\n", 1)[1].split("```", 1)[0]
+    namespace = {"pd": pd}
+    exec(code, namespace)
+    return namespace["engle_granger_coint"]
+
+
+@pytest.mark.parametrize("name", [None, "price_x"])
+def test_engle_granger_handles_series_name(name):
+    rng = np.random.default_rng(42)
+    x = pd.Series(np.cumsum(rng.normal(size=250)), name=name)
+    y = 1.7 * x + pd.Series(rng.normal(scale=0.2, size=250))
+
+    result = _load_engle_granger()(y, x)
+
+    assert result["hedge_ratio"] == pytest.approx(1.7, abs=0.02)


### PR DESCRIPTION
## Summary

Fix Engle-Granger hedge-ratio extraction for unnamed pandas Series.

## Why

Unnamed Series cause the regression parameter to be indexed as `0`, while the example looks for `"x"`, resulting in a `KeyError`.

## Changes

- Give the regression input a stable name.
- Add regression coverage for named and unnamed Series.

## Test Plan

- [x] Reproduced the original failure.
- [x] Verified hedge-ratio extraction after the fix.
- [x] Added regression tests.
- [ ] Full test suite not run.

## Checklist

- [x] No protected areas changed.
- [x] No external services or live trading affected.
- [x] DCO sign-off included.