### PR TITLE
fix(grounding): don't ingest metadata count fields as return evidence (#1420)

### DIFF
--- a/agent/src/agent/grounding.py
+++ b/agent/src/agent/grounding.py
@@ -355,6 +355,11 @@ _ANALYSIS_KIND_ALIASES = {
     "ic_positive_ratio": "win_rate",
 }
 
+# Compound-leaf head nouns that mark a metadata/count field rather than a
+# metric value: return_observations is a sample size, not a return (#1420).
+# Exact alias leaves ("return", "total_return") never reach this check.
+_METADATA_HEAD_TOKENS = frozenset({"observation", "observations", "count", "counts"})
+
 # Order matters: 最大回撤 is drawdown before 收益/return, and 年化波动率 is vol
 # before the generic return branch.
 _ANALYSIS_KIND_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
@@ -1101,12 +1106,18 @@ def _metric_kind_for_path(path: str) -> str | None:
     kind = _ANALYSIS_KIND_ALIASES.get(leaf)
     if kind is not None:
         return kind
+    # Metadata leaves that merely contain a metric token: return_observations
+    # is a sample-size count, not a return (#1420). The head noun decides, and
+    # a denied head must not fall through to the text scan, which would match
+    # the same token all over again.
+    tokens = [token for token in re.split(r"[_.]", leaf) if token]
+    if tokens and tokens[-1] in _METADATA_HEAD_TOKENS:
+        return None
     # Compound leaves name the kind as a token ("reported_annualized_return",
     # "strategy_max_drawdown"). #1338 review: matching only the verbatim alias
     # table makes every other spelling silently ungroundable. Scan from the
     # right — English compounds put the head noun last, so "return_vol"
     # resolves to vol, never to return.
-    tokens = [token for token in re.split(r"[_.]", leaf) if token]
     for size in (2, 1):
         for start in range(len(tokens) - size, -1, -1):
             kind = _ANALYSIS_KIND_ALIASES.get("_".join(tokens[start : start + size]))

--- a/agent/tests/test_agent_grounding.py
+++ b/agent/tests/test_agent_grounding.py
@@ -3747,3 +3747,80 @@ def test_crypto_pair_tables_match_the_resolver() -> None:
     # gold and forex are quoted in it too); grounding decides it by the base
     # whitelist instead, so it is the only permitted difference.
     assert set(g._CRYPTO_QUOTE_ASSETS) | {"USD"} == set(ss._CRYPTO_QUOTE_ASSETS)
+
+
+def test_metadata_count_leaf_is_not_return_evidence(tmp_path: Path) -> None:
+    """#1420: return_observations is a sample-size count, not an 81% return."""
+    from src.agent.grounding import _metric_kind_for_path
+
+    assert _metric_kind_for_path("return_observations") is None
+    assert _metric_kind_for_path("benchmark_return_count") is None
+    assert _metric_kind_for_path("observation_count") is None
+    # real return fields must keep their kind
+    assert _metric_kind_for_path("total_return") == "return"
+    assert _metric_kind_for_path("annualized_return") == "return"
+    assert _metric_kind_for_path("return") == "return"
+    assert _metric_kind_for_path("return_vol") == "vol"
+    assert _metric_kind_for_path("strategy_max_drawdown") == "drawdown"
+
+
+def test_a_count_column_cannot_ground_a_return_claim(tmp_path: Path) -> None:
+    """End to end: an 81 in return_observations must not validate "年化 81%"."""
+    run_dir = tmp_path / "runs" / "count"
+    (run_dir / "artifacts").mkdir(parents=True)
+    (run_dir / "artifacts" / "metrics.csv").write_text(
+        "return_observations,total_return\n81,0.031\n",
+        encoding="utf-8",
+    )
+    ledger = GroundingLedger(run_dir=tmp_path, user_message="回测策略表现")
+    ledger.ingest_tool_result(
+        tool_name="backtest",
+        arguments={"run_dir": str(run_dir)},
+        result=json.dumps(
+            {
+                "status": "ok",
+                "exit_code": 0,
+                "run_dir": str(run_dir),
+                "artifacts": {
+                    "metrics.csv": str(run_dir / "artifacts" / "metrics.csv")
+                },
+            }
+        ),
+        call_id="bt-count",
+        success=True,
+    )
+
+    fabricated = ledger.validate_final_answer("策略年化收益 81%。")
+    assert fabricated.valid is False
+    assert "analysis_claim_unavailable" in {
+        issue["code"] for issue in fabricated.issues
+    }
+
+    honest = ledger.validate_final_answer("策略年化收益 3.1%。")
+    assert honest.valid is True, honest.issues
+
+
+def test_a_count_field_in_analysis_json_cannot_ground_a_return_claim(
+    tmp_path: Path,
+) -> None:
+    """#1420 的真实路径：factor_analysis 的 JSON 叶子 return_observations=81
+    不得把"年化 81%"验证为真（修复前恰好能）。"""
+    ledger = GroundingLedger(run_dir=tmp_path, user_message="分析策略表现")
+    ledger.ingest_tool_result(
+        tool_name="factor_analysis",
+        arguments={},
+        result=json.dumps(
+            {"status": "ok", "return_observations": 81, "total_return": 0.031}
+        ),
+        call_id="fa-count",
+        success=True,
+    )
+
+    fabricated = ledger.validate_final_answer("策略年化收益 81%。")
+    assert fabricated.valid is False
+    assert "analysis_claim_unavailable" in {
+        issue["code"] for issue in fabricated.issues
+    }
+
+    honest = ledger.validate_final_answer("策略年化收益 3.1%。")
+    assert honest.valid is True, honest.issues


### PR DESCRIPTION
## Summary

- Metadata/count fields (`return_observations`, `benchmark_return_count`, `observation_count`) are no longer ingested as return evidence. A sample size of 81 was validating a fabricated "annual return 81%" claim.

## Why

Closes #1420. `_metric_kind_for_path` tokenizes compound leaves, and the right-to-left token scan matched `return` inside `return_observations`, classifying a count field as metric kind `return`. With that in the evidence set, `Annual return: 81%` passed final-answer grounding while `Annual return: 80%` was correctly rejected.

## Changes

- Compound leaves whose head noun marks metadata (`observation(s)`, `count(s)`) resolve to `None` before the token scan, and the text fallback is skipped on that path so the same token cannot match again through the back door.
- Exact alias leaves (`return`, `total_return`, `annualized_return`) and genuine compound metrics (`return_vol` -> vol, `strategy_max_drawdown` -> drawdown) are unchanged.
- Three regression tests: the leaf-level mapping (including the preserved kinds), a `factor_analysis` JSON-leaf end-to-end where `return_observations=81` must not validate `年化 81%` (fails pre-fix, passes post-fix), and the same shape through the backtest CSV path.

## Risk / rollback

Low. The only fields that stop counting as evidence are count/metadata leaves; every metric-bearing leaf keeps its kind, verified by the preserved-kind assertions and the full grounding suite (240/240) plus the whole agent suite (12880 passed, 0 failed). Rollback is reverting the single commit; no state or schema touched.

Scope note for the record: duration-like fields (`*_days`, `*_periods`) are a separate unit-mismatch class and intentionally left out of this PR.

## Test Plan

- [x] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`): 12880 passed, 0 failed
- [x] New tests added (3, in `agent/tests/test_agent_grounding.py`)
- [x] Tested manually: red-first confirmed; both new behavior tests fail on current main (the fabricated 81% claim validates) and pass with the fix

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Documentation updated (not user-facing; evidence-ingestion correctness only)
