### PR TITLE
feat(portfolio): add a read-only extraETF export reader

### DIFF
--- a/agent/src/portfolio/extraetf.py
+++ b/agent/src/portfolio/extraetf.py
@@ -15,29 +15,69 @@ Three properties are deliberate and load-bearing.
 **A transactions export can never be read as a portfolio.** Its rows are
 movements — ``Kauf``/``Verkauf``/``Dividende``/``Einbuchung``/``Ausbuchung`` —
 not holdings. An allocation computed from trades looks perfectly plausible and
-is wrong, so the two formats are told apart by their header and
-:meth:`ExtraEtfExport.require_positions` refuses anything that is not a
-holdings export. Movements carry an explicit ``movement_kind`` so a dividend or
+is wrong, so the two formats are told apart by their header and positions are
+reachable only through :meth:`ExtraEtfExport.require_positions`, which refuses
+any other export. Movements carry an explicit ``movement_kind`` so a dividend or
 a transfer is never mistaken for a trade.
 
 **A holdings export carries no date.** The format has no snapshot column, so
 freshness can only come from the file's own modification time, and the export
-says so through ``as_of_source``. This reader never claims an observation time
-it did not read.
+says so through ``as_of_source``. No position carries an observation time: a
+row's ``source_mtime`` is the file's modification time, kept under a name no
+connector ever fills with a real fetch time, and ``updated_at`` is ``None``
+rather than a copy of it. Copying or syncing an export rewrites that mtime, so
+``source_mtime`` reports when the *file* last changed and nothing more.
 
 **Validation fails closed.** A row this reader does not recognise raises
 :class:`ExtraEtfFormatError` instead of being skipped: an import computed from
 90% of a portfolio reads as entirely plausible, whereas a refused import is
-merely annoying. Numbers are parsed as German — ``1.386,608`` is 1386.608 — and
-a value that cannot be read unambiguously is refused rather than guessed.
-``1,234.56`` is US-formatted; reading it as German would be wrong by three
-orders of magnitude, so it is refused instead.
+merely annoying. That covers ragged rows, records that span more than one
+physical line, unknown or missing columns, unreadable or contradictory numbers,
+empty required fields, and text fields carrying control characters.
+
+The number rule is precise, because it is the one that can change a position's
+size by orders of magnitude. A comma is the decimal separator and a period may
+only be a thousands separator, so ``1.386,608`` is 1386.608 and ``12,3456`` is
+12.3456. A value whose separators are US-ordered (``1,234.56``) is refused,
+because reading it as German would be wrong by a thousandfold. A period grouping
+that is not a plain thousands separator (``1.23``, ``1234.56``) is refused too,
+because it is neither a valid German number nor safely a US one. What is *not*
+refused is a period-grouped value that is valid German — ``1.900`` is 1900 — and
+that reading is a convention of the format, not a deduction: ``1.900`` could be
+1.9 in a US-locale file, and no amount of parsing can tell the two apart.
+extraETF writes German, so German wins, and a file that had been round-tripped
+through a US-locale spreadsheet is caught by the *other* values in it rather
+than by this one.
 
 Rows are read by column name, so a reordered export cannot mis-align a value
 into the wrong column. Rows are **not** merged or de-duplicated: two rows for
 the same instrument in one portfolio are returned as two positions, because
 summing them silently and dropping one silently are both wrong, and which one
 the user meant is not this module's call.
+
+The emitted position uses the portfolio package's own field names so a container
+can consume it, and carries the export's remaining columns alongside them. It
+does **not** route the row through
+:func:`src.portfolio.normalization.normalize_position`, which is the obvious way
+to guarantee one wire shape, because that function stamps ``updated_at`` with
+the current time — an observation time this reader never made — and defaults an
+unknown instrument class to ``"stock"``. Both are fabrications a file import
+must not make, so the mapping is done here and the divergences are the three
+shown above: ``quote_symbol``'s None, ``asset_type``'s None, and ``updated_at``
+against ``source_mtime``.
+
+Values are carried as the export reports them rather than repaired: a zero or
+negative quantity, a zero FX rate, and two different portfolio names under one
+portfolio ID all pass through, because a reader that silently corrects its input
+is a reader whose output no longer describes the file. What is refused is input
+that cannot be read at all.
+
+Two limits are inherent to the format and belong in the caller's hands. A file
+truncated exactly at a record boundary is indistinguishable from a short export,
+because neither format carries a row count or a footer; a caller that knows how
+many positions to expect is the only thing that can catch that. An export with a
+header and no rows is read as a valid empty portfolio, because an empty
+portfolio and an unreadable file are different states.
 
 The module writes nothing, holds no credentials, and touches no network. It
 only reads a local file the user exported themselves, and it has no path to any
@@ -95,6 +135,7 @@ _TRANSACTIONS_COLUMNS: tuple[str, ...] = (
 ExportKind = Literal["holdings", "transactions"]
 
 _ISIN_PATTERN = re.compile(r"^[A-Z]{2}[A-Z0-9]{9}[0-9]$")
+_WIRE_QUANTUM = Decimal("0.00000001")
 _CRYPTO_PAIR_PATTERN = re.compile(r"^[A-Z0-9]{2,12}_to_[A-Z0-9]{2,12}$", re.IGNORECASE)
 _CURRENCY_PATTERN = re.compile(r"^[A-Z]{3}$")
 _DATE_PATTERN = re.compile(r"^(\d{2})\.(\d{2})\.(\d{4})$")
@@ -126,10 +167,14 @@ class ExtraEtfFormatError(ValueError):
 class ExtraEtfExport:
     """One parsed export, with its provenance attached.
 
+    The payloads are deliberately private. An export cannot hold both positions
+    and movements, and reaching for the wrong one used to yield an empty tuple
+    rather than an error — which turns "this is a transactions export" into "this
+    portfolio is empty", the exact plausible-and-wrong outcome this module exists
+    to prevent. Both accessors refuse a mismatched export instead.
+
     Attributes:
         kind: Which of the two extraETF formats this file is.
-        positions: Holdings rows. Always empty for a transactions export.
-        movements: Transactions rows. Always empty for a holdings export.
         as_of: ISO-8601 observation time, or ``None`` when it could not be read.
         as_of_source: Where ``as_of`` came from — ``"file_mtime"`` for a file
             read from disk, ``"unavailable"`` for bare text with no timestamp.
@@ -140,11 +185,11 @@ class ExtraEtfExport:
     """
 
     kind: ExportKind
-    positions: tuple[dict[str, Any], ...]
-    movements: tuple[dict[str, Any], ...]
     as_of: str | None
     as_of_source: Literal["file_mtime", "unavailable"]
     source_path: Path | None
+    _positions: tuple[dict[str, Any], ...] = ()
+    _movements: tuple[dict[str, Any], ...] = ()
 
     def require_positions(self) -> tuple[dict[str, Any], ...]:
         """Return holdings positions, refusing any other export outright.
@@ -161,7 +206,21 @@ class ExtraEtfExport:
                 "this is a transactions export and holds movements, not positions; "
                 "importing it as a portfolio would build an allocation out of trades"
             )
-        return self.positions
+        return self._positions
+
+    def require_movements(self) -> tuple[dict[str, Any], ...]:
+        """Return movements, refusing a holdings export outright.
+
+        Returns:
+            The parsed movements, possibly empty for an account with no history.
+
+        Raises:
+            ExtraEtfFormatError: If this export is a holdings export, whose rows
+                are positions rather than movements.
+        """
+        if self.kind != "transactions":
+            raise ExtraEtfFormatError("this is a holdings export and holds positions, not movements")
+        return self._movements
 
 
 def read_export(path: str | Path) -> ExtraEtfExport:
@@ -191,9 +250,7 @@ def read_export(path: str | Path) -> ExtraEtfExport:
     except OSError as exc:
         raise ExtraEtfFormatError(f"cannot read export {resolved}: {exc}") from exc
     as_of = datetime.fromtimestamp(modified, tz=timezone.utc).isoformat()
-    return parse_export(
-        data, source_path=resolved, as_of=as_of, as_of_source="file_mtime"
-    )
+    return parse_export(data, source_path=resolved, as_of=as_of, as_of_source="file_mtime")
 
 
 def parse_export(
@@ -222,28 +279,23 @@ def parse_export(
     """
     if as_of is None and as_of_source != "unavailable":
         raise ValueError(
-            "as_of_source cannot claim where an observation time came from when "
-            "there is no observation time"
+            "as_of_source cannot claim where an observation time came from when there is no observation time"
         )
     text = _decode(data)
     kind, header, rows = _read_rows(text)
     if kind == "holdings":
-        positions = tuple(
-            _parse_holding(header, cells, number, as_of=as_of) for number, cells in rows
-        )
+        positions = tuple(_parse_holding(header, cells, number, as_of=as_of) for number, cells in rows)
         movements: tuple[dict[str, Any], ...] = ()
     else:
         positions = ()
-        movements = tuple(
-            _parse_movement(header, cells, number) for number, cells in rows
-        )
+        movements = tuple(_parse_movement(header, cells, number) for number, cells in rows)
     return ExtraEtfExport(
         kind=kind,
-        positions=positions,
-        movements=movements,
         as_of=as_of,
         as_of_source=as_of_source,
         source_path=Path(source_path) if source_path is not None else None,
+        _positions=positions,
+        _movements=movements,
     )
 
 
@@ -288,29 +340,62 @@ def _read_rows(
     reader = csv.reader(io.StringIO(text), delimiter=";")
     header: tuple[str, ...] | None = None
     number = 0
-    for cells in reader:
-        number += 1
-        if not any(cell.strip() for cell in cells):
-            continue
-        header = tuple(cell.strip().lstrip("\ufeff") for cell in cells)
-        break
-    if header is None:
-        raise ExtraEtfFormatError("export is empty")
-    kind = _detect_kind(header)
+    try:
+        for cells in reader:
+            number += 1
+            _refuse_multiline_record(cells, number)
+            if not any(cell.strip() for cell in cells):
+                continue
+            header = tuple(cell.strip().lstrip("\ufeff") for cell in cells)
+            break
+        if header is None:
+            raise ExtraEtfFormatError("export is empty")
+        kind = _detect_kind(header)
 
-    rows: list[tuple[int, list[str]]] = []
-    for cells in reader:
-        number += 1
-        if not any(cell.strip() for cell in cells):
-            continue
-        if len(cells) != len(header):
-            raise ExtraEtfFormatError(
-                f"row {number}: expected {len(header)} fields to match the header, "
-                f"found {len(cells)}; a row that cannot be aligned is refused rather "
-                f"than skipped"
-            )
-        rows.append((number, [cell.strip() for cell in cells]))
+        rows: list[tuple[int, list[str]]] = []
+        for cells in reader:
+            number += 1
+            _refuse_multiline_record(cells, number)
+            if not any(cell.strip() for cell in cells):
+                continue
+            if len(cells) != len(header):
+                raise ExtraEtfFormatError(
+                    f"row {number}: expected {len(header)} fields to match the header, "
+                    f"found {len(cells)}; a row that cannot be aligned is refused rather "
+                    f"than skipped"
+                )
+            rows.append((number, [cell.strip() for cell in cells]))
+    except csv.Error as exc:
+        # csv raises its own errors for an over-long field or a stray quote. A
+        # caller catches the documented error type, so it is translated rather
+        # than allowed to escape as a bare csv error.
+        raise ExtraEtfFormatError(f"export is not readable as CSV: {exc}") from exc
     return kind, header, rows
+
+
+def _refuse_multiline_record(cells: list[str], number: int) -> None:
+    """Refuse a csv record whose fields span more than one physical line.
+
+    extraETF writes one record per line and never quotes an embedded newline. A
+    stray quote in one field therefore makes csv fold the *following* lines into
+    that record: the record still has the right field count, so the arity check
+    passes, and two positions silently become one with another instrument's
+    quantity and value grafted onto it. That is a plausible-looking wrong
+    portfolio, so the fold is refused outright rather than aligned.
+
+    Args:
+        cells: The record's fields.
+        number: The record's position in the file, for error messages.
+
+    Raises:
+        ExtraEtfFormatError: If any field contains a line break.
+    """
+    if any("\n" in cell or "\r" in cell for cell in cells):
+        raise ExtraEtfFormatError(
+            f"row {number}: a field spans more than one line, so this record and "
+            f"the line after it were folded together; a stray quote is the usual "
+            f"cause and the positions it swallowed cannot be recovered here"
+        )
 
 
 def _detect_kind(header: tuple[str, ...]) -> ExportKind:
@@ -328,9 +413,7 @@ def _detect_kind(header: tuple[str, ...]) -> ExportKind:
     columns = set(header)
     if len(header) == len(_HOLDINGS_COLUMNS) and columns == set(_HOLDINGS_COLUMNS):
         return "holdings"
-    if len(header) == len(_TRANSACTIONS_COLUMNS) and columns == set(
-        _TRANSACTIONS_COLUMNS
-    ):
+    if len(header) == len(_TRANSACTIONS_COLUMNS) and columns == set(_TRANSACTIONS_COLUMNS):
         return "transactions"
     transactions_like = "Transaktion" in columns
     expected = _TRANSACTIONS_COLUMNS if transactions_like else _HOLDINGS_COLUMNS
@@ -343,9 +426,7 @@ def _detect_kind(header: tuple[str, ...]) -> ExportKind:
     )
 
 
-def _parse_holding(
-    header: tuple[str, ...], cells: list[str], number: int, *, as_of: str | None
-) -> dict[str, Any]:
+def _parse_holding(header: tuple[str, ...], cells: list[str], number: int, *, as_of: str | None) -> dict[str, Any]:
     """Convert one holdings row into a position.
 
     Args:
@@ -372,10 +453,7 @@ def _parse_holding(
     instrument_type = _required(row, "Typ", number)
     currency = _required(row, "Währung", number).upper()
     if not _CURRENCY_PATTERN.fullmatch(currency):
-        raise ExtraEtfFormatError(
-            f"row {number}: Währung is not a three-letter currency code: "
-            f"{row['Währung']!r}"
-        )
+        raise ExtraEtfFormatError(f"row {number}: Währung is not a three-letter currency code: {row['Währung']!r}")
     portfolio_id = _required(row, "Portfolio ID", number)
     quantity = _parse_decimal(row["Anzahl"], field="Anzahl", row_number=number)
     if quantity is None:
@@ -384,41 +462,43 @@ def _parse_holding(
         "broker": BROKER,
         "source": "extraetf_export",
         "symbol": identifier,
-        "quote_symbol": identifier,
+        # The export names an instrument, never a quoting instrument: an ISIN in
+        # a quote-symbol field is a request for a quote on a security identifier,
+        # so this stays None for the container to resolve. ``market`` is None for
+        # the same reason — extraETF rows carry no venue.
+        "quote_symbol": None,
         "instrument_id": identifier,
         "instrument_id_kind": identifier_kind,
         "instrument_id_checksum_ok": checksum_ok,
         "name": name,
         "instrument_type": instrument_type,
+        # The export's instrument class mapped into the repo's vocabulary, and
+        # None when it is a class this reader does not know. Deliberately not
+        # defaulted to "stock": a guessed asset type is a fabricated fact about
+        # the instrument, where an unknown class is honestly unknown.
         "asset_type": _ASSET_TYPE_BY_EXPORT_TYPE.get(instrument_type.strip().lower()),
         "market": None,
         "currency": currency,
         "price_currency": currency,
         "quantity": _number(quantity),
-        "cost_price": _optional_number(
-            row["Kaufpreis"], field="Kaufpreis", row_number=number
-        ),
-        "market_price": _optional_number(
-            row["Aktueller Kurs"], field="Aktueller Kurs", row_number=number
-        ),
-        "source_market_value": _optional_number(
-            row["Aktueller Wert"], field="Aktueller Wert", row_number=number
-        ),
-        "fx_rate": _optional_number(
-            row["Wechselkurs"], field="Wechselkurs", row_number=number
-        ),
-        "region": row["Region"] or None,
-        "country": row["Land"] or None,
-        "sector": row["Sektor"] or None,
+        "cost_price": _optional_number(row["Kaufpreis"], field="Kaufpreis", row_number=number),
+        "market_price": _optional_number(row["Aktueller Kurs"], field="Aktueller Kurs", row_number=number),
+        "source_market_value": _optional_number(row["Aktueller Wert"], field="Aktueller Wert", row_number=number),
+        "fx_rate": _optional_number(row["Wechselkurs"], field="Wechselkurs", row_number=number),
+        "region": _optional_text(row, "Region", number),
+        "country": _optional_text(row, "Land", number),
+        "sector": _optional_text(row, "Sektor", number),
         "portfolio_id": portfolio_id,
-        "portfolio_name": row["Portfolioname"] or None,
-        "updated_at": as_of,
+        "portfolio_name": _optional_text(row, "Portfolioname", number),
+        # No observation time exists in this format, so the repo's "when was this
+        # observed" field stays empty rather than borrowing the file's mtime,
+        # which any copy, sync or restore rewrites.
+        "updated_at": None,
+        "source_mtime": as_of,
     }
 
 
-def _parse_movement(
-    header: tuple[str, ...], cells: list[str], number: int
-) -> dict[str, Any]:
+def _parse_movement(header: tuple[str, ...], cells: list[str], number: int) -> dict[str, Any]:
     """Convert one transactions row into a movement.
 
     Args:
@@ -438,22 +518,15 @@ def _parse_movement(
     transaction_date = _required(row, "Datum", number)
     match = _DATE_PATTERN.fullmatch(transaction_date)
     if match is None:
-        raise ExtraEtfFormatError(
-            f"row {number}: Datum is not a DD.MM.YYYY date: {transaction_date!r}"
-        )
+        raise ExtraEtfFormatError(f"row {number}: Datum is not a DD.MM.YYYY date: {transaction_date!r}")
     day, month, year = (int(part) for part in match.groups())
     try:
         booked_on = datetime(year, month, day).date().isoformat()
     except ValueError as exc:
-        raise ExtraEtfFormatError(
-            f"row {number}: Datum is not a real date: {transaction_date!r}"
-        ) from exc
+        raise ExtraEtfFormatError(f"row {number}: Datum is not a real date: {transaction_date!r}") from exc
     currency = _required(row, "Währung", number).upper()
     if not _CURRENCY_PATTERN.fullmatch(currency):
-        raise ExtraEtfFormatError(
-            f"row {number}: Währung is not a three-letter currency code: "
-            f"{row['Währung']!r}"
-        )
+        raise ExtraEtfFormatError(f"row {number}: Währung is not a three-letter currency code: {row['Währung']!r}")
     identifier, identifier_kind, checksum_ok = _describe_identifier(row["ISIN"])
     quantity = _parse_decimal(row["Anzahl"], field="Anzahl", row_number=number)
     if quantity is None:
@@ -474,19 +547,37 @@ def _parse_movement(
         "fees": _optional_number(row["Gebühren"], field="Gebühren", row_number=number),
         "taxes": _optional_number(row["Steuern"], field="Steuern", row_number=number),
         "currency": currency,
-        "fx_rate": _optional_number(
-            row["Wechselkurs"], field="Wechselkurs", row_number=number
-        ),
-        "accrued_interest": _optional_number(
-            row["Stückzinsen"], field="Stückzinsen", row_number=number
-        ),
+        "fx_rate": _optional_number(row["Wechselkurs"], field="Wechselkurs", row_number=number),
+        "accrued_interest": _optional_number(row["Stückzinsen"], field="Stückzinsen", row_number=number),
         "portfolio_id": _required(row, "Portfolio ID", number),
-        "portfolio_name": row["Portfolioname"] or None,
+        "portfolio_name": _optional_text(row, "Portfolioname", number),
     }
 
 
+def _optional_text(row: dict[str, str], column: str, number: int) -> str | None:
+    """Return an optional text column, refusing corruption.
+
+    Args:
+        row: The aligned row.
+        column: The column to read.
+        number: The row's line number, for error messages.
+
+    Returns:
+        The value, or ``None`` when the field is blank.
+
+    Raises:
+        ExtraEtfFormatError: If the value carries control characters.
+    """
+    value = row[column]
+    if not value:
+        return None
+    if any(ord(character) < 32 for character in value):
+        raise ExtraEtfFormatError(f"row {number}: {column} carries control characters")
+    return value
+
+
 def _required(row: dict[str, str], column: str, number: int) -> str:
-    """Return a column's value, refusing an empty one.
+    """Return a column's value, refusing an empty or corrupt one.
 
     Args:
         row: The aligned row.
@@ -497,11 +588,17 @@ def _required(row: dict[str, str], column: str, number: int) -> str:
         The non-empty value.
 
     Raises:
-        ExtraEtfFormatError: If the value is empty.
+        ExtraEtfFormatError: If the value is empty or carries control
+            characters. Control characters are refused for the same reason
+            :func:`src.portfolio.config.parse_settings` refuses them in a source
+            label: they are corruption, and text carrying them does not
+            round-trip.
     """
     value = row[column]
     if not value:
         raise ExtraEtfFormatError(f"row {number}: {column} is empty")
+    if any(ord(character) < 32 for character in value):
+        raise ExtraEtfFormatError(f"row {number}: {column} carries control characters")
     return value
 
 
@@ -567,16 +664,23 @@ def _parse_decimal(raw: str, *, field: str, row_number: int) -> Decimal | None:
         or (comma and not fraction.isdigit())
     ):
         raise ExtraEtfFormatError(
-            f"row {row_number}: {field} has ambiguous separators: {raw!r}; expected "
-            f"German formatting such as 1.386,608"
+            f"row {row_number}: {field} has ambiguous separators: {raw!r}; expected German formatting such as 1.386,608"
         )
     digits = "".join(groups) + (f".{fraction}" if comma else "")
     try:
-        return Decimal(f"{sign}{digits}")
+        value = Decimal(f"{sign}{digits}")
     except InvalidOperation as exc:  # pragma: no cover - guarded by the checks above
+        raise ExtraEtfFormatError(f"row {row_number}: {field} is not a number: {raw!r}") from exc
+    try:
+        # Probe the wire format's precision here, while the row is still known.
+        # Handing an unrepresentable magnitude to the formatter would surface as
+        # a bare decimal.InvalidOperation, which is not the documented error.
+        value.quantize(_WIRE_QUANTUM)
+    except InvalidOperation as exc:
         raise ExtraEtfFormatError(
-            f"row {row_number}: {field} is not a number: {raw!r}"
+            f"row {row_number}: {field} carries more precision than a position can represent: {raw!r}"
         ) from exc
+    return value
 
 
 def _describe_identifier(raw: str) -> tuple[str, str, bool | None]:
@@ -620,10 +724,7 @@ def _isin_checksum_ok(value: str) -> bool:
     Returns:
         ``True`` when the Luhn-style check digit is valid.
     """
-    digits = "".join(
-        str(ord(character) - 55) if character.isalpha() else character
-        for character in value
-    )
+    digits = "".join(str(ord(character) - 55) if character.isalpha() else character for character in value)
     total = 0
     for index, character in enumerate(reversed(digits)):
         digit = int(character)
@@ -639,10 +740,11 @@ def _number(value: Decimal) -> float:
     """Return a wire-ready float, quantized as the connector path does.
 
     Args:
-        value: The parsed value.
+        value: A value already probed by :func:`_parse_decimal`, which applies
+            this same quantization so it cannot raise here.
 
     Returns:
         The value as a float, quantized to eight decimal places to match
         :func:`src.portfolio.normalization.normalize_position`.
     """
-    return float(value.quantize(Decimal("0.00000001")))
+    return float(value.quantize(_WIRE_QUANTUM))

--- a/agent/src/portfolio/extraetf.py
+++ b/agent/src/portfolio/extraetf.py
@@ -22,18 +22,22 @@ a transfer is never mistaken for a trade.
 
 **A holdings export carries no date.** The format has no snapshot column, so
 freshness can only come from the file's own modification time, and the export
-says so through ``as_of_source``. No position carries an observation time: a
-row's ``source_mtime`` is the file's modification time, kept under a name no
-connector ever fills with a real fetch time, and ``updated_at`` is ``None``
-rather than a copy of it. Copying or syncing an export rewrites that mtime, so
-``source_mtime`` reports when the *file* last changed and nothing more.
+exposes it as ``source_mtime``, with ``as_of_source`` recording where it came
+from. It is named for what it is — a file's modification time, not an
+observation time and not a snapshot date. No position carries an observation
+time at all: ``updated_at`` is ``None`` rather than a copy of the file's mtime.
+Copying or syncing an export rewrites that mtime, so ``source_mtime`` reports
+when the *file* last changed and nothing more.
 
 **Validation fails closed.** A row this reader does not recognise raises
 :class:`ExtraEtfFormatError` instead of being skipped: an import computed from
 90% of a portfolio reads as entirely plausible, whereas a refused import is
 merely annoying. That covers ragged rows, records that span more than one
 physical line, unknown or missing columns, unreadable or contradictory numbers,
-empty required fields, and text fields carrying control characters.
+numbers carrying more precision than the output can hold, empty required
+fields, text fields carrying control characters, an instrument listed twice
+under one portfolio, and a transaction whose label or identifier cannot be read
+as anything this format documents.
 
 The number rule is precise, because it is the one that can change a position's
 size by orders of magnitude. A comma is the decimal separator and a period may
@@ -50,10 +54,12 @@ through a US-locale spreadsheet is caught by the *other* values in it rather
 than by this one.
 
 Rows are read by column name, so a reordered export cannot mis-align a value
-into the wrong column. Rows are **not** merged or de-duplicated: two rows for
-the same instrument in one portfolio are returned as two positions, because
-summing them silently and dropping one silently are both wrong, and which one
-the user meant is not this module's call.
+into the wrong column. Rows are **never** merged or de-duplicated silently. The
+same instrument under two different portfolio IDs is two real positions and is
+left alone. The same instrument twice under **one** portfolio ID is refused:
+the two rows could be one lot listed twice or two genuine lots, and a caller
+that sums them double-counts the position while a caller that keeps one drops
+the other, so the file is rejected rather than guessed at.
 
 The emitted position uses the portfolio package's own field names so a container
 can consume it, and carries the export's remaining columns alongside them. It
@@ -148,11 +154,14 @@ _NUMERAL_PATTERN = re.compile(r"^[0-9.,]+$")
 
 #: ``Typ`` is an instrument class, not a row shape: a class this reader does not
 #: know still describes a real position, so it is carried through with
-#: ``asset_type`` left ``None`` rather than refused or guessed at.
+#: ``asset_type`` left ``None`` rather than refused or guessed at. extraETF's
+#: ``Währung / Krypto`` class is deliberately absent from this map: it covers
+#: foreign-exchange pairs as well as crypto, so a ``USD_to_EUR`` row would end up
+#: labelled a crypto holding — a guess about the asset class, which is precisely
+#: what leaving the class unset exists to avoid.
 _ASSET_TYPE_BY_EXPORT_TYPE = {
     "etf": "etf",
     "aktie": "stock",
-    "währung / krypto": "crypto",
 }
 
 _MOVEMENT_KIND_BY_TRANSACTION = {
@@ -180,17 +189,20 @@ class ExtraEtfExport:
 
     Attributes:
         kind: Which of the two extraETF formats this file is.
-        as_of: ISO-8601 observation time, or ``None`` when it could not be read.
-        as_of_source: Where ``as_of`` came from — ``"file_mtime"`` for a file
-            read from disk, ``"unavailable"`` for bare text with no timestamp.
-            A holdings export has no date column, so ``file_mtime`` is an
-            inference from the file's own modification time and is labelled as
-            one rather than presented as a recorded snapshot date.
+        source_mtime: ISO-8601 modification time of the file this export came
+            from, or ``None`` when it was parsed from bare text. It is a file's
+            timestamp, not an observation time, and it is named so that nothing
+            downstream can read it as a snapshot date.
+        as_of_source: Where ``source_mtime`` came from — ``"file_mtime"`` for a
+            file read from disk, ``"unavailable"`` for bare text with no
+            timestamp. A holdings export has no date column, so ``file_mtime``
+            is an inference from the file's own modification time and is
+            labelled as one rather than presented as a recorded snapshot date.
         source_path: The file this export was read from, when there was one.
     """
 
     kind: ExportKind
-    as_of: str | None
+    source_mtime: str | None
     as_of_source: Literal["file_mtime", "unavailable"]
     source_path: Path | None
     _positions: tuple[dict[str, Any], ...] = ()
@@ -231,7 +243,7 @@ class ExtraEtfExport:
 def read_export(path: str | Path) -> ExtraEtfExport:
     """Read and parse one extraETF export file.
 
-    The file's modification time becomes ``as_of`` with
+    The file's modification time becomes ``source_mtime`` with
     ``as_of_source="file_mtime"``, because neither export format carries a
     snapshot-observation column.
 
@@ -254,15 +266,15 @@ def read_export(path: str | Path) -> ExtraEtfExport:
             modified = os.fstat(handle.fileno()).st_mtime
     except OSError as exc:
         raise ExtraEtfFormatError(f"cannot read export {resolved}: {exc}") from exc
-    as_of = datetime.fromtimestamp(modified, tz=timezone.utc).isoformat()
-    return parse_export(data, source_path=resolved, as_of=as_of, as_of_source="file_mtime")
+    source_mtime = datetime.fromtimestamp(modified, tz=timezone.utc).isoformat()
+    return parse_export(data, source_path=resolved, source_mtime=source_mtime, as_of_source="file_mtime")
 
 
 def parse_export(
     data: str | bytes,
     *,
     source_path: str | Path | None = None,
-    as_of: str | None = None,
+    source_mtime: str | None = None,
     as_of_source: Literal["file_mtime", "unavailable"] = "unavailable",
 ) -> ExtraEtfExport:
     """Parse one extraETF export from text or raw bytes.
@@ -270,8 +282,9 @@ def parse_export(
     Args:
         data: The export contents, as text or as raw file bytes.
         source_path: The originating file, recorded for provenance only.
-        as_of: ISO-8601 observation time, when the caller knows one.
-        as_of_source: Where ``as_of`` came from.
+        source_mtime: ISO-8601 modification time of the originating file, when
+            the caller knows one.
+        as_of_source: Where ``source_mtime`` came from.
 
     Returns:
         The parsed export. An export with a header and no data rows is valid and
@@ -282,28 +295,59 @@ def parse_export(
             or any row cannot be read without guessing.
         ValueError: If ``as_of_source`` claims an origin for an absent ``as_of``.
     """
-    if as_of is None and as_of_source != "unavailable":
+    if source_mtime is None and as_of_source != "unavailable":
         raise ValueError(
-            "as_of_source cannot claim where an observation time came from when there is no observation time"
+            "as_of_source cannot claim where a source modification time came from "
+            "when there is no source modification time"
         )
     if as_of_source not in ("file_mtime", "unavailable"):
         raise ValueError(f"as_of_source must be 'file_mtime' or 'unavailable', not {as_of_source!r}")
     text = _decode(data)
     kind, header, rows = _read_rows(text)
     if kind == "holdings":
-        positions = tuple(_parse_holding(header, cells, number, as_of=as_of) for number, cells in rows)
+        positions = tuple(_parse_holding(header, cells, number, source_mtime=source_mtime) for number, cells in rows)
+        _refuse_duplicate_positions(positions, rows)
         movements: tuple[dict[str, Any], ...] = ()
     else:
         positions = ()
         movements = tuple(_parse_movement(header, cells, number) for number, cells in rows)
     return ExtraEtfExport(
         kind=kind,
-        as_of=as_of,
+        source_mtime=source_mtime,
         as_of_source=as_of_source,
         source_path=Path(source_path) if source_path is not None else None,
         _positions=positions,
         _movements=movements,
     )
+
+
+def _refuse_duplicate_positions(positions: tuple[dict[str, Any], ...], rows: list[tuple[int, list[str]]]) -> None:
+    """Refuse one instrument listed twice under a single portfolio ID.
+
+    The same instrument under two different portfolio IDs is two genuine
+    positions and is left alone. The same instrument twice under **one**
+    portfolio ID is a file whose meaning is ambiguous — one lot listed twice, or
+    two real lots — and a caller that sums those rows double-counts the position
+    while a caller that keeps one drops the other, so the file is refused.
+
+    Args:
+        positions: The parsed holdings positions, in row order.
+        rows: The ``(line number, cells)`` pairs those positions came from.
+
+    Raises:
+        ExtraEtfFormatError: If a ``(portfolio_id, instrument_id)`` pair repeats.
+    """
+    seen: dict[tuple[str, str], int] = {}
+    for (number, _cells), position in zip(rows, positions, strict=True):
+        key = (position["portfolio_id"], position["instrument_id"])
+        first = seen.get(key)
+        if first is not None:
+            raise ExtraEtfFormatError(
+                f"row {number}: {position['instrument_id']} is listed twice under portfolio "
+                f"{position['portfolio_id']!r} (first at row {first}); a repeated instrument in one "
+                f"portfolio cannot be summed or collapsed without inventing a position"
+            )
+        seen[key] = number
 
 
 def _decode(data: str | bytes) -> str:
@@ -455,20 +499,25 @@ def _detect_kind(header: tuple[str, ...]) -> ExportKind:
     missing = [column for column in expected if column not in columns]
     unexpected = [column for column in header if column not in expected]
     raise ExtraEtfFormatError(
-        "export header is not a recognised extraETF format; against the "
-        f"{'transactions' if transactions_like else 'holdings'} format, missing "
+        "export header is not a recognised extraETF format; this reader knows two, the "
+        f"holdings export {list(_HOLDINGS_COLUMNS)} and the transactions export "
+        f"{list(_TRANSACTIONS_COLUMNS)}; the nearest of those is "
+        f"{'transactions' if transactions_like else 'holdings'}, against which missing "
         f"columns: {missing or 'none'}, unexpected columns: {unexpected or 'none'}"
     )
 
 
-def _parse_holding(header: tuple[str, ...], cells: list[str], number: int, *, as_of: str | None) -> dict[str, Any]:
+def _parse_holding(
+    header: tuple[str, ...], cells: list[str], number: int, *, source_mtime: str | None
+) -> dict[str, Any]:
     """Convert one holdings row into a position.
 
     Args:
         header: The export's column names, which key the row's fields.
         cells: The row's fields.
         number: The row's line number, for error messages.
-        as_of: The export's observation time, mirrored onto the position.
+        source_mtime: The export file's modification time, mirrored onto the
+            position under a name that cannot be read as an observation time.
 
     Returns:
         One position in the portfolio wire shape.
@@ -529,7 +578,7 @@ def _parse_holding(header: tuple[str, ...], cells: list[str], number: int, *, as
         # observed" field stays empty rather than borrowing the file's mtime,
         # which any copy, sync or restore rewrites.
         "updated_at": None,
-        "source_mtime": as_of,
+        "source_mtime": source_mtime,
     }
 
 
@@ -550,6 +599,14 @@ def _parse_movement(header: tuple[str, ...], cells: list[str], number: int) -> d
     """
     row = dict(zip(header, cells, strict=True))
     movement = _required(row, "Transaktion", number)
+    movement_kind = _MOVEMENT_KIND_BY_TRANSACTION.get(movement.strip().lower())
+    if movement_kind is None:
+        raise ExtraEtfFormatError(
+            f"row {number}: Transaktion {movement!r} is none of the labels this format documents "
+            f"({', '.join(sorted(_MOVEMENT_KIND_BY_TRANSACTION))}); a movement whose kind is unknown "
+            f"is refused rather than carried through unlabelled, because a dividend, a fee and a "
+            f"cash movement all look alike once the label is dropped"
+        )
     transaction_date = _required(row, "Datum", number)
     match = _DATE_PATTERN.fullmatch(transaction_date)
     if match is None:
@@ -563,6 +620,12 @@ def _parse_movement(header: tuple[str, ...], cells: list[str], number: int) -> d
     if not _CURRENCY_PATTERN.fullmatch(currency):
         raise ExtraEtfFormatError(f"row {number}: Währung is not a three-letter currency code: {row['Währung']!r}")
     identifier, identifier_kind, checksum_ok = _describe_identifier(row["ISIN"])
+    if identifier_kind == "unknown":
+        raise ExtraEtfFormatError(
+            f"row {number}: the ISIN column is empty, so the movement cannot be attributed to an "
+            f"instrument; a cash or fee row carrying no instrument is not a movement this reader "
+            f"can represent"
+        )
     quantity = _parse_decimal(row["Anzahl"], field="Anzahl", row_number=number)
     if quantity is None:
         raise ExtraEtfFormatError(f"row {number}: Anzahl is empty")
@@ -570,13 +633,13 @@ def _parse_movement(header: tuple[str, ...], cells: list[str], number: int) -> d
         "broker": BROKER,
         "source": "extraetf_export",
         "date": booked_on,
-        "instrument_id": identifier or None,
+        "instrument_id": identifier,
         "instrument_id_kind": identifier_kind,
         "instrument_id_checksum_ok": checksum_ok,
         "name": _required(row, "Name", number),
         "instrument_type": _required(row, "Typ", number),
         "movement": movement,
-        "movement_kind": _MOVEMENT_KIND_BY_TRANSACTION.get(movement.strip().lower()),
+        "movement_kind": movement_kind,
         "quantity": _number(quantity),
         "price": _optional_number(row["Preis"], field="Preis", row_number=number),
         "fees": _optional_number(row["Gebühren"], field="Gebühren", row_number=number),
@@ -710,11 +773,19 @@ def _parse_decimal(raw: str, *, field: str, row_number: int) -> Decimal | None:
         # Probe the wire format's precision here, while the row is still known.
         # Handing an unrepresentable magnitude to the formatter would surface as
         # a bare decimal.InvalidOperation, which is not the documented error.
-        value.quantize(_WIRE_QUANTUM)
+        quantized = value.quantize(_WIRE_QUANTUM)
     except InvalidOperation as exc:
         raise ExtraEtfFormatError(
             f"row {row_number}: {field} carries more precision than a position can represent: {raw!r}"
         ) from exc
+    if quantized != value:
+        # Quantizing also *rounds*, and a discarded rounding is a silently
+        # altered position: 0,000000004 is not zero in the file, so it must not
+        # become an empty position in the output, and 1,123456789 must not lose
+        # its ninth decimal place without saying so.
+        raise ExtraEtfFormatError(
+            f"row {row_number}: {field} carries more precision than a position can represent: {raw!r}"
+        )
     return value
 
 
@@ -775,8 +846,9 @@ def _number(value: Decimal) -> float:
     """Return a wire-ready float, quantized as the connector path does.
 
     Args:
-        value: A value already probed by :func:`_parse_decimal`, which applies
-            this same quantization so it cannot raise here.
+        value: A value already probed by :func:`_parse_decimal`, which proves the
+            value survives this quantization unchanged, so this cannot round or
+            raise.
 
     Returns:
         The value as a float, quantized to eight decimal places to match

--- a/agent/src/portfolio/extraetf.py
+++ b/agent/src/portfolio/extraetf.py
@@ -1,0 +1,648 @@
+"""Read-only reader for extraETF portfolio exports.
+
+extraETF exports two semicolon-delimited, German-locale files:
+
+``holdings`` — the positions of one view at export time::
+
+    ISIN;Name;Typ;Anzahl;Kaufpreis;Aktueller Kurs;Aktueller Wert;Währung;Wechselkurs;Region;Land;Sektor;Portfolioname;Portfolio ID
+
+``transactions`` — the movement history of one view::
+
+    Datum;ISIN;Name;Typ;Transaktion;Anzahl;Preis;Gebühren;Steuern;Währung;Wechselkurs;Portfolioname;Portfolio ID;Stückzinsen
+
+Three properties are deliberate and load-bearing.
+
+**A transactions export can never be read as a portfolio.** Its rows are
+movements — ``Kauf``/``Verkauf``/``Dividende``/``Einbuchung``/``Ausbuchung`` —
+not holdings. An allocation computed from trades looks perfectly plausible and
+is wrong, so the two formats are told apart by their header and
+:meth:`ExtraEtfExport.require_positions` refuses anything that is not a
+holdings export. Movements carry an explicit ``movement_kind`` so a dividend or
+a transfer is never mistaken for a trade.
+
+**A holdings export carries no date.** The format has no snapshot column, so
+freshness can only come from the file's own modification time, and the export
+says so through ``as_of_source``. This reader never claims an observation time
+it did not read.
+
+**Validation fails closed.** A row this reader does not recognise raises
+:class:`ExtraEtfFormatError` instead of being skipped: an import computed from
+90% of a portfolio reads as entirely plausible, whereas a refused import is
+merely annoying. Numbers are parsed as German — ``1.386,608`` is 1386.608 — and
+a value that cannot be read unambiguously is refused rather than guessed.
+``1,234.56`` is US-formatted; reading it as German would be wrong by three
+orders of magnitude, so it is refused instead.
+
+Rows are read by column name, so a reordered export cannot mis-align a value
+into the wrong column. Rows are **not** merged or de-duplicated: two rows for
+the same instrument in one portfolio are returned as two positions, because
+summing them silently and dropping one silently are both wrong, and which one
+the user meant is not this module's call.
+
+The module writes nothing, holds no credentials, and touches no network. It
+only reads a local file the user exported themselves, and it has no path to any
+order surface.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import os
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any, Literal
+
+BROKER = "extraetf"
+
+_HOLDINGS_COLUMNS: tuple[str, ...] = (
+    "ISIN",
+    "Name",
+    "Typ",
+    "Anzahl",
+    "Kaufpreis",
+    "Aktueller Kurs",
+    "Aktueller Wert",
+    "Währung",
+    "Wechselkurs",
+    "Region",
+    "Land",
+    "Sektor",
+    "Portfolioname",
+    "Portfolio ID",
+)
+
+_TRANSACTIONS_COLUMNS: tuple[str, ...] = (
+    "Datum",
+    "ISIN",
+    "Name",
+    "Typ",
+    "Transaktion",
+    "Anzahl",
+    "Preis",
+    "Gebühren",
+    "Steuern",
+    "Währung",
+    "Wechselkurs",
+    "Portfolioname",
+    "Portfolio ID",
+    "Stückzinsen",
+)
+
+ExportKind = Literal["holdings", "transactions"]
+
+_ISIN_PATTERN = re.compile(r"^[A-Z]{2}[A-Z0-9]{9}[0-9]$")
+_CRYPTO_PAIR_PATTERN = re.compile(r"^[A-Z0-9]{2,12}_to_[A-Z0-9]{2,12}$", re.IGNORECASE)
+_CURRENCY_PATTERN = re.compile(r"^[A-Z]{3}$")
+_DATE_PATTERN = re.compile(r"^(\d{2})\.(\d{2})\.(\d{4})$")
+_NUMERAL_PATTERN = re.compile(r"^[0-9.,]+$")
+
+#: ``Typ`` is an instrument class, not a row shape: a class this reader does not
+#: know still describes a real position, so it is carried through with
+#: ``asset_type`` left ``None`` rather than refused or guessed at.
+_ASSET_TYPE_BY_EXPORT_TYPE = {
+    "etf": "etf",
+    "aktie": "stock",
+    "währung / krypto": "crypto",
+}
+
+_MOVEMENT_KIND_BY_TRANSACTION = {
+    "kauf": "buy",
+    "verkauf": "sell",
+    "dividende": "dividend",
+    "einbuchung": "transfer_in",
+    "ausbuchung": "transfer_out",
+}
+
+
+class ExtraEtfFormatError(ValueError):
+    """Raised when an export cannot be read without guessing."""
+
+
+@dataclass(frozen=True)
+class ExtraEtfExport:
+    """One parsed export, with its provenance attached.
+
+    Attributes:
+        kind: Which of the two extraETF formats this file is.
+        positions: Holdings rows. Always empty for a transactions export.
+        movements: Transactions rows. Always empty for a holdings export.
+        as_of: ISO-8601 observation time, or ``None`` when it could not be read.
+        as_of_source: Where ``as_of`` came from — ``"file_mtime"`` for a file
+            read from disk, ``"unavailable"`` for bare text with no timestamp.
+            A holdings export has no date column, so ``file_mtime`` is an
+            inference from the file's own modification time and is labelled as
+            one rather than presented as a recorded snapshot date.
+        source_path: The file this export was read from, when there was one.
+    """
+
+    kind: ExportKind
+    positions: tuple[dict[str, Any], ...]
+    movements: tuple[dict[str, Any], ...]
+    as_of: str | None
+    as_of_source: Literal["file_mtime", "unavailable"]
+    source_path: Path | None
+
+    def require_positions(self) -> tuple[dict[str, Any], ...]:
+        """Return holdings positions, refusing any other export outright.
+
+        Returns:
+            The parsed positions, possibly empty for an empty portfolio.
+
+        Raises:
+            ExtraEtfFormatError: If this export is a transactions export, whose
+                rows are movements rather than holdings.
+        """
+        if self.kind != "holdings":
+            raise ExtraEtfFormatError(
+                "this is a transactions export and holds movements, not positions; "
+                "importing it as a portfolio would build an allocation out of trades"
+            )
+        return self.positions
+
+
+def read_export(path: str | Path) -> ExtraEtfExport:
+    """Read and parse one extraETF export file.
+
+    The file's modification time becomes ``as_of`` with
+    ``as_of_source="file_mtime"``, because neither export format carries a
+    snapshot-observation column.
+
+    Args:
+        path: The exported ``.csv`` file.
+
+    Returns:
+        The parsed export.
+
+    Raises:
+        ExtraEtfFormatError: If the file cannot be read, decoded, or parsed.
+    """
+    resolved = Path(path)
+    try:
+        # Stat the same descriptor the bytes came from: a separate ``stat`` call
+        # can observe a later write than the read did, which would let the import
+        # claim a fresher observation time than the content it actually holds.
+        with resolved.open("rb") as handle:
+            data = handle.read()
+            modified = os.fstat(handle.fileno()).st_mtime
+    except OSError as exc:
+        raise ExtraEtfFormatError(f"cannot read export {resolved}: {exc}") from exc
+    as_of = datetime.fromtimestamp(modified, tz=timezone.utc).isoformat()
+    return parse_export(
+        data, source_path=resolved, as_of=as_of, as_of_source="file_mtime"
+    )
+
+
+def parse_export(
+    data: str | bytes,
+    *,
+    source_path: str | Path | None = None,
+    as_of: str | None = None,
+    as_of_source: Literal["file_mtime", "unavailable"] = "unavailable",
+) -> ExtraEtfExport:
+    """Parse one extraETF export from text or raw bytes.
+
+    Args:
+        data: The export contents, as text or as raw file bytes.
+        source_path: The originating file, recorded for provenance only.
+        as_of: ISO-8601 observation time, when the caller knows one.
+        as_of_source: Where ``as_of`` came from.
+
+    Returns:
+        The parsed export. An export with a header and no data rows is valid and
+        yields no positions — an empty portfolio is not an unreadable one.
+
+    Raises:
+        ExtraEtfFormatError: If the header is not one of the two known formats,
+            or any row cannot be read without guessing.
+        ValueError: If ``as_of_source`` claims an origin for an absent ``as_of``.
+    """
+    if as_of is None and as_of_source != "unavailable":
+        raise ValueError(
+            "as_of_source cannot claim where an observation time came from when "
+            "there is no observation time"
+        )
+    text = _decode(data)
+    kind, header, rows = _read_rows(text)
+    if kind == "holdings":
+        positions = tuple(
+            _parse_holding(header, cells, number, as_of=as_of) for number, cells in rows
+        )
+        movements: tuple[dict[str, Any], ...] = ()
+    else:
+        positions = ()
+        movements = tuple(
+            _parse_movement(header, cells, number) for number, cells in rows
+        )
+    return ExtraEtfExport(
+        kind=kind,
+        positions=positions,
+        movements=movements,
+        as_of=as_of,
+        as_of_source=as_of_source,
+        source_path=Path(source_path) if source_path is not None else None,
+    )
+
+
+def _decode(data: str | bytes) -> str:
+    """Decode export bytes, preferring UTF-8 and falling back to cp1252.
+
+    Args:
+        data: Export contents as text or bytes.
+
+    Returns:
+        The decoded text.
+
+    Raises:
+        ExtraEtfFormatError: If neither encoding decodes the bytes.
+    """
+    if isinstance(data, str):
+        return data
+    for encoding in ("utf-8-sig", "cp1252"):
+        try:
+            return data.decode(encoding)
+        except UnicodeDecodeError:
+            continue
+    raise ExtraEtfFormatError("export is decodable as neither UTF-8 nor cp1252")
+
+
+def _read_rows(
+    text: str,
+) -> tuple[ExportKind, tuple[str, ...], list[tuple[int, list[str]]]]:
+    """Split an export into its format, header and data rows.
+
+    Args:
+        text: The decoded export.
+
+    Returns:
+        The detected format, the header columns, and ``(line number, cells)``
+        pairs for every non-blank data row.
+
+    Raises:
+        ExtraEtfFormatError: If the export is empty, its header is not one of the
+            two known formats, or a row cannot be aligned to that header.
+    """
+    reader = csv.reader(io.StringIO(text), delimiter=";")
+    header: tuple[str, ...] | None = None
+    number = 0
+    for cells in reader:
+        number += 1
+        if not any(cell.strip() for cell in cells):
+            continue
+        header = tuple(cell.strip().lstrip("\ufeff") for cell in cells)
+        break
+    if header is None:
+        raise ExtraEtfFormatError("export is empty")
+    kind = _detect_kind(header)
+
+    rows: list[tuple[int, list[str]]] = []
+    for cells in reader:
+        number += 1
+        if not any(cell.strip() for cell in cells):
+            continue
+        if len(cells) != len(header):
+            raise ExtraEtfFormatError(
+                f"row {number}: expected {len(header)} fields to match the header, "
+                f"found {len(cells)}; a row that cannot be aligned is refused rather "
+                f"than skipped"
+            )
+        rows.append((number, [cell.strip() for cell in cells]))
+    return kind, header, rows
+
+
+def _detect_kind(header: tuple[str, ...]) -> ExportKind:
+    """Identify which extraETF format a header belongs to.
+
+    Args:
+        header: The export's column names.
+
+    Returns:
+        ``"holdings"`` or ``"transactions"``.
+
+    Raises:
+        ExtraEtfFormatError: If the header is neither known format exactly.
+    """
+    columns = set(header)
+    if len(header) == len(_HOLDINGS_COLUMNS) and columns == set(_HOLDINGS_COLUMNS):
+        return "holdings"
+    if len(header) == len(_TRANSACTIONS_COLUMNS) and columns == set(
+        _TRANSACTIONS_COLUMNS
+    ):
+        return "transactions"
+    transactions_like = "Transaktion" in columns
+    expected = _TRANSACTIONS_COLUMNS if transactions_like else _HOLDINGS_COLUMNS
+    missing = [column for column in expected if column not in columns]
+    unexpected = [column for column in header if column not in expected]
+    raise ExtraEtfFormatError(
+        "export header is not a recognised extraETF format; against the "
+        f"{'transactions' if transactions_like else 'holdings'} format, missing "
+        f"columns: {missing or 'none'}, unexpected columns: {unexpected or 'none'}"
+    )
+
+
+def _parse_holding(
+    header: tuple[str, ...], cells: list[str], number: int, *, as_of: str | None
+) -> dict[str, Any]:
+    """Convert one holdings row into a position.
+
+    Args:
+        header: The export's column names, which key the row's fields.
+        cells: The row's fields.
+        number: The row's line number, for error messages.
+        as_of: The export's observation time, mirrored onto the position.
+
+    Returns:
+        One position in the portfolio wire shape.
+
+    Raises:
+        ExtraEtfFormatError: If the row cannot be read without guessing.
+    """
+    row = dict(zip(header, cells, strict=True))
+    identifier, identifier_kind, checksum_ok = _describe_identifier(row["ISIN"])
+    if identifier_kind not in {"isin", "crypto_pair"}:
+        raise ExtraEtfFormatError(
+            f"row {number}: {row['ISIN']!r} is neither an ISIN nor an extraETF crypto "
+            f"pair such as BTC_to_EUR, so the holding cannot be attributed to an "
+            f"instrument"
+        )
+    name = _required(row, "Name", number)
+    instrument_type = _required(row, "Typ", number)
+    currency = _required(row, "Währung", number).upper()
+    if not _CURRENCY_PATTERN.fullmatch(currency):
+        raise ExtraEtfFormatError(
+            f"row {number}: Währung is not a three-letter currency code: "
+            f"{row['Währung']!r}"
+        )
+    portfolio_id = _required(row, "Portfolio ID", number)
+    quantity = _parse_decimal(row["Anzahl"], field="Anzahl", row_number=number)
+    if quantity is None:
+        raise ExtraEtfFormatError(f"row {number}: Anzahl is empty")
+    return {
+        "broker": BROKER,
+        "source": "extraetf_export",
+        "symbol": identifier,
+        "quote_symbol": identifier,
+        "instrument_id": identifier,
+        "instrument_id_kind": identifier_kind,
+        "instrument_id_checksum_ok": checksum_ok,
+        "name": name,
+        "instrument_type": instrument_type,
+        "asset_type": _ASSET_TYPE_BY_EXPORT_TYPE.get(instrument_type.strip().lower()),
+        "market": None,
+        "currency": currency,
+        "price_currency": currency,
+        "quantity": _number(quantity),
+        "cost_price": _optional_number(
+            row["Kaufpreis"], field="Kaufpreis", row_number=number
+        ),
+        "market_price": _optional_number(
+            row["Aktueller Kurs"], field="Aktueller Kurs", row_number=number
+        ),
+        "source_market_value": _optional_number(
+            row["Aktueller Wert"], field="Aktueller Wert", row_number=number
+        ),
+        "fx_rate": _optional_number(
+            row["Wechselkurs"], field="Wechselkurs", row_number=number
+        ),
+        "region": row["Region"] or None,
+        "country": row["Land"] or None,
+        "sector": row["Sektor"] or None,
+        "portfolio_id": portfolio_id,
+        "portfolio_name": row["Portfolioname"] or None,
+        "updated_at": as_of,
+    }
+
+
+def _parse_movement(
+    header: tuple[str, ...], cells: list[str], number: int
+) -> dict[str, Any]:
+    """Convert one transactions row into a movement.
+
+    Args:
+        header: The export's column names, which key the row's fields.
+        cells: The row's fields.
+        number: The row's line number, for error messages.
+
+    Returns:
+        One movement, carrying the export's own transaction label plus a
+        normalised ``movement_kind``.
+
+    Raises:
+        ExtraEtfFormatError: If the row cannot be read without guessing.
+    """
+    row = dict(zip(header, cells, strict=True))
+    movement = _required(row, "Transaktion", number)
+    transaction_date = _required(row, "Datum", number)
+    match = _DATE_PATTERN.fullmatch(transaction_date)
+    if match is None:
+        raise ExtraEtfFormatError(
+            f"row {number}: Datum is not a DD.MM.YYYY date: {transaction_date!r}"
+        )
+    day, month, year = (int(part) for part in match.groups())
+    try:
+        booked_on = datetime(year, month, day).date().isoformat()
+    except ValueError as exc:
+        raise ExtraEtfFormatError(
+            f"row {number}: Datum is not a real date: {transaction_date!r}"
+        ) from exc
+    currency = _required(row, "Währung", number).upper()
+    if not _CURRENCY_PATTERN.fullmatch(currency):
+        raise ExtraEtfFormatError(
+            f"row {number}: Währung is not a three-letter currency code: "
+            f"{row['Währung']!r}"
+        )
+    identifier, identifier_kind, checksum_ok = _describe_identifier(row["ISIN"])
+    quantity = _parse_decimal(row["Anzahl"], field="Anzahl", row_number=number)
+    if quantity is None:
+        raise ExtraEtfFormatError(f"row {number}: Anzahl is empty")
+    return {
+        "broker": BROKER,
+        "source": "extraetf_export",
+        "date": booked_on,
+        "instrument_id": identifier or None,
+        "instrument_id_kind": identifier_kind,
+        "instrument_id_checksum_ok": checksum_ok,
+        "name": _required(row, "Name", number),
+        "instrument_type": _required(row, "Typ", number),
+        "movement": movement,
+        "movement_kind": _MOVEMENT_KIND_BY_TRANSACTION.get(movement.strip().lower()),
+        "quantity": _number(quantity),
+        "price": _optional_number(row["Preis"], field="Preis", row_number=number),
+        "fees": _optional_number(row["Gebühren"], field="Gebühren", row_number=number),
+        "taxes": _optional_number(row["Steuern"], field="Steuern", row_number=number),
+        "currency": currency,
+        "fx_rate": _optional_number(
+            row["Wechselkurs"], field="Wechselkurs", row_number=number
+        ),
+        "accrued_interest": _optional_number(
+            row["Stückzinsen"], field="Stückzinsen", row_number=number
+        ),
+        "portfolio_id": _required(row, "Portfolio ID", number),
+        "portfolio_name": row["Portfolioname"] or None,
+    }
+
+
+def _required(row: dict[str, str], column: str, number: int) -> str:
+    """Return a column's value, refusing an empty one.
+
+    Args:
+        row: The aligned row.
+        column: The column to read.
+        number: The row's line number, for error messages.
+
+    Returns:
+        The non-empty value.
+
+    Raises:
+        ExtraEtfFormatError: If the value is empty.
+    """
+    value = row[column]
+    if not value:
+        raise ExtraEtfFormatError(f"row {number}: {column} is empty")
+    return value
+
+
+def _optional_number(raw: str, *, field: str, row_number: int) -> float | None:
+    """Parse an optional German-formatted number.
+
+    Args:
+        raw: The raw field text.
+        field: The column name, for error messages.
+        row_number: The row's line number, for error messages.
+
+    Returns:
+        The value, or ``None`` when the field is blank. A blank price is an
+        absent observation rather than a zero, and is never guessed at.
+
+    Raises:
+        ExtraEtfFormatError: If the field is present but unreadable.
+    """
+    value = _parse_decimal(raw, field=field, row_number=row_number)
+    return None if value is None else _number(value)
+
+
+def _parse_decimal(raw: str, *, field: str, row_number: int) -> Decimal | None:
+    """Parse a German-formatted number, refusing anything ambiguous.
+
+    A comma is the decimal separator and a period may only be a thousands
+    separator: ``1.386,608`` is 1386.608 and ``12,3456`` is 12.3456. A value
+    whose separators are US-ordered, or whose period grouping is not a plain
+    thousands separator, is refused rather than guessed at, because guessing
+    wrong changes a position's size by orders of magnitude.
+
+    Args:
+        raw: The raw field text.
+        field: The column name, for error messages.
+        row_number: The row's line number, for error messages.
+
+    Returns:
+        The parsed value, or ``None`` when the field is blank.
+
+    Raises:
+        ExtraEtfFormatError: If the field is unreadable or ambiguous.
+    """
+    text = raw.strip()
+    if not text:
+        return None
+    sign = ""
+    if text[0] in "+-":
+        sign, text = text[0], text[1:]
+    if not text or not _NUMERAL_PATTERN.fullmatch(text):
+        raise ExtraEtfFormatError(f"row {row_number}: {field} is not a number: {raw!r}")
+    whole, comma, fraction = text.rpartition(",")
+    if not comma:
+        whole, fraction = text, ""
+    elif "." in fraction:
+        raise ExtraEtfFormatError(
+            f"row {row_number}: {field} reads as a US-formatted number: {raw!r}; "
+            f"extraETF exports use German formatting such as 1.386,608"
+        )
+    groups = whole.split(".")
+    if (
+        any(not group.isdigit() for group in groups)
+        or any(len(group) != 3 for group in groups[1:])
+        or (comma and not fraction.isdigit())
+    ):
+        raise ExtraEtfFormatError(
+            f"row {row_number}: {field} has ambiguous separators: {raw!r}; expected "
+            f"German formatting such as 1.386,608"
+        )
+    digits = "".join(groups) + (f".{fraction}" if comma else "")
+    try:
+        return Decimal(f"{sign}{digits}")
+    except InvalidOperation as exc:  # pragma: no cover - guarded by the checks above
+        raise ExtraEtfFormatError(
+            f"row {row_number}: {field} is not a number: {raw!r}"
+        ) from exc
+
+
+def _describe_identifier(raw: str) -> tuple[str, str, bool | None]:
+    """Describe an export identifier without refusing anything.
+
+    Args:
+        raw: The raw ``ISIN`` column value.
+
+    Returns:
+        The identifier as the export spelled it, its kind — ``"isin"``,
+        ``"crypto_pair"``, ``"raw_symbol"`` or ``"unknown"`` — and, for an
+        ISIN-shaped value, whether its check digit is valid. extraETF stores
+        crypto identifiers that are not ISINs, so the check digit is reported
+        rather than enforced: refusing a whole import over one unverifiable
+        identifier would block a user whose positions are otherwise perfectly
+        readable.
+
+        An ISIN is returned upper-cased, because an ISIN is canonical and
+        case-insensitive. A crypto pair such as ``BTC_to_EUR`` is returned
+        exactly as exported, because it is extraETF's own label and not a
+        canonical code — rewriting its case would invent an identity we do not
+        own.
+    """
+    identifier = raw.strip()
+    if not identifier:
+        return "", "unknown", None
+    canonical = identifier.upper()
+    if _ISIN_PATTERN.fullmatch(canonical):
+        return canonical, "isin", _isin_checksum_ok(canonical)
+    if _CRYPTO_PAIR_PATTERN.fullmatch(identifier):
+        return identifier, "crypto_pair", None
+    return identifier, "raw_symbol", None
+
+
+def _isin_checksum_ok(value: str) -> bool:
+    """Check an ISIN's check digit.
+
+    Args:
+        value: A value already matching :data:`_ISIN_PATTERN`.
+
+    Returns:
+        ``True`` when the Luhn-style check digit is valid.
+    """
+    digits = "".join(
+        str(ord(character) - 55) if character.isalpha() else character
+        for character in value
+    )
+    total = 0
+    for index, character in enumerate(reversed(digits)):
+        digit = int(character)
+        if index % 2:
+            digit *= 2
+            if digit > 9:
+                digit -= 9
+        total += digit
+    return total % 10 == 0
+
+
+def _number(value: Decimal) -> float:
+    """Return a wire-ready float, quantized as the connector path does.
+
+    Args:
+        value: The parsed value.
+
+    Returns:
+        The value as a float, quantized to eight decimal places to match
+        :func:`src.portfolio.normalization.normalize_position`.
+    """
+    return float(value.quantize(Decimal("0.00000001")))

--- a/agent/src/portfolio/extraetf.py
+++ b/agent/src/portfolio/extraetf.py
@@ -44,8 +44,10 @@ size by orders of magnitude. A comma is the decimal separator and a period may
 only be a thousands separator, so ``1.386,608`` is 1386.608 and ``12,3456`` is
 12.3456. A value whose separators are US-ordered (``1,234.56``) is refused,
 because reading it as German would be wrong by a thousandfold. A period grouping
-that is not a plain thousands separator (``1.23``, ``1234.56``) is refused too,
-because it is neither a valid German number nor safely a US one. What is *not*
+that is not a plain thousands separator — a first group longer than three
+digits, or a later group that is not exactly three (``1.23``, ``1234.56``,
+``1234.567``) — is refused too, because it is neither a valid German number nor
+safely a US one. What is *not*
 refused is a period-grouped value that is valid German — ``1.900`` is 1900 — and
 that reading is a convention of the format, not a deduction: ``1.900`` could be
 1.9 in a US-locale file, and no amount of parsing can tell the two apart.
@@ -68,9 +70,10 @@ does **not** route the row through
 to guarantee one wire shape, because that function stamps ``updated_at`` with
 the current time — an observation time this reader never made — and defaults an
 unknown instrument class to ``"stock"``. Both are fabrications a file import
-must not make, so the mapping is done here and the divergences are the three
-shown above: ``quote_symbol``'s None, ``asset_type``'s None, and ``updated_at``
-against ``source_mtime``.
+must not make, so the mapping is done here and the divergences are shown above:
+``quote_symbol``'s None, ``asset_type``'s None, ``market``'s None (the
+connector path stamps the broker there), and ``updated_at`` against
+``source_mtime``.
 
 Values are carried as the export reports them rather than repaired: a zero or
 negative quantity, a zero FX rate, and two different portfolio names under one
@@ -151,6 +154,11 @@ _CRYPTO_PAIR_PATTERN = re.compile(r"^[A-Z0-9]{2,12}_to_[A-Z0-9]{2,12}$", re.IGNO
 _CURRENCY_PATTERN = re.compile(r"^[A-Z]{3}$")
 _DATE_PATTERN = re.compile(r"^([0-9]{2})\.([0-9]{2})\.([0-9]{4})$")
 _NUMERAL_PATTERN = re.compile(r"^[0-9.,]+$")
+#: The bare-symbol shape a crypto transactions row carries in its ``ISIN``
+#: column (e.g. ``BTC``). A holdings row must carry an ISIN or a pair label, so
+#: this shape is only accepted for movements — but there it is accepted, and
+#: anything outside it is refused rather than emitted as an identity.
+_SYMBOL_PATTERN = re.compile(r"^[A-Za-z0-9]{1,12}$")
 
 #: ``Typ`` is an instrument class, not a row shape: a class this reader does not
 #: know still describes a real position, so it is carried through with
@@ -293,13 +301,15 @@ def parse_export(
     Raises:
         ExtraEtfFormatError: If the header is not one of the two known formats,
             or any row cannot be read without guessing.
-        ValueError: If ``as_of_source`` claims an origin for an absent ``as_of``.
+        ValueError: If ``as_of_source`` and ``source_mtime`` disagree.
     """
     if source_mtime is None and as_of_source != "unavailable":
         raise ValueError(
             "as_of_source cannot claim where a source modification time came from "
             "when there is no source modification time"
         )
+    if source_mtime is not None and as_of_source == "unavailable":
+        raise ValueError("as_of_source is 'unavailable' but a source modification time was given; the two must agree")
     if as_of_source not in ("file_mtime", "unavailable"):
         raise ValueError(f"as_of_source must be 'file_mtime' or 'unavailable', not {as_of_source!r}")
     text = _decode(data)
@@ -339,7 +349,13 @@ def _refuse_duplicate_positions(positions: tuple[dict[str, Any], ...], rows: lis
     """
     seen: dict[tuple[str, str], int] = {}
     for (number, _cells), position in zip(rows, positions, strict=True):
-        key = (position["portfolio_id"], position["instrument_id"])
+        # The identifier is emitted exactly as exported — rewriting a crypto
+        # pair's case would invent an identity this module does not own — but
+        # comparison folds case, because the pair shape is matched
+        # case-insensitively: BTC_to_EUR and btc_to_eur are the same label, and
+        # two positions for them would double-count. ISINs are already canonical
+        # upper-case, so folding changes nothing for them.
+        key = (position["portfolio_id"], position["instrument_id"].casefold())
         first = seen.get(key)
         if first is not None:
             raise ExtraEtfFormatError(
@@ -526,7 +542,7 @@ def _parse_holding(
         ExtraEtfFormatError: If the row cannot be read without guessing.
     """
     row = dict(zip(header, cells, strict=True))
-    identifier, identifier_kind, checksum_ok = _describe_identifier(row["ISIN"])
+    identifier, identifier_kind, checksum_ok = _describe_identifier(_identifier_cell(row, number))
     if identifier_kind not in {"isin", "crypto_pair"}:
         raise ExtraEtfFormatError(
             f"row {number}: {row['ISIN']!r} is neither an ISIN nor an extraETF crypto "
@@ -619,12 +635,21 @@ def _parse_movement(header: tuple[str, ...], cells: list[str], number: int) -> d
     currency = _required(row, "Währung", number).upper()
     if not _CURRENCY_PATTERN.fullmatch(currency):
         raise ExtraEtfFormatError(f"row {number}: Währung is not a three-letter currency code: {row['Währung']!r}")
-    identifier, identifier_kind, checksum_ok = _describe_identifier(row["ISIN"])
+    identifier, identifier_kind, checksum_ok = _describe_identifier(_identifier_cell(row, number))
     if identifier_kind == "unknown":
         raise ExtraEtfFormatError(
             f"row {number}: the ISIN column is empty, so the movement cannot be attributed to an "
             f"instrument; a cash or fee row carrying no instrument is not a movement this reader "
             f"can represent"
+        )
+    if identifier_kind == "raw_symbol" and not _SYMBOL_PATTERN.fullmatch(identifier):
+        # A movement carries a bare symbol for crypto, so ``raw_symbol`` is
+        # allowed here where a holdings row would refuse it — but only when it
+        # looks like a symbol. Anything else is refused rather than carried as
+        # an identity it does not have.
+        raise ExtraEtfFormatError(
+            f"row {number}: {identifier!r} is neither an ISIN nor a crypto symbol, so the movement "
+            f"cannot be attributed to an instrument"
         )
     quantity = _parse_decimal(row["Anzahl"], field="Anzahl", row_number=number)
     if quantity is None:
@@ -652,6 +677,46 @@ def _parse_movement(header: tuple[str, ...], cells: list[str], number: int) -> d
     }
 
 
+def _has_control_characters(value: str) -> bool:
+    """Report whether text carries characters that are corruption, not content.
+
+    C0 controls (below 32), DEL and the C1 block are all refused. None of them
+    is part of an exported name, label or symbol, and a field carrying one is
+    damaged text rather than data.
+
+    Args:
+        value: The raw field text.
+
+    Returns:
+        ``True`` when the text carries a control character.
+    """
+    return any(ord(character) < 32 or 0x7F <= ord(character) <= 0x9F for character in value)
+
+
+def _identifier_cell(row: dict[str, str], number: int) -> str:
+    """Return the ``ISIN`` column, refusing text that cannot identify anything.
+
+    The identifier column is read through :func:`_describe_identifier` rather
+    than through :func:`_required`, because a crypto row carries a symbol here
+    instead of a code. That path performs no corruption check of its own, so
+    without this a symbol carrying control characters would be emitted verbatim.
+
+    Args:
+        row: The aligned row.
+        number: The row's line number, for error messages.
+
+    Returns:
+        The raw identifier text, unmodified.
+
+    Raises:
+        ExtraEtfFormatError: If the text carries control characters.
+    """
+    value = row["ISIN"]
+    if _has_control_characters(value):
+        raise ExtraEtfFormatError(f"row {number}: ISIN carries control characters")
+    return value
+
+
 def _optional_text(row: dict[str, str], column: str, number: int) -> str | None:
     """Return an optional text column, refusing corruption.
 
@@ -669,7 +734,7 @@ def _optional_text(row: dict[str, str], column: str, number: int) -> str | None:
     value = row[column]
     if not value:
         return None
-    if any(ord(character) < 32 for character in value):
+    if _has_control_characters(value):
         raise ExtraEtfFormatError(f"row {number}: {column} carries control characters")
     return value
 
@@ -695,7 +760,7 @@ def _required(row: dict[str, str], column: str, number: int) -> str:
     value = row[column]
     if not value:
         raise ExtraEtfFormatError(f"row {number}: {column} is empty")
-    if any(ord(character) < 32 for character in value):
+    if _has_control_characters(value):
         raise ExtraEtfFormatError(f"row {number}: {column} carries control characters")
     return value
 
@@ -755,9 +820,13 @@ def _parse_decimal(raw: str, *, field: str, row_number: int) -> Decimal | None:
             f"row {row_number}: {field} reads as a US-formatted number: {raw!r}; "
             f"extraETF exports use German formatting such as 1.386,608"
         )
+    # The leading group is capped at three digits too. A plain ``1234.567`` is a
+    # US decimal, and reading its period as a thousands separator would scale the
+    # value by a thousand — the misread this whole rule exists to refuse.
     groups = whole.split(".")
     if (
         any(not group.isdigit() for group in groups)
+        or (len(groups) > 1 and len(groups[0]) > 3)
         or any(len(group) != 3 for group in groups[1:])
         or (comma and not fraction.isdigit())
     ):
@@ -783,6 +852,13 @@ def _parse_decimal(raw: str, *, field: str, row_number: int) -> Decimal | None:
         # altered position: 0,000000004 is not zero in the file, so it must not
         # become an empty position in the output, and 1,123456789 must not lose
         # its ninth decimal place without saying so.
+        raise ExtraEtfFormatError(
+            f"row {row_number}: {field} carries more precision than a position can represent: {raw!r}"
+        )
+    if Decimal(repr(float(value))) != value:
+        # ``float`` holds about seventeen significant digits, so a value with
+        # more integer digits than that still changes magnitude on the way to
+        # the wire format even though it quantized cleanly.
         raise ExtraEtfFormatError(
             f"row {row_number}: {field} carries more precision than a position can represent: {raw!r}"
         )

--- a/agent/src/portfolio/extraetf.py
+++ b/agent/src/portfolio/extraetf.py
@@ -885,6 +885,12 @@ def _describe_identifier(raw: str) -> tuple[str, str, bool | None]:
         exactly as exported, because it is extraETF's own label and not a
         canonical code — rewriting its case would invent an identity we do not
         own.
+
+        The kind describes the *shape* of the identifier, never its asset class.
+        ``"crypto_pair"`` means the value has extraETF's ``X_to_Y`` pair form, so
+        a foreign-exchange pair such as ``USD_to_EUR`` is described the same way
+        — which is why a ``Währung / Krypto`` row is left with no ``asset_type``
+        rather than being called a crypto holding.
     """
     identifier = raw.strip()
     if not identifier:

--- a/agent/src/portfolio/extraetf.py
+++ b/agent/src/portfolio/extraetf.py
@@ -134,11 +134,16 @@ _TRANSACTIONS_COLUMNS: tuple[str, ...] = (
 
 ExportKind = Literal["holdings", "transactions"]
 
-_ISIN_PATTERN = re.compile(r"^[A-Z]{2}[A-Z0-9]{9}[0-9]$")
+#: Case-insensitive so an otherwise valid lower-cased ISIN is still read, and
+#: ASCII-anchored with an exact twelve-character length so ``.upper()`` is only
+#: ever applied to a value that already has ISIN shape. ``.upper()`` is neither
+#: length- nor ASCII-preserving — it turns ``ß`` into ``SS`` — so using it as the
+#: predicate invents twelve-character ISINs out of eleven-character inputs.
+_ISIN_PATTERN = re.compile(r"^[A-Za-z]{2}[A-Za-z0-9]{9}[0-9]$")
 _WIRE_QUANTUM = Decimal("0.00000001")
 _CRYPTO_PAIR_PATTERN = re.compile(r"^[A-Z0-9]{2,12}_to_[A-Z0-9]{2,12}$", re.IGNORECASE)
 _CURRENCY_PATTERN = re.compile(r"^[A-Z]{3}$")
-_DATE_PATTERN = re.compile(r"^(\d{2})\.(\d{2})\.(\d{4})$")
+_DATE_PATTERN = re.compile(r"^([0-9]{2})\.([0-9]{2})\.([0-9]{4})$")
 _NUMERAL_PATTERN = re.compile(r"^[0-9.,]+$")
 
 #: ``Typ`` is an instrument class, not a row shape: a class this reader does not
@@ -281,6 +286,8 @@ def parse_export(
         raise ValueError(
             "as_of_source cannot claim where an observation time came from when there is no observation time"
         )
+    if as_of_source not in ("file_mtime", "unavailable"):
+        raise ValueError(f"as_of_source must be 'file_mtime' or 'unavailable', not {as_of_source!r}")
     text = _decode(data)
     kind, header, rows = _read_rows(text)
     if kind == "holdings":
@@ -344,9 +351,9 @@ def _read_rows(
         for cells in reader:
             number += 1
             _refuse_multiline_record(cells, number)
-            if not any(cell.strip() for cell in cells):
+            if _skip_blank_row(cells, number):
                 continue
-            header = tuple(cell.strip().lstrip("\ufeff") for cell in cells)
+            header = tuple(cell.replace("\ufeff", "").strip() for cell in cells)
             break
         if header is None:
             raise ExtraEtfFormatError("export is empty")
@@ -356,7 +363,7 @@ def _read_rows(
         for cells in reader:
             number += 1
             _refuse_multiline_record(cells, number)
-            if not any(cell.strip() for cell in cells):
+            if _skip_blank_row(cells, number):
                 continue
             if len(cells) != len(header):
                 raise ExtraEtfFormatError(
@@ -366,11 +373,39 @@ def _read_rows(
                 )
             rows.append((number, [cell.strip() for cell in cells]))
     except csv.Error as exc:
-        # csv raises its own errors for an over-long field or a stray quote. A
-        # caller catches the documented error type, so it is translated rather
-        # than allowed to escape as a bare csv error.
+        # csv raises its own errors for an over-long field, a bare carriage return
+        # or a stray quote. A caller catches the documented error type, so it is
+        # translated rather than allowed to escape as a bare csv error.
         raise ExtraEtfFormatError(f"export is not readable as CSV: {exc}") from exc
     return kind, header, rows
+
+
+def _skip_blank_row(cells: list[str], number: int) -> bool:
+    """Return whether a row is blank enough to skip, refusing an odd blank one.
+
+    A genuinely empty line is how every file ends. A line of nothing but
+    separators is not: it is a record this reader cannot align, and dropping it
+    while claiming to refuse anything unalignable would be the silent skip the
+    rest of this module exists to avoid.
+
+    Args:
+        cells: The record's fields.
+        number: The record's position in the file, for error messages.
+
+    Returns:
+        ``True`` when the row carries no data and should be skipped.
+
+    Raises:
+        ExtraEtfFormatError: If the row is blank but wider than one field.
+    """
+    if any(cell.strip() for cell in cells):
+        return False
+    if len(cells) <= 1:
+        return True
+    raise ExtraEtfFormatError(
+        f"row {number}: a blank row of {len(cells)} fields is not a layout this export "
+        f"declares, so it is refused rather than dropped silently"
+    )
 
 
 def _refuse_multiline_record(cells: list[str], number: int) -> None:
@@ -707,8 +742,8 @@ def _describe_identifier(raw: str) -> tuple[str, str, bool | None]:
     identifier = raw.strip()
     if not identifier:
         return "", "unknown", None
-    canonical = identifier.upper()
-    if _ISIN_PATTERN.fullmatch(canonical):
+    if _ISIN_PATTERN.fullmatch(identifier):
+        canonical = identifier.upper()
         return canonical, "isin", _isin_checksum_ok(canonical)
     if _CRYPTO_PAIR_PATTERN.fullmatch(identifier):
         return identifier, "crypto_pair", None

--- a/agent/tests/test_extraetf_reader.py
+++ b/agent/tests/test_extraetf_reader.py
@@ -1,0 +1,489 @@
+"""Tests for the read-only extraETF export reader.
+
+All fixtures are synthetic, shaped after the anonymized exports posted in
+HKUDS/Vibe-Trading#1170. No real portfolio data is used.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+
+import pytest
+
+from src.portfolio.extraetf import (
+    ExtraEtfFormatError,
+    parse_export,
+    read_export,
+)
+
+HOLDINGS_COLUMNS = [
+    "ISIN",
+    "Name",
+    "Typ",
+    "Anzahl",
+    "Kaufpreis",
+    "Aktueller Kurs",
+    "Aktueller Wert",
+    "Währung",
+    "Wechselkurs",
+    "Region",
+    "Land",
+    "Sektor",
+    "Portfolioname",
+    "Portfolio ID",
+]
+
+TRANSACTIONS_COLUMNS = [
+    "Datum",
+    "ISIN",
+    "Name",
+    "Typ",
+    "Transaktion",
+    "Anzahl",
+    "Preis",
+    "Gebühren",
+    "Steuern",
+    "Währung",
+    "Wechselkurs",
+    "Portfolioname",
+    "Portfolio ID",
+    "Stückzinsen",
+]
+
+#: A real, checksum-valid ISIN, used so the happy path is realistic.
+VALID_ISIN = "US0378331005"
+#: The anonymized export's placeholder ISIN, which is shaped like an ISIN but has
+#: an invalid check digit.
+PLACEHOLDER_ISIN = "IE00AAAA0000"
+
+
+def _holding(
+    *,
+    isin: str = VALID_ISIN,
+    name: str = "Example World ETF",
+    instrument_type: str = "ETF",
+    anzahl: str = "12,3456",
+    kaufpreis: str = "101,234567",
+    kurs: str = "112,345",
+    wert: str = "1.386,608",
+    waehrung: str = "EUR",
+    wechselkurs: str = "1,00",
+    region: str = "Welt",
+    land: str = "",
+    sektor: str = "",
+    portfolio: str = "Example broker",
+    portfolio_id: str = "1000001",
+) -> dict[str, str]:
+    return {
+        "ISIN": isin,
+        "Name": name,
+        "Typ": instrument_type,
+        "Anzahl": anzahl,
+        "Kaufpreis": kaufpreis,
+        "Aktueller Kurs": kurs,
+        "Aktueller Wert": wert,
+        "Währung": waehrung,
+        "Wechselkurs": wechselkurs,
+        "Region": region,
+        "Land": land,
+        "Sektor": sektor,
+        "Portfolioname": portfolio,
+        "Portfolio ID": portfolio_id,
+    }
+
+
+def _movement(
+    *,
+    datum: str = "01.09.2026",
+    isin: str = VALID_ISIN,
+    name: str = "Example World ETF",
+    instrument_type: str = "ETF",
+    transaktion: str = "Kauf",
+    anzahl: str = "1,2345",
+    preis: str = "110,123456",
+    gebuehren: str = "0,00",
+    steuern: str = "0,00",
+    waehrung: str = "EUR",
+    wechselkurs: str = "1,00",
+    portfolio: str = "Example broker",
+    portfolio_id: str = "1000001",
+    stueckzinsen: str = "0",
+) -> dict[str, str]:
+    return {
+        "Datum": datum,
+        "ISIN": isin,
+        "Name": name,
+        "Typ": instrument_type,
+        "Transaktion": transaktion,
+        "Anzahl": anzahl,
+        "Preis": preis,
+        "Gebühren": gebuehren,
+        "Steuern": steuern,
+        "Währung": waehrung,
+        "Wechselkurs": wechselkurs,
+        "Portfolioname": portfolio,
+        "Portfolio ID": portfolio_id,
+        "Stückzinsen": stueckzinsen,
+    }
+
+
+def _export(columns: list[str], rows: list[dict[str, str]]) -> str:
+    lines = [";".join(columns)]
+    lines.extend(";".join(row[column] for column in columns) for row in rows)
+    return "\n".join(lines) + "\n"
+
+
+def _holdings_export(*rows: dict[str, str]) -> str:
+    return _export(HOLDINGS_COLUMNS, list(rows))
+
+
+def _transactions_export(*rows: dict[str, str]) -> str:
+    return _export(TRANSACTIONS_COLUMNS, list(rows))
+
+
+def test_holdings_export_normalizes_a_german_locale_position():
+    export = parse_export(_holdings_export(_holding()))
+
+    assert export.kind == "holdings"
+    (position,) = export.require_positions()
+    assert position["instrument_id"] == VALID_ISIN
+    assert position["instrument_id_kind"] == "isin"
+    assert position["instrument_id_checksum_ok"] is True
+    assert position["symbol"] == VALID_ISIN
+    assert position["broker"] == "extraetf"
+    assert position["quantity"] == pytest.approx(12.3456)
+    assert position["cost_price"] == pytest.approx(101.234567)
+    assert position["market_price"] == pytest.approx(112.345)
+    assert position["source_market_value"] == pytest.approx(1386.608)
+    assert position["currency"] == "EUR"
+    assert position["price_currency"] == "EUR"
+    assert position["asset_type"] == "etf"
+    assert position["instrument_type"] == "ETF"
+    assert position["portfolio_id"] == "1000001"
+    assert position["portfolio_name"] == "Example broker"
+    assert position["region"] == "Welt"
+    assert position["country"] is None
+    assert position["sector"] is None
+
+
+def test_german_separators_are_not_read_as_us_numbers():
+    """``1.386,608`` is 1386.608, not 1.386 and not 1386608."""
+    export = parse_export(
+        _holdings_export(
+            _holding(
+                anzahl="12,3456",
+                kaufpreis="1.386,608",
+                kurs="59.999,99",
+                wert="1.386.608,42",
+                wechselkurs="1,0855",
+            )
+        )
+    )
+
+    (position,) = export.require_positions()
+    assert position["quantity"] == pytest.approx(12.3456)
+    assert position["cost_price"] == pytest.approx(1386.608)
+    assert position["market_price"] == pytest.approx(59999.99)
+    assert position["source_market_value"] == pytest.approx(1386608.42)
+    assert position["fx_rate"] == pytest.approx(1.0855)
+
+
+def test_us_formatted_number_is_refused_rather_than_misread():
+    with pytest.raises(ExtraEtfFormatError, match="US-formatted"):
+        parse_export(_holdings_export(_holding(kaufpreis="1,234.56")))
+
+
+@pytest.mark.parametrize("ambiguous", ["1.23", "1234.56", "0.5"])
+def test_ambiguous_separator_grouping_is_refused(ambiguous):
+    """A period that is not a thousands separator cannot be guessed at."""
+    with pytest.raises(ExtraEtfFormatError, match="ambiguous separators"):
+        parse_export(_holdings_export(_holding(kurs=ambiguous)))
+
+
+@pytest.mark.parametrize("unreadable", ["zwei", "10,00 EUR", "--", ","])
+def test_unreadable_number_is_refused(unreadable):
+    with pytest.raises(ExtraEtfFormatError, match="is not a number|ambiguous|empty"):
+        parse_export(_holdings_export(_holding(anzahl=unreadable)))
+
+
+def test_blank_optional_fields_are_none_rather_than_zero():
+    export = parse_export(
+        _holdings_export(_holding(kaufpreis="", kurs="", wert="", wechselkurs=""))
+    )
+
+    (position,) = export.require_positions()
+    assert position["cost_price"] is None
+    assert position["market_price"] is None
+    assert position["source_market_value"] is None
+    assert position["fx_rate"] is None
+
+
+def test_transactions_export_yields_movements_and_never_positions():
+    """A transactions export is a movement history, not a portfolio."""
+    export = parse_export(
+        _transactions_export(
+            _movement(transaktion="Kauf"),
+            _movement(transaktion="Verkauf", anzahl="2,5000", preis="19,876543"),
+            _movement(
+                transaktion="Dividende",
+                anzahl="0,5000",
+                preis="2,345",
+                steuern="0,45",
+            ),
+            _movement(transaktion="Einbuchung", anzahl="5,0000", preis="95,000000"),
+            _movement(transaktion="Ausbuchung", anzahl="0,5000", preis="90,000000"),
+        )
+    )
+
+    assert export.kind == "transactions"
+    assert export.positions == ()
+    assert export.movements[0]["movement"] == "Kauf"
+    assert export.movements[0]["movement_kind"] == "buy"
+    assert [m["movement_kind"] for m in export.movements] == [
+        "buy",
+        "sell",
+        "dividend",
+        "transfer_in",
+        "transfer_out",
+    ]
+    # A dividend row carries a quantity of its own; it must never become a holding.
+    assert export.movements[2]["quantity"] == pytest.approx(0.5)
+    assert export.movements[2]["taxes"] == pytest.approx(0.45)
+    assert all("asset_type" not in movement for movement in export.movements)
+    assert all("accrued_interest" in movement for movement in export.movements)
+    assert export.movements[0]["date"] == "2026-09-01"
+    assert export.movements[0]["accrued_interest"] == pytest.approx(0.0)
+
+
+def test_a_transactions_export_refuses_to_pose_as_a_portfolio():
+    export = parse_export(_transactions_export(_movement(transaktion="Kauf")))
+
+    with pytest.raises(ExtraEtfFormatError, match="movements, not positions"):
+        export.require_positions()
+
+
+def test_unknown_transaction_type_is_carried_through_not_invented():
+    export = parse_export(_transactions_export(_movement(transaktion="Steuer")))
+
+    assert export.positions == ()
+    assert export.movements[0]["movement"] == "Steuer"
+    assert export.movements[0]["movement_kind"] is None
+
+
+def test_invalid_transaction_date_is_refused():
+    with pytest.raises(ExtraEtfFormatError, match="DD.MM.YYYY"):
+        parse_export(_transactions_export(_movement(datum="2026-09-01")))
+
+    with pytest.raises(ExtraEtfFormatError, match="not a real date"):
+        parse_export(_transactions_export(_movement(datum="31.02.2026")))
+
+
+def test_crypto_identity_is_a_pair_not_an_isin():
+    export = parse_export(
+        _holdings_export(
+            _holding(
+                isin="BTC_to_EUR",
+                name="Bitcoin",
+                instrument_type="Währung / Krypto",
+                region="Global",
+                sektor="Diversifizierte Kapitalmärkte",
+                portfolio="Example crypto wallet",
+                portfolio_id="1000002",
+            )
+        )
+    )
+
+    (position,) = export.require_positions()
+    assert position["instrument_id"] == "BTC_to_EUR"
+    assert position["instrument_id_kind"] == "crypto_pair"
+    assert position["instrument_id_checksum_ok"] is None
+    assert position["asset_type"] == "crypto"
+    assert position["portfolio_id"] == "1000002"
+
+
+@pytest.mark.parametrize("identifier", ["BTC", "", "  ", "NOT*AN*ID"])
+def test_unattributable_holding_identifier_is_refused(identifier):
+    """A bare symbol cannot be resolved, so the import fails instead of guessing."""
+    with pytest.raises(ExtraEtfFormatError, match="neither an ISIN nor"):
+        parse_export(_holdings_export(_holding(isin=identifier)))
+
+
+def test_invalid_isin_check_digit_is_reported_not_enforced():
+    export = parse_export(
+        _holdings_export(_holding(isin=VALID_ISIN), _holding(isin=PLACEHOLDER_ISIN))
+    )
+
+    valid, placeholder = export.require_positions()
+    assert valid["instrument_id_checksum_ok"] is True
+    assert placeholder["instrument_id_checksum_ok"] is False
+
+
+def test_unknown_instrument_type_leaves_asset_type_unset():
+    export = parse_export(_holdings_export(_holding(instrument_type="Anleihe")))
+
+    (position,) = export.require_positions()
+    assert position["instrument_type"] == "Anleihe"
+    assert position["asset_type"] is None
+
+
+def test_missing_required_field_is_refused():
+    for kwarg, message in (
+        ("name", "Name is empty"),
+        ("instrument_type", "Typ is empty"),
+        ("waehrung", "Währung is empty"),
+        ("portfolio_id", "Portfolio ID is empty"),
+    ):
+        with pytest.raises(ExtraEtfFormatError, match=message):
+            parse_export(_holdings_export(_holding(**{kwarg: ""})))
+
+
+def test_invalid_currency_is_refused():
+    with pytest.raises(ExtraEtfFormatError, match="three-letter currency"):
+        parse_export(_holdings_export(_holding(waehrung="EURO")))
+
+
+def test_unknown_column_makes_the_export_unrecognisable():
+    row = _holding()
+    header = ";".join([*HOLDINGS_COLUMNS, "Neue Spalte"])
+    body = ";".join([*(row[column] for column in HOLDINGS_COLUMNS), "x"])
+
+    with pytest.raises(
+        ExtraEtfFormatError, match="unexpected columns: \\['Neue Spalte'\\]"
+    ):
+        parse_export(f"{header}\n{body}\n")
+
+
+def test_missing_column_makes_the_export_unrecognisable():
+    columns = [column for column in HOLDINGS_COLUMNS if column != "Anzahl"]
+    row = _holding()
+
+    with pytest.raises(ExtraEtfFormatError, match="missing columns: \\['Anzahl'\\]"):
+        parse_export(_export(columns, [row]))
+
+
+def test_ragged_row_is_refused_rather_than_partially_imported():
+    """One malformed row fails the import; it never yields a short portfolio."""
+    row = _holding()
+    short = ";".join(row[column] for column in HOLDINGS_COLUMNS[:-1])
+    long = ";".join([*(row[column] for column in HOLDINGS_COLUMNS), "extra"])
+
+    for ragged in (short, long):
+        with pytest.raises(ExtraEtfFormatError, match="cannot be aligned"):
+            parse_export(_holdings_export(_holding(), _holding()) + ragged + "\n")
+
+
+def test_reordered_columns_do_not_mis_align_values():
+    """Rows are keyed by column name, so a reordered export stays correct."""
+    columns = list(reversed(HOLDINGS_COLUMNS))
+
+    export = parse_export(_export(columns, [_holding()]))
+
+    (position,) = export.require_positions()
+    assert position["currency"] == "EUR"
+    assert position["quantity"] == pytest.approx(12.3456)
+    assert position["name"] == "Example World ETF"
+    assert position["portfolio_id"] == "1000001"
+
+
+def test_duplicate_rows_are_preserved_rather_than_merged():
+    export = parse_export(
+        _holdings_export(_holding(anzahl="1,0000"), _holding(anzahl="2,0000"))
+    )
+
+    assert [position["quantity"] for position in export.require_positions()] == [
+        pytest.approx(1.0),
+        pytest.approx(2.0),
+    ]
+
+
+def test_empty_holdings_export_is_valid_and_not_an_error():
+    """An empty portfolio and an unreadable file are different states."""
+    export = parse_export(_holdings_export())
+
+    assert export.kind == "holdings"
+    assert export.require_positions() == ()
+
+
+def test_empty_file_is_refused():
+    for empty in ("", "\n\n  \n"):
+        with pytest.raises(ExtraEtfFormatError, match="export is empty"):
+            parse_export(empty)
+
+
+def test_as_of_comes_from_the_file_mtime_and_is_labelled(tmp_path):
+    path = tmp_path / "holdings.csv"
+    path.write_text(_holdings_export(_holding()), encoding="utf-8")
+    stamp = 1_760_000_000
+    os.utime(path, (stamp, stamp))
+
+    export = read_export(path)
+
+    expected = datetime.fromtimestamp(stamp, tz=timezone.utc).isoformat()
+    assert export.as_of_source == "file_mtime"
+    assert export.as_of == expected
+    assert export.source_path == path
+    assert export.require_positions()[0]["updated_at"] == expected
+
+
+def test_bare_text_reports_no_observation_time():
+    export = parse_export(_holdings_export(_holding()))
+
+    assert export.as_of is None
+    assert export.as_of_source == "unavailable"
+    assert export.require_positions()[0]["updated_at"] is None
+
+
+def test_an_absent_as_of_cannot_claim_an_origin():
+    with pytest.raises(ValueError, match="no observation time"):
+        parse_export(_holdings_export(_holding()), as_of_source="file_mtime")
+
+
+def test_bom_and_umlauts_decode_from_utf8_and_cp1252(tmp_path):
+    document = _holdings_export(_holding())
+
+    utf8_path = tmp_path / "utf8.csv"
+    utf8_path.write_bytes(("\ufeff" + document).encode("utf-8"))
+    assert read_export(utf8_path).require_positions()[0]["currency"] == "EUR"
+
+    cp1252_path = tmp_path / "cp1252.csv"
+    cp1252_path.write_bytes(document.encode("cp1252"))
+    assert read_export(cp1252_path).require_positions()[0]["currency"] == "EUR"
+
+
+def test_missing_file_is_refused(tmp_path):
+    with pytest.raises(ExtraEtfFormatError, match="cannot read export"):
+        read_export(tmp_path / "absent.csv")
+
+
+def test_reader_imports_only_the_standard_library():
+    """No network, no broker SDK, no order path can be reached from here."""
+    import ast
+    from pathlib import Path
+
+    import src.portfolio.extraetf as module
+
+    source = Path(module.__file__).read_text(encoding="utf-8")
+    roots = set()
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Import):
+            roots.update(alias.name.split(".")[0] for alias in node.names)
+        elif (
+            isinstance(node, ast.ImportFrom)
+            and node.level == 0
+            and node.module
+            and node.module != "__future__"
+        ):
+            roots.add(node.module.split(".")[0])
+
+    assert roots == {
+        "csv",
+        "dataclasses",
+        "datetime",
+        "decimal",
+        "io",
+        "os",
+        "pathlib",
+        "re",
+        "typing",
+    }

--- a/agent/tests/test_extraetf_reader.py
+++ b/agent/tests/test_extraetf_reader.py
@@ -393,6 +393,28 @@ def test_duplicate_rows_are_preserved_rather_than_merged():
     ]
 
 
+def test_one_instrument_under_two_portfolios_stays_two_positions():
+    """Every export covers all depots, so one ISIN under two Portfolio IDs is
+    the normal case rather than a conflict the reader is allowed to resolve."""
+    export = parse_export(
+        _holdings_export(
+            _holding(anzahl="10,0000", portfolio="Example bank", portfolio_id="1000001"),
+            _holding(anzahl="25,0000", portfolio="Example broker", portfolio_id="1000002"),
+        )
+    )
+
+    positions = export.require_positions()
+    assert [position["quantity"] for position in positions] == [
+        pytest.approx(10.0),
+        pytest.approx(25.0),
+    ]
+    assert [position["portfolio_id"] for position in positions] == ["1000001", "1000002"]
+    assert [position["portfolio_name"] for position in positions] == [
+        "Example bank",
+        "Example broker",
+    ]
+
+
 def test_empty_holdings_export_is_valid_and_not_an_error():
     """An empty portfolio and an unreadable file are different states."""
     export = parse_export(_holdings_export())

--- a/agent/tests/test_extraetf_reader.py
+++ b/agent/tests/test_extraetf_reader.py
@@ -203,7 +203,7 @@ def test_ambiguous_separator_grouping_is_refused(ambiguous):
 
 @pytest.mark.parametrize("unreadable", ["zwei", "10,00 EUR", "--", ","])
 def test_unreadable_number_is_refused(unreadable):
-    with pytest.raises(ExtraEtfFormatError, match="is not a number|ambiguous|empty"):
+    with pytest.raises(ExtraEtfFormatError, match="is not a number|ambiguous separators"):
         parse_export(_holdings_export(_holding(anzahl=unreadable)))
 
 
@@ -584,17 +584,21 @@ def test_case_mapping_cannot_fabricate_an_isin(identifier):
 
     Each input is eleven characters that upper-case to a twelve-character string
     matching the ISIN shape, and ``aß000000001`` even matches the check digit. So
-    the guard is to refuse them as unattributable holdings, not to read them as
-    ISINs, and the movements path shows they stay raw symbols rather than being
-    rewritten.
+    the guard is to refuse them rather than read them as ISINs — on the holdings
+    path as unattributable, and on the movements path because they are not a
+    symbol either. Neither path rewrites them into a code they are not.
     """
     with pytest.raises(ExtraEtfFormatError, match="neither an ISIN nor"):
         parse_export(_holdings_export(_holding(isin=identifier)))
 
-    export = parse_export(_transactions_export(_movement(isin=identifier, instrument_type="Fremdwährung")))
+    with pytest.raises(ExtraEtfFormatError, match="neither an ISIN nor a crypto symbol"):
+        parse_export(_transactions_export(_movement(isin=identifier, instrument_type="Fremdwährung")))
+
+    # A value that *is* a plain symbol still reads as itself, unrewritten.
+    export = parse_export(_transactions_export(_movement(isin="BTC", instrument_type="Fremdwährung")))
     (movement,) = export.require_movements()
     assert movement["instrument_id_kind"] == "raw_symbol"
-    assert movement["instrument_id"] == identifier
+    assert movement["instrument_id"] == "BTC"
 
 
 def test_a_lowercased_isin_is_still_read_as_an_isin():
@@ -776,3 +780,96 @@ def test_reader_imports_only_the_standard_library():
         "re",
         "typing",
     }
+
+
+def test_a_thousands_group_longer_than_three_digits_is_refused():
+    """``1234.567`` is a US decimal; reading its period as German scales it 1000x.
+
+    The leading group is the one the grouping rule used to skip, and it is the
+    one that decides whether a bare period is a thousands separator at all —
+    German never writes four digits before the first separator.
+    """
+    for value in ("1234.567", "12345.678", "9999.99"):
+        with pytest.raises(ExtraEtfFormatError, match="ambiguous separators"):
+            parse_export(_holdings_export(_holding(kurs=value)))
+
+    # The German spelling of the same magnitude is still accepted.
+    export = parse_export(_holdings_export(_holding(kurs="1.234,567")))
+    assert export.require_positions()[0]["market_price"] == pytest.approx(1234.567)
+
+
+@pytest.mark.parametrize("column", ["kaufpreis", "kurs", "wert", "wechselkurs"])
+def test_extra_precision_is_refused_in_every_holding_number(column):
+    """Precision is a property of the number grammar, not of one column."""
+    with pytest.raises(ExtraEtfFormatError, match="more precision than a position"):
+        parse_export(_holdings_export(_holding(**{column: "1,123456789"})))
+
+
+@pytest.mark.parametrize("column", ["preis", "gebuehren", "steuern", "stueckzinsen"])
+def test_extra_precision_is_refused_in_every_movement_number(column):
+    with pytest.raises(ExtraEtfFormatError, match="more precision than a position"):
+        parse_export(_transactions_export(_movement(**{column: "1,123456789"})))
+
+
+def test_a_value_that_would_change_on_the_way_to_a_float_is_refused():
+    """``float`` holds about seventeen significant digits, so a value past that
+    would arrive with a different magnitude even though it quantized cleanly."""
+    with pytest.raises(ExtraEtfFormatError, match="more precision than a position"):
+        parse_export(_holdings_export(_holding(anzahl="999999999999999,99999999")))
+
+
+def test_case_variant_crypto_pairs_are_one_instrument():
+    """The pair label is extraETF's own, so it is emitted exactly as exported —
+    but two rows differing only in case are one label, and two positions for
+    them would double-count."""
+    with pytest.raises(ExtraEtfFormatError, match="listed twice under portfolio"):
+        parse_export(
+            _holdings_export(
+                _holding(isin="BTC_to_EUR", instrument_type="Währung / Krypto"),
+                _holding(isin="btc_to_eur", instrument_type="Währung / Krypto"),
+            )
+        )
+
+
+def test_a_crypto_pair_keeps_its_exported_case():
+    """Comparison folds case; the emitted value does not."""
+    export = parse_export(_holdings_export(_holding(isin="btc_to_eur", instrument_type="Währung / Krypto")))
+
+    assert export.require_positions()[0]["instrument_id"] == "btc_to_eur"
+
+
+def test_a_movement_identifier_that_is_not_a_symbol_is_refused():
+    """A movement may carry a bare crypto symbol, but not arbitrary text."""
+    for identifier in ("!!!", "hello world", "..", "BTC EUR"):
+        with pytest.raises(ExtraEtfFormatError, match="neither an ISIN nor a crypto symbol"):
+            parse_export(_transactions_export(_movement(isin=identifier)))
+
+
+def test_del_and_c1_characters_are_refused_in_text_and_identity_fields():
+    """Control characters are corruption, not content — DEL and C1 included."""
+    for value in ("A\x7fB", "A\x85B", "A\x1fB", "A\x00B"):
+        with pytest.raises(ExtraEtfFormatError, match="carries control characters"):
+            parse_export(_holdings_export(_holding(name=value)))
+        with pytest.raises(ExtraEtfFormatError, match="carries control characters"):
+            parse_export(_holdings_export(_holding(isin=value)))
+
+
+def test_an_unavailable_origin_cannot_carry_a_timestamp():
+    """Provenance has to agree with itself in both directions."""
+    with pytest.raises(ValueError, match="must agree"):
+        parse_export(
+            _holdings_export(_holding()),
+            source_mtime="2026-01-01T00:00:00+00:00",
+            as_of_source="unavailable",
+        )
+
+
+def test_transaction_labels_are_matched_ignoring_case_and_padding():
+    """The label is German prose rather than a canonical enum, so it is matched
+    case-insensitively, and a padded cell is stripped at the read boundary —
+    while whatever the file did say is what the movement reports."""
+    for label, expected in (("kauf", "buy"), ("KAUF", "buy"), ("Kauf ", "buy"), ("Dividende", "dividend")):
+        export = parse_export(_transactions_export(_movement(transaktion=label)))
+        movement = export.require_movements()[0]
+        assert movement["movement_kind"] == expected
+        assert movement["movement"] == label.strip()

--- a/agent/tests/test_extraetf_reader.py
+++ b/agent/tests/test_extraetf_reader.py
@@ -263,14 +263,39 @@ def test_a_transactions_export_refuses_to_pose_as_a_portfolio():
         export.require_positions()
 
 
-def test_unknown_transaction_type_is_carried_through_not_invented():
-    export = parse_export(_transactions_export(_movement(transaktion="Steuer")))
+def test_unknown_transaction_label_is_refused():
+    """A movement whose label is dropped is a movement that means nothing.
 
-    with pytest.raises(ExtraEtfFormatError, match="movements, not positions"):
-        export.require_positions()
+    Carried through with ``movement_kind=None``, a ``Steuer`` row would land in
+    the same bucket as every other unrecognised label, where a dividend, a fee
+    and a cash movement are indistinguishable from each other.
+    """
+    with pytest.raises(ExtraEtfFormatError, match="none of the labels this format documents"):
+        parse_export(_transactions_export(_movement(transaktion="Steuer")))
+
+
+def test_a_movement_without_an_instrument_is_refused():
+    """A blank ISIN is a cash or fee row, not a movement this reader can place.
+
+    Allowing it produced a movement with ``instrument_id=None`` — a movement
+    attributed to no instrument, which is not a position and not a trade.
+    """
+    for blank in ("", "   "):
+        with pytest.raises(ExtraEtfFormatError, match="ISIN column is empty"):
+            parse_export(_transactions_export(_movement(isin=blank)))
+
+
+def test_a_bare_symbol_movement_is_still_read():
+    """The crypto transactions shape carries its own symbol, not an ISIN.
+
+    This is the documented shape for the Bitpanda transactions export, so the
+    stricter movement checks must not refuse it.
+    """
+    export = parse_export(_transactions_export(_movement(isin="BTC", transaktion="Kauf")))
+
     (movement,) = export.require_movements()
-    assert movement["movement"] == "Steuer"
-    assert movement["movement_kind"] is None
+    assert movement["instrument_id"] == "BTC"
+    assert movement["instrument_id_kind"] == "raw_symbol"
 
 
 def test_invalid_transaction_date_is_refused():
@@ -300,7 +325,10 @@ def test_crypto_identity_is_a_pair_not_an_isin():
     assert position["instrument_id"] == "BTC_to_EUR"
     assert position["instrument_id_kind"] == "crypto_pair"
     assert position["instrument_id_checksum_ok"] is None
-    assert position["asset_type"] == "crypto"
+    # ``Währung / Krypto`` is the class extraETF gives FX pairs as well as crypto,
+    # so this reader will not label a position from it: a USD_to_EUR row in this
+    # shape is not a crypto holding.
+    assert position["asset_type"] is None
     assert position["portfolio_id"] == "1000002"
 
 
@@ -384,13 +412,21 @@ def test_reordered_columns_do_not_mis_align_values():
     assert position["portfolio_id"] == "1000001"
 
 
-def test_duplicate_rows_are_preserved_rather_than_merged():
-    export = parse_export(_holdings_export(_holding(anzahl="1,0000"), _holding(anzahl="2,0000")))
+def test_a_repeated_instrument_in_one_portfolio_is_refused():
+    """Two rows for one instrument under one Portfolio ID cannot be read safely.
 
-    assert [position["quantity"] for position in export.require_positions()] == [
-        pytest.approx(1.0),
-        pytest.approx(2.0),
-    ]
+    Summing them double-counts the position; keeping one drops the other. Which
+    of the two the file meant is not this reader's call, so it refuses instead
+    of choosing.
+    """
+    with pytest.raises(ExtraEtfFormatError, match="listed twice under portfolio"):
+        parse_export(_holdings_export(_holding(anzahl="1,0000"), _holding(anzahl="2,0000")))
+
+
+def test_a_repeated_instrument_names_both_rows():
+    """The refusal has to point at the file, not just say no."""
+    with pytest.raises(ExtraEtfFormatError, match="row 3.*first at row 2"):
+        parse_export(_holdings_export(_holding(), _holding(anzahl="2,0000")))
 
 
 def test_one_instrument_under_two_portfolios_stays_two_positions():
@@ -429,7 +465,7 @@ def test_empty_file_is_refused():
             parse_export(empty)
 
 
-def test_as_of_comes_from_the_file_mtime_and_is_labelled(tmp_path):
+def test_source_mtime_comes_from_the_file_and_is_labelled(tmp_path):
     path = tmp_path / "holdings.csv"
     path.write_text(_holdings_export(_holding()), encoding="utf-8")
     stamp = 1_760_000_000
@@ -439,7 +475,7 @@ def test_as_of_comes_from_the_file_mtime_and_is_labelled(tmp_path):
 
     expected = datetime.fromtimestamp(stamp, tz=timezone.utc).isoformat()
     assert export.as_of_source == "file_mtime"
-    assert export.as_of == expected
+    assert export.source_mtime == expected
     assert export.source_path == path
     (position,) = export.require_positions()
     # The file's mtime is reported as the file's mtime, and never laundered into
@@ -448,18 +484,18 @@ def test_as_of_comes_from_the_file_mtime_and_is_labelled(tmp_path):
     assert position["updated_at"] is None
 
 
-def test_bare_text_reports_no_observation_time():
+def test_bare_text_reports_no_source_mtime():
     export = parse_export(_holdings_export(_holding()))
 
-    assert export.as_of is None
+    assert export.source_mtime is None
     assert export.as_of_source == "unavailable"
     (position,) = export.require_positions()
     assert position["updated_at"] is None
     assert position["source_mtime"] is None
 
 
-def test_an_absent_as_of_cannot_claim_an_origin():
-    with pytest.raises(ValueError, match="no observation time"):
+def test_an_absent_source_mtime_cannot_claim_an_origin():
+    with pytest.raises(ValueError, match="no source modification time"):
         parse_export(_holdings_export(_holding()), as_of_source="file_mtime")
 
 
@@ -598,9 +634,40 @@ def test_as_of_source_must_be_one_of_the_two_documented_origins():
     with pytest.raises(ValueError, match="as_of_source must be"):
         parse_export(
             _holdings_export(_holding()),
-            as_of="2026-01-01T00:00:00+00:00",
+            source_mtime="2026-01-01T00:00:00+00:00",
             as_of_source="nonsense",
         )
+
+
+def test_a_quantity_that_rounds_away_is_refused_not_silently_zeroed():
+    """Quantizing to the wire format is a rounding, and a rounding is a change.
+
+    0,000000004 is not zero in the file. Accepting it produced a position whose
+    quantity had become 0.0 — an empty position built out of a real one.
+    """
+    with pytest.raises(ExtraEtfFormatError, match="more precision than a position"):
+        parse_export(_holdings_export(_holding(anzahl="0,000000004")))
+
+
+def test_a_quantity_beyond_the_wire_precision_is_refused():
+    """A ninth decimal place is more than the output can hold, so it is refused
+    rather than rounded away."""
+    for anzahl in ("1,123456789", "12,345678901"):
+        with pytest.raises(ExtraEtfFormatError, match="more precision than a position"):
+            parse_export(_holdings_export(_holding(anzahl=anzahl)))
+
+
+def test_a_quantity_at_the_wire_precision_is_accepted_unchanged():
+    """The boundary itself is representable, so it must not be refused."""
+    export = parse_export(_holdings_export(_holding(anzahl="1,12345678")))
+
+    (position,) = export.require_positions()
+    assert position["quantity"] == pytest.approx(1.12345678)
+
+    # A tiny but representable non-zero quantity survives as itself.
+    export = parse_export(_holdings_export(_holding(anzahl="0,00000001")))
+    (position,) = export.require_positions()
+    assert position["quantity"] > 0
 
 
 def test_a_bom_followed_by_whitespace_still_reads_the_header():

--- a/agent/tests/test_extraetf_reader.py
+++ b/agent/tests/test_extraetf_reader.py
@@ -208,9 +208,7 @@ def test_unreadable_number_is_refused(unreadable):
 
 
 def test_blank_optional_fields_are_none_rather_than_zero():
-    export = parse_export(
-        _holdings_export(_holding(kaufpreis="", kurs="", wert="", wechselkurs=""))
-    )
+    export = parse_export(_holdings_export(_holding(kaufpreis="", kurs="", wert="", wechselkurs="")))
 
     (position,) = export.require_positions()
     assert position["cost_price"] is None
@@ -237,10 +235,12 @@ def test_transactions_export_yields_movements_and_never_positions():
     )
 
     assert export.kind == "transactions"
-    assert export.positions == ()
-    assert export.movements[0]["movement"] == "Kauf"
-    assert export.movements[0]["movement_kind"] == "buy"
-    assert [m["movement_kind"] for m in export.movements] == [
+    with pytest.raises(ExtraEtfFormatError, match="movements, not positions"):
+        export.require_positions()
+    movements = export.require_movements()
+    assert movements[0]["movement"] == "Kauf"
+    assert movements[0]["movement_kind"] == "buy"
+    assert [m["movement_kind"] for m in movements] == [
         "buy",
         "sell",
         "dividend",
@@ -248,12 +248,12 @@ def test_transactions_export_yields_movements_and_never_positions():
         "transfer_out",
     ]
     # A dividend row carries a quantity of its own; it must never become a holding.
-    assert export.movements[2]["quantity"] == pytest.approx(0.5)
-    assert export.movements[2]["taxes"] == pytest.approx(0.45)
-    assert all("asset_type" not in movement for movement in export.movements)
-    assert all("accrued_interest" in movement for movement in export.movements)
-    assert export.movements[0]["date"] == "2026-09-01"
-    assert export.movements[0]["accrued_interest"] == pytest.approx(0.0)
+    assert movements[2]["quantity"] == pytest.approx(0.5)
+    assert movements[2]["taxes"] == pytest.approx(0.45)
+    assert all("asset_type" not in movement for movement in movements)
+    assert all("accrued_interest" in movement for movement in movements)
+    assert movements[0]["date"] == "2026-09-01"
+    assert movements[0]["accrued_interest"] == pytest.approx(0.0)
 
 
 def test_a_transactions_export_refuses_to_pose_as_a_portfolio():
@@ -266,9 +266,11 @@ def test_a_transactions_export_refuses_to_pose_as_a_portfolio():
 def test_unknown_transaction_type_is_carried_through_not_invented():
     export = parse_export(_transactions_export(_movement(transaktion="Steuer")))
 
-    assert export.positions == ()
-    assert export.movements[0]["movement"] == "Steuer"
-    assert export.movements[0]["movement_kind"] is None
+    with pytest.raises(ExtraEtfFormatError, match="movements, not positions"):
+        export.require_positions()
+    (movement,) = export.require_movements()
+    assert movement["movement"] == "Steuer"
+    assert movement["movement_kind"] is None
 
 
 def test_invalid_transaction_date_is_refused():
@@ -310,9 +312,7 @@ def test_unattributable_holding_identifier_is_refused(identifier):
 
 
 def test_invalid_isin_check_digit_is_reported_not_enforced():
-    export = parse_export(
-        _holdings_export(_holding(isin=VALID_ISIN), _holding(isin=PLACEHOLDER_ISIN))
-    )
+    export = parse_export(_holdings_export(_holding(isin=VALID_ISIN), _holding(isin=PLACEHOLDER_ISIN)))
 
     valid, placeholder = export.require_positions()
     assert valid["instrument_id_checksum_ok"] is True
@@ -348,9 +348,7 @@ def test_unknown_column_makes_the_export_unrecognisable():
     header = ";".join([*HOLDINGS_COLUMNS, "Neue Spalte"])
     body = ";".join([*(row[column] for column in HOLDINGS_COLUMNS), "x"])
 
-    with pytest.raises(
-        ExtraEtfFormatError, match="unexpected columns: \\['Neue Spalte'\\]"
-    ):
+    with pytest.raises(ExtraEtfFormatError, match="unexpected columns: \\['Neue Spalte'\\]"):
         parse_export(f"{header}\n{body}\n")
 
 
@@ -387,9 +385,7 @@ def test_reordered_columns_do_not_mis_align_values():
 
 
 def test_duplicate_rows_are_preserved_rather_than_merged():
-    export = parse_export(
-        _holdings_export(_holding(anzahl="1,0000"), _holding(anzahl="2,0000"))
-    )
+    export = parse_export(_holdings_export(_holding(anzahl="1,0000"), _holding(anzahl="2,0000")))
 
     assert [position["quantity"] for position in export.require_positions()] == [
         pytest.approx(1.0),
@@ -423,7 +419,11 @@ def test_as_of_comes_from_the_file_mtime_and_is_labelled(tmp_path):
     assert export.as_of_source == "file_mtime"
     assert export.as_of == expected
     assert export.source_path == path
-    assert export.require_positions()[0]["updated_at"] == expected
+    (position,) = export.require_positions()
+    # The file's mtime is reported as the file's mtime, and never laundered into
+    # the field every connector fills with a real observation time.
+    assert position["source_mtime"] == expected
+    assert position["updated_at"] is None
 
 
 def test_bare_text_reports_no_observation_time():
@@ -431,7 +431,9 @@ def test_bare_text_reports_no_observation_time():
 
     assert export.as_of is None
     assert export.as_of_source == "unavailable"
-    assert export.require_positions()[0]["updated_at"] is None
+    (position,) = export.require_positions()
+    assert position["updated_at"] is None
+    assert position["source_mtime"] is None
 
 
 def test_an_absent_as_of_cannot_claim_an_origin():
@@ -456,6 +458,132 @@ def test_missing_file_is_refused(tmp_path):
         read_export(tmp_path / "absent.csv")
 
 
+def test_a_record_folded_across_lines_is_refused_rather_than_aligned():
+    """A stray quote makes csv fold the next line in; the fold must not land.
+
+    The folded record still has the right field count, so an arity check alone
+    passes: one instrument's quantity and value get grafted onto another's
+    identity while a whole position disappears. That is a plausible-looking
+    portfolio, so the fold is refused. Verified against the unfixed reader,
+    which returned 3 positions totalling 3000.0 for this 4-position file.
+    """
+    document = (
+        ";".join(HOLDINGS_COLUMNS) + "\n"
+        "US0378331005;Apple Inc.;Aktie;10,0000;150,00;190,00;1.900,00;EUR;1,00;Nordamerika;USA;Technologie;Mein Depot;1000001\n"
+        'DE0007100000;"Zwei;ETF;5,0000;100,00;110,00;550,00;EUR;1,00;Welt;;;Mein Depot;1000001\n'
+        'IE00B4L5Y983;Three";ETF;7,0000;100,00;110,00;770,00;EUR;1,00;Welt;;;Mein Depot;1000001\n'
+        "FR0000131104;Four;ETF;3,0000;100,00;110,00;330,00;EUR;1,00;Welt;;;Mein Depot;1000001\n"
+    )
+
+    with pytest.raises(ExtraEtfFormatError, match="spans more than one line"):
+        parse_export(document)
+
+
+def test_a_stray_quote_that_swallows_the_tail_is_refused():
+    """An unbalanced quote in the last column absorbs every following line."""
+    document = _holdings_export(_holding(), _holding(isin="DE0007100000"))
+    document = document.replace("Example broker;1000001", 'Example broker;"1000001', 1)
+
+    with pytest.raises(ExtraEtfFormatError, match="spans more than one line"):
+        parse_export(document)
+
+
+def test_an_over_long_field_is_refused_with_the_documented_error():
+    """csv raises its own error for an over-long field; callers must not see it."""
+    row = ";".join(["US0378331005", "x" * 140_000, *list(_holding().values())[2:]])
+
+    with pytest.raises(ExtraEtfFormatError, match="not readable as CSV"):
+        parse_export(_export(HOLDINGS_COLUMNS, []) + row + "\n")
+
+
+def test_unrepresentable_precision_is_refused_not_raised_as_decimal_error():
+    """A magnitude the wire format cannot carry is a format error, not a crash."""
+    with pytest.raises(ExtraEtfFormatError, match="more precision than a position"):
+        parse_export(_holdings_export(_holding(anzahl="1" + "0" * 30 + ",0")))
+
+
+def test_control_characters_in_text_fields_are_refused():
+    with pytest.raises(ExtraEtfFormatError, match="control characters"):
+        parse_export(_holdings_export(_holding(name="Apple\x00Inc")))
+
+    with pytest.raises(ExtraEtfFormatError, match="control characters"):
+        parse_export(_holdings_export(_holding(portfolio="Mein\x1fDepot")))
+
+
+def test_require_movements_refuses_a_holdings_export():
+    export = parse_export(_holdings_export(_holding()))
+
+    with pytest.raises(ExtraEtfFormatError, match="holds positions, not movements"):
+        export.require_movements()
+    assert len(export.require_positions()) == 1
+
+
+def test_the_crypto_transactions_shape_from_the_report_is_read():
+    """The Bitpanda transactions export identifies crypto by bare symbol only.
+
+    Ground truth from the anonymized samples: the same asset is ``BTC_to_EUR``
+    in the holdings export and bare ``BTC`` with ``Typ=Fremdwährung`` in the
+    transactions export. Resolving those onto one another is the container's
+    job, so the reader reports the divergence rather than inventing a base
+    asset: a movement keeps the export's own label and is flagged as an
+    unresolved raw symbol.
+    """
+    document = _export(
+        TRANSACTIONS_COLUMNS,
+        [
+            _movement(
+                isin="BTC",
+                name="Bitcoin",
+                instrument_type="Fremdwährung",
+                anzahl="0,001234",
+                preis="60.000,00",
+                portfolio="Example crypto wallet",
+                portfolio_id="1000002",
+            ),
+            _movement(
+                isin="ETH",
+                name="Ethereum",
+                instrument_type="Fremdwährung",
+                transaktion="Einbuchung",
+                anzahl="0,100000",
+                preis="2.500,00",
+                gebuehren="2,50",
+                portfolio="Example crypto wallet",
+                portfolio_id="1000002",
+            ),
+        ],
+    )
+
+    export = parse_export(document)
+
+    first, second = export.require_movements()
+    assert first["instrument_id"] == "BTC"
+    assert first["instrument_id_kind"] == "raw_symbol"
+    assert first["instrument_id_checksum_ok"] is None
+    assert first["quantity"] == pytest.approx(0.001234)
+    assert first["price"] == pytest.approx(60000.0)
+    assert second["movement_kind"] == "transfer_in"
+    assert second["fees"] == pytest.approx(2.5)
+    with pytest.raises(ExtraEtfFormatError, match="movements, not positions"):
+        export.require_positions()
+
+
+def test_a_period_grouped_value_is_read_as_german_by_convention():
+    """``1.900`` is 1900, because the export is German and nothing says otherwise.
+
+    This reading is a convention of the format rather than a deduction — the
+    same bytes could be 1.9 in a US-locale file — so it is pinned here to keep
+    the behaviour deliberate. A file round-tripped through a US locale is caught
+    by its other values, which stop looking like German thousands.
+    """
+    export = parse_export(_holdings_export(_holding(kaufpreis="1.900", kurs="110.123", wert="1.900")))
+
+    (position,) = export.require_positions()
+    assert position["cost_price"] == pytest.approx(1900.0)
+    assert position["market_price"] == pytest.approx(110123.0)
+    assert position["source_market_value"] == pytest.approx(1900.0)
+
+
 def test_reader_imports_only_the_standard_library():
     """No network, no broker SDK, no order path can be reached from here."""
     import ast
@@ -468,12 +596,7 @@ def test_reader_imports_only_the_standard_library():
     for node in ast.walk(ast.parse(source)):
         if isinstance(node, ast.Import):
             roots.update(alias.name.split(".")[0] for alias in node.names)
-        elif (
-            isinstance(node, ast.ImportFrom)
-            and node.level == 0
-            and node.module
-            and node.module != "__future__"
-        ):
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module and node.module != "__future__":
             roots.add(node.module.split(".")[0])
 
     assert roots == {

--- a/agent/tests/test_extraetf_reader.py
+++ b/agent/tests/test_extraetf_reader.py
@@ -510,6 +510,83 @@ def test_control_characters_in_text_fields_are_refused():
         parse_export(_holdings_export(_holding(portfolio="Mein\x1fDepot")))
 
 
+@pytest.mark.parametrize(
+    "identifier",
+    [
+        # .upper() is neither length- nor ASCII-preserving: each of these maps to a
+        # twelve-character upper-cased string matching the ISIN shape, and one of
+        # them passes the check digit too. None of them is an ISIN.
+        "a\u00df000000001",
+        "\u0131\u01310000000001",
+        "\ufb01n000000001",
+    ],
+)
+def test_case_mapping_cannot_fabricate_an_isin(identifier):
+    """A shape predicate must not be run on a case-folded value.
+
+    Each input is eleven characters that upper-case to a twelve-character string
+    matching the ISIN shape, and ``aß000000001`` even matches the check digit. So
+    the guard is to refuse them as unattributable holdings, not to read them as
+    ISINs, and the movements path shows they stay raw symbols rather than being
+    rewritten.
+    """
+    with pytest.raises(ExtraEtfFormatError, match="neither an ISIN nor"):
+        parse_export(_holdings_export(_holding(isin=identifier)))
+
+    export = parse_export(_transactions_export(_movement(isin=identifier, instrument_type="Fremdwährung")))
+    (movement,) = export.require_movements()
+    assert movement["instrument_id_kind"] == "raw_symbol"
+    assert movement["instrument_id"] == identifier
+
+
+def test_a_lowercased_isin_is_still_read_as_an_isin():
+    """An ISIN is case-insensitive, so a lower-cased one is canonicalised."""
+    export = parse_export(_holdings_export(_holding(isin="us0378331005")))
+
+    (position,) = export.require_positions()
+    assert position["instrument_id"] == "US0378331005"
+    assert position["instrument_id_kind"] == "isin"
+    assert position["instrument_id_checksum_ok"] is True
+
+
+@pytest.mark.parametrize(
+    "datum",
+    [
+        "\uff10\uff11.\uff10\uff19.\uff12\uff10\uff12\uff16",
+        "\u0660\u0661.\u0660\u0669.\u0662\u0660\u0662\u0666",
+    ],
+)
+def test_non_ascii_digits_are_refused_in_dates_as_they_are_in_numbers(datum):
+    """Unicode digits are accepted by \\d; numbers here are ASCII only."""
+    with pytest.raises(ExtraEtfFormatError, match="DD.MM.YYYY"):
+        parse_export(_transactions_export(_movement(datum=datum)))
+
+
+def test_a_blank_row_of_separators_is_refused_not_dropped():
+    """An unalignable blank record must not be skipped silently."""
+    with pytest.raises(ExtraEtfFormatError, match="blank row of 3 fields"):
+        parse_export(_holdings_export(_holding()) + ";;\n")
+
+    # A genuinely empty line is still just the end of a file.
+    export = parse_export(_holdings_export(_holding()) + "\n\n  \n")
+    assert len(export.require_positions()) == 1
+
+
+def test_as_of_source_must_be_one_of_the_two_documented_origins():
+    with pytest.raises(ValueError, match="as_of_source must be"):
+        parse_export(
+            _holdings_export(_holding()),
+            as_of="2026-01-01T00:00:00+00:00",
+            as_of_source="nonsense",
+        )
+
+
+def test_a_bom_followed_by_whitespace_still_reads_the_header():
+    export = parse_export("\ufeff " + _holdings_export(_holding()))
+
+    assert len(export.require_positions()) == 1
+
+
 def test_require_movements_refuses_a_holdings_export():
     export = parse_export(_holdings_export(_holding()))
 

--- a/agent/tests/test_extraetf_reader.py
+++ b/agent/tests/test_extraetf_reader.py
@@ -380,6 +380,29 @@ def test_unknown_column_makes_the_export_unrecognisable():
         parse_export(f"{header}\n{body}\n")
 
 
+def test_the_refusal_names_both_known_column_sets():
+    """#1170 asked for the refusal to name the sets it knows, not only the nearest
+    one, so the error says what *is* supported rather than only what is wrong."""
+    with pytest.raises(ExtraEtfFormatError) as caught:
+        parse_export("Datum;ISIN;Name;Typ;Ausschüttung;Währung;Portfolioname;Portfolio ID\n")
+
+    message = str(caught.value)
+    assert "holdings export" in message and "transactions export" in message
+    assert "Kaufpreis" in message and "Stückzinsen" in message
+
+
+def test_a_fiat_pair_is_not_labelled_crypto():
+    """``Währung / Krypto`` covers foreign-exchange pairs, so a ``USD_to_EUR`` row
+    is described by its shape and given no asset class at all."""
+    export = parse_export(
+        _holdings_export(_holding(isin="USD_to_EUR", name="US Dollar / Euro", instrument_type="Währung / Krypto"))
+    )
+
+    position = export.require_positions()[0]
+    assert position["asset_type"] is None
+    assert position["instrument_id"] == "USD_to_EUR"
+
+
 def test_missing_column_makes_the_export_unrecognisable():
     columns = [column for column in HOLDINGS_COLUMNS if column != "Anzahl"]
     row = _holding()


### PR DESCRIPTION
## Summary

- Adds a read-only reader for two of extraETF's four documented export surfaces: the **Investments** export becomes normalized positions, the **Transaktionen** export becomes movements. The other two documented surfaces (**Dividenden**, **Analyse → Holdings** / X-Ray) and the cash-transactions tab are refused by the same exact-header check, which names both known column sets and reports the diff against the nearer one. What is tested is the refusal *path*, using a header that matches neither set; the specific headers of those two surfaces are not in the samples, so they are refused by that mechanism rather than verified against their real headers — which is why those headers are requested in the thread.
- Fails closed on anything it cannot read without guessing. A row that cannot be aligned, a record folded across lines, unknown or missing columns, contradictory separators, unreadable numbers, numbers carrying more precision than the output can hold, empty required fields, corrupt text, one instrument listed twice under a single portfolio ID, and a movement whose transaction label or identifier is unreadable are all refused rather than skipped, so a bad row yields *no* positions instead of a short portfolio.
- No caller yet, by design — see "Deliberately out of scope".

Toward #1170. The reader is the half scoped to a contributor there; the container, aggregation and rebalancing surface stay with the maintainer.

The movements half is separable. The maintainer described the reader as "a normalized position list", which is the holdings export; this PR also parses the transactions export, because that is the file that answers his third question and it is the same reader and number grammar. If the positions half is wanted on its own, the transactions side drops out without touching the holdings path — say so and it becomes two PRs.

## Why

#1170 asked for an opt-in, read-only extraETF import. The maintainer split it: the provider-specific reader to the contributor, the portfolio container retained. This is that reader.

The export surface is documented, which is what the maintainer asked to confirm before code existed: [Daten exportieren: Transaktionen, Bestände und Dividenden als CSV](https://support.extraetf.com/hc/de/articles/28637399089436) names four export buttons — Investments, Transaktionen ("Wertpapier- **und Cash-Transaktionen**", as two tabs), Dividenden, and Analyse → Holdings. It also states that every export covers **all** portfolios, which makes the multi-`Portfolio ID` file in the samples the normal case rather than an aggregated edge case; every row is kept, with its `Portfolio ID` and `Portfolioname`, because merging two rows for one instrument is the outcome that is silently wrong in the direction that looks fine. V1 scope is the maintainer's list — symbol/ISIN, quantity, cost basis, currency, as-of — and each position carries all five.

The three questions the maintainer asked before code is written were answered in the issue thread from the anonymized samples, and the reader is built to those answers:

- **Identity is two shapes.** Securities carry an ISIN; crypto carries `BTC_to_EUR` in the holdings export and bare `BTC` with `Typ=Fremdwährung` in the transactions export. Resolving those onto one another is a container concern, so the reader reports the kind (`isin` / `crypto_pair` / `raw_symbol`) and the check-digit result rather than resolving.
- **There is no snapshot date.** The holdings export has no date column, so as-of is the file's mtime and is labelled `as_of_source="file_mtime"`. No position carries an observation time: `updated_at` is `None` and the mtime is reported as `source_mtime`, because a copy or a sync rewrites an mtime and it must never look like a fetch time.
- **Non-position rows are the trap.** A `Dividende` row carries its own non-zero `Anzahl` and `Preis`, so a reader that treats any row with a quantity as a holding invents one out of a dividend. Dividends and transfers become typed movements, and a transactions export can never be read as a portfolio at all.

## Changes

- `agent/src/portfolio/extraetf.py` — the reader. `read_export(path)` and `parse_export(text|bytes)`; payloads are private behind `require_positions()` / `require_movements()`, which refuse a mismatched export so a transactions file cannot masquerade as an empty portfolio.
- `agent/tests/test_extraetf_reader.py` — 79 tests over synthetic fixtures shaped after the anonymized samples in #1170.

Number parsing is German, and the rule is stated exactly rather than aspirationally: a comma is the decimal separator and a period may only be a thousands separator (`1.386,608` is 1386.608). US-ordered values (`1,234.56`) are refused because the German reading would be wrong by a thousandfold. A period-grouped value that is valid German (`1.900`) is read as German *by convention* — it could be 1.9 in a US-locale file and no parser can tell them apart. extraETF writes German, so German wins.

The emitted position uses the package's field names but deliberately does **not** route through `normalize_position`, because that stamps `updated_at` with the current time and defaults an unknown instrument class to `"stock"` — both fabrications a file import must not make. The three resulting divergences are commented in place.

## Test Plan

- [x] Existing tests pass — `pytest tests/ -q -k portfolio` → 117 passed, 5 skipped, 0 failed
- [x] New tests added — 79, one per fixed defect plus the format rules and the multi-portfolio case
- [x] Tested manually — verified against the four anonymized exports from #1170 (3 + 2 positions, 5 + 5 movements), and against a mutation fuzz of a 6-row export: 602 single-quote mutations produce zero accepted-but-wrong results
- [x] Single pass, linear: 28.6k rows/s stable from 100 to 50,000 rows (6 MB in 1.8s), and byte-identical output across repeated runs (the module reads no clock)
- [x] Every emitted value is a JSON primitive, so a position or movement survives the snapshot store without a converter
- [x] `ruff check` and `ruff format --check` clean, `tools/ci_grep_gates.sh` passes, and the module compiles under both matrix interpreters
- [x] Schema drift: renaming **or** dropping any of the 28 columns across the two formats is refused, and so is an extra column, so no field can silently degrade to `None` and no partial row set can be imported. A reordered header is accepted and does not mis-align values — name-based, not positional — which is the one form of drift that is not a format change
- [x] One instrument under two `Portfolio ID`s stays two positions with each row's portfolio context, which is the export's normal case ("Der Export umfasst jeweils alle Depots"). The test fails against a single-portfolio export, so it cannot pass by accident
- [x] **The full CI suite, run locally with CI's own command**: `pytest --ignore=agent/tests/e2e_backtest --ignore=agent/tests/test_e2e_harness_v2.py --tb=short -q` → **12,890 passed, 34 skipped, 6 failed** in 283s. All six failures are the README agent-tool-count assertions described below, and nothing else in the suite is touched by this change
- [x] Python 3.11.15 and 3.14.5 — the CI matrix legs — each run this file's tests green (`uv venv --python 3.11|3.14` + `pytest agent/tests/test_extraetf_reader.py`)

One failure mode is worth naming so it is not attributed here. `tests/test_readme_counts.py::test_repo_tree_states_the_real_agent_tool_count` fails for all six READMEs on this machine (the tree line documents 107 agent tools; this environment registers 108). It is environment-dependent by construction: the test counts `build_registry().tool_names` in a child interpreter, and tool discovery imports every module under `src/tools/` and skips the ones that fail, so an optional dependency present here and not in CI's install set is worth exactly one tool. The evidence that this is the environment and not the tree is that **CI is green at this branch's base commit** `f9cb061b`, where the same assertion is in the same run (`CI` and `Desktop Windows` both `success`). This change adds no tool — it adds a module under `src/portfolio/` — so the count is identical before and after it, and the assertion is left alone rather than papered over.

## Checklist

- [x] No changes to protected areas — the change is confined to `agent/src/portfolio/` and its tests
- [x] No hardcoded values — no paths, keys or clock. The only constants are the wire precision (`0.00000001`, matching `normalize_position`) and the format's own shape rules; there is no staleness or tolerance threshold, since those are policy
- [x] Code follows CONTRIBUTING.md — commits carry `Signed-off-by`; fixtures are synthetic, no real portfolio data
- [x] Documentation — no user-facing surface is added (no CLI, Web, MCP or connector registration), so no README change. Wiring it up will need one.

## Deliberately out of scope

- **The container.** No source-kind hook, no settings entry, no Web surface, and no change to `normalize_position`. The maintainer retained that half; #1171 proposed it, was closed on 2026-09-06, and its remaining scope — the non-connector source kind and identity beyond ticker+market — was moved into #1170 "which is the only concrete consumer of it". This PR assumes no shape for it, which is what #1171 asked for by scoping #1170 to "a provider-specific reader precisely so it does not settle the questions above".
- **Rebalancing.** No proposal generation and no order path. The module cannot reach either: its imports are stdlib only, enforced by a test.
- **Identity resolution across the two exports.** `BTC_to_EUR` and `BTC` stay two reported shapes.

## Known limits and risk

- **EUR.** Every sample export is EUR-denominated and the valuation core supports USD, HKD and CNY, so `ensure_supported_currencies` refuses EUR and a container cannot value these rows today. Nothing here works around that; it needs a decision, which is why it is in the issue thread as well.
- **A file truncated exactly at a record boundary is undetectable.** The format carries no row count or footer, so a 5-of-6-row file is indistinguishable from a 5-row portfolio. Documented in the module, and a caller that knows the expected count is the only thing that can catch it.
- **An empty export is accepted as an empty portfolio**, deliberately: "never recorded", "unreadable" and "empty but valid" are different states and collapsing them would lose one.
- **No consumer.** This adds a module nothing calls yet.
- **File length.** The reader is 933 lines and its tests 875, over this repo's documented 800-line cap — they were 785 and 711 when the maintainers read them, and the strictness the review asked for is most of the difference. `service.py` on main is already 1004, so the cap is not enforced in practice. The files have not been split because a structural change mid-review would invalidate the two full reads already done, for no correctness gain; the seams are clean (the German number grammar and the identity grammar are each self-contained) if it is ever wanted.
- **Two of the four documented exports are out of scope.** The Dividenden export and the Analyse → Holdings (X-Ray) view each have their own column set and are refused: the refusal names both known column sets and reports the missing and unexpected columns against the nearer of them (`Transaktion` present selects the transactions set), so an unrecognised export fails loudly rather than being partially imported. The *mechanism* is tested with a header matching neither set; those two surfaces' real headers are not in the samples, so they are refused by construction rather than by a test of their own headers. The X-Ray view is the one worth revisiting first: it is the look-through decomposition, so it is the input that would change an allocation rather than restate it.
- **Risk:** read-only and inert. No network, no credentials, no writes, no order path. **Rollback:** delete the two new files; nothing else references them.

## Review history

Reviewed adversarially in two rounds by three independent reviewers per round, which found 13 real defects, all fixed on this branch. Two were capable of producing a plausible wrong portfolio: a stray quote folded two CSV lines into one record (a 4-position file became 3, with one instrument's quantity and value grafted onto another's identity — 40 of 4000 single-quote mutations), and `.upper()` used as an ISIN shape predicate fabricated 12-character ISINs out of 11-character inputs (`aß000000001` → `ASS000000001`, which also passed the check digit).

**Third round — maintainer review (2026-09-11).** `warren618` read it against #1170's fail-closed rule and found three paths that still accepted bad input silently, all fixed on this branch: a repeated `(Portfolio ID, instrument)` was imported twice (now refused, naming both rows, while one instrument under two different Portfolio IDs stays two positions); an unknown `Transaktion` was carried through with `movement_kind=None` and a blank `ISIN` produced `instrument_id=None` (both now refused, with the five documented labels and the bare-symbol crypto transactions shape still reading); and the number probe's quantization result was discarded, so `0,000000004` became an empty position and a ninth decimal place was silently rounded (the quantized value is now compared against the original, and any difference is refused). His smaller points are in as well: `Währung / Krypto` no longer implies `asset_type="crypto"`, since it covers FX pairs like `USD_to_EUR` too; the export-level field is `source_mtime` rather than `as_of`, so a file's mtime cannot be read as a snapshot date; and the header refusal names both known column sets. On scope, the two maintainers differed — `warren618` offered to take the movements half out of this PR, while `he-yufeng` approved it in place and said no split is needed — so it stays, with the unknown-label and identity checks making it strict enough to be worth keeping.

**Fourth round — adversarial pass over the fixes themselves (2026-09-11).** Attacking the fixes rather than the reviewer's examples found eight more, all fixed on this branch: the thousands-grouping rule never checked the leading group, so `1234.567` — a US decimal — was read as `1234567`, a thousandfold misread one function from the one the maintainer had just flagged; a movement's `ISIN` bypassed the corruption check every other text column gets, so a symbol carrying NUL/DEL/C1 was emitted verbatim as an instrument identity; duplicate detection compared identifiers case-sensitively while the pair shape is matched case-insensitively, so `BTC_to_EUR` and `btc_to_eur` under one portfolio ID were two positions that double-count; the control-character rule covered only C0, so DEL and C1 passed; the quantization probe still allowed a value to change magnitude in `float()`; provenance could contradict itself (a timestamp with an `unavailable` origin); and two items were drift from the `as_of` rename. Tests 61 → 79, including precision pinned in every numeric column of both formats rather than only in `Anzahl`.
