### PR TITLE
fix(loaders): synchronize cold registry initialization

### DIFF
--- a/agent/backtest/loaders/registry.py
+++ b/agent/backtest/loaders/registry.py
@@ -164,38 +164,69 @@ _NO_NETWORK_FALLBACK_SOURCES: frozenset[str] = frozenset(
 # that must be politely throttled; Finnhub/AlphaVantage/Tiingo/FMP are key-gated
 # REST fallbacks placed deeper in the chain.
 FALLBACK_CHAINS: dict[str, list[str]] = {
-    "a_share":   ["tencent", "mootdx", "eastmoney", "baostock", "akshare", "tushare", "local"],
-    "us_equity": ["yahoo", "stooq", "sina", "eastmoney", "yfinance", "tiingo", "fmp", "finnhub", "alphavantage", "longbridge", "akshare", "local"],
+    "a_share": [
+        "tencent",
+        "mootdx",
+        "eastmoney",
+        "baostock",
+        "akshare",
+        "tushare",
+        "local",
+    ],
+    "us_equity": [
+        "yahoo",
+        "stooq",
+        "sina",
+        "eastmoney",
+        "yfinance",
+        "tiingo",
+        "fmp",
+        "finnhub",
+        "alphavantage",
+        "longbridge",
+        "akshare",
+        "local",
+    ],
     # HK: tencent leads (no observed IP ban); akshare (Eastmoney-backed)
     # precedes the Yahoo-SDK family, which is blocked from mainland IPs;
     # tushare hk_daily is key-gated.
-    "hk_equity": ["tencent", "eastmoney", "yahoo", "futu", "akshare", "yfinance", "tushare", "longbridge", "local"],
+    "hk_equity": [
+        "tencent",
+        "eastmoney",
+        "yahoo",
+        "futu",
+        "akshare",
+        "yfinance",
+        "tushare",
+        "longbridge",
+        "local",
+    ],
     "india_equity": ["yahoo", "yfinance", "india_broker", "local"],
-    "kr_equity":   ["pykrx", "yahoo", "yfinance", "local"],
+    "kr_equity": ["pykrx", "yahoo", "yfinance", "local"],
     # TSX (.TO) / TSX Venture (.V): direct Yahoo first, SDK fallback second.
-    "ca_equity":   ["yahoo", "yfinance", "local"],
+    "ca_equity": ["yahoo", "yfinance", "local"],
     # UK (LSE .L): direct Yahoo first, SDK fallback second.
-    "uk_equity":   ["yahoo", "yfinance", "local"],
+    "uk_equity": ["yahoo", "yfinance", "local"],
     # Vietnam (.VN): Yahoo lists HOSE only — HNX and UPCOM are unsupported,
     # so those two are reachable only through the user's local files.
     "vietnam_equity": ["yahoo", "yfinance", "local"],
     # OKX first (native), then dedicated Binance, then generic CCXT / Yahoo.
-    "crypto":    ["okx", "binance", "ccxt", "yfinance", "local"],
+    "crypto": ["okx", "binance", "ccxt", "yfinance", "local"],
     # tushare led this chain while implementing no futures endpoint at all
     # (#1395): ``resolve_loader`` walks FALLBACK_CHAINS and never consults a
     # loader's ``markets`` set, so trimming that set alone would have left
     # tushare first in line, returning empty frames before akshare was ever
     # asked. akshare serves Chinese contracts off the token-free Sina daily
     # endpoints; a global contract has no network source and reaches ``local``.
-    "futures":   ["akshare", "local"],
-    "fund":      ["tushare", "akshare", "local"],
-    "macro":     ["akshare", "tushare", "local"],
+    "futures": ["akshare", "local"],
+    "fund": ["tushare", "akshare", "local"],
+    "macro": ["akshare", "tushare", "local"],
     # mt5 leads when a local MetaTrader 5 terminal is attached (Windows-only,
     # broker feed); otherwise it reports unavailable and the chain proceeds.
-    "forex":     ["mt5", "akshare", "yfinance", "local"],
+    "forex": ["mt5", "akshare", "yfinance", "local"],
     # Yahoo index symbols (^SPX, ^NDX, ^FTSE, ^VIX, ...): served verbatim by
     # the public chart endpoint, same as the =F/=X conventions.
-    "index":     ["yahoo", "yfinance", "local"],
+    "index": ["yahoo", "yfinance", "local"],
 }
 
 
@@ -394,7 +425,9 @@ def refresh_source_order_overrides() -> None:
             logger.warning(
                 "Ignoring invalid %s=%r: value must be a permutation of the"
                 " default chain %s; keeping default order",
-                source_order_env_var(market), raw, default,
+                source_order_env_var(market),
+                raw,
+                default,
             )
         FALLBACK_CHAINS[market] = default[:]
         _ACTIVE_SOURCE_ORDER_OVERRIDES.pop(market, None)
@@ -476,16 +509,16 @@ def get_loader_cls_with_fallback(source: str) -> Type[Any]:
     if source in _NO_NETWORK_FALLBACK_SOURCES:
         hint = {
             "local": "Check your Data Bridge config "
-                     "(~/.vibe-trading/data-bridge/config.yaml) — it must exist and "
-                     "list at least one source.",
+            "(~/.vibe-trading/data-bridge/config.yaml) — it must exist and "
+            "list at least one source.",
             "tickerall": "Set TICKERALL_API_KEY and TICKERALL_ACCOUNT_ID.",
             "fmp": "Set FMP_API_KEY.",
             "nobitex": "Nobitex's public endpoint was unreachable. It quotes in "
-                       "Toman (IRT) and has no substitute — check network access "
-                       "to apiv2.nobitex.ir.",
+            "Toman (IRT) and has no substitute — check network access "
+            "to apiv2.nobitex.ir.",
             "wallex": "Wallex's public endpoint was unreachable. It quotes in "
-                      "Toman (TMN) and has no substitute — check network access "
-                      "to api.wallex.ir.",
+            "Toman (TMN) and has no substitute — check network access "
+            "to api.wallex.ir.",
         }.get(source, "")
         raise NoAvailableSourceError(
             f"Data source '{source}' is unavailable and does not fall back to a "
@@ -498,7 +531,9 @@ def get_loader_cls_with_fallback(source: str) -> Type[Any]:
             fallback = resolve_loader(market)
             logger.warning(
                 "%s is unavailable, falling back to %s for market %s",
-                source, fallback.name, market,
+                source,
+                fallback.name,
+                market,
             )
             return type(fallback)
         except NoAvailableSourceError:

--- a/agent/backtest/loaders/registry.py
+++ b/agent/backtest/loaders/registry.py
@@ -10,6 +10,7 @@ of import order.
 from __future__ import annotations
 
 import logging
+from threading import Lock
 from typing import Any, Type
 
 from backtest.loaders.base import NoAvailableSourceError
@@ -23,6 +24,7 @@ logger = logging.getLogger(__name__)
 LOADER_REGISTRY: dict[str, Type[Any]] = {}
 
 _registered = False
+_registration_lock = Lock()
 
 # Canonical set of accepted data-source names: every registered loader plus the
 # ``"auto"`` cross-market selector. Single source of truth shared by the backtest
@@ -75,6 +77,7 @@ def _ensure_registered() -> None:
     """Import every known loader module so ``@register`` decorators fire.
 
     Safe to call multiple times — only runs the imports once.
+    Concurrent callers wait until the import pass finishes.
     Loaders whose dependencies are missing (e.g. ``akshare`` not installed)
     are silently skipped.
     """
@@ -85,43 +88,48 @@ def _ensure_registered() -> None:
     global _registered
     if _registered:
         return
-    _registered = True
 
-    _loader_modules = [
-        "backtest.loaders.tushare",
-        "backtest.loaders.okx",
-        "backtest.loaders.nobitex",
-        "backtest.loaders.wallex",
-        "backtest.loaders.binance_loader",
-        "backtest.loaders.yfinance_loader",
-        "backtest.loaders.akshare_loader",
-        "backtest.loaders.baostock_loader",
-        "backtest.loaders.tencent_loader",
-        "backtest.loaders.mootdx_loader",
-        "backtest.loaders.ccxt_loader",
-        "backtest.loaders.futu",
-        "backtest.loaders.eastmoney_loader",
-        "backtest.loaders.sina_loader",
-        "backtest.loaders.stooq_loader",
-        "backtest.loaders.yahoo_loader",
-        "backtest.loaders.finnhub_loader",
-        "backtest.loaders.alphavantage_loader",
-        "backtest.loaders.tiingo_loader",
-        "backtest.loaders.fmp_loader",
-        "backtest.loaders.qveris_loader",  # QVERIS-INTEGRATION
-        "backtest.loaders.india_broker_loader",
-        "backtest.loaders.pykrx_loader",
-        "backtest.loaders.longbridge",
-        "backtest.loaders.mt5_loader",
-        "backtest.loaders.tickerall_loader",
-        "backtest.loaders.local_loader",
-    ]
-    import importlib
-    for mod in _loader_modules:
-        try:
-            importlib.import_module(mod)
-        except Exception:
-            pass
+    with _registration_lock:
+        if _registered:
+            return
+
+        _loader_modules = [
+            "backtest.loaders.tushare",
+            "backtest.loaders.okx",
+            "backtest.loaders.nobitex",
+            "backtest.loaders.wallex",
+            "backtest.loaders.binance_loader",
+            "backtest.loaders.yfinance_loader",
+            "backtest.loaders.akshare_loader",
+            "backtest.loaders.baostock_loader",
+            "backtest.loaders.tencent_loader",
+            "backtest.loaders.mootdx_loader",
+            "backtest.loaders.ccxt_loader",
+            "backtest.loaders.futu",
+            "backtest.loaders.eastmoney_loader",
+            "backtest.loaders.sina_loader",
+            "backtest.loaders.stooq_loader",
+            "backtest.loaders.yahoo_loader",
+            "backtest.loaders.finnhub_loader",
+            "backtest.loaders.alphavantage_loader",
+            "backtest.loaders.tiingo_loader",
+            "backtest.loaders.fmp_loader",
+            "backtest.loaders.qveris_loader",  # QVERIS-INTEGRATION
+            "backtest.loaders.india_broker_loader",
+            "backtest.loaders.pykrx_loader",
+            "backtest.loaders.longbridge",
+            "backtest.loaders.mt5_loader",
+            "backtest.loaders.tickerall_loader",
+            "backtest.loaders.local_loader",
+        ]
+        import importlib
+
+        for mod in _loader_modules:
+            try:
+                importlib.import_module(mod)
+            except Exception:
+                pass
+        _registered = True
 
 
 # Sources that must NEVER silently fall through to a network loader when the

--- a/agent/tests/test_registry.py
+++ b/agent/tests/test_registry.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor, TimeoutError
+import importlib
+from threading import Event
+from types import ModuleType
 from unittest.mock import patch
 
 import pytest
 
+from backtest.loaders import registry
 from backtest.loaders.base import DataLoaderProtocol, NoAvailableSourceError
 from backtest.loaders.registry import (
     _ensure_registered,
@@ -16,7 +21,6 @@ from backtest.loaders.registry import (
     register,
     resolve_loader,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers — fake loaders
@@ -108,6 +112,64 @@ class TestRegisterDecorator:
         with patch.dict(LOADER_REGISTRY, {}, clear=True):
             result = register(_FakeAvailableLoader)
             assert result is _FakeAvailableLoader
+
+
+@pytest.mark.parametrize("entrypoint", ["market", "source"])
+def test_concurrent_cold_readers_wait_for_registration(
+    monkeypatch: pytest.MonkeyPatch, entrypoint: str
+) -> None:
+    """Cold readers must wait for one complete import pass, including skips."""
+    importing = Event()
+    release = Event()
+    reader_started = Event()
+    imports: list[str] = []
+    real_import = importlib.import_module
+
+    def controlled_import(name: str, package: str | None = None) -> ModuleType:
+        if not name.startswith("backtest.loaders."):
+            return real_import(name, package)
+        imports.append(name)
+        if name == "backtest.loaders.tushare":
+            importing.set()
+            if not release.wait(5):
+                raise RuntimeError("loader import was never released")
+        if name == "backtest.loaders.okx":
+            raise ImportError("optional dependency unavailable")
+        if name == "backtest.loaders.local_loader":
+            register(_FakeAvailableLoader)
+        return ModuleType(name)
+
+    def read_loader() -> type:
+        reader_started.set()
+        if entrypoint == "source":
+            return get_loader_cls_with_fallback(_FakeAvailableLoader.name)
+        return type(resolve_loader("a_share"))
+
+    monkeypatch.setattr(registry, "_registered", False)
+    monkeypatch.setattr(registry, "LOADER_REGISTRY", {})
+    monkeypatch.setitem(FALLBACK_CHAINS, "a_share", [_FakeAvailableLoader.name])
+    monkeypatch.setattr(importlib, "import_module", controlled_import)
+
+    # Keep initialization inside its first import while a public reader enters.
+    # Always release the importer before joining threads or restoring patches.
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        initializer = pool.submit(_ensure_registered)
+        try:
+            assert importing.wait(5)
+            reader = pool.submit(read_loader)
+            assert reader_started.wait(5)
+            with pytest.raises(TimeoutError):
+                reader.result(timeout=0.1)
+        finally:
+            release.set()
+        initializer.result(timeout=5)
+        assert reader.result(timeout=5) is _FakeAvailableLoader
+
+    assert registry._registered is True
+    assert len(imports) == len(set(imports)), "initialization ran more than once"
+    completed_imports = imports[:]
+    assert read_loader() is _FakeAvailableLoader
+    assert imports == completed_imports, "warm readers must not repeat imports"
 
 
 # ---------------------------------------------------------------------------

--- a/agent/tests/test_registry.py
+++ b/agent/tests/test_registry.py
@@ -196,9 +196,20 @@ class TestProtocol:
 class TestFallbackChains:
     def test_all_expected_markets_present(self) -> None:
         expected = {
-            "a_share", "us_equity", "hk_equity", "india_equity", "kr_equity",
-            "ca_equity", "uk_equity", "vietnam_equity", "crypto", "futures",
-            "fund", "macro", "forex", "index",
+            "a_share",
+            "us_equity",
+            "hk_equity",
+            "india_equity",
+            "kr_equity",
+            "ca_equity",
+            "uk_equity",
+            "vietnam_equity",
+            "crypto",
+            "futures",
+            "fund",
+            "macro",
+            "forex",
+            "index",
         }
         assert expected == set(FALLBACK_CHAINS.keys())
 
@@ -225,14 +236,38 @@ class TestFallbackChains:
         """Equity chains lead with throttle-tolerant public sources and trail
         with key-gated REST fallbacks, in the exact reviewed order."""
         assert FALLBACK_CHAINS["a_share"] == [
-            "tencent", "mootdx", "eastmoney", "baostock", "akshare", "tushare", "local",
+            "tencent",
+            "mootdx",
+            "eastmoney",
+            "baostock",
+            "akshare",
+            "tushare",
+            "local",
         ]
         assert FALLBACK_CHAINS["us_equity"] == [
-            "yahoo", "stooq", "sina", "eastmoney", "yfinance", "tiingo", "fmp",
-            "finnhub", "alphavantage", "longbridge", "akshare", "local",
+            "yahoo",
+            "stooq",
+            "sina",
+            "eastmoney",
+            "yfinance",
+            "tiingo",
+            "fmp",
+            "finnhub",
+            "alphavantage",
+            "longbridge",
+            "akshare",
+            "local",
         ]
         assert FALLBACK_CHAINS["hk_equity"] == [
-            "tencent", "eastmoney", "yahoo", "futu", "akshare", "yfinance", "tushare", "longbridge", "local",
+            "tencent",
+            "eastmoney",
+            "yahoo",
+            "futu",
+            "akshare",
+            "yfinance",
+            "tushare",
+            "longbridge",
+            "local",
         ]
 
     def test_us_equity_includes_sina_fallback(self) -> None:
@@ -249,7 +284,13 @@ class TestFallbackChains:
 
     def test_unchanged_chains_preserved(self) -> None:
         """crypto/fund/macro/forex chains must be left untouched."""
-        assert FALLBACK_CHAINS["crypto"] == ["okx", "binance", "ccxt", "yfinance", "local"]
+        assert FALLBACK_CHAINS["crypto"] == [
+            "okx",
+            "binance",
+            "ccxt",
+            "yfinance",
+            "local",
+        ]
         assert FALLBACK_CHAINS["fund"] == ["tushare", "akshare", "local"]
         assert FALLBACK_CHAINS["macro"] == ["akshare", "tushare", "local"]
         # mt5 heads the forex chain (terminal feed when attached), degrading to
@@ -278,9 +319,9 @@ class TestFallbackChains:
         for name in FALLBACK_CHAINS["futures"]:
             loader_cls = LOADER_REGISTRY.get(name)
             assert loader_cls is not None, f"{name} is in the chain but not registered"
-            assert "futures" in loader_cls.markets, (
-                f"{name} leads the futures chain without declaring the market"
-            )
+            assert (
+                "futures" in loader_cls.markets
+            ), f"{name} leads the futures chain without declaring the market"
 
     def test_tickerall_is_explicit_only_never_a_fallback(self) -> None:
         """TickerAll is a valid explicit source but must NEVER join an automatic
@@ -289,7 +330,9 @@ class TestFallbackChains:
         as a degradation target for another source. This guards that contract."""
         assert "tickerall" in VALID_SOURCES
         for market, chain in FALLBACK_CHAINS.items():
-            assert "tickerall" not in chain, f"tickerall must not be in the {market} fallback chain"
+            assert (
+                "tickerall" not in chain
+            ), f"tickerall must not be in the {market} fallback chain"
 
 
 # ---------------------------------------------------------------------------
@@ -301,8 +344,14 @@ class TestValidSources:
     def test_includes_new_loaders(self) -> None:
         """Newly registered loaders must be accepted config sources."""
         new_sources = {
-            "eastmoney", "sina", "stooq", "yahoo",
-            "finnhub", "alphavantage", "tiingo", "fmp",
+            "eastmoney",
+            "sina",
+            "stooq",
+            "yahoo",
+            "finnhub",
+            "alphavantage",
+            "tiingo",
+            "fmp",
         }
         assert new_sources <= VALID_SOURCES
 
@@ -329,23 +378,37 @@ class TestValidSources:
 
 class TestResolveLoader:
     def test_returns_first_available(self) -> None:
-        with patch.dict(LOADER_REGISTRY, {
-            "fake_unavailable": _FakeUnavailableLoader,
-            "fake_available": _FakeAvailableLoader,
-        }, clear=True):
-            with patch.dict(FALLBACK_CHAINS, {
-                "a_share": ["fake_unavailable", "fake_available"],
-            }):
+        with patch.dict(
+            LOADER_REGISTRY,
+            {
+                "fake_unavailable": _FakeUnavailableLoader,
+                "fake_available": _FakeAvailableLoader,
+            },
+            clear=True,
+        ):
+            with patch.dict(
+                FALLBACK_CHAINS,
+                {
+                    "a_share": ["fake_unavailable", "fake_available"],
+                },
+            ):
                 loader = resolve_loader("a_share")
                 assert loader.name == "fake_available"
 
     def test_raises_when_none_available(self) -> None:
-        with patch.dict(LOADER_REGISTRY, {
-            "fake_unavailable": _FakeUnavailableLoader,
-        }, clear=True):
-            with patch.dict(FALLBACK_CHAINS, {
-                "a_share": ["fake_unavailable"],
-            }):
+        with patch.dict(
+            LOADER_REGISTRY,
+            {
+                "fake_unavailable": _FakeUnavailableLoader,
+            },
+            clear=True,
+        ):
+            with patch.dict(
+                FALLBACK_CHAINS,
+                {
+                    "a_share": ["fake_unavailable"],
+                },
+            ):
                 with pytest.raises(NoAvailableSourceError):
                     resolve_loader("a_share")
 
@@ -362,20 +425,31 @@ class TestResolveLoader:
 
 class TestGetLoaderWithFallback:
     def test_returns_requested_if_available(self) -> None:
-        with patch.dict(LOADER_REGISTRY, {
-            "fake_available": _FakeAvailableLoader,
-        }, clear=True):
+        with patch.dict(
+            LOADER_REGISTRY,
+            {
+                "fake_available": _FakeAvailableLoader,
+            },
+            clear=True,
+        ):
             cls = get_loader_cls_with_fallback("fake_available")
             assert cls is _FakeAvailableLoader
 
     def test_falls_back_when_unavailable(self) -> None:
-        with patch.dict(LOADER_REGISTRY, {
-            "fake_unavailable": _FakeUnavailableLoader,
-            "fake_available": _FakeAvailableLoader,
-        }, clear=True):
-            with patch.dict(FALLBACK_CHAINS, {
-                "a_share": ["fake_unavailable", "fake_available"],
-            }):
+        with patch.dict(
+            LOADER_REGISTRY,
+            {
+                "fake_unavailable": _FakeUnavailableLoader,
+                "fake_available": _FakeAvailableLoader,
+            },
+            clear=True,
+        ):
+            with patch.dict(
+                FALLBACK_CHAINS,
+                {
+                    "a_share": ["fake_unavailable", "fake_available"],
+                },
+            ):
                 cls = get_loader_cls_with_fallback("fake_unavailable")
                 assert cls is _FakeAvailableLoader
 
@@ -385,9 +459,13 @@ class TestGetLoaderWithFallback:
                 get_loader_cls_with_fallback("nonexistent")
 
     def test_no_fallback_raises(self) -> None:
-        with patch.dict(LOADER_REGISTRY, {
-            "fake_unavailable": _FakeUnavailableLoader,
-        }, clear=True):
+        with patch.dict(
+            LOADER_REGISTRY,
+            {
+                "fake_unavailable": _FakeUnavailableLoader,
+            },
+            clear=True,
+        ):
             with patch.dict(FALLBACK_CHAINS, {"a_share": ["fake_unavailable"]}):
                 with pytest.raises(NoAvailableSourceError):
                     get_loader_cls_with_fallback("fake_unavailable")
@@ -395,10 +473,14 @@ class TestGetLoaderWithFallback:
     def test_explicit_local_does_not_fall_through_to_network(self) -> None:
         """An explicit unavailable 'local' request must raise a clear error, never
         silently degrade to an unrelated network loader via its broad markets."""
-        with patch.dict(LOADER_REGISTRY, {
-            "local": _FakeLocalLoader,
-            "fake_available": _FakeAvailableLoader,  # available a_share network src
-        }, clear=True):
+        with patch.dict(
+            LOADER_REGISTRY,
+            {
+                "local": _FakeLocalLoader,
+                "fake_available": _FakeAvailableLoader,  # available a_share network src
+            },
+            clear=True,
+        ):
             # Even though a network loader is available for one of local's markets,
             # the explicit 'local' request must not borrow it.
             with patch.dict(FALLBACK_CHAINS, {"a_share": ["fake_available"]}):
@@ -412,7 +494,9 @@ class TestGetLoaderWithFallback:
     def test_explicit_tickerall_does_not_fall_through_to_network(self) -> None:
         """An explicit unavailable 'tickerall' must raise, never silently degrade to a
         public forex source (akshare/yfinance) via its markets — it reads the user's own
-        broker account, so a missing key is a config error to surface, not paper over."""
+        broker account, so a missing key is a config error to surface, not paper over.
+        """
+
         class _FakeTickerall:
             name = "tickerall"
             markets = {"forex"}
@@ -424,10 +508,14 @@ class TestGetLoaderWithFallback:
             def fetch(self, codes, start_date, end_date, *, interval="1D", fields=None):
                 return {}
 
-        with patch.dict(LOADER_REGISTRY, {
-            "tickerall": _FakeTickerall,
-            "fake_available": _FakeAvailableLoader,  # an available loader listed in the forex chain
-        }, clear=True):
+        with patch.dict(
+            LOADER_REGISTRY,
+            {
+                "tickerall": _FakeTickerall,
+                "fake_available": _FakeAvailableLoader,  # an available loader listed in the forex chain
+            },
+            clear=True,
+        ):
             with patch.dict(FALLBACK_CHAINS, {"forex": ["fake_available"]}):
                 with pytest.raises(NoAvailableSourceError) as excinfo:
                     get_loader_cls_with_fallback("tickerall")
@@ -444,23 +532,37 @@ class TestGetLoaderWithFallback:
 
 class TestInitErrorFallback:
     def test_resolve_loader_skips_init_error(self) -> None:
-        with patch.dict(LOADER_REGISTRY, {
-            "fake_init_error": _FakeInitErrorLoader,
-            "fake_available": _FakeAvailableLoader,
-        }, clear=True):
-            with patch.dict(FALLBACK_CHAINS, {
-                "a_share": ["fake_init_error", "fake_available"],
-            }):
+        with patch.dict(
+            LOADER_REGISTRY,
+            {
+                "fake_init_error": _FakeInitErrorLoader,
+                "fake_available": _FakeAvailableLoader,
+            },
+            clear=True,
+        ):
+            with patch.dict(
+                FALLBACK_CHAINS,
+                {
+                    "a_share": ["fake_init_error", "fake_available"],
+                },
+            ):
                 loader = resolve_loader("a_share")
                 assert loader.name == "fake_available"
 
     def test_get_loader_cls_falls_back_when_requested_init_errors(self) -> None:
-        with patch.dict(LOADER_REGISTRY, {
-            "fake_init_error": _FakeInitErrorLoader,
-            "fake_available": _FakeAvailableLoader,
-        }, clear=True):
-            with patch.dict(FALLBACK_CHAINS, {
-                "a_share": ["fake_init_error", "fake_available"],
-            }):
+        with patch.dict(
+            LOADER_REGISTRY,
+            {
+                "fake_init_error": _FakeInitErrorLoader,
+                "fake_available": _FakeAvailableLoader,
+            },
+            clear=True,
+        ):
+            with patch.dict(
+                FALLBACK_CHAINS,
+                {
+                    "a_share": ["fake_init_error", "fake_available"],
+                },
+            ):
                 cls = get_loader_cls_with_fallback("fake_init_error")
                 assert cls is _FakeAvailableLoader


### PR DESCRIPTION
## Summary

<!-- What does this PR do? 1-3 bullet points. -->

- Make concurrent cold-start loader lookups wait for registration to finish.

I picked this issue as my first contribution to Vibe-Trading to get familiar
with the codebase and contribution workflow.

## Why

<!-- What problem does it solve? Link related issues with "Closes #123". -->

Closes #1403.

The initialization flag is set before loader imports finish, so concurrent
cold callers can observe an empty registry. Reproduced on Python 3.11.15
with the Docker runtime lock.

## Changes

<!-- List key changes. For new skills/presets, describe what they cover. -->

- Use a standard-library lock and publish `_registered` after imports finish.
- Preserve the warm fast path, environment refresh, and optional-import skips.
- Test both public lookup paths; keep Black formatting in a separate commit.

No dependency, fallback-order, broker-write, credential, or protected-area changes.

Risk: cold callers wait for imports. Reentrant loader imports could deadlock;
current imports were inspected and passed the real 27-loader cold-start check.
Rollback: revert the fix, restoring the original race.

## Test Plan

- [x] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [x] New tests added (if applicable)
- [x] Tested manually (describe below)

- Python **3.11.15 and 3.14.6**: **12,892 passed, 17 skipped each** in the
  CI-selected backend suite on fix commit `9d560d3a`.
- After formatting: **48 registry/source-order tests passed on each version**;
  ASTs match after docstring whitespace normalization. Full suite not rerun.
- Both regressions fail against the original initializer. All eight cold
  readers now see 27 loaders.
- Full-file Black, Ruff, syntax checks, and repository safety gates pass.

Hosted CI awaits maintainer authorization. Frontend, desktop/Windows,
cross-platform hash-lock jobs, and live E2E were not run locally.

<details>
<summary>Reproduction and verification details</summary>

Base: `f9cb061b3f3b983a62780985008044ceb90c2f81`.
Full-suite results are from `9d560d3a`; the formatting-only follow-up is `61f46241`.

**CI environments and command**

Each Python version used a separate environment:

```bash
uv venv --seed --python VERSION VENV
uv pip install --python VENV/bin/python -e '.[dev,openbb,stats,anthropic]'
```

`pip check` and imports of all four optional extras passed on both versions.
These environments resolve declared dependencies without the Docker lock.
With absolute temporary `VENV`, `TEST_HOME`, and `TEST_TMP` paths, from the
repository root:

```bash
env -i HOME="$TEST_HOME" PATH="$VENV/bin:/usr/bin:/bin" \
  PYTHONDONTWRITEBYTECODE=1 PYTHONPATH="$PWD/agent" \
  COVERAGE_FILE="$TEST_TMP/.coverage" \
  bwrap --unshare-net --bind / / --dev /dev -- timeout 900 \
  "$VENV/bin/python" -m pytest \
  --ignore=agent/tests/e2e_backtest \
  --ignore=agent/tests/test_e2e_harness_v2.py \
  --cov=agent --cov-report="xml:$TEST_TMP/coverage.xml" \
  --junitxml="$TEST_TMP/results.xml" -p no:cacheprovider --tb=short -q
```

The exclusions match `test.yml` and the agent contributor guide. External
networking was blocked for tests and subprocesses; loopback remained available.
No live broker or LLM calls were authorized.

The 17 skips cover credential/live checks, optional OCR, synthetic-panel
preconditions, missing-dependency paths when the dependency is installed, and
an opt-in baseline comparison. Python 3.11 reported 17 warnings; Python 3.14
reported 3,016, including NumPy/Pandas deprecations and SQLite resource warnings.
Warnings were not suppressed.

An initial Python 3.11 run failed 27 tests because global Python socket blocking
also blocked local integration sockets and numeric IP parsing. All 251 tests
in the affected files, then the entire suite, passed under network-namespace
isolation without source changes or weakened tests.

**Locked reproduction environment**

```bash
uv venv --python 3.11.15 --seed .venv
uv pip install --python .venv/bin/python --require-hashes -r requirements-lock.txt
uv pip install --python .venv/bin/python --constraint requirements-lock.txt -e '.[dev]'
.venv/bin/python -m pip check
```

Dependency consistency passed; a repeat hash-locked dry run would change nothing.
This matches the reported Python patch version and Docker runtime lock, not the
entire Docker image or optional channel installation.

The eight-thread cold-start smoke used real imports with no injected delays
and blocked import-time sockets: baseline returned zero loaders to seven
threads and 27 to one; the fix returned 27 to all eight. The patched smoke
also passed on Python 3.14.6. Standalone public-reader probes failed twice
on baseline and passed twice with the fix; the committed regressions also
fail when only the original initializer is restored in memory.

**Post-format and static checks**

Post-format tests on both isolated CI interpreters:

```bash
python -m pytest agent/tests/test_registry.py agent/tests/test_source_order_overrides.py -p no:cacheprovider --tb=short -q
```

Both returned 48 passes; Python 3.14 reported nine NumPy/Pandas deprecation
warnings. Earlier, `pytest tools/test_ci_env_var_gate.py -q` passed 23 tests
on each version. `bash tools/ci_grep_gates.sh` and CI syntax checks also passed
on both, retaining four existing environment-mutation warnings in
`src/providers/llm.py`.

After formatting, full-file static checks passed in the locked Python 3.11.15
development environment (Black 26.5.1):

```bash
.venv/bin/python -m black --check --no-cache --target-version py311 agent/backtest/loaders/registry.py agent/tests/test_registry.py
.venv/bin/python -m ruff check agent/backtest/loaders/registry.py agent/tests/test_registry.py
git diff --check
```

Local results do not establish that hosted CI has passed.

</details>

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] Documentation updated (if user-facing change)

Both commits carry DCO sign-offs. No user-facing CLI, API, configuration, or
safety-boundary contract changed, so README updates are not applicable.
The initializer docstring states the waiting behavior.
