### PR TITLE
fix(grounding): validate each measurement against its own metric kind (#1421)

### DIFF
--- a/agent/src/agent/grounding.py
+++ b/agent/src/agent/grounding.py
@@ -2953,9 +2953,11 @@ class GroundingLedger:
                     continue
                 kind = _metric_kind_for_text(segment)
                 unsupported = [
-                    value
-                    for value in values
-                    if not self._analysis_value_observed(value, kind)
+                    (value, value_kind)
+                    for value, value_kind in GroundingLedger._measure_numbers_with_kinds(
+                        segment, kind
+                    )
+                    if not self._analysis_value_observed(value, value_kind)
                 ]
                 if not unsupported:
                     continue
@@ -2972,15 +2974,29 @@ class GroundingLedger:
                         line, price_records, line_symbol
                     )
                     if len(operands) >= 2 and self._return_derived_from_observed(
-                        unsupported, price_records, line_symbol, operands=operands
+                        [value for value, value_kind in unsupported if value_kind == "return"],
+                        price_records,
+                        line_symbol,
+                        operands=operands,
                     ):
-                        continue
+                        # the return figures derive from observed endpoints;
+                        # anything left belongs to another kind
+                        unsupported = [
+                            (value, value_kind)
+                            for value, value_kind in unsupported
+                            if value_kind != "return"
+                        ]
+                        if not unsupported:
+                            continue
+                if not unsupported:
+                    continue
+                value, issue_kind = unsupported[0]
                 issues.append(
                     {
                         "code": "analysis_claim_unavailable",
                         "claim": segment.strip()[:200],
-                        "value": unsupported[0],
-                        "kind": kind,
+                        "value": value,
+                        "kind": issue_kind,
                         "message": (
                             "No supporting analysis evidence (a completed "
                             "backtest result or observed risk metric) exists for "
@@ -3052,6 +3068,33 @@ class GroundingLedger:
             match.group(0).replace(" ", "").replace(",", "")
             for match in _MEASURE_NUMBER_RE.finditer(masked)
         ]
+
+    @staticmethod
+    def _measure_numbers_with_kinds(
+        text: str, clause_kind: str | None
+    ) -> list[tuple[str, str | None]]:
+        """Pair each measurement with the metric kind its own window names.
+
+        A clause can hold several metrics ("volatility was 23% and max
+        drawdown was -5%"), and validating every number against one
+        clause-wide kind rejects honest answers (#1421). Each value resolves
+        its kind from the text between the previous value and itself, using
+        the same ordered pattern priority as a whole clause; a window with no
+        metric word at all (or an ambiguous parallel listing) falls back to
+        the clause-level kind, which keeps single-metric behavior identical.
+        """
+        masked = _LOCALIZED_DATE_RE.sub(" ", text)
+        masked = _DATE_RE.sub(" ", masked)
+        masked = _SHORT_DATE_RE.sub(" ", masked)
+        masked = _DASH_DATE_RE.sub(" ", masked)
+        pairs: list[tuple[str, str | None]] = []
+        previous_end = 0
+        for match in _MEASURE_NUMBER_RE.finditer(masked):
+            window = masked[previous_end : match.end()]
+            kind = _metric_kind_for_text(window) or clause_kind
+            pairs.append((match.group(0).replace(" ", "").replace(",", ""), kind))
+            previous_end = match.end()
+        return pairs
 
     @staticmethod
     def _pipe_tables(

--- a/agent/tests/test_agent_grounding.py
+++ b/agent/tests/test_agent_grounding.py
@@ -3747,3 +3747,70 @@ def test_crypto_pair_tables_match_the_resolver() -> None:
     # gold and forex are quoted in it too); grounding decides it by the base
     # whitelist instead, so it is the only permitted difference.
     assert set(g._CRYPTO_QUOTE_ASSETS) | {"USD"} == set(ss._CRYPTO_QUOTE_ASSETS)
+
+
+def _multi_metric_ledger(tmp_path: Path) -> GroundingLedger:
+    """A ledger whose backtest holds both volatility and drawdown evidence."""
+    run_dir = tmp_path / "runs" / "multi"
+    (run_dir / "artifacts").mkdir(parents=True)
+    (run_dir / "artifacts" / "metrics.csv").write_text(
+        "annualized_vol,max_drawdown\n0.23,-0.05\n",
+        encoding="utf-8",
+    )
+    ledger = GroundingLedger(run_dir=tmp_path, user_message="回测策略的风险指标")
+    ledger.ingest_tool_result(
+        tool_name="backtest",
+        arguments={"run_dir": str(run_dir)},
+        result=json.dumps(
+            {
+                "status": "ok",
+                "exit_code": 0,
+                "run_dir": str(run_dir),
+                "artifacts": {
+                    "metrics.csv": str(run_dir / "artifacts" / "metrics.csv")
+                },
+            }
+        ),
+        call_id="bt-multi",
+        success=True,
+    )
+    return ledger
+
+
+def test_multi_metric_clause_validates_each_value_against_its_own_kind(
+    tmp_path: Path,
+) -> None:
+    """#1421: one clause, two metrics — each number is checked against the
+    metric it belongs to, not against a single clause-wide kind."""
+    ledger = _multi_metric_ledger(tmp_path)
+
+    good = ledger.validate_final_answer(
+        "Annualized volatility was 23% and max drawdown was -5%."
+    )
+    assert good.valid is True, good.issues
+
+    reversed_order = ledger.validate_final_answer(
+        "Max drawdown was -5% and annualized volatility was 23%."
+    )
+    assert reversed_order.valid is True, reversed_order.issues
+
+
+def test_multi_metric_clause_still_rejects_the_wrong_value(tmp_path: Path) -> None:
+    """Per-value kinds must not launder an unsupported figure either."""
+    ledger = _multi_metric_ledger(tmp_path)
+
+    bad = ledger.validate_final_answer(
+        "Annualized volatility was 23% and max drawdown was -9%."
+    )
+    assert bad.valid is False
+    by_value = {issue.get("value"): issue for issue in bad.issues}
+    assert "-9%" in by_value
+    assert by_value["-9%"]["kind"] == "drawdown"
+
+
+def test_single_metric_clause_behavior_is_unchanged(tmp_path: Path) -> None:
+    ledger = _multi_metric_ledger(tmp_path)
+
+    assert ledger.validate_final_answer("Annualized volatility was 23%.").valid is True
+    bad = ledger.validate_final_answer("Annualized volatility was 24%.")
+    assert bad.valid is False


### PR DESCRIPTION
## Summary

- A clause holding several metrics now validates each measurement against the metric it belongs to, instead of against one clause-wide kind. "Annualized volatility was 23% and max drawdown was -5%" no longer gets rejected when both figures are backed by evidence.

## Why

Closes #1421. `_validate_analysis_claims()` resolved a single metric kind per clause and checked every measurement in it against that kind, so the combined sentence above was rejected with `kind: drawdown, value: 23%` — the 23% is valid volatility evidence being judged as a drawdown. LLM-written reports naturally combine related metrics in one sentence, so correct answers were being rewritten to omit valid evidence.

## Changes

- Each measurement resolves its kind from the text between the previous measurement and itself, using the same ordered pattern priority as the clause-level resolver. A window with no metric word falls back to the clause-level kind, so single-metric clauses behave exactly as before; a genuinely ambiguous parallel listing ("X and Y were v1 and v2") also keeps the conservative clause-level reading (documented residual).
- The return-derivation rescue now applies to return-kind values only; other unsupported kinds in the same clause still produce their issue, and the issue's `kind` field names the kind of the first unsupported value.
- Four regression tests: combined sentence in both orders, the wrong value still rejected with the right kind attached, and the single-metric paths unchanged.

## Risk / rollback

Low. The change only loosens false rejections; every value is still checked against kind-scoped evidence, and an unsupported figure in a mixed clause is still rejected (pinned by the `-9%` test). Full grounding suite 237/237 and the whole agent suite (12880 passed, 0 failed) are green. Rollback is reverting the single commit; no state or schema touched. Composes independently with #1419 (locale numerals), which touches different helpers.

## Test Plan

- [x] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q`): 12880 passed, 0 failed
- [x] New tests added (4, in `agent/tests/test_agent_grounding.py`)
- [x] Tested manually: red-first confirmed; the combined-sentence tests fail on current main and pass with the fix, single-metric control unchanged throughout

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Documentation updated (not user-facing; claim-validation correctness only)
