### PR TITLE
fix(tools): record state.json from the backtest tool so tool-driven runs are ingestible as evidence

### DIFF
--- a/agent/src/tools/backtest_tool.py
+++ b/agent/src/tools/backtest_tool.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 
 from backtest.loaders.registry import VALID_SOURCES
@@ -56,12 +57,24 @@ def run_backtest(run_dir: str) -> str:
         message=f"running backtest engine (source={source})",
     )
     runner = Runner(timeout=300)
-    result = runner.execute(
-        entry_script,
-        run_path,
-        cwd=agent_root,
-        cli_args=[str(run_path)],
-    )
+    try:
+        result = runner.execute(
+            entry_script,
+            run_path,
+            cwd=agent_root,
+            cli_args=[str(run_path)],
+        )
+    except subprocess.TimeoutExpired:
+        # The lifecycle block below is unreachable on a timeout, so record the
+        # failure here — otherwise the run is indistinguishable from never-run
+        # (the evidence gate fail-closes either way, but the reason is lost).
+        reason = f"backtest engine timed out after {runner.timeout}s"
+        RunStateStore().mark_failure(run_path, reason)
+        return json.dumps({
+            "status": "error",
+            "error": reason,
+            "run_dir": run_dir,
+        }, ensure_ascii=False)
 
     # Record lifecycle status so tool-driven runs are ingestible by the
     # evidence pipeline: refresh_strategy_evidence fail-closes without

--- a/agent/src/tools/backtest_tool.py
+++ b/agent/src/tools/backtest_tool.py
@@ -9,6 +9,7 @@ from backtest.loaders.registry import VALID_SOURCES
 from src.agent.progress import emit_progress
 from src.agent.tools import BaseTool
 from src.core.runner import Runner
+from src.core.state import RunStateStore
 from src.tools.path_utils import safe_run_dir
 
 
@@ -61,6 +62,16 @@ def run_backtest(run_dir: str) -> str:
         cwd=agent_root,
         cli_args=[str(run_path)],
     )
+
+    # Record lifecycle status so tool-driven runs are ingestible by the
+    # evidence pipeline: refresh_strategy_evidence fail-closes without
+    # state.json, which previously only the runtime loop wrote (#1412).
+    # Same contract as the runtime — success, or failure with a reason.
+    state_store = RunStateStore()
+    if result.success:
+        state_store.mark_success(run_path)
+    else:
+        state_store.mark_failure(run_path, f"backtest engine exited with code {result.exit_code}")
 
     emit_progress("finalize", message="collecting artifacts")
     artifacts_found = {name: str(path) for name, path in result.artifacts.items()}

--- a/agent/tests/test_backtest_tool_state.py
+++ b/agent/tests/test_backtest_tool_state.py
@@ -1,0 +1,69 @@
+"""The backtest tool must record state.json so evidence ingestion can tell run status.
+
+refresh_strategy_evidence fail-closes on runs without state.json, which used to
+be written only by the runtime loop — so every tool-driven run was rejected as
+unknown-provenance despite complete artifacts (#1412). These tests pin the
+tool-side lifecycle recording: success and failure after an engine execution,
+and no state file when validation rejects the run before the engine starts.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.tools.backtest_tool import run_backtest
+
+
+@dataclass
+class _FakeRunResult:
+    success: bool
+    exit_code: int
+    stdout: str = ""
+    stderr: str = ""
+    artifacts: dict = field(default_factory=dict)
+
+
+@pytest.fixture()
+def tool_run_dir(tmp_path, monkeypatch) -> Path:
+    monkeypatch.setenv("VIBE_TRADING_ALLOWED_RUN_ROOTS", str(tmp_path))
+    run_dir = tmp_path / "run"
+    (run_dir / "code").mkdir(parents=True)
+    (run_dir / "config.json").write_text(json.dumps({"source": "yfinance"}), encoding="utf-8")
+    (run_dir / "code" / "signal_engine.py").write_text("", encoding="utf-8")
+    return run_dir
+
+
+def _run_with_result(run_dir: Path, result: _FakeRunResult) -> dict:
+    with patch("src.tools.backtest_tool.emit_progress"), patch("src.tools.backtest_tool.Runner") as runner_cls:
+        runner_cls.return_value.execute.return_value = result
+        return json.loads(run_backtest(str(run_dir)))
+
+
+def test_successful_run_records_state_success(tool_run_dir):
+    envelope = _run_with_result(tool_run_dir, _FakeRunResult(success=True, exit_code=0))
+
+    assert envelope["status"] == "ok"
+    state = json.loads((tool_run_dir / "state.json").read_text(encoding="utf-8"))
+    assert state == {"status": "success"}
+
+
+def test_failed_run_records_state_failed_with_exit_code(tool_run_dir):
+    envelope = _run_with_result(tool_run_dir, _FakeRunResult(success=False, exit_code=3, stderr="boom"))
+
+    assert envelope["status"] == "error"
+    state = json.loads((tool_run_dir / "state.json").read_text(encoding="utf-8"))
+    assert state == {"status": "failed", "reason": "backtest engine exited with code 3"}
+
+
+def test_validation_error_records_no_state(tool_run_dir):
+    (tool_run_dir / "config.json").unlink()
+
+    envelope = json.loads(run_backtest(str(tool_run_dir)))
+
+    assert envelope["status"] == "error"
+    assert not (tool_run_dir / "state.json").exists()

--- a/agent/tests/test_backtest_tool_state.py
+++ b/agent/tests/test_backtest_tool_state.py
@@ -10,6 +10,7 @@ and no state file when validation rejects the run before the engine starts.
 from __future__ import annotations
 
 import json
+import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 from unittest.mock import patch
@@ -67,3 +68,15 @@ def test_validation_error_records_no_state(tool_run_dir):
 
     assert envelope["status"] == "error"
     assert not (tool_run_dir / "state.json").exists()
+
+
+def test_timeout_records_state_failed_and_returns_error_envelope(tool_run_dir):
+    with patch("src.tools.backtest_tool.emit_progress"), patch("src.tools.backtest_tool.Runner") as runner_cls:
+        runner_cls.return_value.timeout = 300
+        runner_cls.return_value.execute.side_effect = subprocess.TimeoutExpired(cmd="runner.py", timeout=300)
+        envelope = json.loads(run_backtest(str(tool_run_dir)))
+
+    assert envelope["status"] == "error"
+    assert envelope["error"] == "backtest engine timed out after 300s"
+    state = json.loads((tool_run_dir / "state.json").read_text(encoding="utf-8"))
+    assert state == {"status": "failed", "reason": "backtest engine timed out after 300s"}


### PR DESCRIPTION
## Summary

- The `backtest` tool now records `state.json` (via the existing `RunStateStore.mark_success` / `mark_failure`) right after engine execution, so tool-driven runs are no longer rejected as unknown-provenance by `refresh_strategy_evidence`.
- New tests pin all four lifecycle paths: success, engine failure (with reason), engine timeout (with reason), and validation error (no state file — the engine never ran).
- Second commit (self-review follow-up): a timed-out engine (`subprocess.TimeoutExpired` propagated out of `Runner.execute`) previously bypassed the lifecycle block entirely — now it is caught, recorded as `failed` with a timeout reason, and answered with a clean error envelope.

## Why

Closes #1412. The evidence-ingestion gate (`run_artifacts.read_run_status`) fail-closes without `state.json`, and only the runtime loop wrote that file — so **every run produced by the `backtest` MCP tool was rejected** despite complete, hash-manifested artifacts: `hard-gate:exit-nonzero: state.json missing or unreadable (run status unknown)`. Observed at scale during a strategy-validation campaign: 11/11 healthy tool-driven runs skipped, recoverable only by hand-deriving `state.json` from run cards (workaround disclosed in the issue). The evidence pipeline and the project's primary backtest entry point were disconnected.

Of the two directions discussed in the issue, this PR implements the source-side fix: the tool already knows the outcome (`result.success` / `result.exit_code`), and reusing `RunStateStore` keeps one writer and one format contract for `state.json`. The ingestion gate is untouched and stays fail-closed for runs whose status was never recorded.

## Changes

- `agent/src/tools/backtest_tool.py`
  - After `runner.execute(...)`: `RunStateStore().mark_success(run_path)` on success, `mark_failure(run_path, f"backtest engine exited with code {result.exit_code}")` otherwise — same fsync'd writer the runtime uses.
  - Validation errors (missing/invalid config, missing signal engine) return before the engine starts and intentionally record nothing: no execution happened, and artifact-health gates reject those runs anyway.
- `agent/tests/test_backtest_tool_state.py` (new)
  - `test_successful_run_records_state_success` — envelope `ok` + `state.json == {"status": "success"}`.
  - `test_failed_run_records_state_failed_with_exit_code` — `{"status": "failed", "reason": "backtest engine exited with code 3"}`.
  - `test_validation_error_records_no_state` — no `state.json` when config is missing.
  - Mocks `Runner` at the import site; run-root sandbox via `VIBE_TRADING_ALLOWED_RUN_ROOTS` following the existing tool-test pattern.
- Second commit (review follow-up — completes the lifecycle contract):
  - `agent/src/tools/backtest_tool.py`: `runner.execute(...)` is now wrapped in `try/except subprocess.TimeoutExpired`. On timeout the tool records `{"status": "failed", "reason": "backtest engine timed out after 300s"}` via the same `RunStateStore` contract and returns an error envelope instead of propagating a raw exception. Before this, a timed-out run kept partial artifacts with no `state.json` — indistinguishable from a never-executed run (the gate fail-closes either way, but the reason was lost).
  - `agent/tests/test_backtest_tool_state.py`: `test_timeout_records_state_failed_and_returns_error_envelope` pins the state payload and the envelope.

## Test Plan

- [x] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`)
- [x] New tests added (if applicable)
- [x] Tested manually (describe below)

Full-suite result on this branch (after the second commit): **12791 passed, 5 failed, 84 skipped** (4m27s). The 5 failures (`test_anthropic_prompt_cache`, `test_llm_reasoning_effort` ×3, `test_provider_header_isolation`) are **pre-existing and unrelated** — verified by running the same tests on a clean `origin/main` (f9cb061b) checkout in my environment: identical 5 failures (litellm adapter version drift). New tests: 4/4 green; `test_state_fsync.py` (the `RunStateStore` suite) and `test_file_tool_sandbox_security.py` (the only other caller of the tool's `run_backtest`) still green.

Manual E2E on this branch (isolated `VIBE_TRADING_HOME` + `VIBE_TRADING_ALLOWED_RUN_ROOTS`, real engine subprocess, yfinance AAPL 2024-01-01..2024-06-30):

```
1) run_backtest envelope: ok, exit_code 0, artifacts: [equity, metrics, positions, run_card_json, run_card_md, target_positions, trades]
2) state.json written by the tool itself: {"status": "success"}
3) refresh_strategy_evidence_core(runs=[...]): {"status": "ok", "runs": 1, "strategies": 1, "rows": 1}, skipped: []
```

The exact flow that failed 11/11 in the issue now passes with zero bridging.

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Documentation updated (if user-facing change)

