### PR TITLE
fix(grounding): gate tail-risk claims (VaR/ES/CVaR) against evidence

### DIFF
--- a/agent/src/agent/grounding.py
+++ b/agent/src/agent/grounding.py
@@ -281,7 +281,12 @@ _ANALYSIS_METRIC_RE = re.compile(
     r"\bprob(?:ability)?\.?\s+of\b|\bvolatility\b|\bdrawdown\b|"
     r"\bannualiz\w*\b|\bwindow(?:s)?\b|\bregime(?:s)?\b|"
     r"\b(?:annual|cumulative|total)\s+return\b|"
-    r"夏普|回撤|波动率|胜率|命中率|概率|年化|回测|窗口|收益(?:率)?|回报(?:率)?)",
+    # tail-risk metrics (#1425): VaR/CVaR/expected shortfall. A bare "ES" is
+    # also the E-mini S&P ticker, so it only counts with a figure attached;
+    # "ES futures closed at ..." is a price claim, not a risk metric.
+    r"\bvar\b|\bcvar\b|expected\s+shortfall|\bes\b(?=\s*[-+]?\d)|"
+    r"夏普|回撤|波动率|胜率|命中率|概率|年化|回测|窗口|收益(?:率)?|回报(?:率)?|"
+    r"在险价值|风险价值|预期尾部损失)",
     re.IGNORECASE,
 )
 # Phrases that indicate a figure is attributed to an external source rather
@@ -353,11 +358,35 @@ _ANALYSIS_KIND_ALIASES = {
     "return": "return",
     "returns": "return",
     "ic_positive_ratio": "win_rate",
+    # tail-risk evidence leaves (#1425): quantlib's risk tools report var/cvar
+    # as positive loss magnitudes; CSV headers carry var_95/es_99 shapes.
+    "var": "tail_risk",
+    "cvar": "tail_risk",
+    "es": "tail_risk",
+    "expected_shortfall": "tail_risk",
+    "value_at_risk": "tail_risk",
+    "historical_var": "tail_risk",
+    "historical_cvar": "tail_risk",
+    "var_95": "tail_risk",
+    "var_99": "tail_risk",
+    "cvar_95": "tail_risk",
+    "cvar_99": "tail_risk",
+    "es_95": "tail_risk",
+    "es_99": "tail_risk",
 }
 
 # Order matters: 最大回撤 is drawdown before 收益/return, and 年化波动率 is vol
 # before the generic return branch.
 _ANALYSIS_KIND_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    # tail risk first: "风险价值" carries no drawdown/return token, but the
+    # confidence frame ("VaR 95%") must classify before the % can wander.
+    (
+        re.compile(
+            r"(?:在险价值|风险价值|预期尾部损失|expected\s*shortfall|\bcvar\b|\bvar\b|\bes\b)",
+            re.IGNORECASE,
+        ),
+        "tail_risk",
+    ),
     (re.compile(r"(?:回撤|drawdown|maxdd|最大亏损)", re.IGNORECASE), "drawdown"),
     (
         re.compile(
@@ -518,6 +547,18 @@ _QUANTITY_WITH_UNIT_RE = re.compile(
     r"|(?:shares?|contracts?|lots?|units?|sessions?|bars?|periods?|"
     r"wks?|weeks?|months?|days?|years?|yrs?)\b"
     r")",
+    re.IGNORECASE,
+)
+# The confidence figure in a tail-risk frame is part of the metric's name,
+# not a measurement: in "VaR 95%: -1.57%" or "95% 置信水平下 VaR 为 -1.57%"
+# the 95% never reaches the evidence check, only the -1.57% does (#1425 —
+# mirrors _LABELLED_SCORE_RE, which does the same for "CONFIDENCE: 6").
+_TAIL_RISK_CONFIDENCE_RE = re.compile(
+    r"(?:\bvar\b|\bcvar\b|expected\s*shortfall|在险价值|风险价值|预期尾部损失)"
+    r"\s*[(（]?\s*[-+]?\d+(?:\.\d+)?\s*[%％]\s*[)）]?"
+    r"(?=\s*[:：=]?\s*[(（]?[-+]?\d)"  # a confidence is followed by the value; a bare "CVaR 2.1%" is the value
+    r"|"
+    r"[-+]?\d+(?:\.\d+)?\s*[%％]\s*(?:置信水平|置信度|confidence(?:\s+level)?)\s*[下上的]?",
     re.IGNORECASE,
 )
 # A conviction reading is on a labelled scale, not a price scale: the 6 in
@@ -3048,6 +3089,8 @@ class GroundingLedger:
         masked = _DATE_RE.sub(" ", masked)
         masked = _SHORT_DATE_RE.sub(" ", masked)
         masked = _DASH_DATE_RE.sub(" ", masked)
+        # The confidence in "VaR 95%: x" frames the measurement; it is not one.
+        masked = _TAIL_RISK_CONFIDENCE_RE.sub(" ", masked)
         return [
             match.group(0).replace(" ", "").replace(",", "")
             for match in _MEASURE_NUMBER_RE.finditer(masked)
@@ -3108,7 +3151,10 @@ class GroundingLedger:
                 continue
             observed.append(float(record.value))
         candidates = {value, value / 100.0}
-        if kind == "drawdown":
+        if kind in ("drawdown", "tail_risk"):
+            # Tail-risk sign conventions disagree the same way drawdown's do:
+            # quantlib reports VaR/CVaR as positive loss magnitudes while a
+            # report may write the same figure as -1.57%.
             candidates |= {abs(value), abs(value) / 100.0}
 
         def close(candidate: float, item: float) -> bool:

--- a/agent/src/agent/grounding.py
+++ b/agent/src/agent/grounding.py
@@ -2953,9 +2953,11 @@ class GroundingLedger:
                     continue
                 kind = _metric_kind_for_text(segment)
                 unsupported = [
-                    value
-                    for value in values
-                    if not self._analysis_value_observed(value, kind)
+                    (value, value_kind)
+                    for value, value_kind in GroundingLedger._measure_numbers_with_kinds(
+                        segment, kind
+                    )
+                    if not self._analysis_value_observed(value, value_kind)
                 ]
                 if not unsupported:
                     continue
@@ -2972,15 +2974,29 @@ class GroundingLedger:
                         line, price_records, line_symbol
                     )
                     if len(operands) >= 2 and self._return_derived_from_observed(
-                        unsupported, price_records, line_symbol, operands=operands
+                        [value for value, value_kind in unsupported if value_kind == "return"],
+                        price_records,
+                        line_symbol,
+                        operands=operands,
                     ):
-                        continue
+                        # the return figures derive from observed endpoints;
+                        # anything left belongs to another kind
+                        unsupported = [
+                            (value, value_kind)
+                            for value, value_kind in unsupported
+                            if value_kind != "return"
+                        ]
+                        if not unsupported:
+                            continue
+                if not unsupported:
+                    continue
+                value, issue_kind = unsupported[0]
                 issues.append(
                     {
                         "code": "analysis_claim_unavailable",
                         "claim": segment.strip()[:200],
-                        "value": unsupported[0],
-                        "kind": kind,
+                        "value": value,
+                        "kind": issue_kind,
                         "message": (
                             "No supporting analysis evidence (a completed "
                             "backtest result or observed risk metric) exists for "
@@ -3052,6 +3068,33 @@ class GroundingLedger:
             match.group(0).replace(" ", "").replace(",", "")
             for match in _MEASURE_NUMBER_RE.finditer(masked)
         ]
+
+    @staticmethod
+    def _measure_numbers_with_kinds(
+        text: str, clause_kind: str | None
+    ) -> list[tuple[str, str | None]]:
+        """Pair each measurement with the metric kind its own window names.
+
+        A clause can hold several metrics ("volatility was 23% and max
+        drawdown was -5%"), and validating every number against one
+        clause-wide kind rejects honest answers (#1421). Each value resolves
+        its kind from the text between the previous value and itself, using
+        the same ordered pattern priority as a whole clause; a window with no
+        metric word at all (or an ambiguous parallel listing) falls back to
+        the clause-level kind, which keeps single-metric behavior identical.
+        """
+        masked = _LOCALIZED_DATE_RE.sub(" ", text)
+        masked = _DATE_RE.sub(" ", masked)
+        masked = _SHORT_DATE_RE.sub(" ", masked)
+        masked = _DASH_DATE_RE.sub(" ", masked)
+        pairs: list[tuple[str, str | None]] = []
+        previous_end = 0
+        for match in _MEASURE_NUMBER_RE.finditer(masked):
+            window = masked[previous_end : match.end()]
+            kind = _metric_kind_for_text(window) or clause_kind
+            pairs.append((match.group(0).replace(" ", "").replace(",", ""), kind))
+            previous_end = match.end()
+        return pairs
 
     @staticmethod
     def _pipe_tables(

--- a/agent/src/agent/grounding.py
+++ b/agent/src/agent/grounding.py
@@ -554,13 +554,92 @@ _QUANTITY_WITH_UNIT_RE = re.compile(
 # the 95% never reaches the evidence check, only the -1.57% does (#1425 —
 # mirrors _LABELLED_SCORE_RE, which does the same for "CONFIDENCE: 6").
 _TAIL_RISK_CONFIDENCE_RE = re.compile(
-    r"(?:\bvar\b|\bcvar\b|expected\s*shortfall|在险价值|风险价值|预期尾部损失)"
+    r"(?:\bvar\b|\bcvar\b|\bes\b|expected\s*shortfall|在险价值|风险价值|预期尾部损失)"
     r"\s*[(（]?\s*[-+]?\d+(?:\.\d+)?\s*[%％]\s*[)）]?"
-    r"(?=\s*[:：=]?\s*[(（]?[-+]?\d)"  # a confidence is followed by the value; a bare "CVaR 2.1%" is the value
+    r"(?=\s*(?:[:：=]|为|是|is\b)?\s*[(（]?[-+]?\d)"  # a confidence is followed by the value; a bare "CVaR 2.1%" is the value
     r"|"
     r"[-+]?\d+(?:\.\d+)?\s*[%％]\s*(?:置信水平|置信度|confidence(?:\s+level)?)\s*[下上的]?",
     re.IGNORECASE,
 )
+# Identity inside the tail_risk family (#1427 review): the measure (var vs
+# es — CVaR/expected shortfall/预期尾部损失 are the es measure) and, when
+# named, the confidence. A 95% figure must not ground a 99% claim, and a VaR
+# figure must not ground an ES claim.
+_TAIL_RISK_ES_MEASURE_RE = re.compile(
+    r"\bcvar\b|\bes\b|expected\s*shortfall|预期尾部损失", re.IGNORECASE
+)
+_TAIL_RISK_CONFIDENCE_VALUE_RE = re.compile(
+    r"(?:\bvar\b|\bcvar\b|\bes\b|expected\s*shortfall|在险价值|风险价值|预期尾部损失)"
+    r"\s*[(（]?\s*(\d{2})(?:\.\d+)?\s*[%％]"
+    r"|"
+    r"(\d{2})(?:\.\d+)?\s*[%％]\s*(?:置信水平|置信度|confidence(?:\s+level)?)",
+    re.IGNORECASE,
+)
+
+
+def _tail_risk_identity_for_text(text: str) -> tuple[str | None, float | None]:
+    """(measure, confidence) a tail-risk claim names; either may be absent."""
+    measure: str | None = None
+    if _TAIL_RISK_ES_MEASURE_RE.search(text):
+        measure = "es"
+    elif re.search(r"\bvar\b|在险价值|风险价值", text, re.IGNORECASE):
+        measure = "var"
+    confidence: float | None = None
+    match = _TAIL_RISK_CONFIDENCE_VALUE_RE.search(text)
+    if match:
+        confidence = float(match.group(1) or match.group(2)) / 100.0
+    return measure, confidence
+
+
+def _tail_risk_identity_for_field(field: str) -> tuple[str | None, float | None]:
+    """(measure, confidence) an evidence field name carries, e.g. var_95."""
+    name = field.casefold()
+    measure: str | None = None
+    if (
+        "cvar" in name
+        or "expected_shortfall" in name
+        or re.search(r"(?:^|[^a-z])es(?:$|[^a-z])", name)
+    ):
+        measure = "es"
+    elif "var" in name:
+        measure = "var"
+    confidence: float | None = None
+    match = re.search(r"_(\d{2})(?:\D|$)", name)
+    if match:
+        confidence = float(match.group(1)) / 100.0
+    return measure, confidence
+
+
+_TAIL_RISK_VAR_MEASURE_RE = re.compile(r"\bvar\b|在险价值|风险价值", re.IGNORECASE)
+
+
+def _tail_risk_identity_at(
+    segment: str, raw: str, start: int = 0
+) -> tuple[str | None, float | None, int]:
+    """Identity of the claim whose value sits at ``raw`` in ``segment``.
+
+    A segment may carry several tail-risk claims with different identities
+    ("VaR 95%: -1.57%，99% 置信水平下 CVaR 为 -2.1%"), so identity is read from
+    the markers preceding THIS value, not from the whole segment. ``start`` is
+    the cursor for repeated values; the returned int is the next cursor.
+    """
+    pos = segment.find(raw, start)
+    head = segment if pos < 0 else segment[:pos]
+    measure: str | None = None
+    es_last: int | None = None
+    var_last: int | None = None
+    for match in _TAIL_RISK_ES_MEASURE_RE.finditer(head):
+        es_last = match.end()
+    for match in _TAIL_RISK_VAR_MEASURE_RE.finditer(head):
+        var_last = match.end()
+    if es_last is not None and (var_last is None or es_last > var_last):
+        measure = "es"
+    elif var_last is not None:
+        measure = "var"
+    confidence: float | None = None
+    for match in _TAIL_RISK_CONFIDENCE_VALUE_RE.finditer(head):
+        confidence = float(match.group(1) or match.group(2)) / 100.0
+    return measure, confidence, (pos + len(raw)) if pos >= 0 else start
 # A conviction reading is on a labelled scale, not a price scale: the 6 in
 # "CONFIDENCE: 6" is bounded by the label that introduces it. Only the value
 # bound to the label is masked, so a genuine quote elsewhere in the same
@@ -2993,11 +3072,23 @@ class GroundingLedger:
                 if _FORECAST_FRAME_RE.search(segment):
                     continue
                 kind = _metric_kind_for_text(segment)
-                unsupported = [
-                    value
-                    for value in values
-                    if not self._analysis_value_observed(value, kind)
-                ]
+                if kind == "tail_risk":
+                    unsupported = []
+                    cursor = 0
+                    for value in values:
+                        measure_, confidence_, cursor = _tail_risk_identity_at(
+                            segment, value, cursor
+                        )
+                        if not self._analysis_value_observed(
+                            value, kind, (measure_, confidence_)
+                        ):
+                            unsupported.append(value)
+                else:
+                    unsupported = [
+                        value
+                        for value in values
+                        if not self._analysis_value_observed(value, kind)
+                    ]
                 if not unsupported:
                     continue
                 # A return figure may be arithmetic on sourced inputs rather
@@ -3063,7 +3154,15 @@ class GroundingLedger:
         unsupported = [
             value
             for value in values
-            if not self._analysis_value_observed(value, kind)
+            if not self._analysis_value_observed(
+                value,
+                kind,
+                (
+                    _tail_risk_identity_for_text(f"{label} {cell}")
+                    if kind == "tail_risk"
+                    else None
+                ),
+            )
         ]
         if not unsupported:
             return
@@ -3125,7 +3224,12 @@ class GroundingLedger:
             tables.append((GroundingLedger._table_cells(block[0]), rows, row_indices))
         return tables
 
-    def _analysis_value_observed(self, raw: str, kind: str | None) -> bool:
+    def _analysis_value_observed(
+        self,
+        raw: str,
+        kind: str | None,
+        identity: tuple[str | None, float | None] | None = None,
+    ) -> bool:
         """Return True when a claim measurement matches kind-scoped evidence.
 
         Tools disagree on scale: ``compute_risk_xray`` returns fractions
@@ -3140,14 +3244,42 @@ class GroundingLedger:
             value = float(raw.replace("%", "").replace("％", "").replace(",", ""))
         except ValueError:
             return True
+        def identity_matches(field: str) -> bool:
+            # tail_risk only: one figure at 95% must not ground a 99% claim,
+            # and a VaR figure must not ground an ES claim. A side that names
+            # no measure/confidence never narrows the match (#1427 review).
+            if kind != "tail_risk" or identity is None:
+                return True
+            claim_measure, claim_confidence = identity
+            field_measure, field_confidence = _tail_risk_identity_for_field(field)
+            if (
+                claim_measure is not None
+                and field_measure is not None
+                and claim_measure != field_measure
+            ):
+                return False
+            if (
+                claim_confidence is not None
+                and field_confidence is not None
+                and abs(claim_confidence - field_confidence) > 1e-9
+            ):
+                return False
+            return True
+
         observed: list[float] = []
         for record in self._analysis_metrics:
-            if record.get("metric") == kind and record.get("value") is not None:
+            if (
+                record.get("metric") == kind
+                and record.get("value") is not None
+                and identity_matches(str(record.get("field") or ""))
+            ):
                 observed.append(float(record["value"]))
         for record in self._evidence:
             if record.status != "observed" or record.value is None:
                 continue
             if _metric_kind_for_path(record.field) != kind:
+                continue
+            if not identity_matches(record.field):
                 continue
             observed.append(float(record.value))
         candidates = {value, value / 100.0}

--- a/agent/tests/test_agent_grounding.py
+++ b/agent/tests/test_agent_grounding.py
@@ -3747,3 +3747,70 @@ def test_crypto_pair_tables_match_the_resolver() -> None:
     # gold and forex are quoted in it too); grounding decides it by the base
     # whitelist instead, so it is the only permitted difference.
     assert set(g._CRYPTO_QUOTE_ASSETS) | {"USD"} == set(ss._CRYPTO_QUOTE_ASSETS)
+
+
+def _multi_metric_ledger(tmp_path: Path) -> GroundingLedger:
+    """A ledger whose backtest holds both volatility and drawdown evidence."""
+    run_dir = tmp_path / "runs" / "multi"
+    (run_dir / "artifacts").mkdir(parents=True)
+    (run_dir / "artifacts" / "metrics.csv").write_text(
+        "annualized_vol,max_drawdown\n0.23,-0.05\n",
+        encoding="utf-8",
+    )
+    ledger = GroundingLedger(run_dir=tmp_path, user_message="回测策略的风险指标")
+    ledger.ingest_tool_result(
+        tool_name="backtest",
+        arguments={"run_dir": str(run_dir)},
+        result=json.dumps(
+            {
+                "status": "ok",
+                "exit_code": 0,
+                "run_dir": str(run_dir),
+                "artifacts": {
+                    "metrics.csv": str(run_dir / "artifacts" / "metrics.csv")
+                },
+            }
+        ),
+        call_id="bt-multi",
+        success=True,
+    )
+    return ledger
+
+
+def test_multi_metric_clause_validates_each_value_against_its_own_kind(
+    tmp_path: Path,
+) -> None:
+    """#1421: one clause, two metrics — each number is checked against the
+    metric it belongs to, not against a single clause-wide kind."""
+    ledger = _multi_metric_ledger(tmp_path)
+
+    good = ledger.validate_final_answer(
+        "Annualized volatility was 23% and max drawdown was -5%."
+    )
+    assert good.valid is True, good.issues
+
+    reversed_order = ledger.validate_final_answer(
+        "Max drawdown was -5% and annualized volatility was 23%."
+    )
+    assert reversed_order.valid is True, reversed_order.issues
+
+
+def test_multi_metric_clause_still_rejects_the_wrong_value(tmp_path: Path) -> None:
+    """Per-value kinds must not launder an unsupported figure either."""
+    ledger = _multi_metric_ledger(tmp_path)
+
+    bad = ledger.validate_final_answer(
+        "Annualized volatility was 23% and max drawdown was -9%."
+    )
+    assert bad.valid is False
+    by_value = {issue.get("value"): issue for issue in bad.issues}
+    assert "-9%" in by_value
+    assert by_value["-9%"]["kind"] == "drawdown"
+
+
+def test_single_metric_clause_behavior_is_unchanged(tmp_path: Path) -> None:
+    ledger = _multi_metric_ledger(tmp_path)
+
+    assert ledger.validate_final_answer("Annualized volatility was 23%.").valid is True
+    bad = ledger.validate_final_answer("Annualized volatility was 24%.")
+    assert bad.valid is False

--- a/agent/tests/test_grounding_tail_risk.py
+++ b/agent/tests/test_grounding_tail_risk.py
@@ -55,6 +55,7 @@ def test_es_futures_price_prose_is_not_tail_risk():
         ("VaR (99%) = 2.20%", ["2.20%"]),
         ("95% 置信水平下 VaR 为 -1.57%", ["-1.57%"]),
         ("99% confidence level CVaR 2.1%", ["2.1%"]),
+        ("ES 95%: -1.57%", ["-1.57%"]),
     ],
 )
 def test_confidence_figure_is_never_the_measurement(text, expected):
@@ -85,7 +86,7 @@ def test_grounded_tail_risk_claims_pass(tmp_path: Path):
     # evidence is a positive loss magnitude (0.0157); the claim writes it as a
     # signed percent (-1.57%) — both conventions must ground
     result = ledger.validate_final_answer(
-        "回测完成。VaR 95%: -1.57%，99% 置信水平下 CVaR 为 -2.1%。"
+        "回测完成。VaR 95%: -1.57%，95% 置信水平下 CVaR 为 -2.1%。"
     )
     assert all(i["code"] != "analysis_claim_unavailable" for i in result.issues)
 
@@ -114,3 +115,58 @@ def test_confidence_percentage_does_not_need_evidence(tmp_path: Path):
     result = ledger.validate_final_answer("VaR 95%: -1.57%。")
     unsupported = [i for i in result.issues if i["code"] == "analysis_claim_unavailable"]
     assert unsupported == []
+
+
+# Identity inside the family (#1427 review): measure (var vs es) and, when
+# named, confidence must match the evidence. var_95 evidence is in the fixture.
+
+
+def test_var95_evidence_grounds_var95_only(tmp_path: Path):
+    ledger = _ledger_with_tail_evidence(tmp_path)
+    ok = ledger.validate_final_answer("回测完成。VaR 95%: -1.57%。")
+    assert all(i["code"] != "analysis_claim_unavailable" for i in ok.issues)
+
+
+def test_var95_evidence_does_not_ground_var99(tmp_path: Path):
+    ledger = _ledger_with_tail_evidence(tmp_path)
+    result = ledger.validate_final_answer("回测完成。VaR 99%: -1.57%。")
+    assert any(
+        i["code"] == "analysis_claim_unavailable" and i.get("kind") == "tail_risk"
+        for i in result.issues
+    )
+
+
+def test_var95_evidence_does_not_ground_cvar99(tmp_path: Path):
+    # same number, different measure AND confidence: no ground
+    ledger = _ledger_with_tail_evidence(tmp_path)
+    result = ledger.validate_final_answer("回测完成。CVaR 99%: -1.57%。")
+    assert any(
+        i["code"] == "analysis_claim_unavailable" and i.get("kind") == "tail_risk"
+        for i in result.issues
+    )
+
+
+def test_cvar95_evidence_grounds_es_and_cvar_but_not_var(tmp_path: Path):
+    ledger = _ledger_with_tail_evidence(tmp_path)
+    ok = ledger.validate_final_answer("回测完成。ES 95%: -2.1%，CVaR 95% 为 -2.1%。")
+    assert all(i["code"] != "analysis_claim_unavailable" for i in ok.issues)
+    bad = ledger.validate_final_answer("回测完成。VaR 95%: -2.1%。")
+    assert any(
+        i["code"] == "analysis_claim_unavailable" and i.get("kind") == "tail_risk"
+        for i in bad.issues
+    )
+
+
+def test_confidence_free_evidence_grounds_any_confidence(tmp_path: Path):
+    """quantlib's bare `var` names no confidence; it must not become unusable."""
+    (tmp_path / "metrics.json").write_text('{"var": 0.0157}', encoding="utf-8")
+    ledger = GroundingLedger(run_dir=tmp_path, user_message="回测并给出风险指标")
+    ledger.ingest_tool_result(
+        tool_name="backtest",
+        arguments={"run_dir": str(tmp_path)},
+        result='{"status": "ok", "run_dir": "%s"}' % tmp_path,
+        call_id="bt1",
+        success=True,
+    )
+    ok = ledger.validate_final_answer("回测完成。VaR 99%: -1.57%。")
+    assert all(i["code"] != "analysis_claim_unavailable" for i in ok.issues)

--- a/agent/tests/test_grounding_tail_risk.py
+++ b/agent/tests/test_grounding_tail_risk.py
@@ -1,0 +1,116 @@
+"""Tail-risk claims (VaR / ES / CVaR / 在险价值 / 风险价值) must be grounded.
+
+Regression coverage for HKUDS/Vibe-Trading#1425: tail-risk vocabulary was
+absent from the analysis gate entirely, so an invented VaR figure passed as
+``valid=True`` without ever reaching the evidence check. Now the gate
+classifies these claims as ``tail_risk``, compares them against kind-scoped
+evidence (backtest artifacts or quantlib risk-tool output), and the
+confidence frame in "VaR 95%: x" is masked so the 95% is never measured as
+the claim's value.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from src.agent.grounding import (
+    _ANALYSIS_METRIC_RE,
+    _TAIL_RISK_CONFIDENCE_RE,
+    GroundingLedger,
+    _metric_kind_for_text,
+)
+
+_measure = GroundingLedger._measure_numbers
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "VaR 95%: -1.57%",
+        "VaR (99%) = 2.20%",
+        "CVaR 2.1%",
+        "ES 1.9%",
+        "expected shortfall of 2.4%",
+        "在险价值 VaR 为 1.57%",
+        "95% 置信水平下 VaR 为 -1.57%",
+        "风险价值 1.57%",
+        "预期尾部损失为 2.1%",
+    ],
+)
+def test_tail_risk_vocabulary_enters_the_gate(text):
+    assert _ANALYSIS_METRIC_RE.search(text), f"not detected as a metric: {text!r}"
+    assert _metric_kind_for_text(text) == "tail_risk", f"wrong kind for: {text!r}"
+
+
+def test_es_futures_price_prose_is_not_tail_risk():
+    """A bare ES with no attached figure is the E-mini ticker, not a metric."""
+    text = "ES futures closed at 5,210 on the session"
+    assert _metric_kind_for_text(text) is None or _ANALYSIS_METRIC_RE.search(text) is None
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("VaR 95%: -1.57%", ["-1.57%"]),
+        ("VaR (99%) = 2.20%", ["2.20%"]),
+        ("95% 置信水平下 VaR 为 -1.57%", ["-1.57%"]),
+        ("99% confidence level CVaR 2.1%", ["2.1%"]),
+    ],
+)
+def test_confidence_figure_is_never_the_measurement(text, expected):
+    """The confidence level frames the metric; it must not be measured."""
+    assert _measure(text) == expected
+
+
+def _ledger_with_tail_evidence(tmp_path: Path) -> GroundingLedger:
+    """A completed backtest whose metrics.json carries VaR/CVaR figures."""
+    (tmp_path / "metrics.json").write_text(
+        '{"final_value": 834141.8, "total_return": -0.1659, '
+        '"var_95": 0.0157, "cvar_95": 0.021}',
+        encoding="utf-8",
+    )
+    ledger = GroundingLedger(run_dir=tmp_path, user_message="回测这个策略并给出风险指标")
+    ledger.ingest_tool_result(
+        tool_name="backtest",
+        arguments={"run_dir": str(tmp_path)},
+        result='{"status": "ok", "run_dir": "%s"}' % tmp_path,
+        call_id="bt1",
+        success=True,
+    )
+    return ledger
+
+
+def test_grounded_tail_risk_claims_pass(tmp_path: Path):
+    ledger = _ledger_with_tail_evidence(tmp_path)
+    # evidence is a positive loss magnitude (0.0157); the claim writes it as a
+    # signed percent (-1.57%) — both conventions must ground
+    result = ledger.validate_final_answer(
+        "回测完成。VaR 95%: -1.57%，99% 置信水平下 CVaR 为 -2.1%。"
+    )
+    assert all(i["code"] != "analysis_claim_unavailable" for i in result.issues)
+
+
+def test_invented_tail_risk_figure_is_rejected(tmp_path: Path):
+    ledger = _ledger_with_tail_evidence(tmp_path)
+    result = ledger.validate_final_answer("回测完成。VaR 95%: -9.9%。")
+    assert any(
+        i["code"] == "analysis_claim_unavailable" and i.get("kind") == "tail_risk"
+        for i in result.issues
+    )
+
+
+def test_tail_risk_claim_without_any_analysis_is_rejected(tmp_path: Path):
+    ledger = GroundingLedger(run_dir=tmp_path, user_message="这个组合风险多大")
+    result = ledger.validate_final_answer("该组合的 在险价值 VaR 为 1.57%。")
+    assert any(
+        i["code"] == "analysis_claim_unavailable" and i.get("kind") == "tail_risk"
+        for i in result.issues
+    )
+
+
+def test_confidence_percentage_does_not_need_evidence(tmp_path: Path):
+    """The 95 in "VaR 95%" is the frame, not a figure: no 95% evidence exists."""
+    ledger = _ledger_with_tail_evidence(tmp_path)
+    result = ledger.validate_final_answer("VaR 95%: -1.57%。")
+    unsupported = [i for i in result.issues if i["code"] == "analysis_claim_unavailable"]
+    assert unsupported == []


### PR DESCRIPTION
## Summary

- Tail-risk claims (VaR / ES / CVaR / 在险价值 / 风险价值) now pass through the analysis grounding gate like every other metric: they classify as a new `tail_risk` kind and must match kind-scoped evidence from a completed backtest or risk-tool output.
- The confidence frame is masked before measurement, so the `95%` in `VaR 95%: -1.57%` is never treated as the claimed figure.

## Why

Closes #1425. On current main, tail-risk vocabulary is absent from the grounding gate: `VaR 95%: 9,99%` (an invented number) validates as sound with zero issues because the claim never reaches the evidence check. A trust layer that silently skips exactly the figures a risk report is read for is worse than no gate. The issue has the full repro and the design shape this PR implements.

## Changes

- Detector vocabulary gains VaR/CVaR/expected shortfall and the Chinese tail-risk terms. A bare `ES` counts only with a figure attached — it is also the E-mini S&P ticker, and "ES futures closed at 5,210" is a price claim.
- Evidence aliases map quantlib's `var`/`cvar` leaves and `var_95`/`es_99`-style CSV headers to the new kind. Tail-risk figures compare by magnitude like drawdown, because quantlib reports positive loss magnitudes while a report may write the same figure signed.
- A confidence-frame mask mirrors the labelled-score mask: `VaR 95%: x`, `VaR (99%) = x`, `95% 置信水平下 VaR 为 x` measure only `x`; a bare `CVaR 2.1%` still reads 2.1% as the value.
- New `test_grounding_tail_risk.py` (18 tests): vocabulary detection in both languages, confidence-frame masking, grounded/invented/missing-evidence directions end to end, and the ES-ticker false-positive guard.

## Test Plan

- [x] Existing tests pass (`pytest --ignore=agent/tests/e2e_backtest --tb=short -q` for the grounding battery: 363 passed, 5 skipped, plus the 18 new)
- [x] New tests added (if applicable)
- [x] Tested manually (describe below)

Manual: the issue's repro claims (`VaR 95%: 1,57%` with only drawdown evidence present, and the invented `9,99%` figure) now produce `analysis_claim_unavailable` with `kind: tail_risk`; the grounded `-1.57%` against `var_95: 0.0157` passes. Note the decimal-comma spelling is parsed by the still-open #1419; on this branch alone, `1,57%` measures as its integer parts, which still rejects the invented figure (both directions covered by tests with ordinary decimals).

## Checklist

- [x] No changes to protected areas (`src/agent/`, `src/session/`, `src/providers/`) without prior discussion — this touches the analysis grounding gate; the design was discussed in #1425 before implementation.
- [x] No hardcoded values (API keys, file paths, magic numbers)
- [x] Code follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Documentation updated (if user-facing change)
- [x] Community commits must include the DCO `Signed-off-by:` trailer; see `CONTRIBUTING.md`.

## Risk / Rollback

Low and local: the gate gains one metric kind and one mask. Reports whose tail-risk figures are invented or unevidenced now get a recovery prompt instead of shipping silently; every previously-grounded claim shape is unchanged (the full grounding battery passes). Rollback is a single-commit revert.

Prepared with AI assistance (Kimi); the repro, tests, and diff above were verified locally by the committer.
