### PR TITLE
fix(grounding): parse decimal-comma and Unicode-minus numerals (#1418)

### DIFF
--- a/agent/src/agent/grounding.py
+++ b/agent/src/agent/grounding.py
@@ -752,6 +752,30 @@ _CLAUSE_SEPARATOR_RE = re.compile(r"[,，;；。、\n]")
 # needs a digit before it and exactly three digits after.
 _THOUSANDS_SEPARATOR_RE = re.compile(r"(?<=\d),(?=\d{3}(?!\d))")
 
+# Locale numerals (#1418): decimal-comma detection must never flip English
+# list prose ("steps 1,2 and 3") into a decimal, so a bare `1,5` stays
+# ambiguous-by-design and only unambiguous shapes count as markers: a
+# percent-adjacent comma group, a leading-zero group English would never
+# write, or a signed group (nobody signs a list). Once any marker is present
+# the text speaks decimal-comma and every digit-comma is a decimal point
+# (`5,132` is 5.132 there, not 5132). With no marker the text reads as
+# English and commas keep their thousands meaning.
+_DECIMAL_COMMA_MARK_RE = re.compile(
+    r"\d,\d{1,2}\s*[%％]"
+    r"|(?<![\d,])0,\d{3}(?!\d)"
+    r"|[-+]\d+,\d{1,3}(?!\d)"
+)
+_DECIMAL_COMMA_RE = re.compile(r"(?<=\d),(?=\d)")
+_UNICODE_MINUS = "−"
+
+
+def _normalize_locale_numerals(text: str) -> str:
+    """Normalize Unicode minus and decimal commas into English numerals."""
+    normalized = text.replace(_UNICODE_MINUS, "-")
+    if not _DECIMAL_COMMA_MARK_RE.search(normalized):
+        return normalized
+    return _DECIMAL_COMMA_RE.sub(".", normalized)
+
 
 def _split_clauses(text: str) -> list[str]:
     """Split prose into clauses without breaking a grouped number apart.
@@ -763,7 +787,8 @@ def _split_clauses(text: str) -> list[str]:
         The clause segments, with thousands separators removed so a grouped
         price survives as one number.
     """
-    return _CLAUSE_SEPARATOR_RE.split(_THOUSANDS_SEPARATOR_RE.sub("", text))
+    normalized = _normalize_locale_numerals(text)
+    return _CLAUSE_SEPARATOR_RE.split(_THOUSANDS_SEPARATOR_RE.sub("", normalized))
 _TABLE_SEPARATOR_RE = re.compile(r"^:?-{3,}:?$")
 
 _TABLE_FIELD_ALIASES = {
@@ -3044,7 +3069,8 @@ class GroundingLedger:
     @staticmethod
     def _measure_numbers(text: str) -> list[str]:
         """Extract measurement-shaped numbers (decimal or percent) from a claim."""
-        masked = _LOCALIZED_DATE_RE.sub(" ", text)
+        masked = _normalize_locale_numerals(text)
+        masked = _LOCALIZED_DATE_RE.sub(" ", masked)
         masked = _DATE_RE.sub(" ", masked)
         masked = _SHORT_DATE_RE.sub(" ", masked)
         masked = _DASH_DATE_RE.sub(" ", masked)

--- a/agent/tests/test_agent_grounding.py
+++ b/agent/tests/test_agent_grounding.py
@@ -18,6 +18,7 @@ from src.agent.grounding import (
     _JOINED_CRYPTO_RE,
     _normalize_symbol,
     _scan_symbols,
+    _split_clauses,
     _symbol_from_csv_filename,
     _timestamp_matches_claim_date,
 )
@@ -2521,6 +2522,63 @@ def test_a_clause_comma_still_separates_clauses(tmp_path: Path) -> None:
 
     assert result.valid is False
     assert "numeric_claim_conflict" in {issue["code"] for issue in result.issues}
+
+
+def test_spanish_decimal_commas_parse_as_one_number() -> None:
+    """#1418: "1,57%" / "−5,13%" are one measurement, not a clause boundary."""
+    clauses = _split_clauses("回撤为 −5,13%，年化 1,57%。")
+
+    assert clauses == ["回撤为 -5.13%", "年化 1.57%", ""]
+    numbers = GroundingLedger._measure_numbers("回撤为 −5,13%，年化 1,57%。")
+    assert "-5.13%" in numbers
+    assert "1.57%" in numbers
+
+
+def test_decimal_comma_document_reads_three_digit_groups_as_decimals() -> None:
+    """Once the text demonstrably speaks decimal-comma, even the ambiguous
+    `5,132` shape is a decimal, otherwise English thousands would win."""
+    numbers = GroundingLedger._measure_numbers("peor caso −5,132%, mejor 1,57%")
+
+    assert "-5.132%" in numbers
+    assert "1.57%" in numbers
+
+
+def test_zero_prefixed_decimal_comma_is_not_a_thousands_group() -> None:
+    """English never writes `0,188`, so a leading zero marks the decimal comma."""
+    numbers = GroundingLedger._measure_numbers("置信区间为 0,188")
+
+    assert "0.188" in numbers
+
+
+def test_unicode_minus_is_normalized_for_english_decimals_too() -> None:
+    numbers = GroundingLedger._measure_numbers("drawdown −5.13%")
+
+    assert "-5.13%" in numbers
+
+
+def test_english_thousands_grouping_still_wins_without_locale_signal() -> None:
+    """No decimal-comma marker anywhere: `5,132` and `1,309.22` stay English."""
+    assert GroundingLedger._measure_numbers("sampled 5,132 runs") == []
+    assert _split_clauses("收盘价 ¥1,309.22，数据来源：腾讯行情。") == [
+        "收盘价 ¥1309.22",
+        "数据来源：腾讯行情",
+        "",
+    ]
+
+
+def test_signed_decimal_comma_marks_the_locale_by_itself() -> None:
+    numbers = GroundingLedger._measure_numbers("peor caso −5,132%")
+
+    assert "-5.132%" in numbers
+
+
+def test_integer_list_prose_never_flips_to_decimal_comma() -> None:
+    """"steps 1,2 and 3" is a list, not 1.2 plus noise: no marker, no flip."""
+    assert _split_clauses("steps 1,2 and 3 are skipped") == [
+        "steps 1",
+        "2 and 3 are skipped",
+    ]
+    assert GroundingLedger._measure_numbers("置信区间为 2,237") == []
 
 
 @pytest.mark.parametrize("query", ["贵州茅台", "ZZZZ.V"])


### PR DESCRIPTION
## Summary

- The grounding layer now normalizes locale numerals before parsing analysis answers: Unicode minus becomes ASCII, and decimal-comma documents (`1,57%`, `−5,13%`, `0,188`) parse as the single numbers they are instead of being split or regrouped.

## Why

Closes #1418. Spanish-format analysis answers were corrupted at parse time: `1,57%` split at the comma into a bogus `57%` claim, `−5,13%` lost sign and integer part into `13%`, and once a document speaks decimal-comma, `5,132` read as `5132`. The tool output underneath was always correct; the final-answer parser mangled it.

## Changes

- One normalize step feeds both number paths (clause splitting and measurement extraction): Unicode minus always maps to ASCII; when the text shows an unambiguous decimal-comma marker (a percent-adjacent group, a leading-zero group English never writes, or a signed group) every digit-comma is a decimal point.
- Bare ambiguous shapes stay English on purpose: `2,237` without any marker keeps its thousands reading, so list prose like "steps 1,2 and 3" can never flip into a decimal.
- Seven regression tests pin the Spanish shapes, the document-level `5,132` case, the leading-zero case, the signed case, and the English no-flip controls.

## Risk / rollback

Low. Texts with no decimal-comma marker are byte-identical to before (the only unconditional change is Unicode-minus normalization, which previously failed to parse at all). Rollback is reverting the single commit; no state, schema, or config is touched.

Known follow-up, deliberately out of scope: in `VaR 95%: 1,57%` the `95%` confidence level is still a candidate measurement alongside the VaR value itself. That is a metric-kind gating question, separate from numeral parsing, and worth its own issue.

## Test Plan

- [x] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`): 12884 passed, 0 failed
- [x] New tests added (7, in `agent/tests/test_agent_grounding.py`)
- [x] Tested manually: red-first confirmed; the four new behavior tests fail on current main and pass with the fix, and the full agent suite runs clean both ways

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Documentation updated (not user-facing; parsing correctness only)
