### PR TITLE
fix(loader): paginate tencent history backward — the API serves the LAST 500 bars per window

### DIFF
--- a/agent/backtest/loaders/base.py
+++ b/agent/backtest/loaders/base.py
@@ -330,7 +330,9 @@ _LOADER_CACHE_TRUE_VALUES = {"1", "true", "yes", "on"}
 # v5: UK (.L) prices normalized from GBp to GBP (÷100) (#1206).
 # v6: LSE quote currency is fail-closed and per-symbol conversion provenance is
 # persisted. v5 USD/unknown .L entries must never be served as static GBP.
-_LOADER_CACHE_VERSION = 6
+# v7: tencent fqkline paginates backward (#1410) — entries cached under the
+# forward walk hold tail-truncated multi-year series and must never be served.
+_LOADER_CACHE_VERSION = 7
 _LOADER_FRAME_METADATA_ATTRS = ("quote_currency", "currency_conversion")
 
 

--- a/agent/backtest/loaders/tencent_loader.py
+++ b/agent/backtest/loaders/tencent_loader.py
@@ -143,6 +143,11 @@ class DataLoader:
 
         data = json.loads(raw)
         # Response: {"code":0,"data":{"sh601595":{"day":[["2026-06-01","21.32",...], ...]}}}
+        if data.get("code") not in (0, None) and not data.get("data"):
+            # An error-shaped reply is a failure, not an empty window: None
+            # here would let a throttled reply end the walk mid-pagination
+            # and serve (and cache) a truncated series as complete history.
+            raise ValueError(f"tencent fqkline error reply: code={data.get('code')}")
         stock_data = data.get("data", {})
         if not stock_data:
             return None
@@ -234,7 +239,22 @@ class DataLoader:
                 ) from last_error
 
             if page is None or page.empty:
-                break
+                if not chunks:
+                    break
+                # A mid-walk empty page is ambiguous: the genuine start of
+                # history, or a throttled reply. One re-request decides — a
+                # transient glitch returns data, a genuine boundary stays
+                # empty and terminates the walk.
+                time.sleep(_PAGE_BACKOFF)
+                try:
+                    page = self._request_page(code, start_date, cursor_end)
+                except Exception as exc:  # noqa: BLE001 - transient network jitter
+                    raise ValueError(
+                        f"incomplete tencent history: {code} re-request at "
+                        f"{cursor_end} failed: {exc}"
+                    ) from exc
+                if page is None or page.empty:
+                    break
             chunks.append(page)
 
             # A short page means the walk reached start_date.

--- a/agent/backtest/loaders/tencent_loader.py
+++ b/agent/backtest/loaders/tencent_loader.py
@@ -27,9 +27,13 @@ logger = logging.getLogger(__name__)
 
 _BASE_URL = "https://web.ifzq.gtimg.cn/appstock/app/fqkline/get"
 
-# Tencent fqkline caps a single response at `_PAGE_SIZE` bars.  Requests for a
-# multi-year window (e.g. 2018-2025 daily) silently truncate at 500 bars
-# (roughly the first 2 years) unless we paginate by advancing the start date.
+# Tencent fqkline caps a single response at `_PAGE_SIZE` bars and serves the
+# LAST bars of the requested window (ending at the `end` parameter), not the
+# first — verified empirically 2026-09-11: a 2018-01-01..2026-06-30 request
+# returned 500 bars spanning 2024-06-06..2026-06-30, while a window holding
+# fewer than 500 trading days was served in full from its start (the start
+# clamp is honoured).  Multi-year windows therefore paginate BACKWARD: see
+# `_fetch_one`.
 _PAGE_SIZE = 500
 # 12 pages * 500 bars = 6000 bars ≈ 24 trading years; a hard cap also guards
 # against pathological loop behavior if the API ever stops advancing.
@@ -183,28 +187,37 @@ class DataLoader:
         """Paginate [start_date, end_date] in `_PAGE_SIZE`-bar windows.
 
         The Tencent API returns at most 500 bars per request regardless of the
-        requested window, so a multi-year range is silently truncated unless we
-        advance the start date by one day past the last bar of each page. A
-        window this loader cannot serve in full raises instead of returning a
+        requested window, and those are the LAST bars ending at the requested
+        end date (see the `_PAGE_SIZE` comment for the verified semantics).
+        Pagination therefore walks BACKWARD: start_date stays fixed and the end
+        cursor moves to the day before each page's oldest bar, until a short
+        page (< `_PAGE_SIZE`) or an exhausted cursor signals the window is
+        served in full. Walking forward instead — advancing the start cursor
+        past each page's newest bar — silently degrades any window longer than
+        one page to its most recent ~500 bars: the first response already ends
+        at end_date, the advanced cursor steps past the window, the next page
+        is empty, and the loop exits cleanly with a tail-only series.
+
+        A window this loader cannot serve in full raises instead of returning a
         quietly short series, matching the other bounded-window loaders.
         """
         chunks: List[pd.DataFrame] = []
-        cursor = start_date
-        seen_starts: set[str] = set()
+        cursor_end = end_date
+        seen_ends: set[str] = set()
 
         for _ in range(_MAX_PAGES):
-            if cursor in seen_starts:
+            if cursor_end in seen_ends:
                 raise ValueError(
                     f"incomplete tencent history: {code} stopped advancing at "
-                    f"{cursor} before reaching {end_date}"
+                    f"{cursor_end} before reaching {start_date}"
                 )
-            seen_starts.add(cursor)
+            seen_ends.add(cursor_end)
 
             page: Optional[pd.DataFrame] = None
             last_error: Optional[Exception] = None
             for attempt in range(_PAGE_RETRIES):
                 try:
-                    page = self._request_page(code, cursor, end_date)
+                    page = self._request_page(code, start_date, cursor_end)
                     last_error = None
                     break
                 except Exception as exc:  # noqa: BLE001 - transient network jitter
@@ -215,26 +228,27 @@ class DataLoader:
                 # Partial pages already collected would read as a complete
                 # history downstream; a failed page is an error, not a series.
                 raise ValueError(
-                    f"incomplete tencent history: {code} page at {cursor} failed "
-                    f"after {_PAGE_RETRIES} attempts: {last_error}"
+                    f"incomplete tencent history: {code} page ending at "
+                    f"{cursor_end} failed after {_PAGE_RETRIES} attempts: "
+                    f"{last_error}"
                 ) from last_error
 
             if page is None or page.empty:
                 break
             chunks.append(page)
 
-            # A short page means the window is exhausted.
+            # A short page means the walk reached start_date.
             if len(page) < _PAGE_SIZE:
                 break
-            last = page.index.max()
-            next_start = (last + pd.Timedelta(days=1)).strftime("%Y-%m-%d")
-            if next_start > end_date:
+            first = page.index.min()
+            next_end = (first - pd.Timedelta(days=1)).strftime("%Y-%m-%d")
+            if next_end < start_date:
                 break
-            cursor = next_start
+            cursor_end = next_end
         else:
             raise ValueError(
                 f"incomplete tencent history: {code} hit {_MAX_PAGES} pages "
-                f"without reaching {end_date}"
+                f"without reaching {start_date}"
             )
 
         if not chunks:

--- a/agent/tests/test_tencent_loader.py
+++ b/agent/tests/test_tencent_loader.py
@@ -280,3 +280,63 @@ def test_a_bar_on_the_end_date_itself_is_not_dropped(monkeypatch) -> None:
 
     assert df.index.max() == history.index.max()
     assert len(df) == tencent_loader._PAGE_SIZE + 1
+
+
+def test_error_shaped_reply_raises_instead_of_returning_none(monkeypatch) -> None:
+    """A non-zero-code reply with no payload is a failure, not an empty window."""
+    loader = tencent_loader.DataLoader()
+    payload = json.dumps({"code": 1, "msg": "rate limit"})
+
+    def fake_urlopen(req, timeout=None, **kwargs):  # noqa: ANN001, ANN002
+        return _FakeResponse(payload)
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(ValueError, match="error reply"):
+        loader._request_page("600519.SH", "2024-01-01", "2024-06-30")
+
+
+def test_midwalk_empty_page_is_rerequested_before_truncating(monkeypatch) -> None:
+    """A glitched empty mid-walk must not end the walk: one re-request decides."""
+    loader = tencent_loader.DataLoader()
+    history = _history("2020-01-01", tencent_loader._PAGE_SIZE + 10)
+    calls = {"n": 0}
+    sleeps: list[float] = []
+    monkeypatch.setattr(tencent_loader.time, "sleep", sleeps.append)
+
+    def fake_page(code, start, end):  # noqa: ANN001
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return history.iloc[-tencent_loader._PAGE_SIZE:]
+        if calls["n"] == 2:
+            return None
+        return history.iloc[: -tencent_loader._PAGE_SIZE]
+
+    monkeypatch.setattr(loader, "_request_page", fake_page)
+    df = loader._fetch_one("600519.SH", "2020-01-01", "2026-12-31")
+
+    assert calls["n"] == 3
+    assert len(df) == tencent_loader._PAGE_SIZE + 10
+    assert df.index.is_monotonic_increasing
+    assert sleeps == [tencent_loader._PAGE_BACKOFF]
+
+
+def test_midwalk_empty_page_that_persists_ends_the_walk(monkeypatch) -> None:
+    """A genuine data start (e.g. a pre-IPO window) stays empty on re-request."""
+    loader = tencent_loader.DataLoader()
+    history = _history("2020-01-01", tencent_loader._PAGE_SIZE)
+    calls = {"n": 0}
+    sleeps: list[float] = []
+    monkeypatch.setattr(tencent_loader.time, "sleep", sleeps.append)
+
+    def fake_page(code, start, end):  # noqa: ANN001
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return history.iloc[-tencent_loader._PAGE_SIZE:]
+        return None
+
+    monkeypatch.setattr(loader, "_request_page", fake_page)
+    df = loader._fetch_one("600519.SH", "2019-01-01", "2026-12-31")
+
+    assert calls["n"] == 3
+    assert len(df) == tencent_loader._PAGE_SIZE

--- a/agent/tests/test_tencent_loader.py
+++ b/agent/tests/test_tencent_loader.py
@@ -135,42 +135,87 @@ def _daily_page(dates: list[str]) -> pd.DataFrame:
     )
 
 
-def _full_page(start: str) -> pd.DataFrame:
-    """A page of exactly _PAGE_SIZE bars, i.e. one the API truncated."""
-    dates = pd.date_range(start, periods=tencent_loader._PAGE_SIZE, freq="D")
+def _history(start: str, n_days: int) -> pd.DataFrame:
+    """A synthetic daily history of `n_days` consecutive calendar days."""
+    dates = pd.date_range(start, periods=n_days, freq="D")
     return _daily_page([d.strftime("%Y-%m-%d") for d in dates])
 
 
-def test_pagination_walks_past_the_500_bar_cap(monkeypatch) -> None:
-    """A multi-year window must not stop at the API's per-response cap."""
-    loader = tencent_loader.DataLoader()
-    requested: list[str] = []
+def _last500_api(history: pd.DataFrame, requested_ends: list[str] | None = None):
+    """Fake `_request_page` honouring the REAL Tencent fqkline contract.
+
+    The API serves the LAST ≤_PAGE_SIZE bars of [start, end], not the first
+    (verified live 2026-09-11). The previous mocks in this file encoded the
+    opposite first-500 assumption, which is why tail truncation passed CI.
+    """
 
     def fake_page(code, start, end):  # noqa: ANN001
-        requested.append(start)
-        if len(requested) == 1:
-            return _full_page("2020-01-01")
-        return _daily_page(["2021-06-01", "2021-06-02"])
+        if requested_ends is not None:
+            requested_ends.append(end)
+        window = history.loc[
+            (history.index >= pd.Timestamp(start))
+            & (history.index <= pd.Timestamp(end))
+        ]
+        return window.iloc[-tencent_loader._PAGE_SIZE:]
 
-    monkeypatch.setattr(loader, "_request_page", fake_page)
+    return fake_page
+
+
+def test_multiyear_window_is_served_in_full(monkeypatch) -> None:
+    """Regression: a >500-bar window must not degrade to its most recent 500.
+
+    Under the real last-500 semantics, forward pagination (advancing the
+    start cursor) exits after one page holding only the window's tail. The
+    backward walk must serve every bar from start_date through end_date.
+    """
+    loader = tencent_loader.DataLoader()
+    history = _history("2018-01-01", 1500)
+    end_date = history.index.max().strftime("%Y-%m-%d")
+    ends: list[str] = []
+    monkeypatch.setattr(loader, "_request_page", _last500_api(history, ends))
+
+    df = loader._fetch_one("600519.SH", "2018-01-01", end_date)
+
+    assert len(df) == 1500
+    assert df.index.min() == pd.Timestamp("2018-01-01")
+    assert df.index.max() == history.index.max()
+    assert df.index.is_monotonic_increasing
+    assert len(ends) == 3
+    assert ends[0] == end_date
+    assert ends[1] < ends[0]
+    assert ends[2] < ends[1]
+
+
+def test_pagination_moves_the_end_cursor_behind_each_page(monkeypatch) -> None:
+    """Next request's end = the day before the current page's oldest bar."""
+    loader = tencent_loader.DataLoader()
+    history = _history("2020-01-01", tencent_loader._PAGE_SIZE + 2)
+    ends: list[str] = []
+    monkeypatch.setattr(loader, "_request_page", _last500_api(history, ends))
+
     df = loader._fetch_one("600519.SH", "2020-01-01", "2021-12-31")
 
-    assert len(requested) == 2
-    # The second page resumes the day after the first page's last bar.
-    assert requested[1] == "2021-05-15"
     assert len(df) == tencent_loader._PAGE_SIZE + 2
-    assert df.index.is_monotonic_increasing
+    first_page_oldest = history.index[-tencent_loader._PAGE_SIZE]
+    expected_next_end = first_page_oldest - pd.Timedelta(days=1)
+    assert ends[1] == expected_next_end.strftime("%Y-%m-%d")
 
 
 def test_overlapping_pages_are_deduplicated(monkeypatch) -> None:
     """Rows repeated across pages must collapse, not double-count."""
     loader = tencent_loader.DataLoader()
-    pages = [_full_page("2020-01-01"), _daily_page(["2021-05-14", "2021-05-15"])]
+    history = _history("2020-01-01", tencent_loader._PAGE_SIZE)
+    calls = {"n": 0}
 
-    monkeypatch.setattr(
-        loader, "_request_page", lambda code, start, end: pages.pop(0),
-    )
-    df = loader._fetch_one("600519.SH", "2020-01-01", "2021-12-31")
+    def fake_page(code, start, end):  # noqa: ANN001
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return history.iloc[-tencent_loader._PAGE_SIZE:]
+        older = _daily_page(["2019-12-31"])
+        return pd.concat([older, history.iloc[:2]])
+
+    monkeypatch.setattr(loader, "_request_page", fake_page)
+    df = loader._fetch_one("600519.SH", "2019-12-01", "2021-12-31")
 
     assert df.index.duplicated().sum() == 0
     assert len(df) == tencent_loader._PAGE_SIZE + 1
@@ -179,16 +224,11 @@ def test_overlapping_pages_are_deduplicated(monkeypatch) -> None:
 def test_exhausting_the_page_cap_raises_instead_of_truncating(monkeypatch) -> None:
     """Hitting _MAX_PAGES must fail loudly, like the other bounded loaders."""
     loader = tencent_loader.DataLoader()
-    starts = ["2000-01-01"]
+    endless = _history("1990-01-01", 20000)
+    monkeypatch.setattr(loader, "_request_page", _last500_api(endless))
 
-    def fake_page(code, start, end):  # noqa: ANN001
-        page = _full_page(start)
-        starts.append(start)
-        return page
-
-    monkeypatch.setattr(loader, "_request_page", fake_page)
     with pytest.raises(ValueError, match="incomplete tencent history"):
-        loader._fetch_one("600519.SH", "2000-01-01", "2026-12-31")
+        loader._fetch_one("600519.SH", "1990-01-01", "2026-12-31")
 
 
 def test_a_failed_page_raises_instead_of_returning_partial_history(
@@ -196,13 +236,14 @@ def test_a_failed_page_raises_instead_of_returning_partial_history(
 ) -> None:
     """A network failure mid-walk must not read downstream as a short series."""
     loader = tencent_loader.DataLoader()
+    history = _history("2020-01-01", tencent_loader._PAGE_SIZE + 10)
     calls = {"n": 0}
     sleeps: list[float] = []
 
     def fake_page(code, start, end):  # noqa: ANN001
         calls["n"] += 1
         if calls["n"] == 1:
-            return _full_page("2020-01-01")
+            return history.iloc[-tencent_loader._PAGE_SIZE:]
         raise OSError("connection reset")
 
     monkeypatch.setattr(loader, "_request_page", fake_page)
@@ -218,36 +259,24 @@ def test_a_failed_page_raises_instead_of_returning_partial_history(
 def test_a_short_page_ends_the_walk(monkeypatch) -> None:
     """A page below the cap means the window is served; stop requesting."""
     loader = tencent_loader.DataLoader()
-    calls: list[str] = []
+    history = _history("2026-01-05", 2)
+    ends: list[str] = []
+    monkeypatch.setattr(loader, "_request_page", _last500_api(history, ends))
 
-    def fake_page(code, start, end):  # noqa: ANN001
-        calls.append(start)
-        return _daily_page(["2026-01-05", "2026-01-06"])
-
-    monkeypatch.setattr(loader, "_request_page", fake_page)
     df = loader._fetch_one("600519.SH", "2026-01-01", "2026-01-31")
 
-    assert calls == ["2026-01-01"]
+    assert ends == ["2026-01-31"]
     assert len(df) == 2
 
 
 def test_a_bar_on_the_end_date_itself_is_not_dropped(monkeypatch) -> None:
-    """When the next start lands exactly on end_date, that day still counts."""
+    """A bar dated exactly end_date must be part of the served series."""
     loader = tencent_loader.DataLoader()
-    first = _full_page("2020-01-01")
-    boundary = first.index.max() + pd.Timedelta(days=1)
-    end_date = boundary.strftime("%Y-%m-%d")
-    requested: list[str] = []
+    history = _history("2020-01-01", tencent_loader._PAGE_SIZE + 1)
+    end_date = history.index.max().strftime("%Y-%m-%d")
+    monkeypatch.setattr(loader, "_request_page", _last500_api(history))
 
-    def fake_page(code, start, end):  # noqa: ANN001
-        requested.append(start)
-        if len(requested) == 1:
-            return first
-        return _daily_page([end_date])
-
-    monkeypatch.setattr(loader, "_request_page", fake_page)
     df = loader._fetch_one("600519.SH", "2020-01-01", end_date)
 
-    assert requested == ["2020-01-01", end_date]
+    assert df.index.max() == history.index.max()
     assert len(df) == tencent_loader._PAGE_SIZE + 1
-    assert df.index.max() == boundary


### PR DESCRIPTION
## Summary

- Fix the Tencent loader's pagination direction: the fqkline API serves the **last** ≤500 bars of a requested window (ending at the `end` param), not the first — so pagination must walk **backward** from `end_date`. The forward walk added in #1154 silently degrades any multi-year window to its most recent ~500 bars (~2 years) with exit code 0 and no warning.
- Rewrite the pagination tests to mock the **real** last-500 API semantics (the previous mocks encoded the first-500 assumption, which is why the truncation passed CI) and add a multi-year regression test.
- Second commit (self-review follow-up): bump `_LOADER_CACHE_VERSION` 6 → 7 so entries cached by the forward walk during the bug window are never served again, and harden the two paths where a throttled-but-HTTP-200 reply could still truncate a walk silently.

## Why

Closes #1410. Field impact observed during a strategy-validation campaign: two independent backtest runs (A-share index 2015–2026; ETF panel 2018–2026) came back as exactly ~500-bar tail windows — one surfaced as a bogus `trade_count=5` (warmup ate the truncated window), the other as per-symbol files of exactly 500 rows. Both runs reported success (`exit_code 0`, `warnings: []`); only an equity-row-count check against the expected trading-day count caught them. #1154's intent (no silent truncation) regressed because its regression tests mocked the assumed rather than the actual API behavior.

Live verification of the real semantics (no auth, reproducible from any host):

```
param=sh000300,day,2018-01-01,2026-06-30,500,qfq → 500 bars, 2024-06-06 .. 2026-06-30   (LAST-500)
param=sh000300,day,2024-01-01,2024-06-30,500,qfq → 117 bars, 2024-01-02 .. 2024-06-28   (start clamp honoured)
```

## Changes

- `agent/backtest/loaders/tencent_loader.py`
  - `_fetch_one`: backward walk — `start_date` stays fixed; the end cursor moves to the day before each page's oldest bar; stop on a short page (`< _PAGE_SIZE`) or when the cursor passes `start_date`. Page-cap exhaustion (`_MAX_PAGES`) and failed pages still raise `incomplete tencent history` instead of truncating; stall guard kept; dedup/concat unchanged.
  - `_PAGE_SIZE` comment and `_fetch_one` docstring now record the verified API semantics (with probe date) and why forward walking fails — so the direction doesn't get "fixed" back.
- `agent/tests/test_tencent_loader.py`
  - New `_last500_api` fake honoring the real contract (last ≤500 bars of `[start, end]`, start clamp honoured).
  - New `test_multiyear_window_is_served_in_full` regression (1500-bar window: full coverage, 3 pages, end cursor strictly decreasing).
  - New `test_pagination_moves_the_end_cursor_behind_each_page` (cursor = oldest bar − 1 day).
  - Adapted the dedup / page-cap-raise / failed-page-raise / short-page-stop / end-date-bar tests to the backward walk. HK-mapping and intraday-rejection tests untouched.
- Second commit (review follow-up — protects the same "complete window or loud failure" guarantee):
  - `agent/backtest/loaders/base.py`: `_LOADER_CACHE_VERSION` 6 → 7. The opt-in loader cache is content-addressed on `(source, symbol, timeframe, start, end)` with no TTL, so entries written by the forward walk during the bug window (#1154, 2026-08-20, onward) hold tail-truncated series that would keep being served after this fix. Follows the v4/v5/v6 bump precedent for cached-semantics changes.
  - `agent/backtest/loaders/tencent_loader.py`: `_request_page` raises on an error-shaped reply (non-zero `code`, no payload) so it enters the page retry budget instead of reading as an empty window; `_fetch_one` re-requests a mid-walk empty page once before accepting it as the genuine start of history (a transient glitch returns data; a genuine boundary — e.g. a pre-IPO window — stays empty and terminates the walk).
  - `agent/tests/test_tencent_loader.py`: 3 new tests pin all three behaviors (error-reply raise, mid-walk re-request continues, persistent-empty terminates).

## Test Plan

- [x] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [x] New tests added (if applicable)
- [x] Tested manually (describe below)

Full-suite result on this branch (after the second commit): **12791 passed, 5 failed, 84 skipped** (4m21s). The 5 failures (`test_anthropic_prompt_cache`, `test_llm_reasoning_effort` ×3, `test_provider_header_isolation`) are **pre-existing and unrelated** — verified by running the same tests on a clean `origin/main` (f9cb061b) checkout in my environment: identical 5 failures (litellm adapter version drift). Loader-adjacent suites all green: `test_tencent_loader.py` (13) + `test_volume_unit_consistency.py` + `test_loader_volume_units.py` → 28 passed; loader-cache suites → 8 passed, 5 skipped (no test pins the version constant).

Live smoke against the real API with the fix applied:

```python
DataLoader()._fetch_one("000300.SH", "2018-01-01", "2026-06-30")
# before: 500 bars, 2024-06-06 .. 2026-06-30
# after:  2058 bars, 2018-01-02 .. 2026-06-30  ✓
```

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Documentation updated (if user-facing change)

